### PR TITLE
Automation & Queue Settings Fix

### DIFF
--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -88,74 +88,59 @@ class UserPreferences extends ChangeNotifier {
     return '${serverId}_$userId';
   }
 
-  Preference<String>? _scopedResumeSubtractDurationPreference() {
+  static final Set<String> _scopedPreferenceKeys = {
+    'pref_enable_cinema_mode',
+    'pref_resume_preroll',
+    'media_segment_actions',
+    'pref_autoplay_next_episode',
+    'next_up_behavior',
+    'next_up_timeout',
+    'replace_skip_outro_with_next_up',
+    'enable_still_watching',
+  };
+
+  bool _isScopedPreference<T>(Preference<T> pref) {
+    return _scopedPreferenceKeys.contains(pref.key);
+  }
+
+  Preference<dynamic>? _scopedPreference(Preference<dynamic> pref) {
     final scopeSuffix = _activeProfileScopeSuffix();
     if (scopeSuffix == null) {
       return null;
     }
-    return Preference(
-      key: 'pref_resume_preroll_$scopeSuffix',
-      defaultValue: '0',
-    );
-  }
-
-  Preference<bool>? _scopedCinemaModeEnabledPreference() {
-    final scopeSuffix = _activeProfileScopeSuffix();
-    if (scopeSuffix == null) {
-      return null;
+    final scopedKey = '${pref.key}_$scopeSuffix';
+    if (pref is EnumPreference) {
+      return EnumPreference<Enum>(
+        key: scopedKey,
+        defaultValue: pref.defaultValue,
+        values: pref.values.cast<Enum>(),
+      );
     }
-    return Preference(
-      key: 'pref_enable_cinema_mode_$scopeSuffix',
-      defaultValue: true,
+    return Preference<dynamic>(
+      key: scopedKey,
+      defaultValue: pref.defaultValue,
     );
-  }
-
-  bool _isResumeSubtractDurationPreference<T>(Preference<T> pref) {
-    return pref.key == resumeSubtractDuration.key;
-  }
-
-  bool _isCinemaModeEnabledPreference<T>(Preference<T> pref) {
-    return pref.key == cinemaModeEnabled.key;
   }
 
   T get<T>(Preference<T> pref) {
-    if (_isResumeSubtractDurationPreference(pref)) {
-      final scoped = _scopedResumeSubtractDurationPreference();
+    if (_isScopedPreference(pref)) {
+      final scoped = _scopedPreference(pref);
       if (scoped != null && _store.containsKey(scoped.key)) {
         return _store.get(scoped) as T;
       }
-      return _store.get(resumeSubtractDuration) as T;
-    }
-
-    if (_isCinemaModeEnabledPreference(pref)) {
-      final scoped = _scopedCinemaModeEnabledPreference();
-      if (scoped != null && _store.containsKey(scoped.key)) {
-        return _store.get(scoped) as T;
-      }
-      return _store.get(cinemaModeEnabled) as T;
+      return _store.get(pref);
     }
 
     return _store.get(pref);
   }
 
   Future<void> set<T>(Preference<T> pref, T value) async {
-    if (_isResumeSubtractDurationPreference(pref)) {
-      final scoped = _scopedResumeSubtractDurationPreference();
+    if (_isScopedPreference(pref)) {
+      final scoped = _scopedPreference(pref);
       if (scoped != null) {
-        await _store.set(scoped, value as String);
+        await _store.set(scoped, value);
       } else {
-        await _store.set(resumeSubtractDuration, value as String);
-      }
-      notifyListeners();
-      return;
-    }
-
-    if (_isCinemaModeEnabledPreference(pref)) {
-      final scoped = _scopedCinemaModeEnabledPreference();
-      if (scoped != null) {
-        await _store.set(scoped, value as bool);
-      } else {
-        await _store.set(cinemaModeEnabled, value as bool);
+        await _store.set(pref, value);
       }
       notifyListeners();
       return;
@@ -170,16 +155,10 @@ class UserPreferences extends ChangeNotifier {
   bool containsPreferenceKey(String key) => _store.containsKey(key);
 
   bool containsPreference<T>(Preference<T> pref) {
-    if (_isResumeSubtractDurationPreference(pref)) {
-      final scoped = _scopedResumeSubtractDurationPreference();
+    if (_isScopedPreference(pref)) {
+      final scoped = _scopedPreference(pref);
       return (scoped != null && _store.containsKey(scoped.key)) ||
-          _store.containsKey(resumeSubtractDuration.key);
-    }
-
-    if (_isCinemaModeEnabledPreference(pref)) {
-      final scoped = _scopedCinemaModeEnabledPreference();
-      return (scoped != null && _store.containsKey(scoped.key)) ||
-          _store.containsKey(cinemaModeEnabled.key);
+          _store.containsKey(pref.key);
     }
 
     return _store.containsKey(pref.key);

--- a/lib/ui/widgets/settings/preference_binding.dart
+++ b/lib/ui/widgets/settings/preference_binding.dart
@@ -7,16 +7,14 @@ import 'package:jellyfin_preference/jellyfin_preference.dart';
 import '../../../preference/user_preferences.dart';
 
 class PreferenceBinding<T> extends ValueNotifier<T> {
-  final PreferenceStore _store;
   final Preference<T> _preference;
 
-  PreferenceBinding(this._store, this._preference) : super(_store.get(_preference));
+  PreferenceBinding(PreferenceStore store, this._preference) : super(GetIt.instance<UserPreferences>().get(_preference));
 
   @override
   set value(T newValue) {
     super.value = newValue;
-    unawaited(_store.set(_preference, newValue));
-    GetIt.instance<UserPreferences>().notifyPreferenceChanged();
+    unawaited(GetIt.instance<UserPreferences>().set(_preference, newValue));
   }
 
   void reset() {


### PR DESCRIPTION
# Pull Request for Automation & Queue Settings Fix

## Summary
Scopes all settings on the "Automation & Queue" screen per user account (incorporating the server and user ID in the storage key dynamically). This ensures preferences do not bleed across different profiles on the same device. Prior, all settings on this page were shared across user accounts on the same server.

## Related Issues
- Discord mentioned issue

## Type of Change
- [x] Bug fix
- [x] UI/UX update
- [x] Refactor

## Changes Made
- Configured dynamic key generation (`${pref.key}_${serverId}_${userId}`) inside `UserPreferences` for the 8 automation and queue settings:
  - `cinemaModeEnabled`
  - `resumeSubtractDuration`
  - `mediaSegmentActions` (Skip Intros/Outros)
  - `autoplayNextEpisode`
  - `nextUpBehavior`
  - `nextUpTimeout`
  - `replaceSkipOutroWithNextUp`
  - `stillWatchingBehavior`
- Resolved the blank screen crash by returning `Preference<dynamic>` from `_scopedPreference` and reconstructing enum preferences as `EnumPreference<Enum>`. In `get<T>`, we typecast the retrieved dynamic value back to `T`.
- Updated `PreferenceBinding` constructor and value setters to write and read from `UserPreferences` instead of the global `PreferenceStore`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [x] Manual testing completed - built on Windows 11 and tested all configurations across user accounts

### Test Steps
1. Log in to Server A on Account 1, navigate to **Automation & Queue** and enable **Cinema Mode**, set **Next Up Display** to minimal, and enable **Autoplay Next Episode**.
2. Log out and log in to Server A on Account 2. Verify that **Automation & Queue** settings are at their default values (not copied over from Account 1).
3. Change preferences on Account 2, switch back to Account 1, and verify that Account 1's preferences remain intact.
4. Verify that the **Automation & Queue** settings page renders correctly and does not crash to a blank grey panel.

## Screenshots
User 1, 2, 3 showing different combinations of settings:
<img width="250" alt="2026-06-04_22-19-32_moonfin" src="https://github.com/user-attachments/assets/272b587a-5bc8-4d48-a6ac-973b2acacbb6" />
<img width="250" alt="2026-06-04_22-19-55_moonfin" src="https://github.com/user-attachments/assets/e430eaf8-b957-4973-8ad2-ce65f26e93bc" />
<img width="250" alt="2026-06-04_22-20-30_moonfin" src="https://github.com/user-attachments/assets/e7afbd94-2629-46dc-a954-2ad571e12542" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
