### PR TITLE
 Empty Home Row Section Safeguard

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8,6 +8,10 @@
   "@signIn": {
     "description": "Sign in heading and button label"
   },
+  "empty": "Empty",
+  "@empty": {
+    "description": "Label indicating a section or category is empty"
+  },
   "connectingToServer": "Connecting to {serverName}",
   "@connectingToServer": {
     "description": "Subtitle showing which server the user is connecting to",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -233,6 +233,12 @@ abstract class AppLocalizations {
   /// **'Sign In'**
   String get signIn;
 
+  /// Label indicating a section or category is empty
+  ///
+  /// In en, this message translates to:
+  /// **'Empty'**
+  String get empty;
+
   /// Subtitle showing which server the user is connecting to
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -15,6 +15,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get signIn => 'Meld aan';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Koppel tans aan $serverName';
   }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -15,6 +15,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get signIn => 'تسجيل الدخول';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'الاتصال بـ $serverName';
   }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -15,6 +15,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get signIn => 'Увайдзіце';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Падключэнне да $serverName';
   }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -15,6 +15,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get signIn => 'Вход';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Свързване към $serverName';
   }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -15,6 +15,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get signIn => 'সাইন ইন করুন';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return '$serverName এর সাথে সংযুক্ত হচ্ছে';
   }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -15,6 +15,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get signIn => 'Inicieu la sessió';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'S\'està connectant a $serverName';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -15,6 +15,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get signIn => 'Přihlaste se';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Připojování k $serverName';
   }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -15,6 +15,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get signIn => 'Mewngofnodwch';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Yn cysylltu â $serverName';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -15,6 +15,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get signIn => 'Log ind';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Opretter forbindelse til $serverName';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -15,6 +15,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get signIn => 'Anmelden';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Verbindung zu $serverName herstellen';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get signIn => 'Είσοδος';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Σύνδεση στο $serverName';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signIn => 'Sign In';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get signIn => 'Ensalutu';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Konektante al $serverName';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get signIn => 'Iniciar sesión';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Conectándose a $serverName';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -15,6 +15,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get signIn => 'Logi sisse';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Ühenduse loomine aadressiga $serverName';
   }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -15,6 +15,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get signIn => 'وارد شوید';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'در حال اتصال به $serverName';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -15,6 +15,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get signIn => 'Kirjaudu sisään';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Yhdistetään kohteeseen $serverName';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -15,6 +15,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get signIn => 'Se connecter';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connexion à $serverName';
   }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -15,6 +15,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get signIn => 'Iniciar sesión';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Conectando a $serverName';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -15,6 +15,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get signIn => 'היכנס';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -15,6 +15,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get signIn => 'दाखिल करना';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -15,6 +15,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get signIn => 'Prijavite se';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -15,6 +15,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get signIn => 'Jelentkezzen be';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -15,6 +15,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get signIn => 'Masuk';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -15,6 +15,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get signIn => 'Accedi';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -15,6 +15,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get signIn => 'サインイン';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -15,6 +15,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get signIn => 'Кіру';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -15,6 +15,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get signIn => 'ಸೈನ್ ಇನ್ ಮಾಡಿ';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -15,6 +15,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get signIn => '로그인';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -15,6 +15,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get signIn => 'Prisijunkite';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -15,6 +15,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get signIn => 'Pierakstīties';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Savienojuma izveide ar $serverName';
   }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -15,6 +15,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get signIn => 'Пријавете се';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -15,6 +15,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get signIn => 'സൈൻ ഇൻ';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -15,6 +15,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get signIn => 'Нэвтрэх';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return '$serverName-д холбогдож байна';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -15,6 +15,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get signIn => 'Logg på';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -15,6 +15,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get signIn => 'Inloggen';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -15,6 +15,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get signIn => 'ਸਾਈਨ - ਇਨ';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -15,6 +15,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get signIn => 'Zalogować się';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -15,6 +15,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get signIn => 'Entrar';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Conectando-se a $serverName';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -15,6 +15,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get signIn => 'Conectare';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Se conectează la $serverName';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -15,6 +15,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get signIn => 'Войти';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -15,6 +15,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get signIn => 'පුරන්න';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -15,6 +15,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get signIn => 'Prihlásiť sa';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -15,6 +15,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get signIn => 'Prijavite se';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -15,6 +15,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get signIn => 'Hyni';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -15,6 +15,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get signIn => 'Пријавите се';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -15,6 +15,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get signIn => 'Logga in';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -15,6 +15,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get signIn => 'Ingia';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -15,6 +15,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get signIn => 'உள்நுழையவும்';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -15,6 +15,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get signIn => 'సైన్ ఇన్ చేయండి';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -15,6 +15,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get signIn => 'เข้าสู่ระบบ';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'กำลังเชื่อมต่อกับ $serverName';
   }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -15,6 +15,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get signIn => 'Mag-sign In';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Kumokonekta sa $serverName';
   }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -15,6 +15,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get signIn => 'Giris yap';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -15,6 +15,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get signIn => 'تىزىملىتىڭ';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -15,6 +15,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get signIn => 'Увійти';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -15,6 +15,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get signIn => 'Đăng nhập';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Đang kết nối với $serverName';
   }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -15,6 +15,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get signIn => '登入';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -15,6 +15,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get signIn => '登入';
 
   @override
+  String get empty => 'Empty';
+
+  @override
   String connectingToServer(String serverName) {
     return 'Connecting to $serverName';
   }

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -220,6 +220,7 @@ class HomeViewModel extends ChangeNotifier {
             sectionRows = const <HomeRow>[];
           }
           final loadedRows = sectionRows
+              .map((r) => r.copyWith(items: _filterEmptyElements(r.items)))
               .where((r) => r.items.isNotEmpty || r.rowType == HomeRowType.liveTv)
               .toList();
           final placeholder = _placeholderForConfig(cfg);
@@ -290,6 +291,17 @@ class HomeViewModel extends ChangeNotifier {
     return rows.where((row) => _rowBelongsToConfig(row, cfg)).toList(growable: false);
   }
 
+  List<AggregatedItem> _filterEmptyElements(List<AggregatedItem> items) {
+    return items.where((item) {
+      if (item.type == 'BoxSet' || item.type == 'Playlist') {
+        if (item.childCount == 0 || item.recursiveItemCount == 0) {
+          return false;
+        }
+      }
+      return true;
+    }).toList();
+  }
+
   bool _rowBelongsToConfig(HomeRow row, HomeSectionConfig cfg) {
     if (cfg.isPluginDynamic) {
       return row.id == cfg.stableId;
@@ -357,8 +369,9 @@ class HomeViewModel extends ChangeNotifier {
       }
       _rowOffsets[row.id] = currentOffset + 15;
 
+      final filteredItems = _filterEmptyElements(result.$1);
       _rows = List.of(_rows);
-      _rows[rowIndex] = row.copyWith(items: result.$1, totalCount: result.$2);
+      _rows[rowIndex] = row.copyWith(items: filteredItems, totalCount: result.$2);
       notifyListeners();
     } catch (_) {
     } finally {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -371,7 +371,10 @@ class HomeViewModel extends ChangeNotifier {
 
       final filteredItems = _filterEmptyElements(result.$1);
       _rows = List.of(_rows);
-      _rows[rowIndex] = row.copyWith(items: filteredItems, totalCount: result.$2);
+      _rows[rowIndex] = row.copyWith(
+        items: filteredItems,
+        totalCount: result.$2 - (result.$1.length - filteredItems.length),
+      );
       notifyListeners();
     } catch (_) {
     } finally {

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
@@ -111,11 +113,12 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
     final tasks = <Future<void>>[];
 
+    final newEmptyIds = <String>{};
     void setEmpty(String stableId, bool isEmpty) {
       if (isEmpty) {
-        _emptySectionIds.add(stableId);
+        newEmptyIds.add(stableId);
       } else {
-        _emptySectionIds.remove(stableId);
+        newEmptyIds.remove(stableId);
       }
     }
 
@@ -300,6 +303,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
     if (mounted) {
       setState(() {
+        _emptySectionIds
+          ..clear()
+          ..addAll(newEmptyIds);
         _isLoadingEmptyStates = false;
       });
     }
@@ -368,7 +374,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       _persistSections(pushSync: false);
     }
     _refreshPluginSections();
-    _checkEmptyStates();
+    unawaited(_checkEmptyStates());
   }
 
   bool _ensureBuiltinSectionsPresent() {
@@ -435,7 +441,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     if (changed) {
       _persistSections(pushSync: false);
     }
-    _checkEmptyStates();
+    unawaited(_checkEmptyStates());
   }
 
   /// Adds plugin-dynamic sections discovered by the Home Screen Sections
@@ -1088,8 +1094,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                           borderRadius: BorderRadius.circular(4),
                           border: Border.all(color: Colors.red.withValues(alpha: 0.5), width: 0.8),
                         ),
-                        child: const Text(
-                          'Empty',
+                        child: Text(
+                          l10n.empty,
                           style: TextStyle(
                             fontSize: 10,
                             color: Colors.red,
@@ -1265,6 +1271,7 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
@@ -1349,8 +1356,8 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
                         borderRadius: BorderRadius.circular(4),
                         border: Border.all(color: Colors.red.withValues(alpha: 0.5), width: 0.8),
                       ),
-                      child: const Text(
-                        'Empty',
+                      child: Text(
+                        l10n.empty,
                         style: TextStyle(
                           fontSize: 10,
                           color: Colors.red,

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -83,6 +83,228 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   HomeSectionConfig? _mediaBarConfig;
   final _focusNodes = <FocusNode>[];
 
+  final Set<String> _emptySectionIds = {};
+  bool _isLoadingEmptyStates = false;
+
+  static FavoriteTypeFilter _favoriteFilterForSection(HomeSectionType type) {
+    return switch (type) {
+      HomeSectionType.favoriteMovies => FavoriteTypeFilter.movie,
+      HomeSectionType.favoriteSeries => FavoriteTypeFilter.series,
+      HomeSectionType.favoriteEpisodes => FavoriteTypeFilter.episode,
+      HomeSectionType.favoritePeople => FavoriteTypeFilter.person,
+      HomeSectionType.favoriteArtists => FavoriteTypeFilter.musicArtist,
+      HomeSectionType.favoriteMusicVideos => FavoriteTypeFilter.musicVideo,
+      HomeSectionType.favoriteAlbums => FavoriteTypeFilter.musicAlbum,
+      HomeSectionType.favoriteSongs => FavoriteTypeFilter.audio,
+      _ => FavoriteTypeFilter.all,
+    };
+  }
+
+  Future<void> _checkEmptyStates() async {
+    if (!mounted) return;
+    setState(() {
+      _isLoadingEmptyStates = true;
+    });
+
+    final client = GetIt.instance<MediaServerClient>();
+    final userId = client.userId;
+
+    final tasks = <Future<void>>[];
+
+    void setEmpty(String stableId, bool isEmpty) {
+      if (isEmpty) {
+        _emptySectionIds.add(stableId);
+      } else {
+        _emptySectionIds.remove(stableId);
+      }
+    }
+
+    for (final section in _sections) {
+      final stableId = section.stableId;
+      if (section.isBuiltin) {
+        switch (section.type) {
+          case HomeSectionType.resume:
+            // Skip Continue Watching as it populates/removes as needed
+            break;
+          case HomeSectionType.resumeAudio:
+            tasks.add(() async {
+              try {
+                final response = await client.itemsApi.getResumeItems(
+                  includeItemTypes: const ['Audio'],
+                  limit: 1,
+                );
+                final items = response['Items'] as List? ?? [];
+                setEmpty(stableId, items.isEmpty);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.resumeBook:
+            tasks.add(() async {
+              try {
+                final response = await client.itemsApi.getResumeItems(
+                  includeItemTypes: const ['Book'],
+                  limit: 1,
+                );
+                final items = response['Items'] as List? ?? [];
+                setEmpty(stableId, items.isEmpty);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.nextUp:
+            // Skip Next Up as it's a core empty state fallback/always selectable
+            break;
+          case HomeSectionType.playlists:
+            tasks.add(() async {
+              try {
+                final response = await client.itemsApi.getItems(
+                  includeItemTypes: const ['Playlist'],
+                  limit: 1,
+                  recursive: true,
+                );
+                final total = response['TotalRecordCount'] as int? ?? 0;
+                setEmpty(stableId, total == 0);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.favoriteMovies:
+          case HomeSectionType.favoriteSeries:
+          case HomeSectionType.favoriteEpisodes:
+          case HomeSectionType.favoritePeople:
+          case HomeSectionType.favoriteArtists:
+          case HomeSectionType.favoriteMusicVideos:
+          case HomeSectionType.favoriteAlbums:
+          case HomeSectionType.favoriteSongs:
+            final filter = _favoriteFilterForSection(section.type);
+            tasks.add(() async {
+              try {
+                final response = await client.itemsApi.getItems(
+                  isFavorite: true,
+                  includeItemTypes: filter.itemTypes,
+                  limit: 1,
+                  recursive: true,
+                );
+                final total = response['TotalRecordCount'] as int? ?? 0;
+                setEmpty(stableId, total == 0);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.collections:
+            tasks.add(() async {
+              try {
+                final response = await client.itemsApi.getItems(
+                  includeItemTypes: const ['BoxSet'],
+                  limit: 1,
+                  recursive: true,
+                );
+                final total = response['TotalRecordCount'] as int? ?? 0;
+                setEmpty(stableId, total == 0);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.genres:
+            tasks.add(() async {
+              try {
+                final includeItemTypes = _prefs.get(UserPreferences.genresRowItemFilter).includeItemTypes;
+                final response = await client.itemsApi.getGenres(
+                  userId: userId,
+                  recursive: true,
+                  limit: 1,
+                  includeItemTypes: includeItemTypes,
+                );
+                final total = response['TotalRecordCount'] as int? ?? 0;
+                setEmpty(stableId, total == 0);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.activeRecordings:
+            tasks.add(() async {
+              try {
+                final response = await client.liveTvApi.getRecordings(
+                  limit: 1,
+                );
+                final items = response['Items'] as List? ?? [];
+                setEmpty(stableId, items.isEmpty);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.liveTv:
+            tasks.add(() async {
+              try {
+                final response = await client.liveTvApi.getChannels(
+                  userId: userId,
+                  limit: 1,
+                );
+                final items = response['Items'] as List? ?? [];
+                setEmpty(stableId, items.isEmpty);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.libraryTilesSmall:
+          case HomeSectionType.libraryButtons:
+            tasks.add(() async {
+              try {
+                final response = await client.userViewsApi.getUserViews();
+                final items = response['Items'] as List? ?? [];
+                setEmpty(stableId, items.isEmpty);
+              } catch (_) {}
+            }());
+            break;
+          case HomeSectionType.latestMedia:
+            // Skip Latest Media as it's a core empty state fallback/always selectable
+            break;
+          case HomeSectionType.recentlyReleased:
+            // Skip Recently Released as it's a core empty state fallback/always selectable
+            break;
+          default:
+            break;
+        }
+      } else if (section.isPluginDynamic) {
+        if (section.pluginSource == HomeSectionPluginSource.collections) {
+          final collectionId = section.pluginAdditionalData;
+          if (collectionId != null && collectionId.isNotEmpty) {
+            tasks.add(() async {
+              try {
+                final response = await client.itemsApi.getItems(
+                  parentId: collectionId,
+                  limit: 1,
+                  recursive: true,
+                );
+                final total = response['TotalRecordCount'] as int? ?? 0;
+                setEmpty(stableId, total == 0);
+              } catch (_) {}
+            }());
+          }
+        } else if (section.pluginSource == HomeSectionPluginSource.genres) {
+          final genreId = section.pluginAdditionalData;
+          if (genreId != null && genreId.isNotEmpty) {
+            tasks.add(() async {
+              try {
+                final includeItemTypes = _prefs.get(UserPreferences.genresRowItemFilter).includeItemTypes;
+                final response = await client.itemsApi.getItems(
+                  genreIds: [genreId],
+                  limit: 1,
+                  recursive: true,
+                  includeItemTypes: includeItemTypes,
+                  excludeItemTypes: const ['Episode'],
+                );
+                final total = response['TotalRecordCount'] as int? ?? 0;
+                setEmpty(stableId, total == 0);
+              } catch (_) {}
+            }());
+          }
+        }
+      }
+    }
+
+    await Future.wait(tasks);
+
+    if (mounted) {
+      setState(() {
+        _isLoadingEmptyStates = false;
+      });
+    }
+  }
+
   bool _isFavoriteSectionType(HomeSectionType type) {
     return switch (type) {
       HomeSectionType.favoriteMovies ||
@@ -146,6 +368,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       _persistSections(pushSync: false);
     }
     _refreshPluginSections();
+    _checkEmptyStates();
   }
 
   bool _ensureBuiltinSectionsPresent() {
@@ -212,6 +435,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     if (changed) {
       _persistSections(pushSync: false);
     }
+    _checkEmptyStates();
   }
 
   /// Adds plugin-dynamic sections discovered by the Home Screen Sections
@@ -716,6 +940,19 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           context,
           Text(l10n.homeSections),
           actions: [
+            if (_isLoadingEmptyStates)
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Center(
+                  child: SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                    ),
+                  ),
+                ),
+              ),
             IconButton(
               icon: const Icon(Icons.restore),
               tooltip: l10n.resetToDefaults,
@@ -781,6 +1018,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   Widget _buildReorderableList(AppLocalizations l10n) {
     final visibleIndices = _visibleSectionIndices();
     return ReorderableListView.builder(
+      buildDefaultDragHandles: false,
       header: widget.showGeneralOptions ? _buildHeader(l10n) : null,
       itemCount: visibleIndices.length,
       onReorder: (oldIndex, newIndex) {
@@ -809,61 +1047,91 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       itemBuilder: (context, index) {
         final sectionIndex = visibleIndices[index];
         final section = _sections[sectionIndex];
+        final isEmpty = _emptySectionIds.contains(section.stableId);
         return Padding(
           key: ValueKey(section.stableId),
           padding: _kHomeSectionTileOuterPadding,
-          child: Container(
-            decoration: _homeSectionTileDecoration(context, focused: false),
-            child: ListTile(
-              focusColor: Colors.transparent,
-              hoverColor: Colors.transparent,
-              contentPadding: _kHomeSectionTileContentPadding,
-              minLeadingWidth: 44,
-              horizontalTitleGap: 14,
-              leading: buildSettingsLeadingIconShell(
-                context,
-                icon: Icon(
-                  section.enabled ? Icons.check_box : Icons.check_box_outline_blank,
+          child: Opacity(
+            opacity: isEmpty ? 0.45 : 1.0,
+            child: Container(
+              decoration: _homeSectionTileDecoration(context, focused: false),
+              child: ListTile(
+                focusColor: Colors.transparent,
+                hoverColor: Colors.transparent,
+                contentPadding: _kHomeSectionTileContentPadding,
+                minLeadingWidth: 44,
+                horizontalTitleGap: 14,
+                leading: buildSettingsLeadingIconShell(
+                  context,
+                  icon: Icon(
+                    (section.enabled && !isEmpty) ? Icons.check_box : Icons.check_box_outline_blank,
+                  ),
+                  focused: false,
+                  iconColor: AppColorScheme.onSurface.withValues(alpha: 0.78),
                 ),
-                focused: false,
-                iconColor: AppColorScheme.onSurface.withValues(alpha: 0.78),
-              ),
-              title: Text(
-                _labelFor(section, l10n),
-                style: const TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                  fontFamily: kCleanSettingsFontFamily,
-                ),
-              ),
-              subtitle: section.isPluginDynamic
-                  ? Text(
-                      _pluginSubtitle(section),
-                      style: TextStyle(
-                        fontSize: 12,
+                title: Row(
+                  children: [
+                    Text(
+                      _labelFor(section, l10n),
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
                         fontFamily: kCleanSettingsFontFamily,
+                      ),
+                    ),
+                    if (isEmpty) ...[
+                      const SizedBox(width: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(4),
+                          border: Border.all(color: Colors.red.withValues(alpha: 0.5), width: 0.8),
+                        ),
+                        child: const Text(
+                          'Empty',
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: Colors.red,
+                            fontWeight: FontWeight.bold,
+                            fontFamily: kCleanSettingsFontFamily,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                subtitle: section.isPluginDynamic
+                    ? Text(
+                        _pluginSubtitle(section),
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontFamily: kCleanSettingsFontFamily,
+                          color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      )
+                    : null,
+                onTap: isEmpty
+                    ? null
+                    : () {
+                        setState(() {
+                          _sections[sectionIndex] =
+                              section.copyWith(enabled: !section.enabled);
+                        });
+                        _save();
+                      },
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ReorderableDragStartListener(
+                      index: index,
+                      child: Icon(
+                        Icons.drag_handle,
                         color: AppColorScheme.onSurface.withValues(alpha: 0.7),
                       ),
-                    )
-                  : null,
-              onTap: () {
-                setState(() {
-                  _sections[sectionIndex] =
-                      section.copyWith(enabled: !section.enabled);
-                });
-                _save();
-              },
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ReorderableDragStartListener(
-                    index: index,
-                    child: Icon(
-                      Icons.drag_handle,
-                      color: AppColorScheme.onSurface.withValues(alpha: 0.7),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
@@ -883,10 +1151,11 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         final visibleIndex = index - (widget.showGeneralOptions ? 1 : 0);
         final sectionIndex = visibleIndices[visibleIndex];
         final section = _sections[sectionIndex];
+        final isEmpty = _emptySectionIds.contains(section.stableId);
         return _HomeSectionTile(
           key: ValueKey(section.stableId),
           focusNode: _focusNodes[sectionIndex],
-          autofocus: visibleIndex == 0,
+          autofocus: visibleIndex == 0 && !isEmpty,
           label: _labelFor(section, l10n),
           subtitle: section.isPluginDynamic
               ? _pluginSubtitle(section)
@@ -894,6 +1163,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           enabled: section.enabled,
           isFirst: visibleIndex == 0,
           isLast: visibleIndex == visibleIndices.length - 1,
+          isEmpty: isEmpty,
           onToggle: (enabled) {
             setState(() {
               _sections[sectionIndex] = section.copyWith(enabled: enabled);
@@ -951,6 +1221,7 @@ class _HomeSectionTile extends StatefulWidget {
   final bool isFirst;
   final bool isLast;
   final bool autofocus;
+  final bool isEmpty;
   final ValueChanged<bool> onToggle;
   final VoidCallback onMoveUp;
   final VoidCallback onMoveDown;
@@ -964,6 +1235,7 @@ class _HomeSectionTile extends StatefulWidget {
     required this.isFirst,
     required this.isLast,
     this.autofocus = false,
+    this.isEmpty = false,
     required this.onToggle,
     required this.onMoveUp,
     required this.onMoveDown,
@@ -996,6 +1268,7 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
+      canRequestFocus: !widget.isEmpty,
       onFocusChange: (f) {
         if (_focused != f && mounted) {
           setState(() => _focused = f);
@@ -1032,69 +1305,96 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
       },
       child: Padding(
         padding: _kHomeSectionTileOuterPadding,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 90),
-          curve: Curves.easeOut,
-          decoration: _homeSectionTileDecoration(context, focused: _focused),
-          child: ListTile(
-            focusColor: Colors.transparent,
-            hoverColor: Colors.transparent,
-            contentPadding: _kHomeSectionTileContentPadding,
-            minLeadingWidth: 44,
-            horizontalTitleGap: 14,
-            leading: buildSettingsLeadingIconShell(
-              context,
-              icon: Icon(
-                widget.enabled ? Icons.check_box : Icons.check_box_outline_blank,
+        child: Opacity(
+          opacity: widget.isEmpty ? 0.45 : 1.0,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 90),
+            curve: Curves.easeOut,
+            decoration: _homeSectionTileDecoration(context, focused: _focused),
+            child: ListTile(
+              focusColor: Colors.transparent,
+              hoverColor: Colors.transparent,
+              contentPadding: _kHomeSectionTileContentPadding,
+              minLeadingWidth: 44,
+              horizontalTitleGap: 14,
+              leading: buildSettingsLeadingIconShell(
+                context,
+                icon: Icon(
+                  (widget.enabled && !widget.isEmpty) ? Icons.check_box : Icons.check_box_outline_blank,
+                ),
+                focused: _focused,
+                iconColor: _focused
+                    ? AppColors.black.withValues(alpha: 0.54)
+                    : AppColorScheme.onSurface.withValues(alpha: 0.78),
               ),
-              focused: _focused,
-              iconColor: _focused
-                  ? AppColors.black.withValues(alpha: 0.54)
-                  : AppColorScheme.onSurface.withValues(alpha: 0.78),
-            ),
-            title: Text(
-              widget.label,
-              style: TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-                fontFamily: kCleanSettingsFontFamily,
-                color: _focused
-                    ? AppColors.black.withValues(alpha: 0.87)
-                    : AppColorScheme.onSurface,
-              ),
-            ),
-            subtitle: widget.subtitle != null
-                ? Text(
-                    widget.subtitle!,
+              title: Row(
+                children: [
+                  Text(
+                    widget.label,
                     style: TextStyle(
-                      fontSize: 12,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
                       fontFamily: kCleanSettingsFontFamily,
+                      color: _focused
+                          ? AppColors.black.withValues(alpha: 0.87)
+                          : AppColorScheme.onSurface,
+                    ),
+                  ),
+                  if (widget.isEmpty) ...[
+                    const SizedBox(width: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: Colors.red.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(4),
+                        border: Border.all(color: Colors.red.withValues(alpha: 0.5), width: 0.8),
+                      ),
+                      child: const Text(
+                        'Empty',
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: Colors.red,
+                          fontWeight: FontWeight.bold,
+                          fontFamily: kCleanSettingsFontFamily,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              subtitle: widget.subtitle != null
+                  ? Text(
+                      widget.subtitle!,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontFamily: kCleanSettingsFontFamily,
+                        color: _focused
+                            ? AppColors.black.withValues(alpha: 0.54)
+                            : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                    )
+                  : null,
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (!widget.isFirst)
+                    Icon(
+                      Icons.arrow_left,
+                      size: 18,
                       color: _focused
                           ? AppColors.black.withValues(alpha: 0.54)
                           : AppColorScheme.onSurface.withValues(alpha: 0.7),
                     ),
-                  )
-                : null,
-            trailing: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (!widget.isFirst)
-                  Icon(
-                    Icons.arrow_left,
-                    size: 18,
-                    color: _focused
-                        ? AppColors.black.withValues(alpha: 0.54)
-                        : AppColorScheme.onSurface.withValues(alpha: 0.7),
-                  ),
-                if (!widget.isLast)
-                  Icon(
-                    Icons.arrow_right,
-                    size: 18,
-                    color: _focused
-                        ? AppColors.black.withValues(alpha: 0.54)
-                        : AppColorScheme.onSurface.withValues(alpha: 0.7),
-                  ),
-              ],
+                  if (!widget.isLast)
+                    Icon(
+                      Icons.arrow_right,
+                      size: 18,
+                      color: _focused
+                          ? AppColors.black.withValues(alpha: 0.54)
+                          : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
# Empty Home Row Section Safeguard
## Summary
Implements empty-state checking on the Home Sections settings page. If a category (Collections, Genres, Favorites, or active Live TV/Recordings) is empty on the server, it is displayed greyed out, marked with an "Empty" badge, and made unselectable. A loading spinner is shown in the AppBar while background checking runs. Core dynamic rows (Continue Watching, Next Up, Latest Media, Recently Released) are ignored from the check to remain always selectable.
 Additionally, filters out empty collections and playlists (where `childCount == 0` or `recursiveItemCount == 0`) from displaying inside rows on the home screen, and fixes the duplicate drag handle bug on reorderable lists.
## Related Issues
- Related to issue raised on Discord
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Build/CI change
- [ ] Other (describe):
## Changes Made
- Added asynchronous `_checkEmptyStates()` query routines for home rows (checking items, collections, genres, Live TV, and recordings) in `home_sections_screen.dart`.
- Excluded dynamic/core sections (`resume`, `nextUp`, `latestMedia`, and `recentlyReleased`) from empty-state checking.
- Added a `CircularProgressIndicator` in the settings AppBar actions that animates while states are being fetched.
- Greyed out empty home rows with `0.45` opacity, added an "Empty" text badge, disabled checkboxes, and prevented D-pad focus on TV layout.
- Added `_filterEmptyElements()` helper in `HomeViewModel` to filter out empty collections/playlists (e.g. childCount == 0) from the home screen rows during initial load and pagination.
- Set `buildDefaultDragHandles: false` on `ReorderableListView.builder` to remove duplicate white drag handles.
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] Windows
- [ ] Linux
- [x] All / Shared code
## Testing
- [x] Tested on emulator / simulator
- [x] Manual testing completed
### Test Steps
1. Navigate to Settings -> Home Sections.
2. Observe the loading spinner animating in the top right while the empty states are populating.
3. Verify that empty row categories (e.g. Collections, Genres if empty) display with `0.45` opacity, show a red "Empty" badge, and are unselectable.
4. Verify that Continue Watching, Next Up, Latest Media, and Recently Released remain selectable regardless of empty status.
5. Verify that empty collections/playlists (with `childCount == 0`) are filtered out and hidden from rows displayed on the home screen.
6. Verify that each row contains only one drag handle.
## Screenshots
Classic Theme
<img width="250" alt="2026-06-05_15-25-22" src="https://github.com/user-attachments/assets/d998ee42-5a25-49c3-bed2-f6cbbf92a7f9" />
Neon Pulse
<img width="250" alt="2026-06-05_14-37-53" src="https://github.com/user-attachments/assets/84ba5a75-6d0b-4dff-b486-7724023bddeb" />
## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced