### PR TITLE
Set install location to 'auto' in AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>


### PR DESCRIPTION
# Pull Request

## Summary
Sets the Android installation location for this app to "auto", which allows users on Android devices to move the app to a different location if desired.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #293 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Change to manifest to specify the installation location.

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): _Simple change that is supported by the official Android documentation._

### Test Steps
1. Build Android app
2. Install on Android device with an SD card or other similar external storage
3. In Android settings, attempt to move the app to the external storage

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
