### PR TITLE
Media Segment Countdown Customization

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1108,6 +1108,15 @@
       }
     }
   },
+  "endsIn": "Ends in {time}",
+  "@endsIn": {
+    "description": "Label showing remaining time for segment or timeout",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "view": "View",
   "@view": {
     "description": "Action button label for viewing a photo"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6788,6 +6788,26 @@
   "settingsSyncplaySubtitle": "Synchronization logic for group sessions",
   "settingsAdvancedOptionsSubtitle": "Specialized player features. Use with caution, as some options may cause playback issues",
   "settingsSkipIntrosAndOutros": "Skip Intros and Outros?",
+  "settingsMediaSegmentCountdown": "Media Segment Countdown",
+  "@settingsMediaSegmentCountdown": {
+    "description": "Setting label for media segment countdown customizations"
+  },
+  "settingsProgressBar": "Progress Bar",
+  "@settingsProgressBar": {
+    "description": "Option label to show only progress bar on media segment countdown overlay"
+  },
+  "settingsTimer": "Timer",
+  "@settingsTimer": {
+    "description": "Option label to show only countdown timer on media segment countdown overlay"
+  },
+  "settingsBoth": "Both",
+  "@settingsBoth": {
+    "description": "Option label to show both progress bar and countdown timer on media segment countdown overlay"
+  },
+  "settingsNone": "None",
+  "@settingsNone": {
+    "description": "Option label to hide all decorations on media segment countdown overlay"
+  },
   "settingsPromptUser": "Prompt User",
   "settingsSkip": "Skip",
   "settingsDoNothing": "Do Nothing",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1649,6 +1649,12 @@ abstract class AppLocalizations {
   /// **'Ends at {time}'**
   String endsAt(String time);
 
+  /// Label showing remaining time for segment or timeout
+  ///
+  /// In en, this message translates to:
+  /// **'Ends in {time}'**
+  String endsIn(String time);
+
   /// Action button label for viewing a photo
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12425,7 +12425,7 @@ abstract class AppLocalizations {
   /// **'{count, plural, one {# license notice} other {# license notices}}'**
   String settingsLicenseNoticesCount(int count);
 
-  /// No description provided for @settingsBoth.
+  /// Option label to show both progress bar and countdown timer on media segment countdown overlay
   ///
   /// In en, this message translates to:
   /// **'Both'**
@@ -12496,6 +12496,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Skip Intros and Outros?'**
   String get settingsSkipIntrosAndOutros;
+
+  /// Setting label for media segment countdown customizations
+  ///
+  /// In en, this message translates to:
+  /// **'Media Segment Countdown'**
+  String get settingsMediaSegmentCountdown;
+
+  /// Option label to show only progress bar on media segment countdown overlay
+  ///
+  /// In en, this message translates to:
+  /// **'Progress Bar'**
+  String get settingsProgressBar;
+
+  /// Option label to show only countdown timer on media segment countdown overlay
+  ///
+  /// In en, this message translates to:
+  /// **'Timer'**
+  String get settingsTimer;
+
+  /// Option label to hide all decorations on media segment countdown overlay
+  ///
+  /// In en, this message translates to:
+  /// **'None'**
+  String get settingsNone;
 
   /// No description provided for @settingsPromptUser.
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -826,6 +826,11 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Uitsig';
 
   @override

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -7021,6 +7021,18 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Slaan Intro\'s en Outros oor?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Vinnige gebruiker';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -816,6 +816,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'منظر';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -6973,6 +6973,18 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'تخطي المقدمات والنهايات؟';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'المستخدم الفوري';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -7032,6 +7032,18 @@ class AppLocalizationsBe extends AppLocalizations {
       'Прапусціць уводныя і канчатковыя часткі?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Запрасіць карыстальніка';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -822,6 +822,11 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Выгляд';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7077,6 +7077,18 @@ class AppLocalizationsBg extends AppLocalizations {
       'Пропускане на въведения и изключения?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Подкана на потребител';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -821,6 +821,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Преглед';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -7006,6 +7006,18 @@ class AppLocalizationsBn extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros এবং Outros এড়িয়ে যান?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'প্রম্পট ব্যবহারকারী';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -819,6 +819,11 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'দেখুন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -832,6 +832,11 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Veure';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -7119,6 +7119,18 @@ class AppLocalizationsCa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Ometeu introduccions i altres?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Usuari prompte';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7021,6 +7021,18 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Přeskočit úvody a závěry?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Vyzvat uživatele';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -824,6 +824,11 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Pohled';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -7035,6 +7035,18 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Hepgor Intros a Outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Defnyddiwr Prydlon';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -825,6 +825,11 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Golwg';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -820,6 +820,11 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Udsigt';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7012,6 +7012,18 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Springe introer og outros over?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Spørg bruger';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -831,6 +831,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Ansehen';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7072,6 +7072,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros und Outros überspringen?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Prompt-Benutzer';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7118,6 +7118,18 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Παράλειψη εισαγωγών και εξόδων;';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Προτροπή χρήστη';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -831,6 +831,11 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Θέα';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6962,6 +6962,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Skip Intros and Outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Prompt User';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -819,6 +819,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'View';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -821,6 +821,11 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Vido';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -7003,6 +7003,18 @@ class AppLocalizationsEo extends AppLocalizations {
       'Ĉu preterpasi enkondukojn kaj aliajn?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Prompta Uzanto';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -828,6 +828,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Ver';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7083,6 +7083,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '¿Saltar introducciones y finales?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Preguntar al usuario';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -824,6 +824,11 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Vaade';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7023,6 +7023,18 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kas jätta sissejuhatused ja välised vahele?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Küsi kasutajat';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -6975,6 +6975,18 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'از معرفی و برون رفت بگذرید؟';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'کاربر سریع';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -820,6 +820,11 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'مشاهده کنید';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -826,6 +826,11 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Näytä';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7040,6 +7040,18 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Ohitetaanko introt ja loppupalat?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Kehota käyttäjää';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -829,6 +829,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Voir';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7093,6 +7093,18 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ignorer les intros et les outros ?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Inviter l\'utilisateur';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -7110,6 +7110,18 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Omitir intros e outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Usuario avisado';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -831,6 +831,11 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Ver';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -811,6 +811,11 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'נוֹף';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -6917,6 +6917,18 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'לדלג על Intros ו-Outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'משתמש מהיר';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -820,6 +820,11 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'देखना';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -6994,6 +6994,18 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'परिचय और बाह्य को छोड़ें?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'शीघ्र उपयोगकर्ता';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7036,6 +7036,18 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Preskočiti Intros i Outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Brzi korisnik';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -822,6 +822,11 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Pogled';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7079,6 +7079,18 @@ class AppLocalizationsHu extends AppLocalizations {
       'Kihagyja a bevezetőket és a végeket?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Felhasználó kérése';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -825,6 +825,11 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Kilátás';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -826,6 +826,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Melihat';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -7027,6 +7027,18 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Lewati Intro dan Outro?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Pengguna yang Cepat';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -826,6 +826,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Visualizza';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7055,6 +7055,18 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Saltare intro e outro?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Richiedi all\'utente';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -798,6 +798,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'ビュー';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -6835,6 +6835,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'イントロとアウトロをスキップしますか?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'ユーザーにプロンプ​​トを表示';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -824,6 +824,11 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Көру';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -7048,6 +7048,18 @@ class AppLocalizationsKk extends AppLocalizations {
       'Кіріспелер мен шығыстарды өткізіп жіберу керек пе?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Шұғыл пайдаланушы';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -7063,6 +7063,18 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಪರಿಚಯಗಳು ಮತ್ತು ಔಟ್ರೊಗಳನ್ನು ಬಿಟ್ಟುಬಿಡುವುದೇ?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'ಪ್ರಾಂಪ್ಟ್ ಬಳಕೆದಾರ';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -826,6 +826,11 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'ವೀಕ್ಷಿಸಿ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -6827,6 +6827,18 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '인트로와 아웃트로를 건너뛰시겠습니까?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => '사용자에게 프롬프트';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -798,6 +798,11 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => '보다';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -821,6 +821,11 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Žiūrėti';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7038,6 +7038,18 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Praleisti įžangas ir pabaigas?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Raginti vartotoją';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7049,6 +7049,18 @@ class AppLocalizationsLv extends AppLocalizations {
       'Vai izlaist ievadus un noslēgumus?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Pamudināt lietotāju';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -825,6 +825,11 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Skatīt';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -825,6 +825,11 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Прикажи';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -7064,6 +7064,18 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Прескокнете воведни и аутроси?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Пратен корисник';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -7101,6 +7101,18 @@ class AppLocalizationsMl extends AppLocalizations {
       'ആമുഖങ്ങളും ഔട്ട്റോകളും ഒഴിവാക്കണോ?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'പ്രോംപ്റ്റ് ഉപയോക്താവ്';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -827,6 +827,11 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'കാണുക';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -7040,6 +7040,18 @@ class AppLocalizationsMn extends AppLocalizations {
       'Танилцуулга болон гадуурх хэсгийг алгасах уу?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Шуурхай хэрэглэгч';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -823,6 +823,11 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Харах';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7016,6 +7016,18 @@ class AppLocalizationsNb extends AppLocalizations {
       'Vil du hoppe over introer og outroer?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Spør bruker';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -822,6 +822,11 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Utsikt';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -826,6 +826,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Weergave';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7044,6 +7044,18 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intro\'s en Outro\'s overslaan?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Vraag gebruiker';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -822,6 +822,11 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'ਦੇਖੋ';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -7000,6 +7000,18 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros ਅਤੇ Outros ਨੂੰ ਛੱਡਣਾ ਹੈ?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'ਪ੍ਰੋਂਪਟ ਯੂਜ਼ਰ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7056,6 +7056,18 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Pominąć wstępy i zakończenia?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Monituj użytkownika';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -825,6 +825,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Pogląd';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -825,6 +825,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Visualizar';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7065,6 +7065,18 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Pular introduções e outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Solicitar ao usuário';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -824,6 +824,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Vedere';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7060,6 +7060,18 @@ class AppLocalizationsRo extends AppLocalizations {
       'Sari peste introsuri si versiuni suplimentare?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Prompt utilizator';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -825,6 +825,11 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Вид';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -7062,6 +7062,18 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Пропустить интро и аутро?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Подскажите пользователю';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -818,6 +818,11 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'බලන්න';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -7006,6 +7006,18 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'හැඳින්වීම් සහ පිටවීම් මඟ හරින්නද?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'ඉක්මන් පරිශීලක';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7045,6 +7045,18 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Preskočiť úvody a závery?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Vyzvať používateľa';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -826,6 +826,11 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Zobraziť';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -825,6 +825,11 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Pogled';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7043,6 +7043,18 @@ class AppLocalizationsSl extends AppLocalizations {
       'Preskočiti uvodne in končne elemente?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Poziv uporabniku';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -7075,6 +7075,18 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Të kapërcehen hyrjet dhe daljet?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Përdoruesi i shpejtë';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -829,6 +829,11 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Shiko';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -7040,6 +7040,18 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Прескочити уводе и резултате?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Промпт Усер';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -822,6 +822,11 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Виев';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7025,6 +7025,18 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Hoppa över Intros och Outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Fråga användare';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -821,6 +821,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Se';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -830,6 +830,11 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Tazama';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -7066,6 +7066,18 @@ class AppLocalizationsSw extends AppLocalizations {
       'Ungependa Kuruka Utambulisho na Outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Mtumiaji wa haraka';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -827,6 +827,11 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'காண்க';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -7071,6 +7071,18 @@ class AppLocalizationsTa extends AppLocalizations {
       'அறிமுகங்கள் மற்றும் அவுட்ரோக்களை தவிர்க்கவா?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'உடனடி பயனர்';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -7057,6 +7057,18 @@ class AppLocalizationsTe extends AppLocalizations {
       'పరిచయాలు మరియు అవుట్‌రోలను దాటవేయాలా?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'ప్రాంప్ట్ యూజర్';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -825,6 +825,11 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'చూడండి';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -817,6 +817,11 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'ดู';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -6969,6 +6969,18 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'ข้ามช่วงแนะนำและส่วนท้ายใช่ไหม';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'ผู้ใช้พร้อมท์';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -7093,6 +7093,18 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Laktawan ang Intro at Outros?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Prompt User';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -828,6 +828,11 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Tingnan';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -7017,6 +7017,18 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Giriş ve Çıkışlar atlansın mı?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Kullanıcıya Sor';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -821,6 +821,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Görüş';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -7024,6 +7024,18 @@ class AppLocalizationsUg extends AppLocalizations {
       'Intros ۋە Outros نى ئاتلاپ ئۆتۈپ كېتەمسىز؟';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'تېز ئىشلەتكۈچى';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -821,6 +821,11 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'كۆرۈش';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -7052,6 +7052,18 @@ class AppLocalizationsUk extends AppLocalizations {
       'Пропустити введення та завершення?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Підказка користувача';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -821,6 +821,11 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Переглянути';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -827,6 +827,11 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => 'Xem';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -7023,6 +7023,18 @@ class AppLocalizationsVi extends AppLocalizations {
       'Bỏ qua phần giới thiệu và phần kết thúc?';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => 'Nhắc người dùng';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -794,6 +794,11 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => '看法';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -6791,6 +6791,18 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '跳過片頭和片尾？';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => '提示用戶';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6785,6 +6785,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '跳过片头和片尾？';
 
   @override
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+
+  @override
+  String get settingsProgressBar => 'Progress Bar';
+
+  @override
+  String get settingsTimer => 'Timer';
+
+  @override
+  String get settingsNone => 'None';
+
+  @override
   String get settingsPromptUser => '提示用户';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -794,6 +794,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String endsIn(String time) {
+    return 'Ends in $time';
+  }
+
+  @override
   String get view => '看法';
 
   @override

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -176,6 +176,13 @@ enum MediaSegmentAction {
   askToSkip,
 }
 
+enum MediaSegmentCountdown {
+  progressBar,
+  timer,
+  both,
+  none,
+}
+
 enum ImageType {
   poster,
   thumb,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -100,6 +100,7 @@ class UserPreferences extends ChangeNotifier {
     'replace_skip_outro_with_next_up',
     'enable_still_watching',
     'pref_language_override',
+    'pref_media_segment_countdown',
   };
 
   bool _isScopedPreference<T>(Preference<T> pref) {
@@ -734,6 +735,12 @@ class UserPreferences extends ChangeNotifier {
   static final mediaSegmentActions = Preference(
     key: 'media_segment_actions',
     defaultValue: 'intro:askToSkip,outro:askToSkip',
+  );
+
+  static final mediaSegmentCountdown = EnumPreference(
+    key: 'pref_media_segment_countdown',
+    defaultValue: MediaSegmentCountdown.both,
+    values: MediaSegmentCountdown.values,
   );
 
   static final replaceSkipOutroWithNextUp = Preference(

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2327,6 +2327,27 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final isOutro =
         _skipSegment?.type == MediaSegmentType.outro ||
         _segmentService.activeSegment?.type == MediaSegmentType.outro;
+    if (isOutro) {
+      final item = _queue.currentItem;
+      final itemId = _itemIdForQueueItem(item);
+      if (itemId != null && itemId.isNotEmpty) {
+        try {
+          final mutations = ItemMutationRepository(_clientForQueueItem(item));
+          unawaited(mutations.setPlayed(itemId, isPlayed: true).catchError((_) {}));
+          final raw = _rawDataForQueueItem(item);
+          if (raw != null) {
+            final existingUserData = raw['UserData'];
+            final userData = existingUserData is Map<String, dynamic>
+                ? existingUserData
+                : (existingUserData is Map
+                      ? existingUserData.cast<String, dynamic>()
+                      : <String, dynamic>{});
+            userData['Played'] = true;
+            raw['UserData'] = userData;
+          }
+        } catch (_) {}
+      }
+    }
     if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay()) {
       final skipTo = _skipTo;
       if (skipTo != null) {

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3323,6 +3323,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                           ? _tvSkipSegmentFocus
                           : null,
                       onDismiss: _clearSkipSegment,
+                      positionStream: _state.positionStream,
                     ),
                   if (_showNextUp && _nextUpItem != null)
                     NextUpOverlay(

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -2726,7 +2726,7 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
               'intro:doNothing,outro:doNothing': l10n.settingsDoNothing,
             },
           ),
-          if (mediaSegmentActions == _promptSkipSegments)
+          if (mediaSegmentActions == _promptSkipSegments || showNextUpOptions)
             EnumPreferenceTile<MediaSegmentCountdown>(
               preference: UserPreferences.mediaSegmentCountdown,
               title: l10n.settingsMediaSegmentCountdown,

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -2726,6 +2726,18 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
               'intro:doNothing,outro:doNothing': l10n.settingsDoNothing,
             },
           ),
+          if (mediaSegmentActions == _promptSkipSegments)
+            EnumPreferenceTile<MediaSegmentCountdown>(
+              preference: UserPreferences.mediaSegmentCountdown,
+              title: l10n.settingsMediaSegmentCountdown,
+              icon: Icons.timer_outlined,
+              labelOf: (v) => switch (v) {
+                MediaSegmentCountdown.progressBar => l10n.settingsProgressBar,
+                MediaSegmentCountdown.timer => l10n.settingsTimer,
+                MediaSegmentCountdown.both => l10n.settingsBoth,
+                MediaSegmentCountdown.none => l10n.settingsNone,
+              },
+            ),
 
           _SectionHeader(l10n.automaticQueuing),
           ListTile(

--- a/lib/ui/widgets/playback/next_up_overlay.dart
+++ b/lib/ui/widgets/playback/next_up_overlay.dart
@@ -143,7 +143,7 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                                 ? '$minutes:${secs.toString().padLeft(2, '0')}'
                                 : ':${secs.toString().padLeft(2, '0')}';
                             return Text(
-                              'Ends in $timerText',
+                              l10n.endsIn(timerText),
                               style: const TextStyle(
                                 color: Colors.white54,
                                 fontSize: 12,

--- a/lib/ui/widgets/playback/next_up_overlay.dart
+++ b/lib/ui/widgets/playback/next_up_overlay.dart
@@ -136,9 +136,14 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                           animation: _countdownController,
                           builder: (context, _) {
                             final remainingMs = widget.timeoutMs * (1.0 - _countdownController.value);
-                            final seconds = (remainingMs / 1000).ceil();
+                            final remainingSeconds = (remainingMs / 1000).ceil();
+                            final int minutes = remainingSeconds ~/ 60;
+                            final int secs = remainingSeconds % 60;
+                            final timerText = remainingSeconds >= 60
+                                ? '$minutes:${secs.toString().padLeft(2, '0')}'
+                                : ':${secs.toString().padLeft(2, '0')}';
                             return Text(
-                              'Ends in :${seconds.toString().padLeft(2, '0')}',
+                              'Ends in $timerText',
                               style: const TextStyle(
                                 color: Colors.white54,
                                 fontSize: 12,

--- a/lib/ui/widgets/playback/next_up_overlay.dart
+++ b/lib/ui/widgets/playback/next_up_overlay.dart
@@ -3,10 +3,13 @@ import 'dart:async';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/models/aggregated_item.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../preference/preference_constants.dart';
+import '../../../preference/user_preferences.dart';
 
 class NextUpOverlay extends StatefulWidget {
   final AggregatedItem nextItem;
@@ -73,9 +76,16 @@ class _NextUpOverlayState extends State<NextUpOverlay>
         ? 'S${item.parentIndexNumber ?? '?'}:E${item.indexNumber}'
         : null;
 
+    final prefs = GetIt.instance<UserPreferences>();
+    final mediaSegmentCountdown = prefs.get(UserPreferences.mediaSegmentCountdown);
+    final showProgressBar = mediaSegmentCountdown == MediaSegmentCountdown.progressBar ||
+        mediaSegmentCountdown == MediaSegmentCountdown.both;
+    final showTimer = mediaSegmentCountdown == MediaSegmentCountdown.timer ||
+        mediaSegmentCountdown == MediaSegmentCountdown.both;
+
     return Positioned(
       right: 24,
-      bottom: 100,
+      bottom: 120,
       child: Container(
         width: 340,
         decoration: BoxDecoration(
@@ -110,18 +120,39 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    l10n.upNext,
-                    style: const TextStyle(
-                      color: Colors.white54,
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                    ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        l10n.upNext,
+                        style: const TextStyle(
+                          color: Colors.white54,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (showTimer && widget.timeoutMs > 0)
+                        AnimatedBuilder(
+                          animation: _countdownController,
+                          builder: (context, _) {
+                            final remainingMs = widget.timeoutMs * (1.0 - _countdownController.value);
+                            final seconds = (remainingMs / 1000).ceil();
+                            return Text(
+                              'Ends in :${seconds.toString().padLeft(2, '0')}',
+                              style: const TextStyle(
+                                color: Colors.white54,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            );
+                          },
+                        ),
+                    ],
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    [?epInfo, item.name]
-                        .where((s) => s.isNotEmpty)
+                    [epInfo, item.name]
+                        .where((s) => s != null && s.isNotEmpty)
                         .join(' — '),
                     style: const TextStyle(
                       color: Colors.white,
@@ -204,14 +235,14 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                 ],
               ),
             ),
-            if (widget.timeoutMs > 0)
+            if (showProgressBar && widget.timeoutMs > 0)
               AnimatedBuilder(
                 animation: _countdownController,
                 builder: (context, _) => LinearProgressIndicator(
                   value: 1.0 - _countdownController.value,
                   backgroundColor: Colors.transparent,
                   color: AppColorScheme.accent,
-                  minHeight: 3,
+                  minHeight: 6,
                 ),
               ),
           ],

--- a/lib/ui/widgets/playback/skip_segment_overlay.dart
+++ b/lib/ui/widgets/playback/skip_segment_overlay.dart
@@ -1,17 +1,23 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/models/media_segment.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../preference/preference_constants.dart';
+import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../focus/focus_theme.dart';
 
-class SkipSegmentOverlay extends StatelessWidget {
+class SkipSegmentOverlay extends StatefulWidget {
   final MediaSegment segment;
   final VoidCallback onSkip;
   final VoidCallback onDismiss;
   final FocusNode? focusNode;
+  final Stream<Duration>? positionStream;
 
   const SkipSegmentOverlay({
     super.key,
@@ -19,27 +25,108 @@ class SkipSegmentOverlay extends StatelessWidget {
     required this.onSkip,
     required this.onDismiss,
     this.focusNode,
+    this.positionStream,
   });
+
+  @override
+  State<SkipSegmentOverlay> createState() => _SkipSegmentOverlayState();
+}
+
+class _SkipSegmentOverlayState extends State<SkipSegmentOverlay> {
+  StreamSubscription<Duration>? _positionSubscription;
+  Duration _currentPosition = Duration.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentPosition = widget.segment.start;
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(SkipSegmentOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.positionStream != widget.positionStream ||
+        oldWidget.segment != widget.segment) {
+      _unsubscribe();
+      if (widget.segment != oldWidget.segment) {
+        _currentPosition = widget.segment.start;
+      }
+      _subscribe();
+    }
+  }
+
+  @override
+  void dispose() {
+    _unsubscribe();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    if (widget.positionStream != null) {
+      _positionSubscription = widget.positionStream!.listen((position) {
+        if (mounted) {
+          setState(() {
+            _currentPosition = position;
+          });
+        }
+      });
+    }
+  }
+
+  void _unsubscribe() {
+    _positionSubscription?.cancel();
+    _positionSubscription = null;
+  }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final isDesktop = PlatformDetection.useDesktopUi;
+
+    final prefs = GetIt.instance<UserPreferences>();
+    final mediaSegmentCountdown = prefs.get(UserPreferences.mediaSegmentCountdown);
+    final showProgressBar = mediaSegmentCountdown == MediaSegmentCountdown.progressBar ||
+        mediaSegmentCountdown == MediaSegmentCountdown.both;
+    final showTimer = mediaSegmentCountdown == MediaSegmentCountdown.timer ||
+        mediaSegmentCountdown == MediaSegmentCountdown.both;
+
+    final segmentDuration = widget.segment.duration;
+    final elapsed = _currentPosition - widget.segment.start;
+    final progress = segmentDuration.inMilliseconds > 0
+        ? (1.0 - (elapsed.inMilliseconds / segmentDuration.inMilliseconds)).clamp(0.0, 1.0)
+        : 0.0;
+
+    final remaining = widget.segment.end - _currentPosition;
+    final remainingSec = remaining.inSeconds.clamp(0, segmentDuration.inSeconds);
+
+    final int minutes = remainingSec ~/ 60;
+    final int seconds = remainingSec % 60;
+    final String timerSuffix;
+    if (showTimer) {
+      final timerText = remainingSec >= 60
+          ? '$minutes:${seconds.toString().padLeft(2, '0')}'
+          : ':${seconds.toString().padLeft(2, '0')}';
+      timerSuffix = ' - Ends in $timerText';
+    } else {
+      timerSuffix = '';
+    }
+
     return Positioned(
       right: 24,
       bottom: 120,
       child: Material(
         color: Colors.transparent,
         child: Focus(
-          focusNode: focusNode,
+          focusNode: widget.focusNode,
           onKeyEvent: (_, event) {
-            if (focusNode == null) {
+            if (widget.focusNode == null) {
               return KeyEventResult.ignored;
             }
             if (event is KeyDownEvent &&
                 (event.logicalKey == LogicalKeyboardKey.select ||
                     event.logicalKey == LogicalKeyboardKey.enter)) {
-              onSkip();
+              widget.onSkip();
               return KeyEventResult.handled;
             }
             return KeyEventResult.ignored;
@@ -47,10 +134,11 @@ class SkipSegmentOverlay extends StatelessWidget {
           child: Stack(
             children: [
               InkWell(
-                onTap: onSkip,
+                onTap: widget.onSkip,
                 borderRadius: BorderRadius.circular(8),
                 child: Container(
-                  padding: EdgeInsets.fromLTRB(20, 12, isDesktop ? 44 : 20, 12),
+                  width: isDesktop ? 320.0 : 280.0,
+                  clipBehavior: Clip.antiAlias,
                   decoration: FocusTheme.focusDecoration(
                     isFocused: true,
                     radius: 8,
@@ -59,23 +147,39 @@ class SkipSegmentOverlay extends StatelessWidget {
                       alpha: 0.9,
                     ),
                   ),
-                  child: Row(
+                  child: Column(
                     mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Text(
-                        l10n.skipSegment(segment.type.displayName),
-                        style: TextStyle(
-                          color: AppColorScheme.onSurface,
-                          fontSize: 15,
-                          fontWeight: FontWeight.w600,
+                      Padding(
+                        padding: EdgeInsets.fromLTRB(20, 12, isDesktop ? 44 : 20, 12),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              '${l10n.skipSegment(widget.segment.type.displayName)}$timerSuffix',
+                              style: TextStyle(
+                                color: AppColorScheme.onSurface,
+                                fontSize: 15,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Icon(
+                              Icons.skip_next_rounded,
+                              color: AppColorScheme.accent,
+                              size: 22,
+                            ),
+                          ],
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      Icon(
-                        Icons.skip_next_rounded,
-                        color: AppColorScheme.accent,
-                        size: 22,
-                      ),
+                      if (showProgressBar)
+                        LinearProgressIndicator(
+                          value: progress,
+                          backgroundColor: Colors.transparent,
+                          color: AppColorScheme.accent,
+                          minHeight: 6,
+                        ),
                     ],
                   ),
                 ),
@@ -85,7 +189,7 @@ class SkipSegmentOverlay extends StatelessWidget {
                   top: 4,
                   right: 4,
                   child: IconButton(
-                    onPressed: onDismiss,
+                    onPressed: widget.onDismiss,
                     tooltip: l10n.close,
                     padding: EdgeInsets.zero,
                     visualDensity: VisualDensity.compact,

--- a/lib/ui/widgets/playback/skip_segment_overlay.dart
+++ b/lib/ui/widgets/playback/skip_segment_overlay.dart
@@ -107,7 +107,7 @@ class _SkipSegmentOverlayState extends State<SkipSegmentOverlay> {
       final timerText = remainingSec >= 60
           ? '$minutes:${seconds.toString().padLeft(2, '0')}'
           : ':${seconds.toString().padLeft(2, '0')}';
-      timerSuffix = ' - Ends in $timerText';
+      timerSuffix = ' - ${l10n.endsIn(timerText)}';
     } else {
       timerSuffix = '';
     }


### PR DESCRIPTION
# Media Segment Countdown Customization

## Summary
When a segment skip prompt (e.g. Skip Intro, Skip Outro) or a "Next Up" overlay is displayed, this change adds a new customization setting under Playback & SyncPlay -> Automation & Queue to display a progress bar, a countdown timer, both, or neither.

## Related Issues
- Related to Discord feedback

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added MediaSegmentCountdown enum in preference_constants.dart
- Added mediaSegmentCountdown preference in user_preferences.dart
- Added "Media Segment Countdown" EnumPreferenceTile to settings_side_panel.dart
- Modified next_up_overlay.dart to retrieve settings, display the countdown timer text to the right of the title, display the bottom progress bar, double its height to 6.0, and shift the overlay position up to 120.0 to clear the player's progress bar.
- Converted skip_segment_overlay.dart to a stateful widget subscribing to the player position stream, implementing the countdown timer text as "[Segment] - Ends in [Timer]" (format M:SS when >= 60 seconds, otherwise :SS), displaying the bottom progress bar, doubling its height to 6.0, and wrapping it in a fixed-width container.
- Passed the player position stream from video_player_screen.dart to SkipSegmentOverlay.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [x] Manual testing completed on Windows build

### Test Steps
1. Play media items containing intros/outros and verify that setting "Media Segment Countdown" under Automation & Queue changes the visual decoration on Next Up and Skip Intro/Outro buttons.
2. Confirm the countdown timer formatting and progress bar width/height behave as expected.

## Screenshots
Skip Intro (both)
<img width="300" alt="4-skipintro" src="https://github.com/user-attachments/assets/3dbc31df-5991-4b58-b6fe-015fb558970c" />
Skip Outro (both)
<img width="300" alt="5-skipoutro" src="https://github.com/user-attachments/assets/15886aec-8e78-4a0f-b5b8-5ffbdb8a883e" />
Next Up (both)
<img width="300" alt="2026-06-05_09-53-57_explorer" src="https://github.com/user-attachments/assets/2747f053-5832-4533-a345-d85254224bf2" />
Next Up (none)
<img width="300" alt="2026-06-05_10-03-36_moonfin" src="https://github.com/user-attachments/assets/e0673897-6f21-4b87-a23c-fc6c3a69c737" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
