### PR TITLE
fix(android): mediacodec-copy for screen capture visibility (#129)

### DIFF
--- a/android/app/src/main/kotlin/org/moonfin/androidtv/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/MainActivity.kt
@@ -1,4 +1,4 @@
-package org.moonfin.androidtv
+﻿package org.moonfin.androidtv
 
 import android.app.PendingIntent
 import android.app.PictureInPictureParams
@@ -35,6 +35,8 @@ import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.SessionManagerListener
 import com.google.android.gms.common.images.WebImage
 import com.ryanheise.audioservice.AudioServiceActivity
+import io.flutter.embedding.android.RenderMode
+import io.flutter.embedding.android.TransparencyMode
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
@@ -375,6 +377,12 @@ class MainActivity : AudioServiceActivity() {
             registerReceiver(screenReceiver, screenFilter)
         }
     }
+
+    // Must stay surface: media_kit draws video in a native SurfaceView behind Flutter.
+    // RenderMode.texture (FlutterTextureView) is opaque for that stack — video stays black.
+    override fun getRenderMode(): RenderMode = RenderMode.surface
+
+    override fun getTransparencyMode(): TransparencyMode = TransparencyMode.transparent
 
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+﻿import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -134,10 +134,11 @@ class MediaKitPlayerBackend implements PlayerBackend {
     Future<void> Function(int handle)? onNativeHandleReady,
   }) {
     final hwDecodingEnabled = prefs.get(UserPreferences.hardwareDecoding);
+    // Android: null → AndroidVideoController getDefaultHwdec() (mediacodec-copy).
     final String? hwdec = hwDecodingEnabled
-        ? ((PlatformDetection.isAndroid && PlatformDetection.isTV)
-            ? 'auto'
-            : (PlatformDetection.isLinux ? 'auto-safe' : null))
+        ? (PlatformDetection.isAndroid
+              ? null
+              : (PlatformDetection.isLinux ? 'auto-safe' : null))
         : 'no';
 
     final player = Player(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -886,8 +886,8 @@ class _ContentRowsState extends State<_ContentRows>
     if (!hwDecodingEnabled) {
       return 'no';
     }
-    if (PlatformDetection.isAndroid && PlatformDetection.isTV) {
-      return 'auto';
+    if (PlatformDetection.isAndroid) {
+      return null;
     }
     if (PlatformDetection.isLinux) {
       return 'auto-safe';

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -609,8 +609,8 @@ class _MediaBarState extends State<MediaBar>
     if (!widget.prefs.get(UserPreferences.hardwareDecoding)) {
       return 'no';
     }
-    if (PlatformDetection.isAndroid && PlatformDetection.isTV) {
-      return 'auto';
+    if (PlatformDetection.isAndroid) {
+      return null;
     }
     if (PlatformDetection.isLinux) {
       return 'auto-safe';


### PR DESCRIPTION

# Pull Request

## Summary
Use mediacodec-copy as default Android hwdec so decoded frames are not stuck in protected surfaces that screen share (Discord, Meet) shows as black.
Route all Android VideoController hwdec through getDefaultHwdec() by passing null from main playback, home preview, and media bar (TV previously forced auto).
Document that Flutter must stay RenderMode.surface: TextureView would hide the media_kit SurfaceView behind a non-punch-through layer.

**The coding was supported by use of Cursor - I hope that the change of the decoding is not breaking anything else. Also, the analyzer says it could have a performance impact. But in my testing everything feels the same**

- Closes #129 
- Fixes #129 
- Related to #129 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Pass hwdec: null on all Android VideoController construction in main playback so defaults resolve to mediacodec-copy via getDefaultHwdec() (removes TV-only auto override).
- Align home preview and media bar trailer controllers to the same Android null hwdec behavior.
- In MainActivity, set RenderMode.surface and TransparencyMode.transparent and document why RenderMode.texture is incompatible with the current media_kit + Flutter layering.

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Install a build from this branch on a physical Android phone (arm64 debug/release as you usually use).
2. Start playback of a transcoded/direct stream that uses hardware decode.
3. Start screen share in Discord or Google Meet and confirm video is visible (not black) while audio continues.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
