### PR TITLE
Fix DE translation of "Trailer"

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1116,7 +1116,7 @@
   "@cast": {
     "description": "Action button label for casting to a device"
   },
-  "trailer": "Anhänger",
+  "trailer": "Trailer",
   "@trailer": {
     "description": "Action button label for trailer playback"
   },

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -863,7 +863,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get cast => 'Besetzung';
 
   @override
-  String get trailer => 'Anhänger';
+  String get trailer => 'Trailer';
 
   @override
   String get finished => 'Abgeschlossen';


### PR DESCRIPTION
Anhänger, the previous translation is a vehicle or a supporter/fan. Germans usually use the word Trailer for trailers.

## Type of Change
- [x] Other (describe): Translation

