### PR TITLE
Media Details File Size Info

### DIFF
--- a/.github/workflows/build-windows-arm64.yml
+++ b/.github/workflows/build-windows-arm64.yml
@@ -1,0 +1,72 @@
+name: Build Windows ARM64
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  FLUTTER_VERSION: '3.41.2'
+
+jobs:
+  build-windows-arm64:
+    runs-on: windows-11-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: Enable Windows desktop
+        shell: pwsh
+        run: flutter config --enable-windows-desktop
+
+      - name: Resolve dependencies
+        shell: pwsh
+        run: flutter pub get
+
+      - name: Build Windows ARM64 release
+        shell: pwsh
+        run: |
+          flutter build windows --release --dart-define=DISTRIBUTION_CHANNEL=windows
+
+      - name: Package release output
+        shell: pwsh
+        run: |
+          $releaseExe = Get-ChildItem -Path build/windows -Filter moonfin.exe -Recurse -File | Select-Object -First 1
+          if (-not $releaseExe) {
+            throw "Missing moonfin.exe in build/windows"
+          }
+
+          $releaseDir = $releaseExe.Directory
+          $version = (Select-String -Path pubspec.yaml -Pattern '^version:' | Select-Object -First 1).Line.Split(':', 2)[1].Trim().Split('+')[0]
+          $zipPath = Join-Path $PWD "Moonfin_Windows_ARM64_v$version.zip"
+
+          if (Test-Path $zipPath) {
+            Remove-Item $zipPath -Force
+          }
+
+          Compress-Archive -Path (Join-Path $releaseDir.FullName '*') -DestinationPath $zipPath -Force
+          Write-Host "Packaged release from: $($releaseDir.FullName)"
+          Write-Host "Created artifact: $zipPath"
+
+      - name: Verify artifact
+        shell: pwsh
+        run: |
+          $artifact = Get-ChildItem -Path . -Filter "Moonfin_Windows_ARM64_v*.zip" -File -ErrorAction SilentlyContinue
+          if (-not $artifact) {
+            throw "Windows ARM64 package was not created"
+          }
+          Write-Host "Found artifact(s):"
+          $artifact | ForEach-Object { Write-Host "  - $($_.Name)" }
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64
+          path: Moonfin_Windows_ARM64_v*.zip
+          if-no-files-found: error

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -3000,6 +3000,19 @@ class _MetadataRow extends StatelessWidget {
       parts.add(_badge(theme, item.officialRating!));
     }
 
+    final sizeBytes = selectedMediaSource?['Size'] as int? ??
+        (item.mediaSources.isNotEmpty ? item.mediaSources.first['Size'] as int? : null);
+    if (sizeBytes != null && sizeBytes > 0 && item.type != 'Series' && item.type != 'Season') {
+      final double mb = sizeBytes / (1024 * 1024);
+      final String formattedSize;
+      if (mb > 999) {
+        formattedSize = '${(mb / 1024).toStringAsFixed(2)} GB';
+      } else {
+        formattedSize = '${mb.toStringAsFixed(0)} MB';
+      }
+      parts.add(_text(theme, formattedSize));
+    }
+
     final runtime = _runtimeForItem(item, selectedMediaSource);
     if (runtime != null && item.type != 'Series') {
       final h = runtime.inHours;


### PR DESCRIPTION
# Pull Request: Media Details File Size Info
## Summary
Incorporate the file size of the active or default media source on the Media Details page for movies and episodes.
## Related Issues
- Related to feature request made on Discord.
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):
## Changes Made
- Added file size retrieval from `selectedMediaSource` or `item.mediaSources.first` in `_MetadataRow.build` inside `item_detail_screen.dart`.
- Formatted the size to GB with two decimal places if greater than 999MB, and to MB as a whole number if 999MB or less.
- Rendered the formatted size as a text element in the metadata row right after the Official Rating badge.
- Utilizes flexbox for ratings so all content remains on screen (at least on ATV).
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code but only tested on ATV
## Testing
The change was successfully compiled and manually verified on a physical device.
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):
### Test Steps
1. Open the Media Details page for a movie (e.g., Predator Badlands) and verify the size is displayed in GB.
2. Open the Media Details page for an episode (e.g., Peaky Blinders S5E6) and verify the size is displayed.
## Screenshots (if applicable)
- Sent via Discord.
## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
