### PR TITLE
Pull Request for Manual Media Bar Navigation

### DIFF
--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -1518,9 +1518,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
                       child: Center(
                         child: _NavArrow(
                           icon: Icons.chevron_right,
-                          onTap: _currentIndex < items.length - 1
-                              ? () => _goToPage(_currentIndex + 1)
-                              : null,
+                          onTap: () => _goToPage((_currentIndex + 1) % items.length),
                         ),
                       ),
                     ),
@@ -1852,9 +1850,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
                       child: Center(
                         child: _NavArrow(
                           icon: Icons.chevron_right,
-                          onTap: _currentIndex < items.length - 1
-                              ? () => _goToPage(_currentIndex + 1)
-                              : null,
+                          onTap: () => _goToPage((_currentIndex + 1) % items.length),
                         ),
                       ),
                     ),
@@ -1917,7 +1913,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
       return KeyEventResult.handled;
     }
     if (key == LogicalKeyboardKey.arrowRight) {
-      if (_currentIndex < items.length - 1) _goToPage(_currentIndex + 1);
+      _goToPage((_currentIndex + 1) % items.length);
       return KeyEventResult.handled;
     }
     if (key == LogicalKeyboardKey.arrowDown && widget.onNavigateDown != null) {


### PR DESCRIPTION
# Pull Request for Manual Media Bar Navigation
## Summary
Enable right-only cyclical wrapping on the home screen media bar.
## Related Issues
* Closes [GitHub Issue 205](https://github.com/Moonfin-Client/Moonfin-Core/issues/205)
## Type of Change
- [x] UI/UX update
## Changes Made
- Updated right-hand D-pad navigation and slideshow chevrons to wrap from the final slide back to the first item. This mirrors the auto advance behaviour already incorporated in the media bar.
- Preserved left-hand navigation to maintain quick access to the left sidebar menu.
## Platform
- [x] Android (Android TV)
- [x] All / Shared code
## Testing
- [x] Tested on physical device (Nvidia Shield TV Pro)
- [x] Manual testing completed
### Test Steps
1. Navigate to the Home Screen.
2. Focus on the Media Bar.
3. Use the D-pad Right arrow to progress to the last item.
4. Press Right again and verify focus loops back to the first slide.
5. Click/tap the Right chevron button and verify the same loop occurs.
6. Verify pressing Left on the first slide still opens the Left Sidebar.
## Screenshots
I'm at the end!
<img width="500" alt="Shield_Screenshot_2026-06-03_17-09-44" src="https://github.com/user-attachments/assets/188decfa-3933-4a10-869f-b6c0a4855cbe" />
...and back at the beginning!
<img width="500" alt="Shield_Screenshot_2026-06-03_17-09-58" src="https://github.com/user-attachments/assets/55348299-60dd-474e-9c77-4422cc06c0a0" />
## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
