### PR TITLE
Fix Two Navigation Bugs

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -124,6 +124,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   bool _subtitleActive = false;
   bool _subtitleReapplyRetryScheduled = false;
   bool _isStopping = false;
+  bool _readyToPop = false;
   bool _didRestoreSystemUiOnExit = false;
   DateTime? _suppressTvLifecycleExitUntil;
   bool _isOsdLocked = false;
@@ -2345,7 +2346,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   Future<void> _exitPlayback() async {
     if (_isStopping) return;
-    _isStopping = true;
+    setState(() {
+      _isStopping = true;
+    });
     _cancelTvTemporarySpeedHold();
     if (!PlatformDetection.isTV) _pipService.enableAutoPiP(false);
     if (_wasAlwaysOnTopOnEntry == false && _isAlwaysOnTop) {
@@ -2361,7 +2364,15 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
     await _restoreSystemUiForExit();
     if (mounted) {
-      Navigator.of(context).pop();
+      _dismissTopOverlayRouteIfAny();
+      setState(() {
+        _readyToPop = true;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          Navigator.of(context).pop();
+        }
+      });
     }
   }
 
@@ -3044,7 +3055,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
 
     return PopScope(
-      canPop: false,
+      canPop: _readyToPop,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
         if (_isBackNavigationSuppressed()) {


### PR DESCRIPTION
# Pull Request Template: Fix Two Navigation Bugs

## Summary
This PR addresses two navigation issues reported in video playback: the "double-pop" navigation glitch and the exit-blocking behavior when the Media Info pane is active.

### Key Changes
1. **Resolved Double-Pop Back Navigation Bug (`video_player_screen.dart`)**:
   - Parameterized `PopScope`'s `canPop` to bind to a new state flag, `_readyToPop`.
   - Modified `_exitPlayback()` to implement a safe, two-stage exit process:
     - **Stage 1 (Cleanup)**: Sets `_isStopping = true` synchronously at the start of exit teardown to ignore repeat calls and lifecycle triggers. Meanwhile, `_readyToPop` remains `false`, which completely blocks and ignores concurrent system back gestures or remote back clicks during asynchronous cleanups (`_manager.stop()`, system UI restoration).
     - **Stage 2 (Pop)**: Once all asynchronous cleanups complete, sets `_readyToPop = true` via `setState()` and pops the screen cleanly exactly once inside `WidgetsBinding.instance.addPostFrameCallback`.
   - **Result**: Eliminates the timing-dependent double-pop race condition, hopefully guaranteeing the user always returns cleanly and exactly to the preceding Media Details screen and not the Home Page.

2. **Resolved Media Info Pane Exit Block Bug (`video_player_screen.dart`)**:
   - In `_exitPlayback()`, added a call to `_dismissTopOverlayRouteIfAny()` immediately before programmatic route pop.
   - **Result**: Ensures that if the Playback Information dialog (or any other active overlay route) is open when playback finishes/exits, the overlay is dismissed first, allowing the player screen itself to be popped successfully.

## Verification Plan

### Automated Tests
- Ran `flutter analyze` inside the repository to ensure no errors or warnings are introduced.

### Manual Verification
- Purged gradle build cache via `flutter clean` to prevent stale build assembly.
- Compiled local release APK under the `androidTv-beta` flavor targeting `android-arm64`.
- ADB connected to Nvidia Shield TV (`192.168.0.224`) and deployed build upgrade via `adb install -r`.
- **Double-Pop Test**: Started playback and pressed back repeatedly/rapidly. Verified it always returned exactly to the Media Details page without double-popping to the Home screen.
- **Media Info Dialog Test**: Opened Playback Information pane, waited for video to end, and verified the player closed gracefully and returned cleanly to the Media Details page.
