### PR TITLE
Fix TV show main page play and resume behavior

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4329,7 +4329,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
       playButtonLabel = hasProgress ? l10n.resumeReading : l10n.read;
     } else if (isSeries) {
       if (isFullyWatched || isFullyUnwatched) {
-        playButtonLabel = 'Play from Start';
+        playButtonLabel = l10n.play;
       } else {
         final nextUp = viewModel.nextUp;
         if (nextUp != null) {

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4287,9 +4287,17 @@ class _ActionButtonsState extends State<_ActionButtons> {
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final isPhoto = item.type == 'Photo';
     final isBook = _isReadableBookItem(item);
-    final hasProgress =
-        (item.playedPercentage ?? 0) > 0 ||
-        (item.playbackPosition?.inMilliseconds ?? 0) > 0;
+    final isSeries = item.type == 'Series';
+    final totalEpisodes = item.childCount ?? item.recursiveItemCount ?? 0;
+    final unplayed = item.unplayedItemCount ?? totalEpisodes;
+    final isFullyWatched = item.isPlayed || unplayed == 0;
+    final isFullyUnwatched = unplayed == totalEpisodes;
+    final isPartiallyWatched = !isFullyWatched && !isFullyUnwatched;
+
+    final hasProgress = isSeries
+        ? isPartiallyWatched
+        : ((item.playedPercentage ?? 0) > 0 ||
+           (item.playbackPosition?.inMilliseconds ?? 0) > 0);
     final selectedSource = _selectedMediaSourceForItem(
       item,
       widget.selectedMediaSourceId,
@@ -4314,17 +4322,39 @@ class _ActionButtonsState extends State<_ActionButtons> {
         _canUserDownload() &&
         !PlatformDetection.isTV;
 
+    final String playButtonLabel;
+    if (isPhoto) {
+      playButtonLabel = l10n.view;
+    } else if (isBook) {
+      playButtonLabel = hasProgress ? l10n.resumeReading : l10n.read;
+    } else if (isSeries) {
+      if (isFullyWatched || isFullyUnwatched) {
+        playButtonLabel = 'Play from Start';
+      } else {
+        final nextUp = viewModel.nextUp;
+        if (nextUp != null) {
+          final s = nextUp.parentIndexNumber;
+          final e = nextUp.indexNumber;
+          if (s != null && e != null) {
+            playButtonLabel = 'Resume from S$s:E$e';
+          } else {
+            playButtonLabel = 'Resume';
+          }
+        } else {
+          playButtonLabel = 'Resume';
+        }
+      }
+    } else if (hasProgress) {
+      playButtonLabel = l10n.resumeFrom(_formatResumePosition(item.playbackPosition));
+    } else {
+      playButtonLabel = l10n.play;
+    }
+
     _ensureTvPlayFocus(item.id);
 
     var allButtons = <Widget>[
       _DetailActionButton(
-        label: isPhoto
-            ? l10n.view
-            : isBook
-            ? (hasProgress ? l10n.resumeReading : l10n.read)
-            : hasProgress
-            ? l10n.resumeFrom(_formatResumePosition(item.playbackPosition))
-            : l10n.play,
+        label: playButtonLabel,
         icon: isPhoto
             ? Icons.photo
             : isBook
@@ -5160,9 +5190,19 @@ class _ActionButtonsState extends State<_ActionButtons> {
           case 'Series':
             const episodeQueueFields =
                 'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay';
-            final nextUp = viewModel.nextUp;
-            if (nextUp == null || !isEligibleNextEpisodeCandidate(nextUp)) {
-              if (mounted) {
+            
+            final client = _clientForItem(item);
+            final data = await client.itemsApi.getEpisodes(
+              item.id,
+              fields: episodeQueueFields,
+            );
+            final allEpisodes = _mapRawItemsForServer(
+              data['Items'],
+              item.serverId,
+            ).where(isEligibleNextEpisodeCandidate).toList();
+
+            if (allEpisodes.isEmpty) {
+              if (context.mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
                     content: Text(
@@ -5173,42 +5213,60 @@ class _ActionButtonsState extends State<_ActionButtons> {
               }
               throw PlaybackStartupRecoveryAbortedException();
             }
-            final seriesId =
-                (nextUp.seriesId?.isNotEmpty ?? false)
-                    ? nextUp.seriesId!
-                    : item.id;
-            final seasonId = nextUp.seasonId;
-            var episodes = <AggregatedItem>[nextUp];
-            if (seasonId != null && seasonId.isNotEmpty) {
+
+            final totalEpisodes = item.childCount ?? item.recursiveItemCount ?? 0;
+            final unplayed = item.unplayedItemCount ?? totalEpisodes;
+            final isFullyWatched = item.isPlayed || unplayed == 0;
+            final isFullyUnwatched = unplayed == totalEpisodes;
+
+            AggregatedItem targetEpisode;
+            if (isFullyWatched || isFullyUnwatched) {
+              final s1e1 = allEpisodes.firstWhere(
+                (e) => e.parentIndexNumber == 1 && e.indexNumber == 1,
+                orElse: () => allEpisodes.first,
+              );
+              targetEpisode = s1e1;
+            } else {
+              final firstUnwatched = allEpisodes.firstWhere(
+                (e) => !e.isPlayed,
+                orElse: () => allEpisodes.first,
+              );
+              targetEpisode = firstUnwatched;
+            }
+
+            final targetSeasonId = targetEpisode.seasonId;
+            var queueEpisodes = <AggregatedItem>[targetEpisode];
+            if (targetSeasonId != null && targetSeasonId.isNotEmpty) {
               try {
-                final client = _clientForItem(nextUp);
-                final data = await client.itemsApi.getEpisodes(
-                  seriesId,
-                  seasonId: seasonId,
+                final seasonData = await client.itemsApi.getEpisodes(
+                  item.id,
+                  seasonId: targetSeasonId,
                   fields: episodeQueueFields,
                 );
                 final seasonEpisodes = _mapRawItemsForServer(
-                  data['Items'],
-                  nextUp.serverId,
+                  seasonData['Items'],
+                  item.serverId,
                 );
                 final playableSeasonEpisodes = seasonEpisodes
                     .where(isEligibleNextEpisodeCandidate)
                     .toList();
                 if (playableSeasonEpisodes.isNotEmpty) {
-                  episodes = playableSeasonEpisodes;
+                  queueEpisodes = playableSeasonEpisodes;
                 }
               } catch (_) {}
             }
-            final startIndex = episodes.indexWhere((e) => e.id == nextUp.id);
+
+            final startIndex = queueEpisodes.indexWhere((e) => e.id == targetEpisode.id);
             final idx = startIndex >= 0 ? startIndex : 0;
-            final selectedEpisode = episodes[idx];
+            final selectedEpisode = queueEpisodes[idx];
             final seriesQueue = _truncateQueueIfImmediateNextUnplayable(
-              episodes,
+              queueEpisodes,
               startIndex: idx,
             );
             final startPosition = resume
                 ? (selectedEpisode.playbackPosition ?? Duration.zero)
                 : Duration.zero;
+
             if (!context.mounted) return;
             final forceTranscode = await _shouldForceTranscodeForDolbyVision(
               context,


### PR DESCRIPTION
# Pull Request Template

## Summary
Fixes the "Resume" / "Play" button on TV show detail screens, preventing a playback startup failure ("No Episodes Loaded" error) when a show is fully watched or fully unwatched.

## Related Issues
Closes Discord issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Introduced watched status checks using total episodes and unplayed counts on the Series detail screen.
- Dynamically switches the play button between "Play from Start" and "Resume from S{X}:E{Y}".
- Refactored `_playInternal` for Series to dynamically query all episodes, resolving target playback cleanly between S1:E1 and the first unwatched episode.
- Cleared compiler static analysis warnings regarding BuildContext gaps after async executions and string interpolation braces.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code, tested on Android TV

## Testing
Tested and deployed directly onto a physical Nvidia Shield TV Pro via ADB.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Opened the detail page of an unwatched TV show. Verified the button displayed "Play from Start" and successfully started playback on S1:E1.
2. Opened the detail page of a fully watched TV show. Verified the button displayed "Play from Start" and successfully started playback on S1:E1.
3. Opened the detail page of a partially watched TV show. Verified the button displayed "Resume from S$s:E$e" (correctly showing the season and episode number of the next unplayed episode) and played the targeted episode from the correct position.

## Screenshots
ORIGINAL:
<img width="500" alt="2026-05-29_15-50-46_moonfin" src="https://github.com/user-attachments/assets/8029b9ec-a472-4fe8-a890-121da2606072" />

NEW, PARTIALLY WATCHED:
<img width="500" alt="Shield_Screenshot_2026-05-29_15-54-51" src="https://github.com/user-attachments/assets/b87acd87-0f52-48f2-84b3-ea1ccf47b41e" />

NEW, FULLY WATCHED OR UNWATCHED:
<img width="500" alt="Shield_Screenshot_2026-05-29_15-55-21" src="https://github.com/user-attachments/assets/cd9446f9-109d-4450-8bb2-5af27bed04d2" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
