### PR TITLE
Build - add beta build support for windows (and linux maybe)

### DIFF
--- a/build-windows-beta.ps1
+++ b/build-windows-beta.ps1
@@ -1,0 +1,29 @@
+param(
+	[string[]]$FlutterArgs = @()
+)
+
+# Set the build flag for this process only
+$env:MOONFIN_BETA_BUILD = "true"
+
+# wipe out the windows build directory if you're running into build problems
+#$buildDir = Join-Path $PSScriptRoot "build\windows\x64"
+#if (Test-Path $buildDir) {
+#	Write-Host "Removing existing Windows build dir: $buildDir"
+#	Remove-Item -Recurse -Force $buildDir
+#}
+
+# Ensure the dart-define is passed to the Flutter tool so `const.fromEnvironment`
+# in Dart will be set at compile time. Also allow additional args to be passed.
+$argsList = @("build", "windows", "--release") + $FlutterArgs
+if (-not ($argsList -contains "--dart-define=MOONFIN_BETA_BUILD=true")) {
+	$argsList += "--dart-define=MOONFIN_BETA_BUILD=true"
+}
+Write-Host "Running: flutter $($argsList -join ' ')"
+& flutter @argsList
+$exit = $LASTEXITCODE
+if ($exit -ne 0) {
+	Write-Error "flutter build windows failed with exit code $exit"
+	exit $exit
+}
+
+Write-Host "Built Windows Beta version"

--- a/lib/data/database/database_connection_impl_io.dart
+++ b/lib/data/database/database_connection_impl_io.dart
@@ -2,12 +2,13 @@ import 'dart:io';
 
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
+import 'package:moonfin/data/services/storage_path_service.dart';
 import 'package:path_provider/path_provider.dart';
 
 QueryExecutor openConnection() {
   return LazyDatabase(() async {
     final docs = await getApplicationDocumentsDirectory();
-    final dbDir = Directory('${docs.path}/Moonfin/DB');
+    final dbDir = Directory('${docs.path}/${StoragePathService.appFolderName}/DB');
     if (!dbDir.existsSync()) {
       await dbDir.create(recursive: true);
     }

--- a/lib/data/services/storage_path_service.dart
+++ b/lib/data/services/storage_path_service.dart
@@ -17,6 +17,9 @@ class StoragePathService {
 
   void clearCache() => _cachedRoot = null;
 
+  static String get appFolderName =>
+      const bool.fromEnvironment('MOONFIN_BETA_BUILD') ? 'MoonfinBeta' : 'Moonfin';
+
   Future<Directory> getOfflineRoot() async {
     if (_cachedRoot != null) return _cachedRoot!;
 
@@ -45,10 +48,10 @@ class StoragePathService {
     if (PlatformDetection.isAndroid) {
       final extDir = await getExternalStorageDirectory();
       final base = extDir ?? await getApplicationDocumentsDirectory();
-      dir = Directory('${base.path}/Moonfin');
+      dir = Directory('${base.path}/$appFolderName');
     } else if (PlatformDetection.isIOS) {
       final docs = await getApplicationDocumentsDirectory();
-      dir = Directory('${docs.path}/Moonfin');
+      dir = Directory('${docs.path}/$appFolderName');
     } else {
       final support = await getApplicationSupportDirectory();
       dir = Directory('${support.path}/Downloads');
@@ -82,7 +85,7 @@ class StoragePathService {
 
   Future<File> getDatabaseFile() async {
     final docs = await getApplicationDocumentsDirectory();
-    final dbDir = Directory('${docs.path}/Moonfin/DB');
+    final dbDir = Directory('${docs.path}/$appFolderName/DB');
     if (!await dbDir.exists()) await dbDir.create(recursive: true);
     return File('${dbDir.path}/offline.db');
   }
@@ -90,7 +93,7 @@ class StoragePathService {
   Future<Directory> getImageCacheDir() async {
     if (PlatformDetection.isAndroid && _useMediaStore) {
       final support = await getApplicationSupportDirectory();
-      final dir = Directory('${support.path}/Moonfin/images');
+      final dir = Directory('${support.path}/$appFolderName/images');
       if (!await dir.exists()) await dir.create(recursive: true);
       return dir;
     }

--- a/lib/data/services/storage_path_service.dart
+++ b/lib/data/services/storage_path_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -17,13 +18,21 @@ class StoragePathService {
 
   void clearCache() => _cachedRoot = null;
 
-   static String get appFolderName {
-    // Checks for the env var set either from launch configs or dart-define
-    final isBeta = Platform.environment['MOONFIN_BETA_BUILD'] == 'true' ||
-        const bool.fromEnvironment('MOONFIN_BETA_BUILD');
+  static String get appFolderName {
+    // get the flavor passed via --flavor
+    // android/androidtv/macos/ios - only android/androidtv are set up currently
+    const flavor = String.fromEnvironment('FLUTTER_APP_FLAVOR');
+    final betaFlavor = flavor.toLowerCase().contains('beta');
+    // check for --dart-define MOONFIN_BETA_BUILD=true from CLI
+    const betaCLI = bool.fromEnvironment('MOONFIN_BETA_BUILD');
+    // check for env var MOONFIN_BETA_BUILD=true
+    final betaEnvVar = Platform.environment['MOONFIN_BETA_BUILD'] == 'true';
+
+    final isBeta = betaFlavor || betaCLI || betaEnvVar;
+    debugPrint('StoragePathService: isBeta=$isBeta (flavor=$flavor, betaCLI=$betaCLI, betaEnvVar=$betaEnvVar)');
     return isBeta ? 'MoonfinBeta' : 'Moonfin';
   }
- 
+
   Future<Directory> getOfflineRoot() async {
     if (_cachedRoot != null) return _cachedRoot!;
 

--- a/lib/data/services/storage_path_service.dart
+++ b/lib/data/services/storage_path_service.dart
@@ -17,9 +17,13 @@ class StoragePathService {
 
   void clearCache() => _cachedRoot = null;
 
-  static String get appFolderName =>
-      const bool.fromEnvironment('MOONFIN_BETA_BUILD') ? 'MoonfinBeta' : 'Moonfin';
-
+   static String get appFolderName {
+    // Checks for the env var set either from launch configs or dart-define
+    final isBeta = Platform.environment['MOONFIN_BETA_BUILD'] == 'true' ||
+        const bool.fromEnvironment('MOONFIN_BETA_BUILD');
+    return isBeta ? 'MoonfinBeta' : 'Moonfin';
+  }
+ 
   Future<Directory> getOfflineRoot() async {
     if (_cachedRoot != null) return _cachedRoot!;
 

--- a/lib/data/services/storage_path_service.dart
+++ b/lib/data/services/storage_path_service.dart
@@ -20,17 +20,17 @@ class StoragePathService {
 
   static String get appFolderName {
     // get the flavor passed via --flavor
-    // android/androidtv/macos/ios - only android/androidtv are set up currently
+    // android/androidtv/macos/ios/linux too? - only android/androidtv are set up currently
     const flavor = String.fromEnvironment('FLUTTER_APP_FLAVOR');
     final betaFlavor = flavor.toLowerCase().contains('beta');
-    // check for --dart-define MOONFIN_BETA_BUILD=true from CLI
-    const betaCLI = bool.fromEnvironment('MOONFIN_BETA_BUILD');
-    // check for env var MOONFIN_BETA_BUILD=true
-    final betaEnvVar = Platform.environment['MOONFIN_BETA_BUILD'] == 'true';
 
-    final isBeta = betaFlavor || betaCLI || betaEnvVar;
-    debugPrint('StoragePathService: isBeta=$isBeta (flavor=$flavor, betaCLI=$betaCLI, betaEnvVar=$betaEnvVar)');
-    return isBeta ? 'MoonfinBeta' : 'Moonfin';
+    // check for --dart-define MOONFIN_BETA_BUILD=true from CLI
+    // needed for windows, and maybe linux if we don't do a flavor
+    const betaDartDefine = bool.fromEnvironment('MOONFIN_BETA_BUILD');
+
+    final isBeta = betaFlavor || betaDartDefine;
+    debugPrint('StoragePathService: isBeta=$isBeta (flavor=$flavor, betaDartDefine=$betaDartDefine)');
+    return isBeta ? 'Moonfin Beta' : 'Moonfin';
   }
 
   Future<Directory> getOfflineRoot() async {
@@ -106,7 +106,10 @@ class StoragePathService {
   Future<Directory> getImageCacheDir() async {
     if (PlatformDetection.isAndroid && _useMediaStore) {
       final support = await getApplicationSupportDirectory();
-      final dir = Directory('${support.path}/$appFolderName/images');
+      final dir = (!Platform.isWindows)
+        ? Directory('${support.path}/$appFolderName/images')
+        // windows includes the app folder
+        : Directory('${support.path}/images');
       if (!await dir.exists()) await dir.create(recursive: true);
       return dir;
     }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,8 +2,16 @@
 cmake_minimum_required(VERSION 3.13)
 project(runner LANGUAGES CXX)
 
-set(BINARY_NAME "moonfin")
-set(APPLICATION_ID "org.moonfin.linux")
+# for CLI - flutter run --dart-define=MOONFIN_BETA_BUILD=true
+# for launch configurations - add an env for "MOONFIN_BETA_BUILD": "true"
+if(DEFINED ENV{MOONFIN_BETA_BUILD})
+  set(BINARY_NAME "moonfin-beta")
+  set(APPLICATION_ID "org.moonfin.linux.beta")
+  add_definitions(-DMOONFIN_BETA_BUILD)
+else()
+  set(BINARY_NAME "moonfin")
+  set(APPLICATION_ID "org.moonfin.linux")
+endif()
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -17,7 +17,11 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
+#ifdef MOONFIN_BETA_BUILD
+  gtk_window_set_title(window, "Moonfin Beta");
+#else
   gtk_window_set_title(window, "Moonfin");
+#endif
 
   gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -2,7 +2,14 @@
 cmake_minimum_required(VERSION 3.14)
 project(moonfin LANGUAGES CXX)
 
-set(BINARY_NAME "moonfin")
+# for CLI - flutter run --dart-define=MOONFIN_WINDOWS_BETA=true
+# for launch configurations - add an env for "MOONFIN_WINDOWS_BETA": "true"
+if(DEFINED ENV{MOONFIN_BETA_BUILD})
+  set(BINARY_NAME "Moonfin-Beta")
+  add_definitions(-DMOONFIN_BETA_BUILD)
+else()
+  set(BINARY_NAME "moonfin")
+endif ()
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -2,8 +2,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(moonfin LANGUAGES CXX)
 
-# for CLI - flutter run --dart-define=MOONFIN_WINDOWS_BETA=true
-# for launch configurations - add an env for "MOONFIN_WINDOWS_BETA": "true"
+# for CLI - flutter run --dart-define=MOONFIN_BETA_BUILD=true
+# for launch configurations - add an env for "MOONFIN_BETA_BUILD": "true"
 if(DEFINED ENV{MOONFIN_BETA_BUILD})
   set(BINARY_NAME "Moonfin-Beta")
   add_definitions(-DMOONFIN_BETA_BUILD)

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,19 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "org.moonfin" "\0"
+#ifdef MOONFIN_BETA_BUILD
+            VALUE "FileDescription", "Moonfin Beta" "\0"
+            VALUE "InternalName", "moonfin-beta" "\0"
+            VALUE "OriginalFilename", "moonfin-beta.exe" "\0"
+            VALUE "ProductName", "Moonfin Beta" "\0"
+#else
             VALUE "FileDescription", "Moonfin" "\0"
-            VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "moonfin" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2026 org.moonfin. All rights reserved." "\0"
             VALUE "OriginalFilename", "moonfin.exe" "\0"
             VALUE "ProductName", "Moonfin" "\0"
+#endif
+            VALUE "FileVersion", VERSION_AS_STRING "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2026 org.moonfin. All rights reserved." "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
+#ifdef MOONFIN_BETA_BUILD
+  if (!window.Create(L"Moonfin Beta", origin, size)) {
+#else
   if (!window.Create(L"Moonfin", origin, size)) {
+#endif
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
add beta build support for windows, and probably linux since it's similar
add an env var in your launch config for MOONFIN_BETA_BUILD to true - this is needed for cmake changes
also pass it in command line with --dart-define - this is for flutter constants in the app for changing paths

added build-windows-beta.ps1 script to handle setting the env and passing --dart-define for building if you want something that runs on command line.

Beta builds will now have separate path locations for their data if you set env and pass the dart-define.

Using build flavors with 'beta' will use these path changes too.

example launch.json for vscode
```
    {
      "name": "Moonfin (Windows - Beta)",
      "request": "launch",
      "type": "dart",
      "program": "lib/main.dart",
      "flutterMode": "debug",
      "deviceId": "windows",
      "env": {
        "MOONFIN_BETA_BUILD": "true"
      },
      "args": [
        "--dart-define=MOONFIN_BETA_BUILD=true"
      ]
    },
```

Windows wasn't able to get dart-define at the cmake level, only in flutter compilation.  So you need to do both steps for windows.
Linux may be able to get them during cmake, but safer to just match windows and use both the env and pass --dart-define to make sure until someone can try.

## Type of Change
- [X] Build/CI change

## Changes Made
- added handling of env var 'MOONFIN_BETA_BUILD' in both windows and linux CMakeLists.txt
- conditionally set different output file properties in Runner.rc
- conditionally change the window title in the application in main.cpp/my_application.cc
- add a static helper in storage_path_service.dart that checks for the 'MOONFIN_BETA_BUILD', from passing --dart-define.  This is used to set different write paths depending on build type.
- added flavor detection, and flavors with 'beta' will use the beta app paths too.
- getOfflineRoot, getDatabaseFile, and getImageCacheDir now use the conditional path string instead of the hardcoded 'Moonfin'
- database_connection_impl.io.dart now uses the static helper that was added to storage_path_service.dart to use a conditional path too

## Platform
- [X] Windows
- [X] Linux
- [X] All / Shared code
Some hardcoded paths were changed, this will affect all platforms if the env var is used in your build configuration.

## Testing
- [X] Tested on physical device
- [X] Manual testing completed
- [X] Not tested (explain why):
only windows was tested, linux might work if someone tries

### Test Steps
1. Add MOONFIN_BETA_BUILD env to launch.json
2. Run/Debug
3. Verify new build exe name, and distinct storage paths for the beta variant

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
