### PR TITLE
Cinema Mode Safety Check & Transition Fixes

### DIFF
--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -188,6 +188,22 @@ class MediaKitPlayerBackend implements PlayerBackend {
   static final Map<String, _ParsedMpvConfCacheEntry> _parsedMpvConfCache =
       <String, _ParsedMpvConfCacheEntry>{};
 
+  bool _isStale = false;
+  String? _currentUrl;
+
+  void _updateStaleState() {
+    if (!_isStale) return;
+    try {
+      final playlist = _player.state.playlist;
+      if (playlist.index >= 0 && playlist.index < playlist.medias.length) {
+        final currentMedia = playlist.medias[playlist.index];
+        if (currentMedia.uri == _currentUrl) {
+          _isStale = false;
+        }
+      }
+    } catch (_) {}
+  }
+
   Future<String?> _tryNativeGetProperty(Object native, String key) async {
     try {
       final dynamic dyn = native;
@@ -468,6 +484,9 @@ class MediaKitPlayerBackend implements PlayerBackend {
         : payload['url']?.toString() ?? '';
     if (url.isEmpty) return;
 
+    _currentUrl = url;
+    _isStale = true;
+
     await _notifyNativeHandleReady();
     await _configureAppleMobileLibassFont();
     await _applyAudioPassthroughOptions();
@@ -476,6 +495,7 @@ class MediaKitPlayerBackend implements PlayerBackend {
     final media = Media(url);
     final openPaused = startPosition > Duration.zero;
     await _player.open(media, play: !openPaused);
+    _updateStaleState();
     await _applyLinuxHwdecFallbackIfNeeded(media, openPaused: openPaused);
     if (!_useLibass) {
       _enableNativeSubtitleRendering();
@@ -1025,6 +1045,7 @@ class MediaKitPlayerBackend implements PlayerBackend {
 
   @override
   Future<void> stop() async {
+    _isStale = true;
     await _player.stop();
   }
 
@@ -1041,43 +1062,80 @@ class MediaKitPlayerBackend implements PlayerBackend {
   }
 
   @override
-  Duration get position => _player.state.position;
+  Duration get position {
+    _updateStaleState();
+    return _isStale ? Duration.zero : _player.state.position;
+  }
 
   @override
-  Duration get duration => _player.state.duration;
+  Duration get duration {
+    _updateStaleState();
+    return _isStale ? Duration.zero : _player.state.duration;
+  }
 
   @override
-  Duration get buffer => _player.state.buffer;
+  Duration get buffer {
+    _updateStaleState();
+    return _isStale ? Duration.zero : _player.state.buffer;
+  }
 
   @override
-  bool get isPlaying => _player.state.playing;
+  bool get isPlaying {
+    _updateStaleState();
+    return _isStale ? false : _player.state.playing;
+  }
 
   @override
-  bool get isBuffering => _player.state.buffering;
+  bool get isBuffering {
+    _updateStaleState();
+    return _isStale ? false : _player.state.buffering;
+  }
 
   @override
   double get playbackSpeed => _player.state.rate;
 
   @override
-  Stream<Duration> get positionStream => _player.stream.position;
+  Stream<Duration> get positionStream => _player.stream.position.map((pos) {
+        _updateStaleState();
+        return _isStale ? Duration.zero : pos;
+      });
 
   @override
-  Stream<Duration> get durationStream => _player.stream.duration;
+  Stream<Duration> get durationStream => _player.stream.duration.map((dur) {
+        _updateStaleState();
+        return _isStale ? Duration.zero : dur;
+      });
 
   @override
-  Stream<Duration> get bufferStream => _player.stream.buffer;
+  Stream<Duration> get bufferStream => _player.stream.buffer.map((buf) {
+        _updateStaleState();
+        return _isStale ? Duration.zero : buf;
+      });
 
   @override
-  Stream<bool> get playingStream => _player.stream.playing;
+  Stream<bool> get playingStream => _player.stream.playing.map((playing) {
+        _updateStaleState();
+        return _isStale ? false : playing;
+      });
 
   @override
-  Stream<bool> get bufferingStream => _player.stream.buffering;
+  Stream<bool> get bufferingStream => _player.stream.buffering.map((buffering) {
+        _updateStaleState();
+        return _isStale ? false : buffering;
+      });
 
   @override
-  Stream<bool> get completedStream => _player.stream.completed;
+  Stream<bool> get completedStream => _player.stream.completed.map((completed) {
+        _updateStaleState();
+        return _isStale ? false : completed;
+      });
 
   @override
-  Stream<Map<String, dynamic>>? get errorStream => null;
+  Stream<Map<String, dynamic>>? get errorStream =>
+      _player.stream.error.map((err) => <String, dynamic>{
+            'event': 'error',
+            'message': err,
+          });
 
   @override
   Future<void> setPlaybackSpeed(double speed) async {
@@ -1197,12 +1255,16 @@ class MediaKitPlayerBackend implements PlayerBackend {
 
   @override
   Future<void> waitForTracksReady() async {
-    if (_player.state.tracks.audio.isNotEmpty) {
+    _updateStaleState();
+    if (!_isStale && _player.state.tracks.audio.isNotEmpty) {
       return;
     }
     try {
       final tracks = await _player.stream.tracks
-          .firstWhere((t) => t.audio.isNotEmpty)
+          .firstWhere((t) {
+            _updateStaleState();
+            return !_isStale && t.audio.isNotEmpty;
+          })
           .timeout(const Duration(seconds: 5));
       if (tracks.audio.isEmpty) return;
     } catch (_) {}
@@ -1211,12 +1273,16 @@ class MediaKitPlayerBackend implements PlayerBackend {
   @override
   Future<void> waitForEmbeddedSubtitleCount(int count) async {
     if (count <= 0) return;
-    if (_player.state.tracks.subtitle.length >= count) {
+    _updateStaleState();
+    if (!_isStale && _player.state.tracks.subtitle.length >= count) {
       return;
     }
     try {
       final tracks = await _player.stream.tracks
-          .firstWhere((t) => t.subtitle.length >= count)
+          .firstWhere((t) {
+            _updateStaleState();
+            return !_isStale && t.subtitle.length >= count;
+          })
           .timeout(const Duration(seconds: 5));
       if (tracks.subtitle.length < count) return;
     } catch (_) {}

--- a/lib/ui/widgets/settings/preference_binding.dart
+++ b/lib/ui/widgets/settings/preference_binding.dart
@@ -7,16 +7,14 @@ import 'package:jellyfin_preference/jellyfin_preference.dart';
 import '../../../preference/user_preferences.dart';
 
 class PreferenceBinding<T> extends ValueNotifier<T> {
-  final PreferenceStore _store;
   final Preference<T> _preference;
 
-  PreferenceBinding(this._store, this._preference) : super(_store.get(_preference));
+  PreferenceBinding(PreferenceStore store, this._preference) : super(GetIt.instance<UserPreferences>().get(_preference));
 
   @override
   set value(T newValue) {
     super.value = newValue;
-    unawaited(_store.set(_preference, newValue));
-    GetIt.instance<UserPreferences>().notifyPreferenceChanged();
+    unawaited(GetIt.instance<UserPreferences>().set(_preference, newValue));
   }
 
   void reset() {

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -940,16 +940,7 @@ class PlaybackManager {
       } catch (_) {}
 
       if (_isPreroll(item)) {
-        final hadNext = queueService.next();
-        if (hadNext) {
-          await _playCurrentItem(
-            startPosition: startPosition,
-            enableDirectPlay: enableDirectPlay,
-            enableDirectStream: enableDirectStream,
-            enableTranscoding: enableTranscoding,
-            allowStartupRecovery: allowStartupRecovery,
-          );
-        }
+        await next();
         return;
       }
 

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -484,11 +484,20 @@ class PlaybackManager {
   }
 
   Future<void> _handleBackendErrorEvent(Map<String, dynamic> event) async {
+    final queueItem = queueService.currentItem;
+    if (_isPreroll(queueItem)) {
+      _suppressNextGenericBackendError = true;
+      try {
+        await _backend!.stop();
+      } catch (_) {}
+      await next();
+      return;
+    }
+
     final eventType = event['event']?.toString();
     final kind = event['kind']?.toString();
     final recoverable = event['recoverable'] == true;
     final resolution = _currentResolution ?? _lastPlaybackResolution;
-    final queueItem = queueService.currentItem;
 
     void emitFailedBringupState(String fallbackMessage) {
       final message = event['message']?.toString().trim();
@@ -708,6 +717,21 @@ class PlaybackManager {
     );
   }
 
+  bool _isPreroll(dynamic item) {
+    if (item == null) return false;
+    try {
+      if (item is Map) {
+        return item['__moonfinIsPreroll'] == true;
+      }
+      final dynamic dynItem = item;
+      final rawData = dynItem.rawData;
+      if (rawData is Map) {
+        return rawData['__moonfinIsPreroll'] == true;
+      }
+    } catch (_) {}
+    return false;
+  }
+
   Future<void> _playCurrentItem({
     Duration startPosition = Duration.zero,
     bool enableDirectPlay = true,
@@ -914,6 +938,20 @@ class PlaybackManager {
       try {
         await _backend!.stop();
       } catch (_) {}
+
+      if (_isPreroll(item)) {
+        final hadNext = queueService.next();
+        if (hadNext) {
+          await _playCurrentItem(
+            startPosition: startPosition,
+            enableDirectPlay: enableDirectPlay,
+            enableDirectStream: enableDirectStream,
+            enableTranscoding: enableTranscoding,
+            allowStartupRecovery: allowStartupRecovery,
+          );
+        }
+        return;
+      }
 
       if (allowStartupRecovery) {
         final forceTranscodeFallback =


### PR DESCRIPTION
# Pull Request for Cinema Mode Safety Check & Transition Fixes

## Summary
Implements a safety check and transition fix for Cinema Mode pre-rolls. This prevents playback from hanging on a black screen when pre-rolls fail to load (which can happen on restricted secondary accounts) or during transitions from a pre-roll to the main movie.

## Related Issues
- Closes issue [209](https://github.com/Moonfin-Client/Moonfin-Core/issues/209)

## Type of Change
- [x] Bug fix
- [x] UI/UX update
- [x] Refactor

## Changes Made
- **Error Propagation & Watchdog Auto-Skip:**
  - Added an `errorStream` to `MediaKitPlayerBackend` to expose underlying media kit errors.
  - Implemented error handling and queue fallback in `PlaybackManager`. If a pre-roll fails to play or load, the player cleanly stops, suppresses the playback error prompt, advances the queue, and automatically starts the main movie.
- **Stale State Management during Transitions:**
  - Implemented an `_isStale` boolean flag in `MediaKitPlayerBackend`. During stop/play transitions, `_isStale` remains true until the media player playlist active index matches the loaded target URL.
  - When `_isStale` is true, position/duration/buffering streams and getters return zero/false, preventing incorrect UI state updates or transition hangs.
  - Modified `waitForTracksReady` and `waitForEmbeddedSubtitleCount` to yield immediately if the player state is stale.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [x] Manual testing completed - verified on Windows 11 Desktop across primary and secondary accounts

### Test Steps
1. Log in to a secondary account that does not have permissions or access to pre-rolls, and play a movie with Cinema Mode enabled.
2. Verify that the player gracefully skips the pre-roll immediately without showing a black screen or throwing an error, playing the movie.
3. Log in to a primary account, play a movie with Cinema Mode enabled, and verify that the pre-roll plays and transitions to the main feature automatically without hanging.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
