### PR TITLE
Update Releases link to Core Repo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Control other Jellyfin devices on your network directly from Moonfin.
 ## Installation
 
 ### Pre-built Releases
-Download platform artifacts from the [Releases page](https://github.com/Moonfin-Client/Mobile-Desktop/releases).
+Download platform artifacts from the [Releases page](https://github.com/Moonfin-Client/Moonfin-Core/releases).
 
 ### Arch Linux (AUR)
 Install from the AUR using any of these commands:


### PR DESCRIPTION
README Releases Link Moonfin-Core Update/Migration

# Pull Request

## Summary
Updates the "Moonfin Releases" link to the new Moonfin-Core Repo Releases page instead of the old one

## Type of Change
- [ X] Other (describe): Github README edit

## Changes Made

- Replaced old link to mobile rep with link to Moonfin-core repo

