### PR TITLE
fix: correct Letterboxd rating display (use score/20 instead of value)

### DIFF
--- a/lib/data/services/rating_icon_provider.dart
+++ b/lib/data/services/rating_icon_provider.dart
@@ -38,6 +38,7 @@ class RatingIconProvider {
       'tomatoes' || 'popcorn' || 'tomatoes_audience' ||
       'tmdb' || 'metacritic' || 'metacriticuser' || 'trakt' || 'anilist' =>
         '${value.toInt()}%',
+      'letterboxd' => '${value.toStringAsFixed(1)}/5',
       _ => value.toStringAsFixed(1),
     };
   }


### PR DESCRIPTION
# Pull Request for Letterboxd Rating Fix

## Summary

Fixes Letterboxd ratings displaying as doubled values across all clients.
MDBList's `value` field for Letterboxd is on an ambiguous 0-10 scale
(Letterboxd's native scale is 0-5). The previous `value > 5` halving
guard failed silently for any film scoring **2.5/5 or below** - those
values after doubling are <= 5 and are indistinguishable from a real
low-end score, so they passed through un-halved and displayed incorrectly.

The fix switches to `score / 20`, where `score` is MDBList's always-correct
0-100 normalized field, producing a reliable 0-5 result regardless of
what `value` contains.

## Related Issues

- Fixes known issue of Letterboxd ratings showing doubled values

## Type of Change
- [x] Bug fix

## Changes Made

- **`mdblist_repository.dart`**: Added a `letterboxd`-specific branch in
  the rating value switch that reads `score / 20` instead of `value`.
  Normalizing at the source means all clients will get a correct
  0-5 value automatically.
- **`rating_icon_provider.dart`**: Added a `letterboxd` case to
  `formatRating()` that appends `/5` so the display reads `3.7/5`
  rather than a bare `3.7`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing

- [x] Tested on physical device
- [x] Manual testing completed - built plugin and tested via web UI as well as on Android TV

### Test Steps
1. Open Moonfin beta on a device with MDBList ratings enabled
2. Navigate to a film with a known Letterboxd score (e.g. *Sorry to Bother You* - 3.7/5 on LB)
3. Confirm the rating badge reads `3.7/5` rather than `7.4` or `7.4/5`
4. Repeat with a poorly-rated film (e.g. a film known to score below 2.5/5) to confirm the lower half of the scale is also correct. Confirmed with The Descent: Part 2 which shows 2.4 (matches Letterboxd.com).

### Screenshots
Current build:
<img width="500" alt="Shield_Screenshot_2026-05-31_22-14-45" src="https://github.com/user-attachments/assets/4ef05d83-9d8c-43e1-ae21-b9ef5ba1df32" />

Fixed:
<img width="500" alt="Shield_Screenshot_2026-05-31_22-11-49" src="https://github.com/user-attachments/assets/b10377e7-0de1-4ab0-b5ea-7303c5b67d0d" />

Low Score (undeserved!):
<img width="500" alt="Shield_Screenshot_2026-05-31_22-29-34" src="https://github.com/user-attachments/assets/f8097733-07cb-417e-9a1d-eb6d6e1f9a00" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
