### PR TITLE
Pull Request for Shuffle Logic and Presentation Update

### DIFF
--- a/lib/ui/widgets/shuffle_options_dialog.dart
+++ b/lib/ui/widgets/shuffle_options_dialog.dart
@@ -299,15 +299,20 @@ Future<List<AggregatedItem>> fetchRandomItems({
     final shuffledLibraries = List<AggregatedLibrary>.from(libs)..shuffle();
     final collected = <AggregatedItem>[];
     final seenIds = <String>{};
-    for (final library in shuffledLibraries) {
+    for (var i = 0; i < shuffledLibraries.length; i++) {
       if (collected.length >= limit) break;
+      final library = shuffledLibraries[i];
+      final remainingLibraries = shuffledLibraries.length - i;
+      final needed = limit - collected.length;
+      final targetLimit = (needed / remainingLibraries).ceil();
+
       try {
         final items = await _fetchRandomItemsScoped(
           client: client,
           contentType: contentType,
           parentId: library.id,
           genreName: null,
-          limit: limit,
+          limit: targetLimit,
           fields: fields,
         );
         for (final item in items) {

--- a/lib/ui/widgets/shuffle_overlay.dart
+++ b/lib/ui/widgets/shuffle_overlay.dart
@@ -152,13 +152,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
     Map<String, Object?> context = const <String, Object?>{},
     Object? error,
     StackTrace? stackTrace,
-  }) {
-    final _ = message;
-    final __ = level;
-    final ___ = context;
-    final ____ = error;
-    final _____ = stackTrace;
-  }
+  }) {}
 
   String _describeError(Object error) {
     if (error is TimeoutException) {
@@ -971,14 +965,14 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
     return LayoutBuilder(
       builder: (context, constraints) {
         const posterAspectRatio = 2 / 3;
-        const centerScale = 1.18;
+        const centerScale = 1.3;
         final cardExpansionScale = cardFocusExpansion == true ? 1.05 : 1.0;
         final selectedScale = centerScale * cardExpansionScale;
         final textBlockHeight = isTv ? 8.0 : 6.0;
 
-        final spacing = isTv ? 18.0 : 14.0;
-        final minCardWidth = isTv ? 130.0 : 112.0;
-        final maxCardWidth = isTv ? 250.0 : 220.0;
+        final spacing = isTv ? 24.0 : 18.0;
+        final minCardWidth = isTv ? 190.0 : 160.0;
+        final maxCardWidth = isTv ? 340.0 : 280.0;
 
         final cardsAvailableWidth = math.max(0, constraints.maxWidth - 4);
         final totalSpacing = spacing * (_items.length - 1);
@@ -991,7 +985,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
               )
             : minCardWidth;
 
-        final maxStripHeight = constraints.maxHeight - (isTv ? 64 : 26);
+        final maxStripHeight = constraints.maxHeight - (isTv ? 16 : 8);
         final maxImageHeight = math.max(
           0,
           (maxStripHeight - textBlockHeight) / selectedScale,
@@ -1017,7 +1011,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
                         duration: const Duration(milliseconds: 180),
                         curve: Curves.easeOut,
                         alignment: Alignment.topCenter,
-                        scale: index == _selectedIndex ? centerScale : 0.9,
+                        scale: index == _selectedIndex ? centerScale : 1.00,
                         child: AnimatedOpacity(
                           duration: const Duration(milliseconds: 180),
                           opacity: disablePosterOpacity
@@ -1362,7 +1356,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
         overflow: TextOverflow.ellipsis,
         style: TextStyle(
           color: AppColorScheme.onSurface,
-          fontSize: isMobile ? 22 : 32,
+          fontSize: isMobile ? 22 : 24,
           fontWeight: FontWeight.w800,
           height: 1.05,
         ),

--- a/lib/ui/widgets/shuffle_overlay.dart
+++ b/lib/ui/widgets/shuffle_overlay.dart
@@ -774,7 +774,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
       child: SafeArea(
         minimum: EdgeInsets.symmetric(
           horizontal: isMobile ? 8 : 24,
-          vertical: isMobile ? 8 : 18,
+          vertical: isMobile ? 8 : 8,
         ),
         child: Center(
           child: ConstrainedBox(
@@ -834,9 +834,9 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
                       Padding(
                         padding: EdgeInsets.fromLTRB(
                           isMobile ? 12 : 18,
-                          isMobile ? 10 : 16,
+                          isMobile ? 10 : 10,
                           isMobile ? 12 : 18,
-                          isMobile ? 12 : 16,
+                          isMobile ? 12 : 10,
                         ),
                         child: Column(
                           children: [
@@ -845,11 +845,11 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
                               SizedBox(height: isMobile ? 6 : 8),
                             ],
                             Expanded(child: _buildCardsArea(l10n)),
-                            SizedBox(height: isMobile ? 8 : 10),
+                            SizedBox(height: isMobile ? 8 : 6),
                             _buildFocusHeader(l10n),
-                            SizedBox(height: isMobile ? 6 : 8),
+                            SizedBox(height: isMobile ? 6 : 6),
                             _buildInfoPanel(l10n),
-                            SizedBox(height: isMobile ? 10 : 12),
+                            SizedBox(height: isMobile ? 10 : 8),
                             _buildActionButtons(l10n),
                           ],
                         ),
@@ -970,9 +970,9 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
         final selectedScale = centerScale * cardExpansionScale;
         final textBlockHeight = isTv ? 8.0 : 6.0;
 
-        final spacing = isTv ? 24.0 : 18.0;
-        final minCardWidth = isTv ? 190.0 : 160.0;
-        final maxCardWidth = isTv ? 340.0 : 280.0;
+        final spacing = isTv ? 28.0 : 20.0;
+        final minCardWidth = isTv ? 240.0 : 190.0;
+        final maxCardWidth = isTv ? 400.0 : 320.0;
 
         final cardsAvailableWidth = math.max(0, constraints.maxWidth - 4);
         final totalSpacing = spacing * (_items.length - 1);
@@ -985,7 +985,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
               )
             : minCardWidth;
 
-        final maxStripHeight = constraints.maxHeight - (isTv ? 16 : 8);
+        final maxStripHeight = constraints.maxHeight;
         final maxImageHeight = math.max(
           0,
           (maxStripHeight - textBlockHeight) / selectedScale,
@@ -1371,7 +1371,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
       width: double.infinity,
       padding: EdgeInsets.symmetric(
         horizontal: isMobile ? 12 : 14,
-        vertical: isMobile ? 10 : 12,
+        vertical: isMobile ? 10 : 8,
       ),
       decoration: BoxDecoration(
         color: AppColorScheme.scrim.withValues(alpha: 0.35),
@@ -1462,6 +1462,8 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
       );
     }
 
+    final isMobile = PlatformDetection.useMobileUi;
+    final maxOverviewLines = isMobile ? 3 : 2;
     final overview = (item.overview ?? '').trim();
     final overviewText = overview.isEmpty ? _heroTagline(item) : overview;
     final overviewStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -1471,7 +1473,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
     final overviewFontSize = overviewStyle?.fontSize ?? 12;
     final overviewLineHeight =
         overviewFontSize * (overviewStyle?.height ?? 1.0);
-    final overviewMinHeight = (overviewLineHeight * 3) + 4;
+    final overviewMinHeight = (overviewLineHeight * maxOverviewLines) + 4;
 
     return KeyedSubtree(
       key: ValueKey<String>('${item.serverId}:${item.id}'),
@@ -1495,7 +1497,7 @@ class _ShuffleOverlayState extends State<_ShuffleOverlay> {
               constraints: BoxConstraints(minHeight: overviewMinHeight),
               child: Text(
                 overviewText,
-                maxLines: 3,
+                maxLines: maxOverviewLines,
                 overflow: TextOverflow.ellipsis,
                 style: overviewStyle,
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -902,10 +902,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -980,10 +980,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1744,10 +1744,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
# Pull Request for Shuffle Logic and Presentation Update

## Summary
Implements dynamic quota distribution for library shuffle to ensure mixed content results (movies and TV shows) are returned when Shuffle TV Shows and Movies is requested, and optimizes the TV/Desktop shuffle overlay layout with larger posters and a smaller focused title text.

## Related Issues
* Bug discussed on Discord

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `fetchRandomItems` to dynamically slice target limits for each library as it iterates, preventing the search loop from breaking early with items from only a single library type.
- Increased TV/Desktop poster width bounds, spacing, and center scale ratios.
- Decreased TV/Desktop focused item title font size from 32 to 24 to accommodate larger posters.
- Reverted mobile cardWidth and scale behavior back to original values in `_buildMobileCardsArea`.
- Cleared unused local variables in `_logShuffleEvent` to satisfy analyzer checks.

## Platform
- [x] Android
- [x] All / Shared code

## Testing
- Compiled and built local release APKs for the `androidTv-beta` flavor.
- Deployed to a physical Nvidia Shield TV via ADB.
- Manually verified that the shuffle overlay returns a mixture of movies and series, and that TV/Desktop posters are larger and title text is correctly sized.

### Test Steps
1. Open the Shuffle Overlay on Android TV.
2. Verify that random items show a blended mix of both TV Series and Movies.
3. Observe that poster dimensions are larger on TV/Desktop and the title text is appropriately sized.

## Screenshots 
IS THAT AS BIG AS THEY GO?!

<img width="600" alt="Shield_Screenshot_2026-06-04_13-21-48" src="https://github.com/user-attachments/assets/38e6ca32-07fd-4a23-8b04-cf075ff53e92" />
<img width="600" alt="Shield_Screenshot_2026-06-04_13-23-48" src="https://github.com/user-attachments/assets/52558128-57b1-4eb8-ac15-4891c148671c" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
