### PR TITLE
feat/style: Split MediaCard border and focus glow to prevent washed-out poster overlay

### DIFF
--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -382,11 +382,24 @@ class _CardImage extends StatelessWidget {
     final showBorder = !suppressFocusBorder && (focused || hovered);
     final borderColor = focusColor ?? Theme.of(context).colorScheme.primary;
     final borders = ThemeRegistry.active.borders;
+    final showGlow = showBorder && !suppressFocusGlow && borders.focusGlow.isNotEmpty;
+
     return AspectRatio(
       aspectRatio: aspectRatio,
       child: Stack(
         fit: StackFit.expand,
         children: [
+          if (showGlow)
+            IgnorePointer(
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: isCircular
+                      ? BorderRadius.circular(radius)
+                      : borders.cardRadius,
+                  boxShadow: borders.focusGlow,
+                ),
+              ),
+            ),
           ClipRRect(
             borderRadius: BorderRadius.circular(radius),
             child: Stack(
@@ -459,10 +472,6 @@ class _CardImage extends StatelessWidget {
                   border: Border.fromBorderSide(
                     borders.focusBorder.copyWith(color: borderColor),
                   ),
-                  boxShadow:
-                      (!suppressFocusGlow && borders.focusGlow.isNotEmpty)
-                      ? borders.focusGlow
-                      : null,
                 ),
               ),
             ),


### PR DESCRIPTION
# Pull Request for Opaque Overlay in Neon Pulse Theme

## Summary
Fixes the card focus/hover glow overlay issue under the Neon Pulse theme (and derived custom themes). Previously, custom theme glow shadows (`focusGlow` list of BoxShadows) were rendered in a transparent container on top of the poster image, which caused the blur to bleed inwards and cover the poster with a faded, semi-transparent colored wash.  This PR splits the rendering: the glow shadow is now painted behind the poster image stack so that the solid image masks out the inward-bleeding blur while letting the neon glow radiate outwards from behind. The crisp solid border outline remains painted on top of the image to keep the focus ring sharp and visible.

## Related Issues
- User feedback on Discord

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added a `showGlow` layout state to the `_CardImage` widget in `lib/ui/widgets/media_card.dart`.
- Inserted a background glow `Container` behind the image `ClipRRect` stack when `showGlow` is active.
- Removed `boxShadow` from the top-layer focus border `Container` so only the sharp border outline is printed on top of the image.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device - built locally and tested on Android TV (NVidia Shield)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Select the **Neon Pulse** theme (or a custom theme with active `focusGlow` shadows).
2. Navigate to a view containing media cards (e.g. Shuffle Overlay, Search screen, or Seerr browse lists).
3. Focus or hover on an item and verify the poster is perfectly clear and crisp (no faded/whitish overlay).
4. Verify that the neon glow (magenta & cyan) radiates beautifully outwards from behind the boundaries of the card.
5. Verify that the solid pink focus border outline is drawn sharply on top of the poster.

## Screenshots (if applicable)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
 
NOTE: This effect is user in multiple instances around the app. I especially notice it in the Shuffle view and the individual Cast details pages.
