### PR TITLE
Normalize mobile switch user menu button sizing

### DIFF
--- a/lib/ui/widgets/user_menu_dialog.dart
+++ b/lib/ui/widgets/user_menu_dialog.dart
@@ -182,16 +182,22 @@ class _AccountDialogState extends State<_AccountDialog> {
     required Widget second,
   }) {
     if (PlatformDetection.isMobile) {
-      return SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SizedBox(width: 170, child: first),
-            const SizedBox(width: 10),
-            SizedBox(width: 170, child: second),
-          ],
-        ),
+      return Row(
+        children: [
+          Expanded(
+            child: SizedBox(
+              height: 52,
+              child: first,
+            ),
+          ),
+          SizedBox(width: 10),
+          Expanded(
+            child: SizedBox(
+              height: 52,
+              child: second,
+            ),
+          ),
+        ],
       );
     }
 

--- a/lib/ui/widgets/user_menu_dialog.dart
+++ b/lib/ui/widgets/user_menu_dialog.dart
@@ -186,14 +186,14 @@ class _AccountDialogState extends State<_AccountDialog> {
         children: [
           Expanded(
             child: SizedBox(
-              height: 52,
+              height: 76,
               child: first,
             ),
           ),
           SizedBox(width: 10),
           Expanded(
             child: SizedBox(
-              height: 52,
+              height: 76,
               child: second,
             ),
           ),
@@ -713,9 +713,6 @@ class _ActionButtonState extends State<_ActionButton> {
           child: Center(
             child: Text(
               widget.label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              softWrap: false,
               textAlign: TextAlign.center,
               style: TextStyle(
                 fontSize: 17,


### PR DESCRIPTION
# Pull Request

## Summary
fix the button sizes on the "switch user" menu on mobile to stay consistent across display sizes

## Related Issues
no issue, discord discussion only

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Changed _buildPairedActionButtons for mobile only to use expanded width instead of hard coded widths
- Hard coded the height to normalize buttons where text does not fit on 1 row due to screen width

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device (Samsung S25+)
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Load onto phone
2. Open switch user menu
3. See even/aligned buttons regardless of screen size

## Screenshots (if applicable)
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/eaec1cff-33c8-415d-8a24-f0bb56369608" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
