### PR TITLE
Add 2x speed hold for mobile and desktop

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2594,7 +2594,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 ? () => unawaited(_activateMobileTemporarySpeedHold())
                 : null,
             onLongPressEnd: PlatformDetection.useMobileUi
-                ? (_) => unawaited(_cancelMobileTemporarySpeedHold())
+                ? (_) => _cancelMobileTemporarySpeedHold()
                 : null,
             onDoubleTapDown: PlatformDetection.isTV
                 ? null

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -59,7 +59,7 @@ class VideoPlayerScreen extends StatefulWidget {
 class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     with WidgetsBindingObserver {
   static final _camelCaseSpaceRe = RegExp(r'(?<=[a-z])(?=[A-Z])');
-  static const _tvTemporarySpeed = 2.0;
+  static const _temporarySpeed = 2.0;
   static const _tvTemporarySpeedHoldDelay = Duration(milliseconds: 420);
   static const _seekPromptSuppressionDuration = Duration(milliseconds: 1200);
   static const _seekDragPromptSuppressionDuration = Duration(seconds: 4);
@@ -131,6 +131,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   LogicalKeyboardKey? _tvTemporarySpeedHoldKey;
   bool _tvTemporarySpeedHoldActive = false;
   double? _tvTemporarySpeedRestoreSpeed;
+  bool _mobileTemporarySpeedHoldActive = false;
+  double? _mobileTemporarySpeedRestoreSpeed;
 
   MediaSegment? _skipSegment;
   Duration? _skipTo;
@@ -714,6 +716,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _cancelTvTemporarySpeedHold();
+    _cancelMobileTemporarySpeedHold();
     _hideTimer?.cancel();
     _volumeOverlayTimer?.cancel();
     _brightnessOverlayTimer?.cancel();
@@ -962,6 +965,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   void didChangeAppLifecycleState(AppLifecycleState lifecycleState) {
     if (lifecycleState != AppLifecycleState.resumed) {
       _cancelTvTemporarySpeedHold();
+      _cancelMobileTemporarySpeedHold();
     }
     switch (lifecycleState) {
       case AppLifecycleState.inactive:
@@ -2045,7 +2049,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   bool _canUseTvTemporarySpeedHold() {
-    if (!PlatformDetection.isTV) return false;
+    if (!PlatformDetection.isTV && !PlatformDetection.useDesktopUi) return false;
     if (_castService.activeKind != null) return false;
     if (_isCurrentPreroll) return false;
     if (_isOsdLocked) return false;
@@ -2111,16 +2115,16 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _tvTemporarySpeedHoldActive = true;
     _tvTemporarySpeedRestoreSpeed ??= _state.playbackSpeed;
 
-    if ((_state.playbackSpeed - _tvTemporarySpeed).abs() < 0.001) {
+    if ((_state.playbackSpeed - _temporarySpeed).abs() < 0.001) {
       return;
     }
 
     try {
-      await _manager.setPlaybackSpeed(_tvTemporarySpeed);
+      await _manager.setPlaybackSpeed(_temporarySpeed);
     } catch (_) {}
   }
 
-  Future<void> _restoreTvTemporarySpeed(double speed) async {
+  Future<void> _restoreTemporarySpeed(double speed) async {
     try {
       await _manager.setPlaybackSpeed(speed);
     } catch (_) {}
@@ -2138,8 +2142,41 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _tvTemporarySpeedRestoreSpeed = null;
 
     if (shouldRestore && restoreSpeed != null) {
-      unawaited(_restoreTvTemporarySpeed(restoreSpeed));
+      unawaited(_restoreTemporarySpeed(restoreSpeed));
     }
+  }
+
+  bool _canUseMobileTemporarySpeedHold() {
+    if (!PlatformDetection.isMobile) return false;
+    if (_castService.activeKind != null) return false;
+    if (_isCurrentPreroll) return false;
+    if (_isOsdLocked) return false;
+    if (!_state.isPlaying) return false;
+    if (_syncPlayManager?.state.enabled == true) return false;
+    return true;
+  }
+
+  Future<void> _activateMobileTemporarySpeedHold() async {
+    if (!mounted) return;
+    if (!_canUseMobileTemporarySpeedHold()) return;
+    _mobileTemporarySpeedHoldActive = true;
+    _mobileTemporarySpeedRestoreSpeed ??= _state.playbackSpeed;
+    _hideTimer?.cancel();
+    if ((_state.playbackSpeed - _temporarySpeed).abs() < 0.001) return;
+    try {
+      await _manager.setPlaybackSpeed(_temporarySpeed);
+    } catch (_) {}
+  }
+
+  void _cancelMobileTemporarySpeedHold() {
+    final shouldRestore = _mobileTemporarySpeedHoldActive;
+    final restoreSpeed = _mobileTemporarySpeedRestoreSpeed;
+    _mobileTemporarySpeedHoldActive = false;
+    _mobileTemporarySpeedRestoreSpeed = null;
+    if (shouldRestore && restoreSpeed != null) {
+      unawaited(_restoreTemporarySpeed(restoreSpeed));
+    }
+    if (_controlsVisible) _scheduleHide();
   }
 
   int _accelerateSeekStep(int baseMs, KeyEvent event) {
@@ -2261,7 +2298,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       return KeyEventResult.ignored;
     }
 
-    if (PlatformDetection.isTV) {
+    if (PlatformDetection.isTV || PlatformDetection.useDesktopUi) {
       final temporarySpeedResult = _handleTvTemporarySpeedKeyDownOrRepeat(
         event,
       );
@@ -2553,6 +2590,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           onKeyEvent: _handleKeyEvent,
           child: GestureDetector(
             onTap: PlatformDetection.isTV ? null : _toggleControls,
+            onLongPress: PlatformDetection.useMobileUi && !_isOsdLocked
+                ? () => unawaited(_activateMobileTemporarySpeedHold())
+                : null,
+            onLongPressEnd: PlatformDetection.useMobileUi
+                ? (_) => unawaited(_cancelMobileTemporarySpeedHold())
+                : null,
             onDoubleTapDown: PlatformDetection.isTV
                 ? null
                 : PlatformDetection.useMobileUi && !_isOsdLocked


### PR DESCRIPTION
## Summary
Adds long-press 2x speed hold for mobile and extends the existing TV speed hold to desktop. Includes minor renames to reflect that the speed constant and restore method are now shared across supported platforms.

## Related Issues
- Related to #153 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Add `_mobileTemporarySpeedHoldActive` / `_mobileTemporarySpeedRestoreSpeed` state variables for mobile hold tracking
- Add `_canUseMobileTemporarySpeedHold`, `_activateMobileTemporarySpeedHold`, and `_cancelMobileTemporarySpeedHold` to implement long-press 2x speed on mobile
- Wire `onLongPress` / `onLongPressEnd` on the main `GestureDetector` to activate/cancel the mobile speed hold
- Cancel the hide timer during mobile speed hold so the OSD cannot auto-lock while the finger is down; reschedule it on release
- Extend `_canUseTvTemporarySpeedHold` and the key event handler to include `useDesktopUi`, enabling the media key hold for 2× speed on desktop
- Call `_cancelMobileTemporarySpeedHold` in `dispose` and `didChangeAppLifecycleState` to clean up properly
- Rename `_tvTemporarySpeed` → `_temporarySpeed` and `_restoreTvTemporarySpeed` → `_restoreTemporarySpeed` since both are now shared across TV, mobile, and desktop

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start playing a video on mobile
2. Long-press the screen and verify playback switches to 2x speed
3. Release and verify speed restores and OSD auto-hides normally
4. On desktop, hold the media pause / play-pause key and verify 2x speed activates; release to verify it restores

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

## Notes
There should probably be some sort of indicator for when the video is on 2x speed, maybe near the top of the player. It may also be a good idea to use the space bar/left click on desktop for 2x, but I left it to media keys for now. 

I also had some troubles with unlocking the OSD during testing, however I also experienced these on stable 1.4.0, so I don't think they're related to these changes.