### PR TITLE
Continue Watching & Next Up TV Show Information Reorganization

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2797,9 +2797,58 @@ class _ContentRowsState extends State<_ContentRows>
             }
           }
 
+          final String cardTitle;
+          final String? cardSubtitle;
+          final Widget? cardSubtitleWidget;
+
+          if (isRowsV2 && item.type == 'Episode') {
+            final s = item.parentIndexNumber;
+            final e = item.indexNumber;
+            final episodeInfo = switch ((s, e)) {
+              (final season?, final episode?) => 'S$season:E$episode',
+              _ => null,
+            };
+            cardTitle = item.seriesName ?? item.name;
+            if (effectiveV2Focused) {
+              cardSubtitle = null;
+              final row2Text = episodeInfo != null ? '$episodeInfo - ${item.name}' : item.name;
+              final row3Text = _v2MetadataLine(item);
+              final baseTextStyle = Theme.of(context).textTheme.bodySmall ?? const TextStyle(fontSize: 12);
+              final subtitleColor = Theme.of(context).colorScheme.onSurface.withAlpha(153);
+              final subtitleStyle = baseTextStyle.copyWith(color: subtitleColor);
+              cardSubtitleWidget = Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    row2Text,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: subtitleStyle,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    row3Text,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: subtitleStyle,
+                  ),
+                ],
+              );
+            } else {
+              cardSubtitle = episodeInfo ?? item.name;
+              cardSubtitleWidget = null;
+            }
+          } else {
+            cardTitle = item.name;
+            cardSubtitle = isRowsV2 && effectiveV2Focused ? _v2MetadataLine(item) : item.subtitle;
+            cardSubtitleWidget = null;
+          }
+
           final card = MediaCard(
-            title: item.name,
-            subtitle: isRowsV2 && effectiveV2Focused ? _v2MetadataLine(item) : item.subtitle,
+            title: cardTitle,
+            subtitle: cardSubtitle,
+            subtitleWidget: cardSubtitleWidget,
             imageUrl: imageUrl,
             width: width,
             aspectRatio: ar,


### PR DESCRIPTION
# Pull Request for CW&NU Show Information Change

## Summary
Reorganizes title and basic information for CW&NU television shows. Simplies unfocused layout to display Show Title and SX:EX and implements three-line metadata rendering for FOCUSED TV show episodes on home rows under the v2 layout style (`isRowsV2`), improving layout context and visual symmetry between movies and shows.

## Related Issues
None. Mentioned on Discord.

## Type of Change
- [x] UI/UX update

## Changes Made
- Modified the card metadata builder in `home_screen.dart`'s `_buildMediaRow` for `Episode` type items:
  - **Unselected (Unfocused)**:
    - Row 1: Show Title (`item.seriesName ?? item.name`)
    - Row 2: SX:EX (`S${season}:E${episode}`)
  - **Selected (Focused)**:
    - Row 1: Show Title (`item.seriesName ?? item.name`)
    - Row 2: SX:EX - Episode Title (`S${season}:E${episode} - ${item.name}`)
    - Row 3: Year • Genres • Runtime

## Platform
- [x] All / Shared code

## Testing
- [x] Manual testing completed
- Verified via `flutter analyze` locally, compiling with 0 errors or warnings in the modified file.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
