### PR TITLE
Improve Bookshelf image prefetching

### DIFF
--- a/lib/data/models/media_bar_slide_item.dart
+++ b/lib/data/models/media_bar_slide_item.dart
@@ -5,6 +5,7 @@ class MediaBarSlideItem {
   final String? overview;
   final String? backdropUrl;
   final String? logoUrl;
+  final String? posterUrl;
   final String? officialRating;
   final int? year;
   final List<String> genres;
@@ -23,6 +24,7 @@ class MediaBarSlideItem {
     this.overview,
     this.backdropUrl,
     this.logoUrl,
+    this.posterUrl,
     this.officialRating,
     this.year,
     this.genres = const [],

--- a/lib/data/repositories/media_bar_repository.dart
+++ b/lib/data/repositories/media_bar_repository.dart
@@ -336,6 +336,9 @@ class MediaBarRepository {
       ? _client.imageApi.getLogoImageUrl(itemId, tag: logoTag, maxWidth: 600)
         : null;
 
+    final primaryTag = (data['ImageTags'] as Map?)?['Primary'] as String?;
+    final posterUrl = _client.imageApi.getPrimaryImageUrl(itemId, tag: primaryTag);
+
     final runTimeTicks = data['RunTimeTicks'] as int?;
 
     return MediaBarSlideItem(
@@ -345,6 +348,7 @@ class MediaBarRepository {
       overview: data['Overview'] as String?,
       backdropUrl: backdropUrl,
       logoUrl: logoUrl,
+      posterUrl: posterUrl,
       officialRating: data['OfficialRating'] as String?,
       year: data['ProductionYear'] as int?,
       genres: (data['Genres'] as List?)?.cast<String>().take(3).toList() ?? const [],

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -331,6 +331,16 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
     int centerIndex,
   ) {
     if (!mounted || items.isEmpty) return;
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    final screenWidth = MediaQuery.sizeOf(context).width;
+
+    // Calculate dimensions matching layout constraints exactly to maximize memory cache hits.
+    final isMobile = PlatformDetection.useMobileUi;
+    final contentHeight = widget.height - (isMobile ? 108.0 : 0.0);
+    final activeBookHeight = contentHeight * 0.84;
+    final activeBookWidth = activeBookHeight * 0.72;
+    final posterCacheW = (activeBookWidth * 0.88 * dpr).round().clamp(150, 400);
+    final backdropCacheW = (screenWidth * dpr).round().clamp(640, 1280);
 
     final warmIndices = <int>{
       centerIndex,
@@ -338,27 +348,54 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
       if (centerIndex + 2 < items.length) centerIndex + 2,
       if (centerIndex + 3 < items.length) centerIndex + 3,
       if (centerIndex - 1 >= 0) centerIndex - 1,
+      if (centerIndex - 2 >= 0) centerIndex - 2,
     };
 
+    final isBookshelf = _isBookshelfMode();
+
     Future<void>(() async {
+      // Allow active and adjacent images to load first without network contention
+      await Future<void>.delayed(const Duration(milliseconds: 1500));
       for (var i = 0; i < items.length; i++) {
         if (warmIndices.contains(i)) continue;
 
         final item = items[i];
         if (!mounted) return;
+
+        // Add a brief delay between items to prevent clogging the network queue
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+        if (!mounted) return;
+
         try {
-          if (item.backdropUrl != null) {
-            await precacheImage(
-              CachedNetworkImageProvider(item.backdropUrl!),
-              context,
-            );
-            if (!mounted) return;
-          }
-          if (item.logoUrl != null) {
-            await precacheImage(
-              CachedNetworkImageProvider(item.logoUrl!),
-              context,
-            );
+          if (isBookshelf) {
+            if (item.posterUrl != null) {
+              await precacheImage(
+                ResizeImage(
+                  CachedNetworkImageProvider(item.posterUrl!),
+                  width: posterCacheW,
+                ),
+                context,
+              );
+            }
+          } else {
+            if (item.backdropUrl != null) {
+              await precacheImage(
+                ResizeImage(
+                  CachedNetworkImageProvider(
+                    item.backdropUrl!,
+                  ),
+                  width: backdropCacheW,
+                ),
+                context,
+              );
+              if (!mounted) return;
+            }
+            if (item.logoUrl != null) {
+              await precacheImage(
+                CachedNetworkImageProvider(item.logoUrl!),
+                context,
+              );
+            }
           }
         } catch (_) {}
       }
@@ -489,22 +526,63 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
 
   void _prefetchAround(List<MediaBarSlideItem> items, int centerIndex) {
     if (!mounted || items.isEmpty) return;
-
-    final next = centerIndex + 1;
-    if (next >= items.length) return;
-    final item = items[next];
     final dpr = MediaQuery.devicePixelRatioOf(context);
-    final cacheW = (widget.height * 16 / 9 * dpr).round();
-    if (item.backdropUrl != null) {
-      precacheImage(
-        ResizeImage(
-          CachedNetworkImageProvider(item.backdropUrl!),
-          width: cacheW,
-        ),
-        context,
-      );
+    final screenWidth = MediaQuery.sizeOf(context).width;
+
+    // Calculate dimensions matching layout constraints exactly to maximize memory cache hits.
+    final isMobile = PlatformDetection.useMobileUi;
+    final contentHeight = widget.height - (isMobile ? 108.0 : 0.0);
+    final activeBookHeight = contentHeight * 0.84;
+    final activeBookWidth = activeBookHeight * 0.72;
+    final posterCacheW = (activeBookWidth * 0.88 * dpr).round().clamp(150, 400);
+    final backdropCacheW = (screenWidth * dpr).round().clamp(640, 1280);
+
+    final isBookshelf = _isBookshelfMode();
+
+    // Prefetch close items (next 2 slides and previous 2 slides)
+    final indicesToPrefetch = [
+      centerIndex + 1,
+      centerIndex + 2,
+      centerIndex - 1,
+      centerIndex - 2,
+    ];
+    for (final idx in indicesToPrefetch) {
+      if (idx >= 0 && idx < items.length) {
+        final item = items[idx];
+
+        if (isBookshelf) {
+          if (item.posterUrl != null) {
+            precacheImage(
+              ResizeImage(
+                CachedNetworkImageProvider(item.posterUrl!),
+                width: posterCacheW,
+              ),
+              context,
+            );
+          }
+        } else {
+          if (item.backdropUrl != null) {
+            precacheImage(
+              ResizeImage(
+                CachedNetworkImageProvider(
+                  item.backdropUrl!,
+                ),
+                width: backdropCacheW,
+              ),
+              context,
+            );
+          }
+
+          if (item.logoUrl != null) {
+            precacheImage(
+              CachedNetworkImageProvider(item.logoUrl!),
+              context,
+          );
+        }
+      }
     }
   }
+}
 
   void _setPaused(bool paused) {
     if (_isPaused == paused) return;
@@ -1935,8 +2013,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
     final items = widget.viewModel.items;
     if (index < 0 || index >= items.length) return;
     if (index == _currentIndex) return;
-    setState(() => _currentIndex = index);
-    _startAutoAdvance();
+    _goToPage(index);
     unawaited(widget.viewModel.ensureBookshelfDetail(items[index].itemId));
   }
 

--- a/lib/ui/widgets/mediabar/bookshelf_layout.dart
+++ b/lib/ui/widgets/mediabar/bookshelf_layout.dart
@@ -1,10 +1,10 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../../data/models/bookshelf_detail.dart';
 import '../../../data/models/media_bar_slide_item.dart';
-import '../bounded_network_image.dart';
 import 'bookshelf_glow.dart';
 
 class BookshelfLayout extends StatelessWidget {
@@ -277,7 +277,7 @@ class BookshelfLayout extends StatelessWidget {
   }) {
     final baseColor = glowColorForGenres(item.genres);
     final imageApi = GetIt.instance<MediaServerClient>().imageApi;
-    final posterUrl = imageApi.getPrimaryImageUrl(item.itemId);
+    final posterUrl = item.posterUrl ?? imageApi.getPrimaryImageUrl(item.itemId);
 
     // Adjusted centering alignment: center within the cover face area (crease to right edge)
     final creaseWidth = width * 0.12;
@@ -294,6 +294,46 @@ class BookshelfLayout extends StatelessWidget {
       0,                    0,                    0,                    1, 0,
     ];
 
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    final cacheW = (width * 0.88 * dpr).round().clamp(150, 400);
+
+    return CachedNetworkImage(
+      imageUrl: posterUrl,
+      memCacheWidth: cacheW,
+      maxWidthDiskCache: cacheW,
+      fadeInDuration: const Duration(milliseconds: 250),
+      fadeOutDuration: Duration.zero,
+      placeholder: (context, url) => const SizedBox.shrink(),
+      errorWidget: (context, url, error) => _buildActualBookWidget(
+        context: context,
+        width: width,
+        height: height,
+        creaseWidth: creaseWidth,
+        baseColor: baseColor,
+        desatMatrix: desatMatrix,
+        imageProvider: null,
+      ),
+      imageBuilder: (context, imageProvider) => _buildActualBookWidget(
+        context: context,
+        width: width,
+        height: height,
+        creaseWidth: creaseWidth,
+        baseColor: baseColor,
+        desatMatrix: desatMatrix,
+        imageProvider: imageProvider,
+      ),
+    );
+  }
+
+  Widget _buildActualBookWidget({
+    required BuildContext context,
+    required double width,
+    required double height,
+    required double creaseWidth,
+    required Color baseColor,
+    required List<double> desatMatrix,
+    required ImageProvider? imageProvider,
+  }) {
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
@@ -336,20 +376,19 @@ class BookshelfLayout extends StatelessWidget {
                     children: [
                       ColorFiltered(
                         colorFilter: ColorFilter.matrix(desatMatrix),
-                        child: BoundedNetworkImage(
-                          imageUrl: posterUrl,
-                          minWidth: 150,
-                          maxWidth: 400,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) => Container(
-                            color: Colors.grey[900],
-                            child: const Icon(
-                              Icons.movie_rounded,
-                              color: Colors.white24,
-                              size: 32,
-                            ),
-                          ),
-                        ),
+                        child: imageProvider != null
+                            ? Image(
+                                image: imageProvider,
+                                fit: BoxFit.cover,
+                              )
+                            : Container(
+                                color: Colors.grey[900],
+                                child: const Icon(
+                                  Icons.movie_rounded,
+                                  color: Colors.white24,
+                                  size: 32,
+                                ),
+                              ),
                       ),
                       // Subtle warm aged paper tint (BlendMode.multiply)
                       Positioned.fill(


### PR DESCRIPTION
# Better Books, the Pull Request

## Summary
The initial attempt at Bookshelf rendered in the backgrounds before the poster images were available. This implementation attempts to pre-fetch the images but also holds drawing each book until it is fully available (so it doesn't have the "book loads in... then gets slapper with a poster" problem.

## Related Issues
Just mental ones on my end.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Adds `posterUrl` to `MediaBarSlideItem` and populates it from primary image tags in `MediaBarRepository`.
- Optimizes prefetching by mode: in Bookshelf mode, prefetches only `posterUrl`
- Aligns cache width calculations with layout rendering dimensions (using `activeBookWidth * 0.88 * dpr` for posters, and screen width for backdrops) to ensure perfect memory cache hits.
- Routes manual/spine book selections in `_selectBookshelfIndex` through `_goToPage` to consistently trigger the pre-fetching pipeline.
- Adds a startup delay of 1.5s and spacing of 200ms between items in `_prefetchAllInBackground` to eliminate network and image decoding contention.
- Restructures `_buildActiveBook` in `bookshelf_layout.dart` to use `CachedNetworkImage` directly: keeps the book cover invisible while loading to prevent rendering blank templates, snapping all cover graphics into view together once loaded.

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built for Shield
2. Turned it on
3. Saw books

## Screenshots (if applicable)
Just optimizations.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
