### PR TITLE
Prevent the Blackout

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
-import 'package:moonfin_design/moonfin_design.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'data/services/app_update_service.dart';
@@ -729,12 +728,6 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
           }
 
           final key = event.logicalKey;
-          if (key.isBackKey) {
-            DialogBackSuppressor.markDismissed();
-            Navigator.of(ctx).pop();
-            return KeyEventResult.handled;
-          }
-
           if (key.isDirectional) {
             if (!okFocusNode.hasFocus && okFocusNode.canRequestFocus) {
               okFocusNode.requestFocus();
@@ -752,7 +745,7 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
             TextButton(
               focusNode: okFocusNode,
               autofocus: true,
-              onPressed: () => Navigator.of(ctx).pop(),
+              onPressed: () => Navigator.of(ctx, rootNavigator: true).pop(),
               child: Text(l10n.ok),
             ),
           ],

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -33,6 +33,9 @@ import 'util/global_shortcut_focus.dart';
 import 'util/focus/input_mode_tracker.dart';
 import 'util/platform_detection.dart';
 import 'ui/widgets/overlay_sheet.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'util/focus/key_event_utils.dart';
+import 'ui/widgets/focus/request_initial_focus.dart';
 
 class MoonfinApp extends StatefulWidget {
   const MoonfinApp({super.key});
@@ -720,48 +723,11 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
       return;
     }
 
-    final okFocusNode = FocusNode(debugLabel: 'AdminMessageOkButton');
-    final dialogScopeNode = FocusScopeNode(debugLabel: 'AdminMessageDialogScope');
-    final l10n = AppLocalizations.of(navContext);
     showFocusRestoringDialog<void>(
       context: navContext,
       barrierDismissible: false,
-      builder: (ctx) => FocusScope(
-        node: dialogScopeNode,
-        autofocus: true,
-        onKeyEvent: (node, event) {
-          if (!event.isActionable) {
-            return KeyEventResult.ignored;
-          }
-
-          final key = event.logicalKey;
-          if (key.isDirectional) {
-            if (!okFocusNode.hasFocus && okFocusNode.canRequestFocus) {
-              okFocusNode.requestFocus();
-            }
-            return KeyEventResult.handled;
-          }
-
-          return KeyEventResult.ignored;
-        },
-        child: AlertDialog(
-          icon: const Icon(Icons.campaign_outlined),
-          title: Text(l10n.adminSendMessage),
-          content: Text(message),
-          actions: [
-            TextButton(
-              focusNode: okFocusNode,
-              autofocus: true,
-              onPressed: () => Navigator.of(ctx, rootNavigator: true).pop(),
-              child: Text(l10n.ok),
-            ),
-          ],
-        ),
-      ),
-    ).whenComplete(() {
-      okFocusNode.dispose();
-      dialogScopeNode.dispose();
-    });
+      builder: (ctx) => _AdminMessageDialog(message: message),
+    );
   }
 
   Future<void> _runDesktopUpdateCheck() async {
@@ -818,5 +784,131 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
     _wasOnline = isOnline;
 
     return widget.child;
+  }
+}
+
+class _AdminMessageDialog extends StatefulWidget {
+  final String message;
+
+  const _AdminMessageDialog({required this.message});
+
+  @override
+  State<_AdminMessageDialog> createState() => _AdminMessageDialogState();
+}
+
+class _AdminMessageDialogState extends State<_AdminMessageDialog> {
+  final _okFocusNode = FocusNode(debugLabel: 'AdminMessageOkButton');
+  final _dialogScopeNode = FocusScopeNode(debugLabel: 'AdminMessageDialogScope');
+  bool _focused = false;
+
+  @override
+  void dispose() {
+    _okFocusNode.dispose();
+    _dialogScopeNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return FocusScope(
+      node: _dialogScopeNode,
+      autofocus: true,
+      onKeyEvent: (node, event) {
+        if (!event.isActionable) {
+          return KeyEventResult.ignored;
+        }
+
+        final key = event.logicalKey;
+        if (key.isDirectional) {
+          if (!_okFocusNode.hasFocus && _okFocusNode.canRequestFocus) {
+            _okFocusNode.requestFocus();
+          }
+          return KeyEventResult.handled;
+        }
+
+        return KeyEventResult.ignored;
+      },
+      child: RequestInitialFocus(
+        targetNode: _okFocusNode,
+        child: Dialog(
+          backgroundColor: Colors.transparent,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 500),
+            child: Container(
+              padding: const EdgeInsets.all(32),
+              decoration: BoxDecoration(
+                color: AppColorScheme.surface,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.fromBorderSide(ThemeRegistry.active.borders.chipBorder),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.campaign_outlined,
+                    size: 40,
+                    color: AppColorScheme.accent,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    l10n.adminSendMessage,
+                    style: TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.w600,
+                      color: AppColorScheme.onSurface,
+                      decoration: TextDecoration.none,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    widget.message,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w400,
+                      color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                      decoration: TextDecoration.none,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Focus(
+                    focusNode: _okFocusNode,
+                    autofocus: true,
+                    onFocusChange: (f) => setState(() => _focused = f),
+                    onKeyEvent: (node, event) => handleOneShotSelect(event, () {
+                      Navigator.of(context, rootNavigator: true).pop();
+                    }),
+                    child: GestureDetector(
+                      onTap: () {
+                        Navigator.of(context, rootNavigator: true).pop();
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                        decoration: BoxDecoration(
+                          color: _focused
+                              ? AppColorScheme.onSurface
+                              : AppColorScheme.onSurface.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          l10n.ok,
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w500,
+                            color: _focused ? AppColors.black : AppColorScheme.onSurface,
+                            decoration: TextDecoration.none,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -393,6 +393,13 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
       await navigatorState.maybePop();
       return true;
     }
+    if (!appRouter.canPop()) {
+      if (!_exitDialogShowing) {
+        _exitDialogShowing = true;
+        unawaited(_showExitConfirmation());
+      }
+      return true;
+    }
     return false;
   }
 

--- a/lib/ui/widgets/overlay_sheet.dart
+++ b/lib/ui/widgets/overlay_sheet.dart
@@ -40,6 +40,19 @@ VoidCallback createDialogBackCloseHandler(BuildContext dialogContext) {
   };
 }
 
+void _safeRestoreFocus(FocusNode? node) {
+  try {
+    if (node != null &&
+        node.context != null &&
+        node.context!.mounted &&
+        node.canRequestFocus) {
+      node.requestFocus();
+    }
+  } catch (_) {
+    // Avoid crash on disposed or unmounted focus node
+  }
+}
+
 /// Drop-in replacement for [showDialog] that captures the currently focused
 /// node before opening and restores focus to it after the dialog closes.
 /// Use this everywhere [showDialog] is called from a TV-facing screen so
@@ -82,9 +95,7 @@ Future<T?> showFocusRestoringDialog<T>({
     routeSettings: routeSettings,
     barrierLabel: barrierLabel,
   ).whenComplete(() {
-    if (previousFocus != null && previousFocus.canRequestFocus) {
-      previousFocus.requestFocus();
-    }
+    _safeRestoreFocus(previousFocus);
   });
 }
 
@@ -144,9 +155,7 @@ Future<T?> showFocusRestoringModalBottomSheet<T>({
     transitionAnimationController: transitionAnimationController,
     anchorPoint: anchorPoint,
   ).whenComplete(() {
-    if (previousFocus != null && previousFocus.canRequestFocus) {
-      previousFocus.requestFocus();
-    }
+    _safeRestoreFocus(previousFocus);
   });
 }
 
@@ -178,10 +187,8 @@ class OverlaySheetController {
         animationDuration: animationDuration,
         onClosed: (restoreFocus) {
           entry.remove();
-          if (restoreFocus &&
-              previousFocus != null &&
-              previousFocus.canRequestFocus) {
-            previousFocus.requestFocus();
+          if (restoreFocus) {
+            _safeRestoreFocus(previousFocus);
           }
         },
       ),


### PR DESCRIPTION
# Stop Admin Messages from Crashing ATV Devices

## Summary
When a broadcast admin message dialog is displayed on Android TV devicse, it does not immediately capture D-pad focus. As a result, focus remains on the background home screen card (or the previously focused element). Pressing "Enter" on the remote triggers the underlying card's action (which pushes a detail screen) while the dialog is active on top. This GoRouter desynchronization leads to a black screen. Not fun.

## Related Issues

None.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

1. Places the admin message dialog into a stateful widget `_AdminMessageDialog`.
2. Integrates the dialog with `RequestInitialFocus` targeting the OK button. This retries requesting focus (every 50ms for up to 3 seconds) until route transition animations settle and focus is successfully captured.
3. Integrates `handleOneShotSelect` to cleanly handle key select/enter events and pop the dialog via the root navigator `Navigator.of(context, rootNavigator: true).pop()`.

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Deployed to Android Shield
2. Sent Admin message
3. Acknowledged it with enter
4. Sent another
5. Dismissed it with back
6. Neither crashed; rejoiced.

## Screenshots (if applicable)
Picture this:
<img width="500" alt="Shield_Screenshot_2026-06-05_21-59-34" src="https://github.com/user-attachments/assets/8ec63315-dfe3-4c45-bc60-2531b4437160" />
Now picture it without the message.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced