### PR TITLE
feat(playback): Restrict remote controls during Cinema Mode pre-rolls

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2758,6 +2758,93 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (_isCurrentPreroll) {
+      if (event is KeyUpEvent) {
+        final isBackKey =
+            event.logicalKey == LogicalKeyboardKey.goBack ||
+            event.logicalKey == LogicalKeyboardKey.escape ||
+            event.logicalKey == LogicalKeyboardKey.browserBack ||
+            event.logicalKey == LogicalKeyboardKey.backspace;
+        if (isBackKey) {
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      }
+
+      if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+        return KeyEventResult.ignored;
+      }
+
+      if (event is KeyDownEvent) {
+        final isBackKey =
+            event.logicalKey == LogicalKeyboardKey.goBack ||
+            event.logicalKey == LogicalKeyboardKey.escape ||
+            event.logicalKey == LogicalKeyboardKey.browserBack ||
+            event.logicalKey == LogicalKeyboardKey.backspace;
+
+        if (isBackKey) {
+          if (!_isBackNavigationSuppressed()) {
+            _exitPlayback();
+          }
+          return KeyEventResult.handled;
+        }
+
+        switch (event.logicalKey) {
+          case LogicalKeyboardKey.mediaPlay:
+            unawaited(_resumeWithConfiguredRewind());
+            return KeyEventResult.handled;
+          case LogicalKeyboardKey.mediaPause:
+            _manager.pause();
+            return KeyEventResult.handled;
+          case LogicalKeyboardKey.mediaPlayPause:
+          case LogicalKeyboardKey.space:
+          case LogicalKeyboardKey.enter:
+          case LogicalKeyboardKey.select:
+            _togglePlayPause();
+            return KeyEventResult.handled;
+
+          case LogicalKeyboardKey.mediaFastForward:
+            unawaited(_manager.next());
+            return KeyEventResult.handled;
+
+          case LogicalKeyboardKey.mediaRewind:
+            unawaited(_manager.seekTo(Duration.zero));
+            unawaited(_manager.resume());
+            return KeyEventResult.handled;
+
+          default:
+            return KeyEventResult.handled;
+        }
+      }
+
+      if (event is KeyRepeatEvent) {
+        final isBackKey =
+            event.logicalKey == LogicalKeyboardKey.goBack ||
+            event.logicalKey == LogicalKeyboardKey.escape ||
+            event.logicalKey == LogicalKeyboardKey.browserBack ||
+            event.logicalKey == LogicalKeyboardKey.backspace;
+        if (isBackKey) {
+          return KeyEventResult.handled;
+        }
+
+        switch (event.logicalKey) {
+          case LogicalKeyboardKey.mediaPlay:
+          case LogicalKeyboardKey.mediaPause:
+          case LogicalKeyboardKey.mediaPlayPause:
+          case LogicalKeyboardKey.space:
+          case LogicalKeyboardKey.enter:
+          case LogicalKeyboardKey.select:
+          case LogicalKeyboardKey.mediaFastForward:
+          case LogicalKeyboardKey.mediaRewind:
+            return KeyEventResult.handled;
+          default:
+            return KeyEventResult.handled;
+        }
+      }
+
+      return KeyEventResult.ignored;
+    }
+
     if (event is KeyUpEvent) {
       final temporarySpeedResult = _handleTvTemporarySpeedKeyUp(event);
       if (temporarySpeedResult != KeyEventResult.ignored) {


### PR DESCRIPTION
# Pull Request Template

## Summary
During pre-roll clips (played via the Local Intros plugin when Cinema Mode is active), the on-screen display (OSD) is disabled to maintain clean aesthetics. This PR introduces input constraints on the remote control during pre-roll playback to prevent timeline fast-forward/rewind search while allowing essential play/pause, pre-roll skip (FF), and pre-roll restart (REW) controls. This prevents the UI from appearing broken or buggy during button presses while a pre-roll is active.

## Related Issues
None.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Intercepted remote key events in `_handleKeyEvent` in `video_player_screen.dart` when `_isCurrentPreroll` is active.
- Allowed Space, Enter, Select, and Media Play/Pause/Play/Pause keys to toggle or control playback.
- Mapped Media Fast Forward to `_manager.next()` to skip the pre-roll and immediately play the main feature.
- Mapped Media Rewind to `_manager.seekTo(Duration.zero)` and `_manager.resume()` to restart the pre-roll cleanly.
- Allowed Back/Exit keys to exit playback as normal.
- Consumed all other key events to prevent unintended timeline seeking or OSD/UI focus changes.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Tested manually on a physical Nvidia Shield TV.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built the beta APK using `flutter build apk --release --flavor androidTv-beta --target-platform android-arm64`.
2. Deployed using `adb install -r` to the Nvidia Shield TV.
3. Enabled Cinema Mode in settings and played a movie with active pre-rolls.
4. Verified play/pause controls.
5. Verified pressing FF skipped the pre-roll and immediately loaded the movie.
6. Verified pressing REW restarted the pre-roll from 0:00.
7. Verified other keys like left/right arrows were blocked to prevent seek search.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
