### PR TITLE
feat(mediabar): Fallback to movie and tv libraries if no profile resolved

### DIFF
--- a/lib/data/repositories/media_bar_repository.dart
+++ b/lib/data/repositories/media_bar_repository.dart
@@ -30,18 +30,25 @@ class MediaBarRepository {
     }
 
     final contentType = _prefs.get(UserPreferences.mediaBarContentType);
-    final maxItems =
-        int.tryParse(_prefs.get(UserPreferences.mediaBarItemCount)) ?? 10;
-    final libraryIds = _prefs
-        .get(UserPreferences.mediaBarLibraryIds)
-        .split(',')
-        .where((s) => s.isNotEmpty)
-        .toList();
-    final collectionIds = _prefs
-        .get(UserPreferences.mediaBarCollectionIds)
-        .split(',')
-        .where((s) => s.isNotEmpty)
-        .toList();
+    final pluginSyncEnabled = _prefs.get(UserPreferences.pluginSyncEnabled);
+
+    final maxItems = pluginSyncEnabled
+        ? (int.tryParse(_prefs.get(UserPreferences.mediaBarItemCount)) ?? 10)
+        : 5;
+    final libraryIds = pluginSyncEnabled
+        ? _prefs
+            .get(UserPreferences.mediaBarLibraryIds)
+            .split(',')
+            .where((s) => s.isNotEmpty)
+            .toList()
+        : <String>[];
+    final collectionIds = pluginSyncEnabled
+        ? _prefs
+            .get(UserPreferences.mediaBarCollectionIds)
+            .split(',')
+            .where((s) => s.isNotEmpty)
+            .toList()
+        : <String>[];
     final excludedGenres = _prefs
         .get(UserPreferences.mediaBarExcludedGenres)
         .split(',')


### PR DESCRIPTION
# Pull Request Template
## Summary
Fallback to movie and tv libraries with exactly 5 items if the resolved profile is null.
## Related Issues
Fixes media bar pull logic.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):
## Changes Made
- Introduced client-side fallback in `MediaBarRepository.loadItems` when settings sync is not enabled (`pluginSyncEnabled` is `false`).
- Overrode settings to force source type to `"library"`, targeted libraries to all libraries (`null`), and item limit to `5`.
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code
## Testing
Tested using Moonbase uninstalled and only local new profile available.
- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):
## Screenshots
Loads exactly 5 items as fallback, with trailer support:
<img width="400" alt="Shield_Screenshot_2026-05-29_17-11-41" src="https://github.com/user-attachments/assets/5af93efc-7447-4248-8463-57ca6d6e4ab7" />
<img width="400" alt="Shield_Screenshot_2026-05-29_17-12-17" src="https://github.com/user-attachments/assets/f42aa5fd-73eb-4ddd-a0cb-6da79553c396" />
## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
