### PR TITLE
Fix/previews

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2279,7 +2279,7 @@ class _ContentRowsState extends State<_ContentRows>
                 bottom: neededBottomPadding,
               ),
               itemCount: rows.length + headerCount,
-              scrollCacheExtent: const ScrollCacheExtent.pixels(600),
+              cacheExtent: 600,
               itemBuilder: (context, index) {
               if (includeMediaBar && index == 0) {
                 return AnimatedOpacity(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -566,6 +567,8 @@ class _ContentRowsState extends State<_ContentRows>
   bool _chromeFocusActive = false;
   bool _windowHasFocus = true;
   bool _holdMediaBarWhileSidebarFocused = false;
+  bool get _isSidebarFocus => LeftSidebar.isFocusedNotifier.value;
+  bool _wasSidebarFocused = false;
   FocusNode? _lastGlobalPrimaryFocus;
   String? _activePreviewKey;
   String? _mobilePressedV2Key;
@@ -598,28 +601,13 @@ class _ContentRowsState extends State<_ContentRows>
     return _activeFocusedRowIndex;
   }
 
-  bool _isSidebarFocus(FocusNode? node) {
-    final nodeContext = node?.context;
-    if (nodeContext == null) return false;
-
-    var insideSidebar = false;
-    nodeContext.visitAncestorElements((element) {
-      if (element.widget is LeftSidebar) {
-        insideSidebar = true;
-        return false;
-      }
-      return true;
-    });
-    return insideSidebar;
-  }
-
   void _onGlobalFocusChanged() {
     if (!mounted) return;
     final isMobileUi = PlatformDetection.useMobileUi;
     final primary = FocusManager.instance.primaryFocus;
     final onMediaBar = identical(primary, _mediaBarFocusNode);
-    final onSidebar = _isSidebarFocus(primary);
-    final wasOnSidebar = _isSidebarFocus(_lastGlobalPrimaryFocus);
+    final onSidebar = _isSidebarFocus;
+    final wasOnSidebar = _wasSidebarFocused;
     if (onSidebar && !wasOnSidebar) {
       _holdMediaBarWhileSidebarFocused = identical(
         _lastGlobalPrimaryFocus,
@@ -657,6 +645,7 @@ class _ContentRowsState extends State<_ContentRows>
       });
     }
 
+    _wasSidebarFocused = onSidebar;
     _lastGlobalPrimaryFocus = primary;
 
     if (chromeFocusActive && (chromeChanged || _activePreviewKey != null)) {
@@ -1909,7 +1898,7 @@ class _ContentRowsState extends State<_ContentRows>
         setState(() => _mediaBarVisible = false);
       }
     } else if (_activeFocusedRowIndex == rowIndex) {
-      if (_isSidebarFocus(FocusManager.instance.primaryFocus)) {
+      if (_isSidebarFocus) {
         return;
       }
       if (_activePreviewKey != null) {
@@ -2290,7 +2279,7 @@ class _ContentRowsState extends State<_ContentRows>
                 bottom: neededBottomPadding,
               ),
               itemCount: rows.length + headerCount,
-              cacheExtent: 600,
+              scrollCacheExtent: const ScrollCacheExtent.pixels(600),
               itemBuilder: (context, index) {
               if (includeMediaBar && index == 0) {
                 return AnimatedOpacity(

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -43,6 +43,11 @@ class LeftSidebar extends StatefulWidget {
   final FocusNode? contentFocusNode;
   final bool showBackButton;
 
+  /// Notifier updated when the sidebar's focus state changes.
+  /// Use this instead of walking the element tree to determine if the
+  /// current focus is within the sidebar; it's resilient during teardown.
+  static final ValueNotifier<bool> isFocusedNotifier = ValueNotifier<bool>(false);
+
   const LeftSidebar({
     super.key,
     this.activeRoute,
@@ -72,7 +77,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
   bool _librariesExpanded = false;
   bool _canExpandViaFocus = false;
   bool _skipExpandOnNextFocusFromNavigation = false;
-  bool _sidebarHadFocus = false;
+  bool get _sidebarHadFocus => LeftSidebar.isFocusedNotifier.value;
   Timer? _clockTimer;
   Timer? _labelTimer;
   Timer? _focusExpandGateTimer;
@@ -145,6 +150,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
     } catch (_) {}
     _prefs.removeListener(_onPrefsChanged);
     _currentTime.dispose();
+    LeftSidebar.isFocusedNotifier.value = false;
     super.dispose();
   }
 
@@ -302,7 +308,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
     } else if (!hasFocus && _sidebarHadFocus && _canExpandViaFocus) {
       _collapse();
     }
-    _sidebarHadFocus = hasFocus;
+    LeftSidebar.isFocusedNotifier.value = hasFocus;
   }
 
   void _markNavigationAwayFromSidebar() {
@@ -350,18 +356,8 @@ class _LeftSidebarState extends State<LeftSidebar> {
 
   void _trackPreviousFocus() {
     final primary = FocusManager.instance.primaryFocus;
-    if (primary == null) return;
-    if (_isInsideSidebarScope(primary)) return;
+    if (primary == null || _sidebarFocus.hasFocus) return;
     _previousFocus = primary;
-  }
-
-  bool _isInsideSidebarScope(FocusNode node) {
-    FocusNode? current = node;
-    while (current != null) {
-      if (identical(current, _sidebarFocus)) return true;
-      current = current.parent;
-    }
-    return false;
   }
 
   void _restoreFocusOutsideSidebar() {


### PR DESCRIPTION
## Summary
fix ui issues blocking previews after playing something in the main player

## Related Issues
#198 

fixes the previews not playing anymore for me, some other things still present in 198, but this is a big one

## Type of Change
- [X] Bug fix
- [X] Refactor
- [X] Performance improvement - less tree walking

## Changes Made
left_sidebar.dart
Add static isFocusedNotifier to LeftSidebar
This allows other widgets (like HomeScreen) to determine if the sidebar is focused without searching the widget tree, which is unreliable during disposal.

Removed _isInsideSidebarScope in favor of using the more efficient _sidebarFocus.hasFocus property directly in _trackPreviousFocus.

home_screen.dart
Replaced  widget tree searches with the new static isFocusedNotifier from LeftSidebar

Added local _wasSidebarFocused state to help keep track of focus entering/leaving the sidebar.

Refactored _onGlobalFocusChanged to use the notifier

Changed deprecated cacheExtent to the newer scrollCacheExtent - saw this after updating flutter

## Platform
- [X] All / Shared code

## Testing
tested on android tv

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
