### PR TITLE
Fix: Hide Audio Playlists from Playlists Page

### DIFF
--- a/lib/data/utils/playlist_utils.dart
+++ b/lib/data/utils/playlist_utils.dart
@@ -87,7 +87,9 @@ Future<bool> playlistHasBrowsableItems(
   }
 
   final summaryMediaType = item.rawData['MediaType'] as String?;
-  if (summaryMediaType != null && summaryMediaType != 'Audio') {
+  if (summaryMediaType != null &&
+      summaryMediaType != 'Audio' &&
+      summaryMediaType != 'Unknown') {
     return true;
   }
 


### PR DESCRIPTION
# Pull Request Template

## Summary
Surgically resolves an issue where audio-only playlists were displayed on the Playlists page and general playlist rows, and mixed movie playlists were erroneously hidden due to unreliable metadata summaries from Jellyfin. This change also applies to Emby.

## Related Issues
Closes issues related to playlist visibility.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `playlistHasBrowsableItems` in `playlist_utils.dart` to bypass items checks only for definitely-video playlist types.
- Forces content verification for `'Audio'` and `'Unknown'` playlists by querying their entries, ensuring correct visibility regardless of unreliable summary metadata tags.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [x] Tested on physical device (ATV, Nvidia Shield TV)
- [x] Tested on Web UI
- [x] Tested on Pixel 10 Pro (Android mobile)  
- [x] Manual testing completed

### Test Steps
1. Navigate to My Media -> Playlists.
2. Confirm audio-only playlists are hidden.
3. Confirm all expected playlists are (containing movie/show media) are visible.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
