### PR TITLE
Fixed subtitle scoring ignoring matched language in later position

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4694,7 +4694,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
     final preferSdh = prefs.get(UserPreferences.preferSdhSubtitles);
 
     Map<String, dynamic>? bestStream;
-    var bestScore = -1;
+    var bestScore = -(subtitleStreams.length + 1);
 
     for (var i = 0; i < subtitleStreams.length; i++) {
       final stream = subtitleStreams[i];


### PR DESCRIPTION
# Pull Request

## Summary
There was algorithm where as subtitle get lower in position, score get subtracted. This is so there can't be conflict with other subtitle. Issue is that when selected language gets 0 score but went below -1, causing rejection due to being in later position.

### Before (bug)

| Track | SDH match | Embedded | Base score | Position penalty | Final score | Threshold | Result |
|-------|-----------|----------|------------|-----------------|-------------|-----------|--------|
| English HI External (position 4) | +0 | +0 | 0 | −4 | **−4** | −1 | ❌ Rejected — falls back to `IsDefault` |

### After (fix)

Threshold changed to `-(subtitleStreams.length + 1)`, scaling with the number of tracks. A language matched track can never score below this threshold regardless of position.

| Track | SDH match | Embedded | Base score | Position penalty | Final score | Threshold | Result |
|-------|-----------|----------|------------|-----------------|-------------|-----------|--------|
| English HI External (position 4) | +0 | +0 | 0 | −4 | **−4** | −6 | ✅ Selected |

## Related Issues
Just found this bug myself, I believe other people have reported this in Discord.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

-  Lowers threshold based on amount of subtitle stream.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to any video with English subtitle later in position. External subtitle maybe can get you in last position.
2. It must get selected right with your Language Preference.


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
