### PR TITLE
Fix PIN Security and Login Preferences

### DIFF
--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -87,7 +87,7 @@ class SessionRepository {
       case UserSelectBehavior.lastUser:
         serverId = _authPrefs.savedLastServerId;
         userId = _authPrefs.savedLastUserId;
-      case UserSelectBehavior.specificUser:
+      case UserSelectBehavior.currentUser:
         serverId = _authPrefs.savedAutoLoginServerId;
         userId = _authPrefs.savedAutoLoginUserId;
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4076,9 +4076,9 @@
   "@lastUser": {
     "description": "Option: last user"
   },
-  "specificUser": "Specific User",
-  "@specificUser": {
-    "description": "Option: specific user"
+  "currentUser": "Current User",
+  "@currentUser": {
+    "description": "Option: current user"
   },
   "alwaysAuthenticate": "Always Authenticate",
   "@alwaysAuthenticate": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5381,11 +5381,11 @@ abstract class AppLocalizations {
   /// **'Last User'**
   String get lastUser;
 
-  /// Option: specific user
+  /// Option: current user
   ///
   /// In en, this message translates to:
-  /// **'Specific User'**
-  String get specificUser;
+  /// **'Current User'**
+  String get currentUser;
 
   /// Setting for always authenticate
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -2943,7 +2943,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get lastUser => 'Laaste gebruiker';
 
   @override
-  String get specificUser => 'Spesifieke gebruiker';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Verifieer altyd';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2927,7 +2927,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get lastUser => 'المستخدم الأخير';
 
   @override
-  String get specificUser => 'مستخدم محدد';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'المصادقة دائما';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -2943,7 +2943,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get lastUser => 'Апошні карыстальнік';
 
   @override
-  String get specificUser => 'Канкрэтны карыстальнік';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Заўсёды правяраць сапраўднасць';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2956,7 +2956,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get lastUser => 'Последен потребител';
 
   @override
-  String get specificUser => 'Конкретен потребител';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Винаги удостоверявай';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -2932,7 +2932,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get lastUser => 'শেষ ব্যবহারকারী';
 
   @override
-  String get specificUser => 'নির্দিষ্ট ব্যবহারকারী';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'সর্বদা প্রমাণীকরণ';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -2975,7 +2975,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get lastUser => 'Últim usuari';
 
   @override
-  String get specificUser => 'Usuari específic';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autenticar-se sempre';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2938,7 +2938,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get lastUser => 'Poslední uživatel';
 
   @override
-  String get specificUser => 'Konkrétní uživatel';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vždy ověřit';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -2947,7 +2947,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get lastUser => 'Defnyddiwr Diwethaf';
 
   @override
-  String get specificUser => 'Defnyddiwr Penodol';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Dilysu bob amser';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2939,7 +2939,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get lastUser => 'Sidste bruger';
 
   @override
-  String get specificUser => 'Specifik bruger';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentificer altid';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2959,7 +2959,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get lastUser => 'Letzter Benutzer';
 
   @override
-  String get specificUser => 'Bestimmter Benutzer';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Immer authentifizieren';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2971,7 +2971,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get lastUser => 'Τελευταίος χρήστης';
 
   @override
-  String get specificUser => 'Συγκεκριμένος χρήστης';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Πάντα έλεγχος ταυτότητας';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2926,7 +2926,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get lastUser => 'Last User';
 
   @override
-  String get specificUser => 'Specific User';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Always Authenticate';
@@ -10798,9 +10798,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get lastUser => 'Last User';
-
-  @override
-  String get specificUser => 'Specific User';
 
   @override
   String get alwaysAuthenticate => 'Always Authenticate';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -2936,7 +2936,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get lastUser => 'Lasta Uzanto';
 
   @override
-  String get specificUser => 'Specifa Uzanto';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Ĉiam Aŭtentikigi';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2960,7 +2960,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get lastUser => 'Último usuario';
 
   @override
-  String get specificUser => 'Usuario específico';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Siempre autenticar';
@@ -10983,9 +10983,6 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get lastUser => 'Último usuario';
-
-  @override
-  String get specificUser => 'Usuario específico';
 
   @override
   String get alwaysAuthenticate => 'Autenticar siempre';
@@ -19019,9 +19016,6 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get lastUser => 'Último usuario';
 
   @override
-  String get specificUser => 'Usuario específico';
-
-  @override
   String get alwaysAuthenticate => 'Autenticar siempre';
 
   @override
@@ -27053,9 +27047,6 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get lastUser => 'Último usuario';
 
   @override
-  String get specificUser => 'Usuario específico';
-
-  @override
   String get alwaysAuthenticate => 'Autenticar siempre';
 
   @override
@@ -35085,9 +35076,6 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get lastUser => 'Último usuario';
-
-  @override
-  String get specificUser => 'Usuario específico';
 
   @override
   String get alwaysAuthenticate => 'Autenticar siempre';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2945,7 +2945,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get lastUser => 'Viimane kasutaja';
 
   @override
-  String get specificUser => 'Konkreetne kasutaja';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentige alati';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -2922,7 +2922,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get lastUser => 'آخرین کاربر';
 
   @override
-  String get specificUser => 'کاربر خاص';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'همیشه احراز هویت';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2950,7 +2950,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get lastUser => 'Viimeinen käyttäjä';
 
   @override
-  String get specificUser => 'Tietty käyttäjä';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Todenna aina';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2971,7 +2971,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lastUser => 'Dernier utilisateur';
 
   @override
-  String get specificUser => 'Utilisateur spécifique';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Toujours s’authentifier';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -2975,7 +2975,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get lastUser => 'Último Usuario';
 
   @override
-  String get specificUser => 'Usuario específico';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autenticarse sempre';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2908,7 +2908,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get lastUser => 'משתמש אחרון';
 
   @override
-  String get specificUser => 'משתמש ספציפי';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'אימות תמיד';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2931,7 +2931,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get lastUser => 'अंतिम उपयोगकर्ता';
 
   @override
-  String get specificUser => 'विशिष्ट उपयोगकर्ता';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'हमेशा प्रमाणित करें';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2943,7 +2943,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get lastUser => 'Zadnji korisnik';
 
   @override
-  String get specificUser => 'Određeni korisnik';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Uvijek provjeri autentičnost';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2954,7 +2954,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get lastUser => 'Utolsó felhasználó';
 
   @override
-  String get specificUser => 'Konkrét felhasználó';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Mindig hitelesítsen';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2942,7 +2942,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get lastUser => 'Pengguna Terakhir';
 
   @override
-  String get specificUser => 'Pengguna Tertentu';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Selalu Otentikasi';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2954,7 +2954,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get lastUser => 'Ultimo Utente';
 
   @override
-  String get specificUser => 'Utente Specifico';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentica Sempre';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2882,7 +2882,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get lastUser => '最後のユーザー';
 
   @override
-  String get specificUser => '特定のユーザー';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => '常に認証する';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -2950,7 +2950,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get lastUser => 'Соңғы пайдаланушы';
 
   @override
-  String get specificUser => 'Арнайы пайдаланушы';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Әрқашан аутентификация';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -2952,7 +2952,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get lastUser => 'ಕೊನೆಯ ಬಳಕೆದಾರ';
 
   @override
-  String get specificUser => 'ನಿರ್ದಿಷ್ಟ ಬಳಕೆದಾರ';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ಯಾವಾಗಲೂ ಪ್ರಮಾಣೀಕರಿಸಿ';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2875,7 +2875,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get lastUser => '마지막 사용자';
 
   @override
-  String get specificUser => '특정 사용자';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => '항상 인증';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2939,7 +2939,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get lastUser => 'Paskutinis vartotojas';
 
   @override
-  String get specificUser => 'Konkretus vartotojas';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Visada autentifikuoti';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2951,7 +2951,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get lastUser => 'Pēdējais lietotājs';
 
   @override
-  String get specificUser => 'Konkrēts lietotājs';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vienmēr autentificēt';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -2957,7 +2957,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get lastUser => 'Последен корисник';
 
   @override
-  String get specificUser => 'Специфичен корисник';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Секогаш автентицирај';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2958,7 +2958,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get lastUser => 'അവസാന ഉപയോക്താവ്';
 
   @override
-  String get specificUser => 'നിർദ്ദിഷ്ട ഉപയോക്താവ്';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'എപ്പോഴും പ്രാമാണീകരിക്കുക';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -2943,7 +2943,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get lastUser => 'Сүүлийн хэрэглэгч';
 
   @override
-  String get specificUser => 'Тодорхой хэрэглэгч';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Үргэлж баталгаажуулах';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2937,7 +2937,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get lastUser => 'Siste bruker';
 
   @override
-  String get specificUser => 'Spesifikk bruker';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentiser alltid';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2950,7 +2950,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get lastUser => 'Laatste gebruiker';
 
   @override
-  String get specificUser => 'Specifieke gebruiker';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Altijd authenticeren';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -2935,7 +2935,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get lastUser => 'ਆਖਰੀ ਉਪਭੋਗਤਾ';
 
   @override
-  String get specificUser => 'ਖਾਸ ਉਪਭੋਗਤਾ';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ਹਮੇਸ਼ਾ ਪ੍ਰਮਾਣਿਤ ਕਰੋ';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2950,7 +2950,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get lastUser => 'Ostatni użytkownik';
 
   @override
-  String get specificUser => 'Konkretny użytkownik';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Zawsze uwierzytelniaj';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2953,7 +2953,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get lastUser => 'Último Usuário';
 
   @override
-  String get specificUser => 'Usuário Específico';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Sempre Autenticar';
@@ -10947,9 +10947,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get lastUser => 'Último usuário';
 
   @override
-  String get specificUser => 'Usuário específico';
-
-  @override
   String get alwaysAuthenticate => 'Sempre autenticar';
 
   @override
@@ -18925,9 +18922,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get lastUser => 'Último usuário';
-
-  @override
-  String get specificUser => 'Usuário específico';
 
   @override
   String get alwaysAuthenticate => 'Sempre autenticar';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2956,7 +2956,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get lastUser => 'Ultimul utilizator';
 
   @override
-  String get specificUser => 'Utilizator specific';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentificați-vă întotdeauna';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2954,7 +2954,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get lastUser => 'Последний пользователь';
 
   @override
-  String get specificUser => 'Конкретный пользователь';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Всегда аутентифицироваться';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -2934,7 +2934,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get lastUser => 'අවසාන පරිශීලකයා';
 
   @override
-  String get specificUser => 'විශේෂිත පරිශීලක';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'සැමවිටම සත්‍යාපනය කරන්න';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2948,7 +2948,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get lastUser => 'Posledný používateľ';
 
   @override
-  String get specificUser => 'Konkrétny používateľ';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vždy overiť';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2950,7 +2950,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get lastUser => 'Zadnji uporabnik';
 
   @override
-  String get specificUser => 'Določen uporabnik';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Vedno preveri pristnost';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -2959,7 +2959,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get lastUser => 'Përdoruesi i fundit';
 
   @override
-  String get specificUser => 'Përdorues specifik';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentifiko gjithmonë';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -2946,7 +2946,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get lastUser => 'Последњи корисник';
 
   @override
-  String get specificUser => 'Одређени корисник';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Увек аутентификујте';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2946,7 +2946,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get lastUser => 'Senaste användare';
 
   @override
-  String get specificUser => 'Specifik användare';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Autentisera alltid';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -2960,7 +2960,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get lastUser => 'Mtumiaji wa Mwisho';
 
   @override
-  String get specificUser => 'Mtumiaji Maalum';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Thibitisha kila wakati';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -2958,7 +2958,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get lastUser => 'கடைசி பயனர்';
 
   @override
-  String get specificUser => 'குறிப்பிட்ட பயனர்';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'எப்போதும் அங்கீகரிக்கவும்';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2951,7 +2951,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get lastUser => 'చివరి వినియోగదారు';
 
   @override
-  String get specificUser => 'నిర్దిష్ట వినియోగదారు';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ఎల్లప్పుడూ ప్రమాణీకరించండి';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -2919,7 +2919,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get lastUser => 'ผู้ใช้คนสุดท้าย';
 
   @override
-  String get specificUser => 'ผู้ใช้เฉพาะ';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ตรวจสอบสิทธิ์เสมอ';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -2967,7 +2967,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get lastUser => 'Huling Gumagamit';
 
   @override
-  String get specificUser => 'Partikular na Gumagamit';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Palaging Authenticate';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2939,7 +2939,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get lastUser => 'Son Kullanıcı';
 
   @override
-  String get specificUser => 'Belirli Kullanıcı';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Daima Kimlik Doğrula';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -2943,7 +2943,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get lastUser => 'ئاخىرقى ئىشلەتكۈچى';
 
   @override
-  String get specificUser => 'كونكرېت ئىشلەتكۈچى';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'ھەمىشە دەلىللەش';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2948,7 +2948,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get lastUser => 'Останній користувач';
 
   @override
-  String get specificUser => 'Конкретний користувач';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Завжди автентифікувати';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2944,7 +2944,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get lastUser => 'Người dùng cuối cùng';
 
   @override
-  String get specificUser => 'Người dùng cụ thể';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Luôn xác thực';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2860,7 +2860,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get lastUser => '最後一個用戶';
 
   @override
-  String get specificUser => '特定用戶';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => '始終進行身份驗證';
@@ -10547,9 +10547,6 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get lastUser => '最后一个用户';
 
   @override
-  String get specificUser => '特定用户';
-
-  @override
   String get alwaysAuthenticate => '始终进行身份验证';
 
   @override
@@ -18226,9 +18223,6 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get lastUser => '最後一個用戶';
-
-  @override
-  String get specificUser => '特定用戶';
 
   @override
   String get alwaysAuthenticate => '始終進行身份驗證';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2855,7 +2855,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get lastUser => '最后一个用户';
 
   @override
-  String get specificUser => '特定用户';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => '始终进行身份验证';
@@ -10498,9 +10498,6 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get lastUser => '最后一个用户';
-
-  @override
-  String get specificUser => '特定用户';
 
   @override
   String get alwaysAuthenticate => '始终进行身份验证';
@@ -18180,9 +18177,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get lastUser => '最後一個用戶';
-
-  @override
-  String get specificUser => '特定用戶';
 
   @override
   String get alwaysAuthenticate => '始終進行身份驗證';

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -185,7 +185,7 @@ enum ImageType {
 enum UserSelectBehavior {
   disabled,
   lastUser,
-  specificUser,
+  currentUser,
 }
 
 enum HomeSectionType {

--- a/lib/ui/screens/auth/startup_screen.dart
+++ b/lib/ui/screens/auth/startup_screen.dart
@@ -11,6 +11,7 @@ import '../../../auth/store/authentication_preferences.dart';
 import '../../../auth/store/credential_store.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../util/pin_code_util.dart';
+import '../../../preference/preference_constants.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/pin_entry_dialog.dart';
@@ -71,7 +72,26 @@ class _StartupScreenState extends State<StartupScreen>
       return;
     }
 
-    final restored = authPrefs.shouldAlwaysAuthenticate
+    final behavior = authPrefs.loginBehavior;
+    String? targetServerId;
+    String? targetUserId;
+
+    if (behavior == UserSelectBehavior.lastUser) {
+      targetServerId = authPrefs.savedLastServerId;
+      targetUserId = authPrefs.savedLastUserId;
+    } else if (behavior == UserSelectBehavior.currentUser) {
+      targetServerId = authPrefs.savedAutoLoginServerId;
+      targetUserId = authPrefs.savedAutoLoginUserId;
+    }
+
+    bool pinEnabledForAutoLoginUser = false;
+    if (targetUserId != null && targetUserId.isNotEmpty) {
+      final store = GetIt.instance<PreferenceStore>();
+      final pinUtil = PinCodeUtil(store, targetUserId);
+      pinEnabledForAutoLoginUser = pinUtil.isPinEnabled;
+    }
+
+    final restored = (authPrefs.shouldAlwaysAuthenticate || pinEnabledForAutoLoginUser)
         ? false
         : await session.restoreSession();
 
@@ -104,7 +124,13 @@ class _StartupScreenState extends State<StartupScreen>
 
       if (mounted) context.go(Destinations.home);
     } else {
-      if (mounted) context.go(Destinations.serverSelect);
+      if (mounted) {
+        if (pinEnabledForAutoLoginUser && targetServerId != null && targetServerId.isNotEmpty) {
+          context.go('${Destinations.server}?serverId=$targetServerId');
+        } else {
+          context.go(Destinations.serverSelect);
+        }
+      }
     }
   }
 

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -453,7 +453,7 @@ class _AuthenticationCategoryScreen extends StatelessWidget {
             labelOf: (v) => switch (v) {
               UserSelectBehavior.disabled => l10n.disabled,
               UserSelectBehavior.lastUser => l10n.lastUser,
-              UserSelectBehavior.specificUser => l10n.specificUser,
+              UserSelectBehavior.currentUser => l10n.currentUser,
             },
           ),
           SwitchPreferenceTile(

--- a/lib/ui/widgets/user_menu_dialog.dart
+++ b/lib/ui/widgets/user_menu_dialog.dart
@@ -6,6 +6,8 @@ import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+
 import '../../auth/models/server.dart';
 import '../../auth/models/user.dart';
 import '../../auth/repositories/server_repository.dart';
@@ -14,9 +16,11 @@ import '../../auth/repositories/user_repository.dart';
 import '../../auth/store/authentication_store.dart';
 import '../../l10n/app_localizations.dart';
 import '../../util/platform_detection.dart';
+import '../../util/pin_code_util.dart';
 import '../navigation/destinations.dart';
 import '../screens/settings/settings_side_panel.dart';
 import 'overlay_sheet.dart';
+import 'pin_entry_dialog.dart';
 import 'remote_control_dialog.dart';
 import 'settings/settings_panel.dart';
 
@@ -103,7 +107,6 @@ class _AccountDialogState extends State<_AccountDialog> {
     }
     return '$base&tag=$tag';
   }
-
   Future<void> _switchAccount(_StoredAccount account) async {
     if (_busy) return;
 
@@ -112,12 +115,31 @@ class _AccountDialogState extends State<_AccountDialog> {
       return;
     }
 
+    final store = GetIt.instance<PreferenceStore>();
+    final pinUtil = PinCodeUtil(store, account.user.id);
+
+    if (pinUtil.isPinEnabled) {
+      final verified = await PinEntryDialog.show(
+        context,
+        mode: PinEntryMode.verify,
+        onVerify: pinUtil.verifyPin,
+        onForgotPin: () {
+          if (mounted) {
+            Navigator.of(context).pop();
+            GoRouter.of(context).go(
+              '${Destinations.login}?serverId=${account.server.id}&username=${Uri.encodeComponent(account.user.name)}',
+            );
+          }
+        },
+      );
+      if (!verified) return;
+    }
+
     setState(() => _busy = true);
     final ok = await _sessionRepo.switchCurrentSession(
       serverId: account.server.id,
       userId: account.user.id,
     );
-
     if (!mounted) return;
     setState(() => _busy = false);
     final router = GoRouter.of(context);

--- a/packages/preference/lib/src/store/preference_store.dart
+++ b/packages/preference/lib/src/store/preference_store.dart
@@ -133,8 +133,9 @@ class PreferenceStore {
     try {
       var stored = _requirePrefs.getString(preference.key);
       if (stored == null || stored.isEmpty) return preference.defaultValue;
-      if (stored == 'specificUser') {
+      if (preference.key == 'pref_auto_login_behavior' && stored == 'specificUser') {
         stored = 'currentUser';
+        _requirePrefs.setString(preference.key, 'currentUser');
       }
       for (final v in preference.values) {
         if ((v as Enum).name == stored) return v;

--- a/packages/preference/lib/src/store/preference_store.dart
+++ b/packages/preference/lib/src/store/preference_store.dart
@@ -131,8 +131,11 @@ class PreferenceStore {
 
   dynamic _getEnumDynamic(EnumPreference<dynamic> preference) {
     try {
-      final stored = _requirePrefs.getString(preference.key);
+      var stored = _requirePrefs.getString(preference.key);
       if (stored == null || stored.isEmpty) return preference.defaultValue;
+      if (stored == 'specificUser') {
+        stored = 'currentUser';
+      }
       for (final v in preference.values) {
         if ((v as Enum).name == stored) return v;
       }


### PR DESCRIPTION
# Fix PIN Security and Login Preferences

## Summary
Implements PIN security checks when switching profiles in-app, bypasses immediate PIN verification locks on startup (routing instead to the user selection screen), and renames the auto-login option "Specific User" to "Current User" with dynamic backward compatibility.

## Related Issues
- Issue reported on Discord

## Type of Change
- [x] Bug fix
- [x] UI/UX update

## Changes Made
- **PIN Verification on Profile Switch**: In `user_menu_dialog.dart`, integrated a PIN check utilizing `PinEntryDialog` prior to switching the active session. If "Forgot PIN" is selected, the dialog closes and navigates to that user's login screen.
- **PIN Auto-Login Bypass on Startup**: In `startup_screen.dart`, if the configured auto-login target user has a PIN enabled, auto-login is bypassed and the app routes directly to the server's user selection screen (`ServerScreen`) instead of prompting for the PIN immediately, preventing other users from being locked out.
- **Renamed Auto-Login UI Text**: Renamed the enum value `specificUser` to `currentUser` in `UserSelectBehavior` and updated the UI label to `"Current User"` in English locale files.
- **Backward Compatibility Mapping**: Added dynamic mapping in `PreferenceStore._getEnumDynamic` to automatically translate saved `'specificUser'` strings in `shared_preferences` to `'currentUser'`.

## Platform
- [x] All / Shared code

## Testing
- [x] Tested on physical device (Windows client built locally)
- [x] Manual testing completed

### Test Steps
1. Enable PIN code on a user profile.
2. Select "Current User" under Auto Login in settings.
3. Switch profiles using the profile selection dialog in-app; verify that the PIN entry dialog correctly prompts for authentication and successfully logs in when correct, or aborts/goes to login when canceled/forgotten.
4. Restart the app; verify that instead of prompting immediately for the last user's PIN, it loads the server's user selection screen.
5. Tap the PIN-enabled user and verify that it prompts for the PIN.
6. Verify that a test merge with PR #373 (Language Override) merges cleanly and builds successfully.

## Screenshots
From Switch User screen
<img width="500" alt="2026-06-05_11-58-17_moonfin" src="https://github.com/user-attachments/assets/965a9f95-eb0b-47b2-be1f-25aa9111c1e4" />
From Login screen
<img width="500" alt="2026-06-05_11-58-43_moonfin" src="https://github.com/user-attachments/assets/e9bd39dc-f99d-415b-9aff-63091597c780" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
