### PR TITLE
fix discord link

### DIFF
--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1548,7 +1548,7 @@ class _AboutCategoryScreen extends StatelessWidget {
             subtitle: Text(l10n.settingsJoinDiscordSubtitle),
             onTap: () => showQrOrLaunch(
               context,
-              url: 'https://discord.gg/u7ny4Rnxze',
+              url: 'https://discord.gg/moonfin',
               title: l10n.settingsJoinTheDiscord,
             ),
           ),


### PR DESCRIPTION
# Pull Request

## Summary
Updated discord link to discord.gg/moonfin instead of the random invite link

## Related Issues
Discord MB3

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [X] Other (describe):

## Changes Made
List the key changes included in this PR.

- changed discord link

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): I just changed the link lol

### Test Steps
1. Click link?

## Screenshots (if applicable)
n/a

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
