### PR TITLE
Re-instate OS Level Screensaver

### DIFF
--- a/lib/ui/screens/livetv/live_tv_player_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_player_screen.dart
@@ -20,6 +20,7 @@ import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/subtitle_preview.dart';
+import '../../screensaver/screensaver_controller.dart';
 
 class LiveTvPlayerScreen extends StatefulWidget {
   final List<GuideChannel> channels;
@@ -40,6 +41,7 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
   final _backend = GetIt.instance<MediaKitPlayerBackend>();
   final _client = GetIt.instance<MediaServerClient>();
   final _prefs = GetIt.instance<UserPreferences>();
+  final _screensaverController = GetIt.instance<ScreensaverController>();
 
   MediaKitPlayerBackend? get _activeMediaKitBackend {
     final backend = _manager.backend;
@@ -66,6 +68,7 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
   GuideProgram? _currentProgram;
   Timer? _programRefreshTimer;
   StreamSubscription<PlayerBackend>? _backendSub;
+  StreamSubscription<bool>? _screensaverPlayingSub;
 
   final _overlayFocus = FocusNode();
   PlayerState get _state => _manager.state;
@@ -73,6 +76,10 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
   @override
   void initState() {
     super.initState();
+    _screensaverController.setPlaybackActive(true);
+    _screensaverPlayingSub = _state.playingStream.listen(
+      _screensaverController.setPlaybackActive,
+    );
     _currentIndex = widget.startIndex;
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
     SystemChrome.setPreferredOrientations([
@@ -92,6 +99,8 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
 
   @override
   void dispose() {
+    _screensaverPlayingSub?.cancel();
+    _screensaverController.setPlaybackActive(false);
     _hideTimer?.cancel();
     _programRefreshTimer?.cancel();
     _backendSub?.cancel();

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -47,6 +47,7 @@ import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/subtitle_preview.dart';
+import '../../screensaver/screensaver_controller.dart';
 import '../../widgets/remote_play_to_session_dialog.dart';
 import '../../widgets/track_selector_dialog.dart';
 import '../../widgets/playback/player_loading_overlay.dart';
@@ -87,6 +88,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   final _pipService = GetIt.instance<PipService>();
   final _lifecycleHandler = GetIt.instance<PlaybackLifecycleHandler>();
   final _themeMusicService = GetIt.instance<ThemeMusicService>();
+  final _screensaverController = GetIt.instance<ScreensaverController>();
   final SyncPlayManager? _syncPlayManager =
       GetIt.instance.isRegistered<SyncPlayManager>()
       ? GetIt.instance<SyncPlayManager>()
@@ -145,6 +147,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   bool _isPlayerMutationInFlight = false;
   Duration? _positionBeforeScreenLock;
   StreamSubscription<bool>? _screenLockSub;
+  StreamSubscription<bool>? _screensaverPlayingSub;
   StreamSubscription<void>? _completedSub;
   bool _isRestoringPosition = false;
   DateTime? _suppressSeekPromptsUntil;
@@ -733,6 +736,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   @override
   void initState() {
     super.initState();
+    _screensaverController.setPlaybackActive(true);
+    _screensaverPlayingSub = _state.playingStream.listen(
+      _screensaverController.setPlaybackActive,
+    );
     if (PlatformDetection.useNativeVideoSurface) {
       _subtitleActive = (_manager.subtitleStreamIndex ?? -1) >= 0;
     }
@@ -883,6 +890,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   @override
   void dispose() {
+    _screensaverPlayingSub?.cancel();
+    _screensaverController.setPlaybackActive(false);
     _prefs.removeListener(_syncMediaQueuingPreference);
     _manager.autoAdvanceEnabled = true;
     WidgetsBinding.instance.removeObserver(this);
@@ -1209,7 +1218,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           if (_isTvLifecycleExitSuppressed()) return;
           if (_didHandleBackgroundSuspend) return;
           _didHandleBackgroundSuspend = true;
-          _scheduleTvBackgroundExit();
+          if (_state.isPlaying) {
+            _scheduleTvBackgroundExit();
+          }
           return;
         }
         if (PlatformDetection.isIOS) {

--- a/lib/ui/screensaver/screensaver_controller.dart
+++ b/lib/ui/screensaver/screensaver_controller.dart
@@ -8,6 +8,7 @@ class ScreensaverController {
   }
 
   bool _activityPaused = false;
+  bool _playbackActive = false;
   bool _wakeLockEnabled = false;
 
   bool get activityPaused => _activityPaused;
@@ -15,6 +16,12 @@ class ScreensaverController {
   set activityPaused(bool value) {
     if (_activityPaused == value) return;
     _activityPaused = value;
+    _refreshWakeLock();
+  }
+
+  void setPlaybackActive(bool value) {
+    if (_playbackActive == value) return;
+    _playbackActive = value;
     _refreshWakeLock();
   }
 
@@ -29,7 +36,7 @@ class ScreensaverController {
   }
 
   void _refreshWakeLock() {
-    final shouldEnable = !_activityPaused;
+    final shouldEnable = !_activityPaused && _playbackActive;
     if (_wakeLockEnabled == shouldEnable) {
       return;
     }


### PR DESCRIPTION
# Pull Request: Re-instate OS Level Screensaver
## Summary
Reincorporate native OS screensaver integration by limiting system-wide wake lock holding strictly to periods of active media playback, and refine Android TV background suspend safety.
## Related Issues
Fixes issue with wake lock being held continuously in the foreground, which blocked the OS-level daydream screensaver from running when paused or idle in menus, presenting screen burn-in risks on TVs. Also resolves issues with automatic background suspend exiting playback when sleep or screensavers trigger.
* References: https://github.com/Moonfin-Client/Mobile-Desktop/discussions/303
## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):
## Changes Made
- **ScreensaverController**: Added a `_playbackActive` boolean field and `setPlaybackActive(bool value)` setter. Modified `_refreshWakeLock()` to only enable the system wake lock if the app is in the foreground AND active playback is running.
- **VideoPlayerScreen**: Wired `ScreensaverController` hookups during `initState()` and `dispose()` to toggle playback activity based on active player states and ensure clean-up on exit. Modified the Android TV background suspend lifecycle check to only schedule playback exits if media is actively playing, ensuring waking up from screensavers/sleep preserves the paused player screen.
- **LiveTvPlayerScreen**: Wired `ScreensaverController` hookups similarly for active live TV channel streaming.
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code but tested on Android TV
## Testing
Describe how this change was tested.
- [ ] Tested on emulator / simulator
- [x] Tested on physical device (Nvidia Shield TV Pro)
- [x] Manual testing completed
- [ ] Not tested (explain why):
### Test Steps
1. Play video/live TV and verify wake lock prevents screen sleep during active playback.
2. Pause playback and verify wake lock is released immediately, allowing OS screensaver to trigger naturally.
3. Verify that waking the TV from the screensaver successfully preserves the paused player screen rather than exiting.
4. Exit player back to menus and verify wake lock is released.
## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
## Screenshots:

### From Main Menu:
<img width="400" alt="Shield_Screenshot_2026-05-29_13-44-10" src="https://github.com/user-attachments/assets/8e5f6a02-296c-4a97-a6c5-1bf9f1fbb08c" />
<img width="400" alt="Shield_Screenshot_2026-05-29_13-49-19" src="https://github.com/user-attachments/assets/4a83c019-7624-4228-91c9-19739094cedd" />

### From Playback (screensaver returns to paused OSD):
<img width="400" alt="Shield_Screenshot_2026-05-29_13-29-35" src="https://github.com/user-attachments/assets/8ea3be79-d8a7-474d-a026-d553243f039d" />
