### PR TITLE
Pull Request for Collections Support in Media Bar

### DIFF
--- a/lib/data/repositories/media_bar_repository.dart
+++ b/lib/data/repositories/media_bar_repository.dart
@@ -68,7 +68,7 @@ class MediaBarRepository {
 
       final fetchTasks = <Future<List<Map<String, dynamic>>>>[];
 
-      if (libraryIds.isEmpty) {
+      if (libraryIds.isEmpty && collectionIds.isEmpty) {
         fetchTasks.add(_fetchItems(includeTypes, fetchLimit));
       } else {
         for (final libraryId in libraryIds) {

--- a/lib/ui/screens/settings/media_bar_settings_screen.dart
+++ b/lib/ui/screens/settings/media_bar_settings_screen.dart
@@ -199,8 +199,9 @@ class _MediaBarSettingsScreenState extends State<MediaBarSettingsScreen> {
     return showFocusRestoringDialog<Set<String>>(
       context: context,
       useRootNavigator: false,
-      builder: (ctx) {
-        final closeOnce = createDialogBackCloseHandler(ctx);
+      builder: (dialogContext) {
+        var popped = false;
+        final closeOnce = createDialogBackCloseHandler(dialogContext);
         return Focus(
           canRequestFocus: false,
           skipTraversal: true,
@@ -215,8 +216,8 @@ class _MediaBarSettingsScreenState extends State<MediaBarSettingsScreen> {
           child: FocusScope(
             autofocus: true,
             child: StatefulBuilder(
-              builder: (ctx, setDialogState) => withCleanSettingsTypography(
-                ctx,
+              builder: (builderContext, setDialogState) => withCleanSettingsTypography(
+                builderContext,
                 AlertDialog(
                   title: Text(title),
                   content: SizedBox(
@@ -240,30 +241,35 @@ class _MediaBarSettingsScreenState extends State<MediaBarSettingsScreen> {
                                 setDialogState(() => working.clear());
                               },
                               child: Text(l10n.clear),
-                            ),
+                                  ),
                           ],
                         ),
                         Flexible(
                           child: ListView(
                             shrinkWrap: true,
-                            children: orderedEntries.map((e) {
-                              return CheckboxListTile(
-                                dense: true,
-                                visualDensity: VisualDensity.compact,
-                                contentPadding: EdgeInsets.zero,
-                                controlAffinity:
-                                    ListTileControlAffinity.leading,
-                                title: Text(e.value),
-                                value: working.contains(e.key),
-                                onChanged: (checked) {
-                                  setDialogState(() {
-                                    if (checked == true) {
-                                      working.add(e.key);
-                                    } else {
-                                      working.remove(e.key);
-                                    }
-                                  });
-                                },
+                            children: orderedEntries.asMap().entries.map((entry) {
+                              final i = entry.key;
+                              final e = entry.value;
+                              return TvFocusHighlight(
+                                builder: (ctx, focused) => CheckboxListTile(
+                                  autofocus: i == 0,
+                                  dense: true,
+                                  visualDensity: VisualDensity.compact,
+                                  contentPadding: EdgeInsets.zero,
+                                  controlAffinity:
+                                      ListTileControlAffinity.leading,
+                                  title: Text(e.value),
+                                  value: working.contains(e.key),
+                                  onChanged: (checked) {
+                                    setDialogState(() {
+                                      if (checked == true) {
+                                        working.add(e.key);
+                                      } else {
+                                        working.remove(e.key);
+                                      }
+                                    });
+                                  },
+                                ),
                               );
                             }).toList(),
                           ),
@@ -273,11 +279,19 @@ class _MediaBarSettingsScreenState extends State<MediaBarSettingsScreen> {
                   ),
                   actions: [
                     TextButton(
-                      onPressed: () => Navigator.pop(ctx),
+                      onPressed: () {
+                        if (popped) return;
+                        popped = true;
+                        Navigator.pop(dialogContext);
+                      },
                       child: Text(l10n.cancel),
                     ),
                     FilledButton(
-                      onPressed: () => Navigator.pop(ctx, working),
+                      onPressed: () {
+                        if (popped) return;
+                        popped = true;
+                        Navigator.pop(dialogContext, working);
+                      },
                       child: Text(l10n.save),
                     ),
                   ],
@@ -348,7 +362,7 @@ class _MediaBarSettingsScreenState extends State<MediaBarSettingsScreen> {
               subtitle: Text(
                 _sourceSubtitle(
                   UserPreferences.mediaBarLibraryIds,
-                  l10n.allLibraries,
+                  l10n.noneSelected,
                   l10n,
                 ),
               ),

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -88,7 +88,8 @@ Widget buildSettingsLeadingIconShell(
 
 EdgeInsets _settingsTileOuterPadding(BuildContext context) {
   final inDialog =
-      context.findAncestorWidgetOfExactType<SimpleDialog>() != null;
+      context.findAncestorWidgetOfExactType<SimpleDialog>() != null ||
+      context.findAncestorWidgetOfExactType<AlertDialog>() != null;
   if (inDialog) {
     return const EdgeInsets.symmetric(vertical: 2);
   }


### PR DESCRIPTION
# Pull Request for Collections Support in Media Bar
## Summary
Fixes the collection querying logic in `MediaBarRepository` to ensure the media bar only pulls items from configured source collections instead of defaulting to querying all libraries. Additionally, restores D-pad focus highlight in the multi-select preference dialogs and resolves the double-popping navigation bug when confirming a selection. New logic: If only Collections are selected, media bar will only pull from those Collections (unchecking libraries means they do not get included). If everything is unchecked, media bar defaults to pulling from full library. If a library and a collection are both selected, results are pulled from both (so gives additional weighting to the collection contents).
## Related Issues
- Related to bug discussed on Discord
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):
## Changes Made
- Changed `MediaBarRepository.loadItems` so that it doesn't query library roots if only source collections are configured.
- Wrapped dialog `CheckboxListTile` widgets in `TvFocusHighlight` and enabled `autofocus: true` on the first element so that focus starts inside the checkbox list.
- Replaced direct popping using shadowed contexts with `popped` boolean guard in dialog `onPressed` callbacks to ensure the dialog only pops once and returns back to the Media Bar subpanel (rather than double-popping back to the Dynamic Content page).
- Updated the fallback subtitle label for Source Libraries in `media_bar_settings_screen.dart` from `l10n.allLibraries` to `l10n.noneSelected` when no libraries are selected.

## Platform
- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code
## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):
### Test Steps
1. Navigate to Dynamic Content > Media Bar settings on the TV client.
2. Select "Source Collections", "Source Libraries", or "Excluded Genres" to open a multi-select dialog.
3. Verify that D-pad focus correctly highlights the active checkbox item.
4. Check/uncheck some items, then select "Save" or "Cancel".
5. Verify that clicking "Save" or "Cancel" pops only the dialog, leaving the user on the Media Bar subpanel screen (instead of popping back to Dynamic Content).
6. Verify that only items from the selected collection(s) are drawn for display in the Media Bar.
## Screenshots (if applicable)
<img width="500" alt="2026-06-03_14-50-58_moonfin" src="https://github.com/user-attachments/assets/0295a779-94b4-458a-80f8-5ca9171e656d" />
<img width="500" alt="Shield_Screenshot_2026-06-03_15-49-03" src="https://github.com/user-attachments/assets/2776243f-dad2-4954-b88b-4448de65f99f" />
<img width="500" alt="Shield_Screenshot_2026-06-03_15-49-34" src="https://github.com/user-attachments/assets/f379683f-d420-49dd-8f9f-09a3ac698e51" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
