### PR TITLE
feat(home page): Implement horizontal infinite scrolling for home rows

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:server_core/server_core.dart';
 
@@ -7,6 +8,8 @@ import '../../auth/models/server.dart';
 import '../../auth/repositories/session_repository.dart';
 import '../../auth/store/authentication_store.dart';
 import '../../auth/store/credential_store.dart';
+import '../../preference/preference_constants.dart';
+import '../../preference/user_preferences.dart';
 import '../models/aggregated_item.dart';
 import '../models/aggregated_library.dart';
 import '../models/home_row.dart';
@@ -50,6 +53,7 @@ class MultiServerRepository {
   static const _imageTypes = 'Primary,Backdrop,Thumb';
   static const _imageTypeLimit = 1;
   static const _defaultLimit = 15;
+  static const _maxItems = 100;
   static const _defaultSortBy = 'SortName';
   static const _defaultSortOrder = 'Ascending';
   static const _genreArtworkConcurrency = 6;
@@ -278,11 +282,15 @@ class MultiServerRepository {
     final all = results.expand((e) => e).toList()
       ..sort((a, b) => a.name.compareTo(b.name));
 
+    final takenItems = all.take(limit).toList();
+    final totalCount = takenItems.length < limit ? takenItems.length : _maxItems;
+
     return HomeRow(
       id: 'playlists',
       title: _l10n.playlists,
-      items: all.take(limit).toList(),
+      items: takenItems,
       rowType: HomeRowType.playlists,
+      totalCount: totalCount,
     );
   }
 
@@ -360,12 +368,171 @@ class MultiServerRepository {
       sortOrder: sortOrder,
     );
 
+    final takenItems = all.take(limit).toList();
+    final totalCount = takenItems.length < limit ? takenItems.length : _maxItems;
+
     return HomeRow(
       id: 'genres',
       title: _l10n.genres,
-      items: all.take(limit).toList(),
+      items: takenItems,
       rowType: HomeRowType.genres,
+      totalCount: totalCount,
     );
+  }
+
+  FavoriteTypeFilter _favoriteFilterForId(String id) {
+    return switch (id) {
+      'favorites_movies' => FavoriteTypeFilter.movie,
+      'favorites_series' => FavoriteTypeFilter.series,
+      'favorites_episodes' => FavoriteTypeFilter.episode,
+      'favorites_people' => FavoriteTypeFilter.person,
+      'favorites_artists' => FavoriteTypeFilter.musicArtist,
+      'favorites_musicvideos' => FavoriteTypeFilter.musicVideo,
+      'favorites_albums' => FavoriteTypeFilter.musicAlbum,
+      'favorites_songs' => FavoriteTypeFilter.audio,
+      _ => FavoriteTypeFilter.all,
+    };
+  }
+
+  Future<List<AggregatedItem>> loadMore({
+    required HomeRow row,
+  }) async {
+    if (!row.hasMore || row.items.length >= _maxItems) return row.items;
+
+    final prefs = GetIt.instance.isRegistered<UserPreferences>()
+        ? GetIt.instance<UserPreferences>()
+        : null;
+    final sessions = await getLoggedInServers();
+
+    // Group existing items by serverId to know how many items we already have for each server
+    final Map<String, List<AggregatedItem>> itemsByServer = {};
+    for (final item in row.items) {
+      itemsByServer.putIfAbsent(item.serverId, () => []).add(item);
+    }
+
+    final results = await Future.wait(
+      sessions.map((session) => _withTimeout(() async {
+        final serverId = session.server.id;
+        final existingCount = itemsByServer[serverId]?.length ?? 0;
+
+        switch (row.rowType) {
+          case HomeRowType.playlists:
+            final pageCount = (existingCount / _defaultLimit).ceil();
+            final startIndex = pageCount * _defaultLimit;
+            final response = await session.client.itemsApi.getItems(
+              includeItemTypes: const ['Playlist'],
+              sortBy: 'SortName',
+              sortOrder: 'Ascending',
+              recursive: true,
+              startIndex: startIndex,
+              limit: _defaultLimit,
+              fields: _fields,
+              enableImageTypes: _imageTypes,
+              imageTypeLimit: _imageTypeLimit,
+            );
+            return filterBrowsablePlaylists(
+              session.client,
+              _parseItems(response, serverId),
+            );
+          case HomeRowType.favorites:
+            final favoriteFilter = _favoriteFilterForId(row.id);
+            final sortBy = prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ?? _defaultSortBy;
+            final response = await session.client.itemsApi.getItems(
+              includeItemTypes: favoriteFilter.itemTypes,
+              sortBy: sortBy,
+              sortOrder: 'Ascending',
+              recursive: true,
+              startIndex: existingCount,
+              limit: _defaultLimit,
+              isFavorite: true,
+              fields: _fields,
+              enableImageTypes: _imageTypes,
+              imageTypeLimit: _imageTypeLimit,
+            );
+            return _parseItems(response, serverId);
+          case HomeRowType.collections:
+            final sortBy = prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ?? _defaultSortBy;
+            final response = await session.client.itemsApi.getItems(
+              includeItemTypes: const ['BoxSet'],
+              sortBy: sortBy,
+              sortOrder: 'Ascending',
+              recursive: true,
+              startIndex: existingCount,
+              limit: _defaultLimit,
+              fields: _fields,
+              enableImageTypes: _imageTypes,
+              imageTypeLimit: _imageTypeLimit,
+            );
+            return _parseItems(response, serverId);
+          case HomeRowType.genres:
+            final sortBy = prefs?.get(UserPreferences.genresRowSortBy).apiValue ?? _defaultSortBy;
+            final includeItemTypes = prefs?.get(UserPreferences.genresRowItemFilter).includeItemTypes;
+            final browseItemTypes = normalizeBrowsableGenreItemTypes(includeItemTypes);
+            final pageCount = (existingCount / _defaultLimit).ceil();
+            final startIndex = pageCount * _defaultLimit;
+            final response = await session.client.itemsApi.getGenres(
+              sortBy: sortBy,
+              sortOrder: 'Ascending',
+              recursive: true,
+              startIndex: startIndex,
+              limit: _defaultLimit,
+              fields: 'ItemCounts',
+              includeItemTypes: browseItemTypes,
+            );
+            return _buildBrowsableGenresForSession(
+              session,
+              response,
+              includeItemTypes: browseItemTypes,
+            );
+          case HomeRowType.latestMedia:
+            if (row.id.startsWith('latest_')) {
+              final parts = row.id.split('_');
+              if (parts.length >= 3) {
+                final rowServerId = parts[1];
+                final parentId = parts[2];
+                if (serverId != rowServerId) return const <AggregatedItem>[];
+
+                final response = await session.client.itemsApi.getLatestItems(
+                  parentId: parentId,
+                  limit: row.items.length + _defaultLimit,
+                  fields: _fields,
+                  enableImageTypes: _imageTypes,
+                  imageTypeLimit: _imageTypeLimit,
+                );
+                return normalizeLatestMediaItems(
+                  _parseItems(response, serverId),
+                  limit: row.items.length + _defaultLimit,
+                );
+              }
+            }
+            return const <AggregatedItem>[];
+          default:
+            return const <AggregatedItem>[];
+        }
+      }, label: 'loadMore ${row.rowType} from ${session.server.name}')),
+    );
+
+    final newItems = results.expand((e) => e).toList();
+    if (newItems.isEmpty) return row.items;
+
+    // Merge and sort
+    final combined = [...row.items, ...newItems];
+
+    if (row.rowType == HomeRowType.playlists || row.rowType == HomeRowType.latestMedia) {
+      if (row.rowType == HomeRowType.playlists) {
+        combined.sort((a, b) => a.name.compareTo(b.name));
+      }
+      return combined;
+    }
+
+    final sortBy = switch (row.rowType) {
+      HomeRowType.favorites => prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ?? _defaultSortBy,
+      HomeRowType.collections => prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ?? _defaultSortBy,
+      HomeRowType.genres => prefs?.get(UserPreferences.genresRowSortBy).apiValue ?? _defaultSortBy,
+      _ => _defaultSortBy,
+    };
+
+    return _sortAggregatedItems(combined, sortBy: sortBy, sortOrder: 'Ascending');
   }
 
   Future<HomeRow> _getAggregatedSortedItemsRow({
@@ -407,11 +574,15 @@ class MultiServerRepository {
       sortOrder: sortOrder,
     );
 
+    final takenItems = all.take(limit).toList();
+    final totalCount = takenItems.length < limit ? takenItems.length : _maxItems;
+
     return HomeRow(
       id: id,
       title: title,
-      items: all.take(limit).toList(),
+      items: takenItems,
       rowType: rowType,
+      totalCount: totalCount,
     );
   }
 
@@ -505,12 +676,14 @@ class MultiServerRepository {
               limit: _defaultLimit,
             );
             if (items.isNotEmpty) {
+              final totalCount = items.length < _defaultLimit ? items.length : _maxItems;
               rows.add(
                 HomeRow(
                   id: 'latest_${session.server.id}_$id',
                   title: _l10n.latestLibraryName(displayName),
                   items: items,
                   rowType: HomeRowType.latestMedia,
+                  totalCount: totalCount,
                 ),
               );
             }

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -60,6 +60,13 @@ class MultiServerRepository {
 
   List<ServerUserSession>? _cachedSessions;
   DateTime _cacheExpiry = DateTime(0);
+  final Map<String, int> _rowOffsets = {};
+  final Map<String, int> _rowTotals = {};
+
+  void clearOffsets() {
+    _rowOffsets.clear();
+    _rowTotals.clear();
+  }
 
   MultiServerRepository(
     this._authStore,
@@ -271,10 +278,12 @@ class MultiServerRepository {
             enableImageTypes: _imageTypes,
             imageTypeLimit: _imageTypeLimit,
           );
-          return filterBrowsablePlaylists(
+          final items = await filterBrowsablePlaylists(
             session.client,
             _parseItems(response, session.server.id),
           );
+          _rowTotals['playlists_${session.server.id}'] = response['TotalRecordCount'] as int? ?? items.length;
+          return items;
         }, label: 'playlists from ${session.server.name}'),
       ),
     );
@@ -283,7 +292,9 @@ class MultiServerRepository {
       ..sort((a, b) => a.name.compareTo(b.name));
 
     final takenItems = all.take(limit).toList();
-    final totalCount = takenItems.length < limit ? takenItems.length : _maxItems;
+    final totalCount = sessions.fold<int>(0, (sum, session) {
+      return sum + (_rowTotals['playlists_${session.server.id}'] ?? 0);
+    });
 
     return HomeRow(
       id: 'playlists',
@@ -353,11 +364,13 @@ class MultiServerRepository {
             fields: 'ItemCounts',
             includeItemTypes: browseItemTypes,
           );
-          return _buildBrowsableGenresForSession(
+          final items = await _buildBrowsableGenresForSession(
             session,
             response,
             includeItemTypes: browseItemTypes,
           );
+          _rowTotals['genres_${session.server.id}'] = response['TotalRecordCount'] as int? ?? items.length;
+          return items;
         }, label: 'genres from ${session.server.name}'),
       ),
     );
@@ -369,7 +382,9 @@ class MultiServerRepository {
     );
 
     final takenItems = all.take(limit).toList();
-    final totalCount = takenItems.length < limit ? takenItems.length : _maxItems;
+    final totalCount = sessions.fold<int>(0, (sum, session) {
+      return sum + (_rowTotals['genres_${session.server.id}'] ?? 0);
+    });
 
     return HomeRow(
       id: 'genres',
@@ -380,24 +395,12 @@ class MultiServerRepository {
     );
   }
 
-  FavoriteTypeFilter _favoriteFilterForId(String id) {
-    return switch (id) {
-      'favorites_movies' => FavoriteTypeFilter.movie,
-      'favorites_series' => FavoriteTypeFilter.series,
-      'favorites_episodes' => FavoriteTypeFilter.episode,
-      'favorites_people' => FavoriteTypeFilter.person,
-      'favorites_artists' => FavoriteTypeFilter.musicArtist,
-      'favorites_musicvideos' => FavoriteTypeFilter.musicVideo,
-      'favorites_albums' => FavoriteTypeFilter.musicAlbum,
-      'favorites_songs' => FavoriteTypeFilter.audio,
-      _ => FavoriteTypeFilter.all,
-    };
-  }
-
-  Future<List<AggregatedItem>> loadMore({
+  Future<(List<AggregatedItem>, int)> loadMore({
     required HomeRow row,
   }) async {
-    if (!row.hasMore || row.items.length >= _maxItems) return row.items;
+    if (!row.hasMore || row.items.length >= _maxItems) {
+      return (row.items, row.totalCount);
+    }
 
     final prefs = GetIt.instance.isRegistered<UserPreferences>()
         ? GetIt.instance<UserPreferences>()
@@ -413,77 +416,121 @@ class MultiServerRepository {
     final results = await Future.wait(
       sessions.map((session) => _withTimeout(() async {
         final serverId = session.server.id;
+        final cacheKey = '${row.id}_$serverId';
         final existingCount = itemsByServer[serverId]?.length ?? 0;
+
+        int startIndex = existingCount;
+        final trackedOffset = _rowOffsets[cacheKey];
+        if (trackedOffset != null && trackedOffset > existingCount) {
+          startIndex = trackedOffset;
+        }
 
         switch (row.rowType) {
           case HomeRowType.playlists:
-            final pageCount = (existingCount / _defaultLimit).ceil();
-            final startIndex = pageCount * _defaultLimit;
+            final pageCount = (startIndex / _defaultLimit).ceil();
+            final targetStartIndex = pageCount * _defaultLimit;
+            _rowOffsets[cacheKey] = targetStartIndex + _defaultLimit;
+
             final response = await session.client.itemsApi.getItems(
               includeItemTypes: const ['Playlist'],
               sortBy: 'SortName',
               sortOrder: 'Ascending',
               recursive: true,
-              startIndex: startIndex,
+              startIndex: targetStartIndex,
               limit: _defaultLimit,
               fields: _fields,
               enableImageTypes: _imageTypes,
               imageTypeLimit: _imageTypeLimit,
             );
-            return filterBrowsablePlaylists(
+            final items = await filterBrowsablePlaylists(
               session.client,
               _parseItems(response, serverId),
             );
+            _rowTotals[cacheKey] = response['TotalRecordCount'] as int? ?? items.length;
+            return items;
           case HomeRowType.favorites:
-            final favoriteFilter = _favoriteFilterForId(row.id);
+            final favoriteFilter = FavoriteTypeFilter.fromRowId(row.id);
             final sortBy = prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ?? _defaultSortBy;
+            _rowOffsets[cacheKey] = startIndex + _defaultLimit;
+
             final response = await session.client.itemsApi.getItems(
               includeItemTypes: favoriteFilter.itemTypes,
               sortBy: sortBy,
               sortOrder: 'Ascending',
               recursive: true,
-              startIndex: existingCount,
+              startIndex: startIndex,
               limit: _defaultLimit,
               isFavorite: true,
               fields: _fields,
               enableImageTypes: _imageTypes,
               imageTypeLimit: _imageTypeLimit,
             );
-            return _parseItems(response, serverId);
+            final items = _parseItems(response, serverId);
+            _rowTotals[cacheKey] = response['TotalRecordCount'] as int? ?? items.length;
+            return items;
           case HomeRowType.collections:
             final sortBy = prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ?? _defaultSortBy;
+            _rowOffsets[cacheKey] = startIndex + _defaultLimit;
+
             final response = await session.client.itemsApi.getItems(
               includeItemTypes: const ['BoxSet'],
               sortBy: sortBy,
               sortOrder: 'Ascending',
               recursive: true,
-              startIndex: existingCount,
+              startIndex: startIndex,
               limit: _defaultLimit,
               fields: _fields,
               enableImageTypes: _imageTypes,
               imageTypeLimit: _imageTypeLimit,
             );
-            return _parseItems(response, serverId);
+            final items = _parseItems(response, serverId);
+            _rowTotals[cacheKey] = response['TotalRecordCount'] as int? ?? items.length;
+            return items;
           case HomeRowType.genres:
             final sortBy = prefs?.get(UserPreferences.genresRowSortBy).apiValue ?? _defaultSortBy;
             final includeItemTypes = prefs?.get(UserPreferences.genresRowItemFilter).includeItemTypes;
             final browseItemTypes = normalizeBrowsableGenreItemTypes(includeItemTypes);
-            final pageCount = (existingCount / _defaultLimit).ceil();
-            final startIndex = pageCount * _defaultLimit;
-            final response = await session.client.itemsApi.getGenres(
-              sortBy: sortBy,
-              sortOrder: 'Ascending',
-              recursive: true,
-              startIndex: startIndex,
-              limit: _defaultLimit,
-              fields: 'ItemCounts',
-              includeItemTypes: browseItemTypes,
-            );
-            return _buildBrowsableGenresForSession(
-              session,
-              response,
-              includeItemTypes: browseItemTypes,
-            );
+            if (row.id == 'genres') {
+              final pageCount = (startIndex / _defaultLimit).ceil();
+              final targetStartIndex = pageCount * _defaultLimit;
+              _rowOffsets[cacheKey] = targetStartIndex + _defaultLimit;
+
+              final response = await session.client.itemsApi.getGenres(
+                sortBy: sortBy,
+                sortOrder: 'Ascending',
+                recursive: true,
+                startIndex: targetStartIndex,
+                limit: _defaultLimit,
+                fields: 'ItemCounts',
+                includeItemTypes: browseItemTypes,
+              );
+              final items = await _buildBrowsableGenresForSession(
+                session,
+                response,
+                includeItemTypes: browseItemTypes,
+              );
+              _rowTotals[cacheKey] = response['TotalRecordCount'] as int? ?? items.length;
+              return items;
+            } else {
+              _rowOffsets[cacheKey] = startIndex + _defaultLimit;
+
+              final response = await session.client.itemsApi.getItems(
+                genreIds: [row.id],
+                sortBy: sortBy,
+                sortOrder: 'Ascending',
+                recursive: true,
+                startIndex: startIndex,
+                limit: _defaultLimit,
+                includeItemTypes: includeItemTypes,
+                excludeItemTypes: const ['Episode'],
+                fields: _fields,
+                enableImageTypes: _imageTypes,
+                imageTypeLimit: _imageTypeLimit,
+              );
+              final items = _parseItems(response, serverId);
+              _rowTotals[cacheKey] = response['TotalRecordCount'] as int? ?? items.length;
+              return items;
+            }
           case HomeRowType.latestMedia:
             if (row.id.startsWith('latest_')) {
               final parts = row.id.split('_');
@@ -492,17 +539,26 @@ class MultiServerRepository {
                 final parentId = parts[2];
                 if (serverId != rowServerId) return const <AggregatedItem>[];
 
+                _rowOffsets[cacheKey] = startIndex + _defaultLimit;
+                final targetLimit = startIndex + _defaultLimit;
+
                 final response = await session.client.itemsApi.getLatestItems(
                   parentId: parentId,
-                  limit: row.items.length + _defaultLimit,
+                  limit: targetLimit,
                   fields: _fields,
                   enableImageTypes: _imageTypes,
                   imageTypeLimit: _imageTypeLimit,
                 );
-                return normalizeLatestMediaItems(
+                final items = normalizeLatestMediaItems(
                   _parseItems(response, serverId),
-                  limit: row.items.length + _defaultLimit,
+                  limit: targetLimit,
                 );
+                if (items.length <= existingCount) {
+                  _rowTotals[cacheKey] = items.length;
+                } else {
+                  _rowTotals[cacheKey] = response['TotalRecordCount'] as int? ?? _maxItems;
+                }
+                return items;
               }
             }
             return const <AggregatedItem>[];
@@ -513,26 +569,37 @@ class MultiServerRepository {
     );
 
     final newItems = results.expand((e) => e).toList();
-    if (newItems.isEmpty) return row.items;
+    if (newItems.isEmpty) return (row.items, row.totalCount);
 
     // Merge and sort
     final combined = [...row.items, ...newItems];
 
+    // Deduplicate unique items
+    final seen = <String>{};
+    final uniqueCombined = combined.where((item) => seen.add('${item.serverId}_${item.id}')).toList();
+
+    final List<AggregatedItem> sortedCombined;
     if (row.rowType == HomeRowType.playlists || row.rowType == HomeRowType.latestMedia) {
       if (row.rowType == HomeRowType.playlists) {
-        combined.sort((a, b) => a.name.compareTo(b.name));
+        uniqueCombined.sort((a, b) => a.name.compareTo(b.name));
       }
-      return combined;
+      sortedCombined = uniqueCombined;
+    } else {
+      final sortBy = switch (row.rowType) {
+        HomeRowType.favorites => prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ?? _defaultSortBy,
+        HomeRowType.collections => prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ?? _defaultSortBy,
+        HomeRowType.genres => prefs?.get(UserPreferences.genresRowSortBy).apiValue ?? _defaultSortBy,
+        _ => _defaultSortBy,
+      };
+
+      sortedCombined = _sortAggregatedItems(uniqueCombined, sortBy: sortBy, sortOrder: 'Ascending');
     }
 
-    final sortBy = switch (row.rowType) {
-      HomeRowType.favorites => prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ?? _defaultSortBy,
-      HomeRowType.collections => prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ?? _defaultSortBy,
-      HomeRowType.genres => prefs?.get(UserPreferences.genresRowSortBy).apiValue ?? _defaultSortBy,
-      _ => _defaultSortBy,
-    };
+    final totalCount = sessions.fold<int>(0, (sum, session) {
+      return sum + (_rowTotals['${row.id}_${session.server.id}'] ?? 0);
+    });
 
-    return _sortAggregatedItems(combined, sortBy: sortBy, sortOrder: 'Ascending');
+    return (sortedCombined, totalCount);
   }
 
   Future<HomeRow> _getAggregatedSortedItemsRow({
@@ -563,7 +630,9 @@ class MultiServerRepository {
             enableImageTypes: _imageTypes,
             imageTypeLimit: _imageTypeLimit,
           );
-          return _parseItems(response, session.server.id);
+          final items = _parseItems(response, session.server.id);
+          _rowTotals['${id}_${session.server.id}'] = response['TotalRecordCount'] as int? ?? items.length;
+          return items;
         }, label: '$logPrefix from ${session.server.name}'),
       ),
     );
@@ -575,7 +644,9 @@ class MultiServerRepository {
     );
 
     final takenItems = all.take(limit).toList();
-    final totalCount = takenItems.length < limit ? takenItems.length : _maxItems;
+    final totalCount = sessions.fold<int>(0, (sum, session) {
+      return sum + (_rowTotals['${id}_${session.server.id}'] ?? 0);
+    });
 
     return HomeRow(
       id: id,
@@ -677,6 +748,7 @@ class MultiServerRepository {
             );
             if (items.isNotEmpty) {
               final totalCount = items.length < _defaultLimit ? items.length : _maxItems;
+              _rowTotals['latest_${session.server.id}_${id}_${session.server.id}'] = totalCount;
               rows.add(
                 HomeRow(
                   id: 'latest_${session.server.id}_$id',

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 
 import '../../preference/home_section_config.dart';
 import '../../preference/user_preferences.dart';
+import '../../preference/preference_constants.dart';
 import '../../l10n/app_localizations.dart';
 import '../../l10n/current_app_localizations.dart';
 import '../models/aggregated_item.dart';
@@ -607,19 +608,6 @@ class RowDataSource {
     );
   }
 
-  List<String>? _favoriteItemTypesForId(String id) {
-    return switch (id) {
-      'favorites_movies' => ['Movie'],
-      'favorites_series' => ['Series'],
-      'favorites_episodes' => ['Episode'],
-      'favorites_people' => ['Person'],
-      'favorites_artists' => ['MusicArtist'],
-      'favorites_musicvideos' => ['MusicVideo'],
-      'favorites_albums' => ['MusicAlbum'],
-      'favorites_songs' => ['Audio'],
-      _ => null,
-    };
-  }
 
   _ParsedStableId? _parseStableId(String id) {
     if (!id.startsWith('pluginDynamic:')) return null;
@@ -649,20 +637,24 @@ class RowDataSource {
     );
   }
 
-  Future<List<AggregatedItem>> loadMore({
+  Future<(List<AggregatedItem>, int)> loadMore({
     required HomeRow row,
     required String serverId,
+    int? offset,
   }) async {
-    if (!row.hasMore || row.items.length >= _maxItems) return row.items;
+    if (!row.hasMore || row.items.length >= _maxItems) {
+      return (row.items, row.totalCount);
+    }
 
     final prefs = GetIt.instance.isRegistered<UserPreferences>()
         ? GetIt.instance<UserPreferences>()
         : null;
     Map<String, dynamic> response;
+    final currentOffset = offset ?? row.items.length;
 
     switch (row.rowType) {
       case HomeRowType.playlists:
-        final pageCount = (row.items.length / _defaultLimit).ceil();
+        final pageCount = (currentOffset / _defaultLimit).ceil();
         final startIndex = pageCount * _defaultLimit;
         response = await _getItemsWithFallback(
           includeItemTypes: ['Playlist'],
@@ -675,11 +667,11 @@ class RowDataSource {
       case HomeRowType.favorites:
         final sortBy = prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ?? _defaultSortBy;
         response = await _getItemsWithFallback(
-          includeItemTypes: _favoriteItemTypesForId(row.id),
+          includeItemTypes: FavoriteTypeFilter.fromRowId(row.id).itemTypes,
           sortBy: sortBy,
           sortOrder: 'Ascending',
           recursive: true,
-          startIndex: row.items.length,
+          startIndex: currentOffset,
           limit: _defaultLimit,
           isFavorite: true,
         );
@@ -696,7 +688,7 @@ class RowDataSource {
           sortBy: sortBy,
           sortOrder: 'Ascending',
           recursive: true,
-          startIndex: row.items.length,
+          startIndex: currentOffset,
           limit: _defaultLimit,
         );
       case HomeRowType.genres:
@@ -705,7 +697,7 @@ class RowDataSource {
         final parsed = _parseStableId(row.id);
         if (row.id == 'genres') {
           final browseItemTypes = normalizeBrowsableGenreItemTypes(includeItemTypes);
-          final pageCount = (row.items.length / _defaultLimit).ceil();
+          final pageCount = (currentOffset / _defaultLimit).ceil();
           final startIndex = pageCount * _defaultLimit;
           try {
             response = await _client.itemsApi.getGenres(
@@ -734,7 +726,8 @@ class RowDataSource {
             includeItemTypes: browseItemTypes,
           );
           final newItems = _parseItems(enrichedResponse, serverId);
-          return [...row.items, ...newItems];
+          final totalCount = enrichedResponse['TotalRecordCount'] as int? ?? (row.items.length + newItems.length);
+          return ([...row.items, ...newItems], totalCount);
         } else {
           final genreId = (parsed != null && parsed.source == HomeSectionPluginSource.genres)
               ? parsed.additionalData
@@ -744,7 +737,7 @@ class RowDataSource {
             sortBy: sortBy,
             sortOrder: 'Ascending',
             recursive: true,
-            startIndex: row.items.length,
+            startIndex: currentOffset,
             limit: _defaultLimit,
             includeItemTypes: includeItemTypes,
             excludeItemTypes: const ['Episode'],
@@ -755,13 +748,14 @@ class RowDataSource {
           final parentId = row.id.substring('latest_'.length);
           final response = await _getLatestItemsWithFallback(
             parentId: parentId,
-            limit: row.items.length + _defaultLimit,
+            limit: currentOffset + _defaultLimit,
           );
           final items = normalizeLatestMediaItems(
             _parseItems(response, serverId),
-            limit: row.items.length + _defaultLimit,
+            limit: currentOffset + _defaultLimit,
           );
-          return items;
+          final totalCount = items.length <= row.items.length ? items.length : _maxItems;
+          return (items, totalCount);
         } else if (row.id.startsWith('favorites_')) {
           final parentId = row.id.substring('favorites_'.length);
           response = await _getItemsWithFallback(
@@ -770,7 +764,7 @@ class RowDataSource {
             sortBy: 'SortName',
             sortOrder: 'Ascending',
             recursive: true,
-            startIndex: row.items.length,
+            startIndex: currentOffset,
             limit: _defaultLimit,
           );
         } else if (row.id.startsWith('collections_')) {
@@ -781,7 +775,7 @@ class RowDataSource {
             sortBy: 'SortName',
             sortOrder: 'Ascending',
             recursive: true,
-            startIndex: row.items.length,
+            startIndex: currentOffset,
             limit: _defaultLimit,
           );
         } else if (row.id.startsWith('lastPlayed_')) {
@@ -792,7 +786,7 @@ class RowDataSource {
             sortOrder: 'Descending',
             filters: const ['IsPlayed'],
             recursive: true,
-            startIndex: row.items.length,
+            startIndex: currentOffset,
             limit: _defaultLimit,
           );
         } else if (row.id.startsWith('albumartist_')) {
@@ -803,7 +797,7 @@ class RowDataSource {
             sortBy: 'SortName',
             sortOrder: 'Ascending',
             recursive: true,
-            startIndex: row.items.length,
+            startIndex: currentOffset,
             limit: _defaultLimit,
             fields: 'PrimaryImageAspectRatio,SortName',
           );
@@ -819,11 +813,11 @@ class RowDataSource {
               sortBy: 'SortName',
               sortOrder: 'Ascending',
               recursive: true,
-              startIndex: row.items.length,
+              startIndex: currentOffset,
               limit: _defaultLimit,
             );
           } else {
-            return row.items;
+            return (row.items, row.totalCount);
           }
         }
       case HomeRowType.resume:
@@ -836,7 +830,7 @@ class RowDataSource {
       case HomeRowType.activeRecordings:
       case HomeRowType.mediaBar:
       case HomeRowType.pluginDynamic:
-        return row.items;
+        return (row.items, row.totalCount);
     }
 
     final newItems =
@@ -851,7 +845,8 @@ class RowDataSource {
                         : null,
               )
             : _parseItems(response, serverId);
-    return [...row.items, ...newItems];
+    final totalCount = response['TotalRecordCount'] as int? ?? (row.items.length + newItems.length);
+    return ([...row.items, ...newItems], totalCount);
   }
 
   Future<Map<String, dynamic>> _getItemsWithFallback({

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -167,7 +167,7 @@ class RowDataSource {
       title: _l10n.latestLibraryName(libraryName),
       items: items,
       rowType: HomeRowType.latestMedia,
-      totalCount: items.length,
+      totalCount: items.length < _defaultLimit ? items.length : _maxItems,
     );
   }
 
@@ -266,13 +266,15 @@ class RowDataSource {
       includeItemTypes: browseItemTypes,
     );
 
-    return _buildRow(
+    final row = _buildRow(
       id: 'genres',
       title: _l10n.genres,
       response: enrichedResponse,
       serverId: serverId,
       rowType: HomeRowType.genres,
     );
+    final totalCount = row.items.length < _defaultLimit ? row.items.length : _maxItems;
+    return row.copyWith(totalCount: totalCount);
   }
 
   Future<Map<String, dynamic>> _enrichGenreResponseForBrowse(
@@ -376,13 +378,16 @@ class RowDataSource {
     required String rowId,
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
+    int startIndex = 0,
+    int limit = _defaultLimit,
   }) async {
     final response = await _getItemsWithFallback(
       parentId: collectionId,
       sortBy: sortBy,
       sortOrder: sortOrder,
       recursive: true,
-      limit: _defaultLimit,
+      startIndex: startIndex,
+      limit: limit,
     );
     return _buildRow(
       id: rowId,
@@ -401,13 +406,16 @@ class RowDataSource {
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
     List<String>? includeItemTypes,
+    int startIndex = 0,
+    int limit = _defaultLimit,
   }) async {
     final response = await _getItemsWithFallback(
       genreIds: [genreId],
       sortBy: sortBy,
       sortOrder: sortOrder,
       recursive: true,
-      limit: _defaultLimit,
+      startIndex: startIndex,
+      limit: limit,
       includeItemTypes: includeItemTypes,
       excludeItemTypes: const ['Episode'],
     );
@@ -429,13 +437,14 @@ class RowDataSource {
     bool? isFavorite,
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
+    int limit = _defaultLimit,
   }) async {
     final response = await _getItemsWithFallback(
       includeItemTypes: includeItemTypes,
       sortBy: sortBy,
       sortOrder: sortOrder,
       recursive: true,
-      limit: _defaultLimit,
+      limit: limit,
       isFavorite: isFavorite,
     );
     return _buildRow(
@@ -598,31 +607,228 @@ class RowDataSource {
     );
   }
 
+  List<String>? _favoriteItemTypesForId(String id) {
+    return switch (id) {
+      'favorites_movies' => ['Movie'],
+      'favorites_series' => ['Series'],
+      'favorites_episodes' => ['Episode'],
+      'favorites_people' => ['Person'],
+      'favorites_artists' => ['MusicArtist'],
+      'favorites_musicvideos' => ['MusicVideo'],
+      'favorites_albums' => ['MusicAlbum'],
+      'favorites_songs' => ['Audio'],
+      _ => null,
+    };
+  }
+
+  _ParsedStableId? _parseStableId(String id) {
+    if (!id.startsWith('pluginDynamic:')) return null;
+    final lastColon = id.lastIndexOf(':');
+    if (lastColon < 0) return null;
+    final additionalData = id.substring(lastColon + 1);
+
+    final rest = id.substring(0, lastColon);
+    final secondLastColon = rest.lastIndexOf(':');
+    if (secondLastColon < 0) return null;
+    final section = rest.substring(secondLastColon + 1);
+
+    final rest2 = rest.substring(0, secondLastColon);
+    const prefix = 'pluginDynamic:';
+    if (rest2.length <= prefix.length) return null;
+    final sub = rest2.substring(prefix.length);
+    final sourceEnd = sub.indexOf(':');
+    if (sourceEnd < 0) return null;
+    final sourceName = sub.substring(0, sourceEnd);
+    final serverIdPart = sub.substring(sourceEnd + 1);
+
+    return _ParsedStableId(
+      source: HomeSectionPluginSource.fromSerialized(sourceName),
+      serverId: serverIdPart,
+      section: section,
+      additionalData: additionalData,
+    );
+  }
+
   Future<List<AggregatedItem>> loadMore({
     required HomeRow row,
     required String serverId,
   }) async {
     if (!row.hasMore || row.items.length >= _maxItems) return row.items;
 
+    final prefs = GetIt.instance.isRegistered<UserPreferences>()
+        ? GetIt.instance<UserPreferences>()
+        : null;
     Map<String, dynamic> response;
 
     switch (row.rowType) {
       case HomeRowType.playlists:
+        final pageCount = (row.items.length / _defaultLimit).ceil();
+        final startIndex = pageCount * _defaultLimit;
         response = await _getItemsWithFallback(
           includeItemTypes: ['Playlist'],
           sortBy: 'SortName',
           sortOrder: 'Ascending',
           recursive: true,
+          startIndex: startIndex,
+          limit: _defaultLimit,
+        );
+      case HomeRowType.favorites:
+        final sortBy = prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ?? _defaultSortBy;
+        response = await _getItemsWithFallback(
+          includeItemTypes: _favoriteItemTypesForId(row.id),
+          sortBy: sortBy,
+          sortOrder: 'Ascending',
+          recursive: true,
+          startIndex: row.items.length,
+          limit: _defaultLimit,
+          isFavorite: true,
+        );
+      case HomeRowType.collections:
+        final sortBy = prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ?? _defaultSortBy;
+        final parsed = _parseStableId(row.id);
+        final parentId = (parsed != null && parsed.source == HomeSectionPluginSource.collections)
+            ? parsed.additionalData
+            : (row.id == 'collections' ? null : row.id);
+        final includeItemTypes = row.id == 'collections' ? const ['BoxSet'] : null;
+        response = await _getItemsWithFallback(
+          parentId: parentId,
+          includeItemTypes: includeItemTypes,
+          sortBy: sortBy,
+          sortOrder: 'Ascending',
+          recursive: true,
           startIndex: row.items.length,
           limit: _defaultLimit,
         );
+      case HomeRowType.genres:
+        final sortBy = prefs?.get(UserPreferences.genresRowSortBy).apiValue ?? _defaultSortBy;
+        final includeItemTypes = prefs?.get(UserPreferences.genresRowItemFilter).includeItemTypes;
+        final parsed = _parseStableId(row.id);
+        if (row.id == 'genres') {
+          final browseItemTypes = normalizeBrowsableGenreItemTypes(includeItemTypes);
+          final pageCount = (row.items.length / _defaultLimit).ceil();
+          final startIndex = pageCount * _defaultLimit;
+          try {
+            response = await _client.itemsApi.getGenres(
+              sortBy: sortBy,
+              sortOrder: 'Ascending',
+              recursive: true,
+              startIndex: startIndex,
+              limit: _defaultLimit,
+              fields: 'ItemCounts',
+              includeItemTypes: browseItemTypes,
+            );
+          } on DioException catch (e) {
+            final statusCode = e.response?.statusCode ?? 0;
+            if (statusCode < 500) rethrow;
+            response = await _client.itemsApi.getGenres(
+              sortBy: sortBy,
+              sortOrder: 'Ascending',
+              recursive: true,
+              startIndex: startIndex,
+              limit: _defaultLimit,
+              includeItemTypes: browseItemTypes,
+            );
+          }
+          final enrichedResponse = await _enrichGenreResponseForBrowse(
+            response,
+            includeItemTypes: browseItemTypes,
+          );
+          final newItems = _parseItems(enrichedResponse, serverId);
+          return [...row.items, ...newItems];
+        } else {
+          final genreId = (parsed != null && parsed.source == HomeSectionPluginSource.genres)
+              ? parsed.additionalData
+              : row.id;
+          response = await _getItemsWithFallback(
+            genreIds: [genreId],
+            sortBy: sortBy,
+            sortOrder: 'Ascending',
+            recursive: true,
+            startIndex: row.items.length,
+            limit: _defaultLimit,
+            includeItemTypes: includeItemTypes,
+            excludeItemTypes: const ['Episode'],
+          );
+        }
+      case HomeRowType.latestMedia:
+        if (row.id.startsWith('latest_')) {
+          final parentId = row.id.substring('latest_'.length);
+          final response = await _getLatestItemsWithFallback(
+            parentId: parentId,
+            limit: row.items.length + _defaultLimit,
+          );
+          final items = normalizeLatestMediaItems(
+            _parseItems(response, serverId),
+            limit: row.items.length + _defaultLimit,
+          );
+          return items;
+        } else if (row.id.startsWith('favorites_')) {
+          final parentId = row.id.substring('favorites_'.length);
+          response = await _getItemsWithFallback(
+            parentId: parentId,
+            isFavorite: true,
+            sortBy: 'SortName',
+            sortOrder: 'Ascending',
+            recursive: true,
+            startIndex: row.items.length,
+            limit: _defaultLimit,
+          );
+        } else if (row.id.startsWith('collections_')) {
+          final parentId = row.id.substring('collections_'.length);
+          response = await _getItemsWithFallback(
+            parentId: parentId,
+            includeItemTypes: const ['BoxSet'],
+            sortBy: 'SortName',
+            sortOrder: 'Ascending',
+            recursive: true,
+            startIndex: row.items.length,
+            limit: _defaultLimit,
+          );
+        } else if (row.id.startsWith('lastPlayed_')) {
+          final parentId = row.id.substring('lastPlayed_'.length);
+          response = await _getItemsWithFallback(
+            parentId: parentId,
+            sortBy: 'DatePlayed',
+            sortOrder: 'Descending',
+            filters: const ['IsPlayed'],
+            recursive: true,
+            startIndex: row.items.length,
+            limit: _defaultLimit,
+          );
+        } else if (row.id.startsWith('albumartist_')) {
+          final parentId = row.id.substring('albumartist_'.length);
+          response = await _client.itemsApi.getAlbumArtists(
+            parentId: parentId,
+            userId: _client.userId,
+            sortBy: 'SortName',
+            sortOrder: 'Ascending',
+            recursive: true,
+            startIndex: row.items.length,
+            limit: _defaultLimit,
+            fields: 'PrimaryImageAspectRatio,SortName',
+          );
+        } else {
+          final underscoreIndex = row.id.indexOf('_');
+          if (underscoreIndex >= 0) {
+            final type = row.id.substring(0, underscoreIndex);
+            final parentId = row.id.substring(underscoreIndex + 1);
+            final itemType = type.isEmpty ? '' : '${type[0].toUpperCase()}${type.substring(1)}';
+            response = await _getItemsWithFallback(
+              parentId: parentId,
+              includeItemTypes: [itemType],
+              sortBy: 'SortName',
+              sortOrder: 'Ascending',
+              recursive: true,
+              startIndex: row.items.length,
+              limit: _defaultLimit,
+            );
+          } else {
+            return row.items;
+          }
+        }
       case HomeRowType.resume:
       case HomeRowType.resumeAudio:
       case HomeRowType.nextUp:
-      case HomeRowType.latestMedia:
-      case HomeRowType.favorites:
-      case HomeRowType.collections:
-      case HomeRowType.genres:
       case HomeRowType.libraryTiles:
       case HomeRowType.libraryTilesSmall:
       case HomeRowType.liveTv:
@@ -636,14 +842,14 @@ class RowDataSource {
     final newItems =
         row.rowType == HomeRowType.playlists
             ? await filterBrowsablePlaylists(
-              _client,
-              _parseItems(response, serverId),
-              mediaType:
-                  row.items.isNotEmpty &&
-                          row.items.every(isAudioPlaylistSummary)
-                      ? 'Audio'
-                      : null,
-            )
+                _client,
+                _parseItems(response, serverId),
+                mediaType:
+                    row.items.isNotEmpty &&
+                            row.items.every(isAudioPlaylistSummary)
+                        ? 'Audio'
+                        : null,
+              )
             : _parseItems(response, serverId);
     return [...row.items, ...newItems];
   }
@@ -1074,7 +1280,7 @@ class RowDataSource {
 
   Future<Map<String, dynamic>?> _runKefinSpec(Map<String, dynamic> spec) async {
     final kind = spec['kind']?.toString() ?? '';
-    final limit = (spec['limit'] as num?)?.toInt() ?? _defaultLimit;
+    final limit = (spec['limit'] as num?)?.toInt() ?? 200;
     switch (kind) {
       case 'recentlyReleasedMovies':
         return _client.itemsApi.getItems(
@@ -1384,4 +1590,18 @@ class RowDataSource {
         .where((e) => e.isNotEmpty)
         .toSet();
   }
+}
+
+class _ParsedStableId {
+  final HomeSectionPluginSource source;
+  final String serverId;
+  final String section;
+  final String additionalData;
+
+  _ParsedStableId({
+    required this.source,
+    required this.serverId,
+    required this.section,
+    required this.additionalData,
+  });
 }

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -301,6 +301,20 @@ enum FavoriteTypeFilter {
     musicArtist => ['MusicArtist'],
     audio => ['Audio'],
   };
+
+  static FavoriteTypeFilter fromRowId(String id) {
+    return switch (id) {
+      'favorites_movies' => FavoriteTypeFilter.movie,
+      'favorites_series' => FavoriteTypeFilter.series,
+      'favorites_episodes' => FavoriteTypeFilter.episode,
+      'favorites_people' => FavoriteTypeFilter.person,
+      'favorites_artists' => FavoriteTypeFilter.musicArtist,
+      'favorites_musicvideos' => FavoriteTypeFilter.musicVideo,
+      'favorites_albums' => FavoriteTypeFilter.musicAlbum,
+      'favorites_songs' => FavoriteTypeFilter.audio,
+      _ => FavoriteTypeFilter.all,
+    };
+  }
 }
 
 enum SeerrFetchLimit {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2796,7 +2796,7 @@ class _ContentRowsState extends State<_ContentRows>
           isUp: isUp,
         ),
         onLeftEdge: _onRowLeftEdge,
-        onIndexChanged: (_, item) {
+        onIndexChanged: (index, item) {
           final forceReveal = _forceRevealOnNextRowFocusFromMediaBar;
           _forceRevealOnNextRowFocusFromMediaBar = false;
           widget.onItemSelected(item);
@@ -2815,6 +2815,9 @@ class _ContentRowsState extends State<_ContentRows>
           } else {
             _finishSharedPreview();
           }
+          if (index >= row.items.length - 8) {
+            widget.viewModel.loadMoreForRow(rowIndex);
+          }
         },
         onLongPress: (_, item) => showContextMenu(
           context,
@@ -2825,7 +2828,7 @@ class _ContentRowsState extends State<_ContentRows>
           _finishSharedPreview(releaseResources: true);
           if (row.rowType == HomeRowType.libraryTiles) {
             _navigateToLibrary(context, item);
-          } else if (row.rowType == HomeRowType.genres) {
+          } else if (row.rowType == HomeRowType.genres && row.id == 'genres') {
             context.push(Destinations.genre(item.name, genreId: item.id));
           } else {
             context.push(Destinations.itemOrPhoto(
@@ -2916,7 +2919,7 @@ class _ContentRowsState extends State<_ContentRows>
           void navigateToItem() {
             if (row.rowType == HomeRowType.libraryTiles) {
               _navigateToLibrary(context, item);
-            } else if (row.rowType == HomeRowType.genres) {
+            } else if (row.rowType == HomeRowType.genres && row.id == 'genres') {
               context.push(Destinations.genre(item.name, genreId: item.id));
             } else {
               context.push(Destinations.itemOrPhoto(

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -24,6 +24,7 @@ class HomeViewModel extends ChangeNotifier {
   final MultiServerRepository _multiServerRepo;
   final HomeRowCacheStore _cacheStore = HomeRowCacheStore();
   final Set<String> _inFlightPagingRowIds = {};
+  final Map<String, int> _rowOffsets = {};
 
   List<HomeRow> _rows = [];
   List<HomeRow> get rows => _rows;
@@ -96,6 +97,8 @@ class HomeViewModel extends ChangeNotifier {
     }
     _isLoading = true;
     notifyListeners();
+    _rowOffsets.clear();
+    _multiServerRepo.clearOffsets();
     try {
       var hydratedFromCache = false;
       if (_rows.isEmpty) {
@@ -345,14 +348,17 @@ class HomeViewModel extends ChangeNotifier {
 
     _inFlightPagingRowIds.add(row.id);
     try {
-      final List<AggregatedItem> items;
+      final int currentOffset = _rowOffsets[row.id] ?? row.items.length;
+      final (List<AggregatedItem> items, int totalCount) result;
       if (_multiServerEnabled && !row.id.startsWith('pluginDynamic:')) {
-        items = await _multiServerRepo.loadMore(row: row);
+        result = await _multiServerRepo.loadMore(row: row);
       } else {
-        items = await _dataSource.loadMore(row: row, serverId: _serverId);
+        result = await _dataSource.loadMore(row: row, serverId: _serverId, offset: currentOffset);
       }
+      _rowOffsets[row.id] = currentOffset + 15;
+
       _rows = List.of(_rows);
-      _rows[rowIndex] = row.copyWith(items: items);
+      _rows[rowIndex] = row.copyWith(items: result.$1, totalCount: result.$2);
       notifyListeners();
     } catch (_) {
     } finally {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -23,6 +23,7 @@ class HomeViewModel extends ChangeNotifier {
   final MediaBarViewModel _mediaBarViewModel;
   final MultiServerRepository _multiServerRepo;
   final HomeRowCacheStore _cacheStore = HomeRowCacheStore();
+  final Set<String> _inFlightPagingRowIds = {};
 
   List<HomeRow> _rows = [];
   List<HomeRow> get rows => _rows;
@@ -340,14 +341,23 @@ class HomeViewModel extends ChangeNotifier {
   Future<void> loadMoreForRow(int rowIndex) async {
     if (rowIndex < 0 || rowIndex >= _rows.length) return;
     final row = _rows[rowIndex];
-    if (!row.hasMore) return;
+    if (!row.hasMore || _inFlightPagingRowIds.contains(row.id)) return;
 
+    _inFlightPagingRowIds.add(row.id);
     try {
-      final items = await _dataSource.loadMore(row: row, serverId: _serverId);
+      final List<AggregatedItem> items;
+      if (_multiServerEnabled && !row.id.startsWith('pluginDynamic:')) {
+        items = await _multiServerRepo.loadMore(row: row);
+      } else {
+        items = await _dataSource.loadMore(row: row, serverId: _serverId);
+      }
       _rows = List.of(_rows);
       _rows[rowIndex] = row.copyWith(items: items);
       notifyListeners();
-    } catch (_) {}
+    } catch (_) {
+    } finally {
+      _inFlightPagingRowIds.remove(row.id);
+    }
   }
 
   Future<List<HomeRow>> _loadConfig(HomeSectionConfig cfg) async {


### PR DESCRIPTION
# Pull Request: The Lazy Loader

## Summary
Add seamless horizontal infinite scrolling (lazy loading) for all paginatable built-in home screen rows (Playlists, Favorites, Collections, Genres, and Latest Media) under both single-server and multi-server library modes. Bonus: ensure they are properly linked to their Media Details view.

## Related Issues
- Related to Randall's request

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Initial Limits**: Committed to initial load limit to `_defaultLimit` (15) for core and custom collection, genre, and favorite row loading methods.
- **Scroll Pagination Trigger**: Updated `LockedFocusRow` in `home_screen.dart` to automatically trigger `loadMoreForRow` when the focused item index is at the end of the row.
- **Unified Offset Tracking**: Integrated offset pagination for `loadMore` queries in `RowDataSource` and `MultiServerRepository` (aggregating query offsets per active server using the current count of items from that server in the combined row).
- **Offset Alignment (Duplicates Fix)**: Aligned page-based offsets to multiples of the default page size (`_defaultLimit`) for `Playlists` and `Genres` queries to prevent item overlaps caused by local client-side filtering.
- **Stable ID Parsing Fix**: Switched `_parseStableId` parsing to a right-to-left method (`lastIndexOf(':')`) to support server URLs containing colons (e.g. `http://...`) without corrupting genre/collection IDs.
- **Genres/Aggregated Rows `totalCount` Fix**: Fixed `totalCount` properties in `RowDataSource.loadGenres` and aggregated row builders to correctly enable scroll pagination.

## Platform
- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Perform clean build and deploy the `androidTv-beta` APK to Nvidia Shield TV.
2. Scroll through home screen rows (Genres, Latest Media, Playlists, Favorites).
3. Scroll horizontally near the end of any custom or core row to verify that additional items load and append seamlessly without duplicates.

### Screenshot
Showing the end of the Genres row (27 items):
<img width="500" alt="Shield_Screenshot_2026-06-03_01-21-31" src="https://github.com/user-attachments/assets/ad74661c-819c-4b5a-9272-d1ae0c818418" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
