### PR TITLE
Fix box borders showing up on some settings

### DIFF
--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -168,19 +168,29 @@ class SettingsListTypography extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return ListTileTheme(
-      data: ListTileTheme.of(context).copyWith(
-        titleTextStyle:
-            theme.textTheme.bodyMedium?.merge(_kSettingsTitleTextStyle) ??
-            _kSettingsTitleTextStyle,
-        subtitleTextStyle:
-            theme.textTheme.bodySmall?.merge(_kSettingsSubtitleTextStyle) ??
-            _kSettingsSubtitleTextStyle,
-        contentPadding: _kSettingsTileContentPadding,
-        minLeadingWidth: _kSettingsIconShellSize,
-        horizontalTitleGap: 14,
+    return Theme(
+      data: theme.copyWith(
+        focusColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+        highlightColor: Colors.transparent,
+        splashColor: Colors.transparent,
       ),
-      child: child,
+      child: ListTileTheme(
+        tileColor: Colors.transparent,
+        selectedTileColor: Colors.transparent,
+        data: ListTileTheme.of(context).copyWith(
+          titleTextStyle:
+              theme.textTheme.bodyMedium?.merge(_kSettingsTitleTextStyle) ??
+              _kSettingsTitleTextStyle,
+          subtitleTextStyle:
+              theme.textTheme.bodySmall?.merge(_kSettingsSubtitleTextStyle) ??
+              _kSettingsSubtitleTextStyle,
+          contentPadding: _kSettingsTileContentPadding,
+          minLeadingWidth: _kSettingsIconShellSize,
+          horizontalTitleGap: 14,
+        ),
+        child: child,
+      ),
     );
   }
 }
@@ -321,8 +331,6 @@ class _EnumPreferenceTileState<T extends Enum>
         builder: (context, value, _) {
           final current = values.contains(value) ? value : values.first;
           return ListTile(
-            focusColor: Colors.transparent,
-            hoverColor: Colors.transparent,
             leading: widget.icon != null
                 ? buildSettingsLeadingIconShell(
                     context,
@@ -508,8 +516,6 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
             child: ValueListenableBuilder<int>(
               valueListenable: _binding,
               builder: (context, value, _) => ListTile(
-                focusColor: Colors.transparent,
-                hoverColor: Colors.transparent,
                 leading: widget.icon != null
                     ? buildSettingsLeadingIconShell(
                         context,
@@ -604,8 +610,6 @@ class _StringPickerPreferenceTileState
       builder: (context, focused) => ValueListenableBuilder<String>(
         valueListenable: _binding,
         builder: (context, value, _) => ListTile(
-          focusColor: Colors.transparent,
-          hoverColor: Colors.transparent,
           leading: widget.icon != null
               ? buildSettingsLeadingIconShell(
                   context,
@@ -719,8 +723,6 @@ class _IntPickerPreferenceTileState extends State<IntPickerPreferenceTile> {
       builder: (context, focused) => ValueListenableBuilder<int>(
         valueListenable: _binding,
         builder: (context, value, _) => ListTile(
-          focusColor: Colors.transparent,
-          hoverColor: Colors.transparent,
           leading: widget.icon != null
               ? buildSettingsLeadingIconShell(
                   context,


### PR DESCRIPTION
## Summary
Fixes some settings tiles having square borders outside their rounded rects when highlighted.


## Related Issues
none

## Type of Change
- [X] Bug fix

## Changes Made
Change SettingsListTypography so tile colors and focus colors are transparent by default instead of setting them everywhere individually, with some being missed.

- Added a theme wrapper around the ListTileTheme return that changes focusColor, highlightColor, splashColor, hoverColor to transparent.
- Added tileColor and selectedTileColor to the child ListTileTheme with transparent color.
- Removed these settings from other ListTileTheme children of TvFocusHighlight that already did have them.

## Platform
- [X] All / Shared code

## Testing
android tv

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. move focus to any switchpreferencetile, or stringpreferencetile like the picker for audio/subtitle language
2. verify no more highlights escaping the rounded border

## Screenshots (if applicable)
before
<img width="834" height="360" alt="image" src="https://github.com/user-attachments/assets/c85fc7d0-d480-45a1-b435-f55e11fccf24" />
after
<img width="791" height="229" alt="image" src="https://github.com/user-attachments/assets/072dbc7e-208c-414e-b22f-7022be901c2c" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
