### PR TITLE
[codex] Fix TV add-server keyboard dismissal

### DIFF
--- a/lib/ui/screens/auth/server_select_screen.dart
+++ b/lib/ui/screens/auth/server_select_screen.dart
@@ -918,6 +918,10 @@ class _AddServerDialogState extends State<_AddServerDialog> {
   Future<void> _submit() async {
     final address = widget.controller.text.trim();
     if (address.isEmpty) return;
+    if (PlatformDetection.isTV) {
+      _tvFieldKey.currentState?.hideKeyboard();
+      _connectFocus.requestFocus();
+    }
 
     setState(() {
       _isConnecting = true;
@@ -944,7 +948,9 @@ class _AddServerDialogState extends State<_AddServerDialog> {
       _errorMessage = message;
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _connectFocus.requestFocus();
+      if (!mounted) return;
+      _tvFieldKey.currentState?.hideKeyboard();
+      _connectFocus.requestFocus();
     });
   }
 

--- a/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
+++ b/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
@@ -292,8 +292,12 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
   }
 
   void closeKeyboard() {
+    hideKeyboard(submit: true);
+  }
+
+  void hideKeyboard({bool submit = false}) {
     if (_keyboardController.isVisible) {
-      _keyboardController.hide(true);
+      _keyboardController.hide(submit);
       return;
     }
     _deactivateSystemIme();
@@ -324,6 +328,8 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
     setState(() {
       _useSystemImeSession = false;
     });
+    _systemInputFocusNode.unfocus();
+    SystemChannels.textInput.invokeMethod<void>('TextInput.hide');
     _notifyVisibilityChanged();
   }
 


### PR DESCRIPTION
## Summary

- Add a non-submitting keyboard hide path to CustomTVTextField.
- Hide the TV keyboard and move focus to the Connect button before/after add-server connection attempts.
- Explicitly hide the system IME when deactivating a system keyboard session.

## Why

On Android/Google/TCL TV devices, connection errors while entering a server address can leave the on-screen keyboard visible or focused while the dialog shows an error. That traps remote navigation in the keyboard layer and makes it difficult to hide the keyboard or reach dialog actions.

## Validation

- git diff --check passed.
- Attempted targeted dart analyze, but this local checkout has unresolved package dependencies, including Flutter package imports, so analysis could not produce useful patch-specific results.