### PR TITLE
Fix: Detect iOS devices as mobile to catch iPads

### DIFF
--- a/lib/util/platform_detection.dart
+++ b/lib/util/platform_detection.dart
@@ -274,6 +274,7 @@ class PlatformDetection {
   }
 
   static bool get _hasMobileFormFactor {
+    if (defaultTargetPlatform == TargetPlatform.iOS) return true;
     final size = _screenLogicalSize;
     if (size == null) return _isMobilePlatformSignal;
     if (size.shortestSide <= 0) return _isMobilePlatformSignal;


### PR DESCRIPTION
# Pull Request

## Summary
Fix iPad being incorrectly detected as desktop form factor in PlatformDetection, causing the wrong UI mode to be used.

## Related Issues
#342

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

Added if (defaultTargetPlatform == TargetPlatform.iOS) return true; as the first guard in _hasMobileFormFactor

## Platform
- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Install the app on an iPad
2. Verify that you are getting the correct platform detected and UI

## Screenshots (if applicable)
Before fix:
<img width="1133" height="744" alt="IMG_1682" src="https://github.com/user-attachments/assets/4c767725-a685-47c5-9956-814b63a20472" />

After fix:
<img width="1133" height="744" alt="IMG_1683" src="https://github.com/user-attachments/assets/a9a3dfce-a02f-48e8-84a5-3a03e4b5c16d" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
