### PR TITLE
fix(settings): robust preference type coercion and safe parsing for web compatability

### DIFF
--- a/packages/preference/lib/src/store/preference_store.dart
+++ b/packages/preference/lib/src/store/preference_store.dart
@@ -20,26 +20,60 @@ class PreferenceStore {
   }
 
   T get<T>(Preference<T> preference) {
-    final key = preference.key;
-    final defaultValue = preference.defaultValue;
+    try {
+      final key = preference.key;
+      final defaultValue = preference.defaultValue;
 
-    if (preference is EnumPreference) {
-      return _getEnumDynamic(preference as EnumPreference) as T;
-    }
+      if (preference is EnumPreference) {
+        return _getEnumDynamic(preference as EnumPreference) as T;
+      }
 
-    switch (defaultValue) {
-      case int _:
-        return (_requirePrefs.getInt(key) ?? defaultValue) as T;
-      case double _:
-        return (_requirePrefs.getDouble(key) ?? defaultValue) as T;
-      case bool _:
-        return (_requirePrefs.getBool(key) ?? defaultValue) as T;
-      case String _:
-        return (_requirePrefs.getString(key) ?? defaultValue) as T;
-      case List<String> _:
-        return (_requirePrefs.getStringList(key) ?? defaultValue) as T;
-      default:
-        throw ArgumentError('Unsupported preference type: ${defaultValue.runtimeType}');
+      switch (defaultValue) {
+        case int _:
+          final val = _requirePrefs.get(key);
+          if (val is num) {
+            return val.toInt() as T;
+          }
+          if (val is String) {
+            final clean = val.replaceAll('#', '').trim();
+            if (clean.length == 6) {
+              final parsed = int.tryParse(clean, radix: 16);
+              if (parsed != null) return (0xFF000000 | parsed) as T;
+            } else if (clean.length == 8) {
+              final parsed = int.tryParse(clean, radix: 16);
+              if (parsed != null) return parsed as T;
+            }
+            return (int.tryParse(val) ?? defaultValue) as T;
+          }
+          return (val ?? defaultValue) as T;
+        case double _:
+          final val = _requirePrefs.get(key);
+          if (val is num) {
+            return val.toDouble() as T;
+          }
+          if (val is String) {
+            return (double.tryParse(val) ?? defaultValue) as T;
+          }
+          return (val ?? defaultValue) as T;
+        case bool _:
+          final val = _requirePrefs.get(key);
+          if (val is bool) {
+            return val as T;
+          }
+          if (val is String) {
+            if (val.toLowerCase() == 'true') return true as T;
+            if (val.toLowerCase() == 'false') return false as T;
+          }
+          return (val ?? defaultValue) as T;
+        case String _:
+          return (_requirePrefs.getString(key) ?? defaultValue) as T;
+        case List<String> _:
+          return (_requirePrefs.getStringList(key) ?? defaultValue) as T;
+        default:
+          throw ArgumentError('Unsupported preference type: ${defaultValue.runtimeType}');
+      }
+    } catch (_) {
+      return preference.defaultValue;
     }
   }
 
@@ -96,11 +130,13 @@ class PreferenceStore {
   Future<void> reset<T>(Preference<T> preference) => set(preference, preference.defaultValue);
 
   dynamic _getEnumDynamic(EnumPreference<dynamic> preference) {
-    final stored = _requirePrefs.getString(preference.key);
-    if (stored == null || stored.isEmpty) return preference.defaultValue;
-    for (final v in preference.values) {
-      if ((v as Enum).name == stored) return v;
-    }
+    try {
+      final stored = _requirePrefs.getString(preference.key);
+      if (stored == null || stored.isEmpty) return preference.defaultValue;
+      for (final v in preference.values) {
+        if ((v as Enum).name == stored) return v;
+      }
+    } catch (_) {}
     return preference.defaultValue;
   }
 


### PR DESCRIPTION
# Pull Request to Fix Subtitles Customization Pane in Web UI
## Summary
Fix a crash in the "Customize Subtitles" settings panel in the Web UI caused by strict runtime type checks during SharedPreferences loading.
## Related Issues
Resolves the grey square render error in `/Moonfin/Web/` Customize Subtitles screen.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):
## Changes Made
- Added robust type coercion and parsing inside `PreferenceStore.get<T>()` for `int`, `double`, and `bool` values.
- Handled Jellyfin color hex string values (e.g. `"#ffffff"`) gracefully by parsing them to ARGB integer colors.
- Wrapped preference accesses in a try-catch block to return `defaultValue` safely instead of throwing and crashing UI rendering.
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code (specifically impacting Web/Jellyfin integrations)
## Testing
Describe how this change was tested.
- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed (Tested via standalone local preview server running on port 8080)
- [ ] Not tested (explain why):
### Test Steps
1. Built Flutter Web using `flutter build web --release --wasm`.
2. Serves standalone Moonfin Web client locally.
3. Confirmed that Customize Subtitles loading and customization interface displays perfectly without widget tree crashes.
## Screenshots
Before Fix:
<img width="500" alt="2026-05-31_21-17-46" src="https://github.com/user-attachments/assets/e423cab0-e0fd-402e-a48b-ce55ebba2d81" />
After Fix:
<img width="350" alt="2026-05-31_23-26-20_brave" src="https://github.com/user-attachments/assets/33cf0ad9-1177-4adf-bc4e-b5b2441b61b6" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
