### PR TITLE
Getting Dates in Order

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -43,7 +43,7 @@ class MultiServerRepository {
   static const _sessionCacheDuration = Duration(seconds: 5);
   static const _serverTimeout = Duration(seconds: 8);
   static const _fields =
-      'Type,UserData,Overview,Genres,CommunityRating,CriticRating,'
+      'DateCreated,Type,UserData,Overview,Genres,CommunityRating,CriticRating,'
       'OfficialRating,RunTimeTicks,ProductionYear,SeriesName,'
       'ParentIndexNumber,IndexNumber,Status,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,'
@@ -247,7 +247,8 @@ class MultiServerRepository {
             imageTypeLimit: _imageTypeLimit,
             enableResumable: false,
           );
-          return _parseItems(response, session.server.id);
+          final parsed = _parseItems(response, session.server.id);
+          return await _enrichNextUpItemsWithSeriesLastPlayed(parsed, session.client);
         }, label: 'next up from ${session.server.name}'),
       ),
     );
@@ -987,5 +988,97 @@ class MultiServerRepository {
     final aDate = a.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
     final bDate = b.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
     return bDate.compareTo(aDate);
+  }
+
+  Future<List<AggregatedItem>> _enrichNextUpItemsWithSeriesLastPlayed(
+    List<AggregatedItem> items,
+    MediaServerClient client,
+  ) async {
+    final seriesIds = items
+        .map((item) => item.rawData['SeriesId'] as String?)
+        .where((id) => id != null && id.isNotEmpty)
+        .cast<String>()
+        .toSet()
+        .toList();
+
+    if (seriesIds.isEmpty) return items;
+
+    try {
+      // 1. Fetch 100 most recently played episodes
+      final recentPlayedResponse = await client.itemsApi.getItems(
+        includeItemTypes: const ['Episode'],
+        filters: const ['IsPlayed'],
+        recursive: true,
+        sortBy: 'DatePlayed',
+        sortOrder: 'Descending',
+        limit: 100,
+        fields: 'UserData,SeriesId',
+      );
+
+      final recentItems = recentPlayedResponse['Items'] as List? ?? [];
+      final seriesLastPlayedMap = <String, String>{};
+      for (final item in recentItems) {
+        if (item is Map) {
+          final sId = item['SeriesId'] as String?;
+          final lastPlayed = item['UserData']?['LastPlayedDate'] as String?;
+          if (sId != null && lastPlayed != null && lastPlayed.isNotEmpty) {
+            seriesLastPlayedMap.putIfAbsent(sId, () => lastPlayed);
+          }
+        }
+      }
+
+      // 2. For any series not found in the top 100, fall back to batch querying the Series items directly
+      final missingSeriesIds = seriesIds.where((id) => !seriesLastPlayedMap.containsKey(id)).toList();
+      if (missingSeriesIds.isNotEmpty) {
+        final seriesResponse = await client.itemsApi.getItems(
+          ids: missingSeriesIds,
+          fields: 'UserData',
+          recursive: true,
+          limit: missingSeriesIds.length,
+        );
+        final seriesItems = seriesResponse['Items'] as List? ?? [];
+        for (final s in seriesItems) {
+          if (s is Map) {
+            final id = s['Id'] as String?;
+            final lastPlayed = s['UserData']?['LastPlayedDate'] as String?;
+            if (id != null && lastPlayed != null && lastPlayed.isNotEmpty) {
+              seriesLastPlayedMap[id] = lastPlayed;
+            }
+          }
+        }
+      }
+
+      // 3. Determine the effective date
+      return items.map((item) {
+        final sId = item.rawData['SeriesId'] as String?;
+        final seriesLastPlayed = sId != null ? seriesLastPlayedMap[sId] : null;
+        final episodeDateCreated = item.rawData['DateCreated'] as String?;
+
+        final lastPlayedDate = seriesLastPlayed != null ? DateTime.tryParse(seriesLastPlayed) : null;
+        final dateCreated = episodeDateCreated != null ? DateTime.tryParse(episodeDateCreated) : null;
+
+        DateTime? effectiveDate;
+        if (lastPlayedDate != null && dateCreated != null) {
+          effectiveDate = lastPlayedDate.isAfter(dateCreated) ? lastPlayedDate : dateCreated;
+        } else {
+          effectiveDate = lastPlayedDate ?? dateCreated;
+        }
+
+        if (effectiveDate != null) {
+          final updatedRaw = Map<String, dynamic>.from(item.rawData);
+          final userData = Map<String, dynamic>.from(updatedRaw['UserData'] as Map? ?? {});
+          userData['LastPlayedDate'] = effectiveDate.toIso8601String();
+          updatedRaw['UserData'] = userData;
+          return AggregatedItem(
+            id: item.id,
+            serverId: item.serverId,
+            rawData: updatedRaw,
+          );
+        }
+        return item;
+      }).toList();
+    } catch (_) {
+      return items;
+    }
   }
 }

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -17,6 +17,7 @@ import '../services/media_server_client_factory.dart';
 import '../utils/bounded_concurrency.dart';
 import '../utils/genre_browse_utils.dart';
 import '../utils/latest_media_row_normalizer.dart';
+import '../utils/next_up_enrichment.dart';
 import '../utils/playlist_utils.dart';
 import '../../l10n/app_localizations.dart';
 import '../../l10n/current_app_localizations.dart';
@@ -993,92 +994,6 @@ class MultiServerRepository {
   Future<List<AggregatedItem>> _enrichNextUpItemsWithSeriesLastPlayed(
     List<AggregatedItem> items,
     MediaServerClient client,
-  ) async {
-    final seriesIds = items
-        .map((item) => item.rawData['SeriesId'] as String?)
-        .where((id) => id != null && id.isNotEmpty)
-        .cast<String>()
-        .toSet()
-        .toList();
-
-    if (seriesIds.isEmpty) return items;
-
-    try {
-      // 1. Fetch 100 most recently played episodes
-      final recentPlayedResponse = await client.itemsApi.getItems(
-        includeItemTypes: const ['Episode'],
-        filters: const ['IsPlayed'],
-        recursive: true,
-        sortBy: 'DatePlayed',
-        sortOrder: 'Descending',
-        limit: 100,
-        fields: 'UserData,SeriesId',
-      );
-
-      final recentItems = recentPlayedResponse['Items'] as List? ?? [];
-      final seriesLastPlayedMap = <String, String>{};
-      for (final item in recentItems) {
-        if (item is Map) {
-          final sId = item['SeriesId'] as String?;
-          final lastPlayed = item['UserData']?['LastPlayedDate'] as String?;
-          if (sId != null && lastPlayed != null && lastPlayed.isNotEmpty) {
-            seriesLastPlayedMap.putIfAbsent(sId, () => lastPlayed);
-          }
-        }
-      }
-
-      // 2. For any series not found in the top 100, fall back to batch querying the Series items directly
-      final missingSeriesIds = seriesIds.where((id) => !seriesLastPlayedMap.containsKey(id)).toList();
-      if (missingSeriesIds.isNotEmpty) {
-        final seriesResponse = await client.itemsApi.getItems(
-          ids: missingSeriesIds,
-          fields: 'UserData',
-          recursive: true,
-          limit: missingSeriesIds.length,
-        );
-        final seriesItems = seriesResponse['Items'] as List? ?? [];
-        for (final s in seriesItems) {
-          if (s is Map) {
-            final id = s['Id'] as String?;
-            final lastPlayed = s['UserData']?['LastPlayedDate'] as String?;
-            if (id != null && lastPlayed != null && lastPlayed.isNotEmpty) {
-              seriesLastPlayedMap[id] = lastPlayed;
-            }
-          }
-        }
-      }
-
-      // 3. Determine the effective date
-      return items.map((item) {
-        final sId = item.rawData['SeriesId'] as String?;
-        final seriesLastPlayed = sId != null ? seriesLastPlayedMap[sId] : null;
-        final episodeDateCreated = item.rawData['DateCreated'] as String?;
-
-        final lastPlayedDate = seriesLastPlayed != null ? DateTime.tryParse(seriesLastPlayed) : null;
-        final dateCreated = episodeDateCreated != null ? DateTime.tryParse(episodeDateCreated) : null;
-
-        DateTime? effectiveDate;
-        if (lastPlayedDate != null && dateCreated != null) {
-          effectiveDate = lastPlayedDate.isAfter(dateCreated) ? lastPlayedDate : dateCreated;
-        } else {
-          effectiveDate = lastPlayedDate ?? dateCreated;
-        }
-
-        if (effectiveDate != null) {
-          final updatedRaw = Map<String, dynamic>.from(item.rawData);
-          final userData = Map<String, dynamic>.from(updatedRaw['UserData'] as Map? ?? {});
-          userData['LastPlayedDate'] = effectiveDate.toIso8601String();
-          updatedRaw['UserData'] = userData;
-          return AggregatedItem(
-            id: item.id,
-            serverId: item.serverId,
-            rawData: updatedRaw,
-          );
-        }
-        return item;
-      }).toList();
-    } catch (_) {
-      return items;
-    }
-  }
+  ) =>
+      enrichNextUpItemsWithSeriesLastPlayed(items, client);
 }

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -27,14 +27,14 @@ class RowDataSource {
   static const _genreArtworkConcurrency = 6;
 
   static const _fields =
-      'Type,UserData,Overview,Genres,CommunityRating,CriticRating,'
+      'DateCreated,Type,UserData,Overview,Genres,CommunityRating,CriticRating,'
       'OfficialRating,RunTimeTicks,ProductionYear,SeriesName,'
       'ParentIndexNumber,IndexNumber,Status,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,'
       'ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,'
       'ParentLogoItemId,ParentLogoImageTag';
   static const _fallbackFields =
-      'Type,UserData,OfficialRating,RunTimeTicks,ProductionYear,SeriesName,'
+      'DateCreated,Type,UserData,OfficialRating,RunTimeTicks,ProductionYear,SeriesName,'
       'ParentIndexNumber,IndexNumber,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,'
       'ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,'
@@ -107,13 +107,15 @@ class RowDataSource {
       limit: _defaultLimit,
       enableResumable: false,
     );
-    return _buildRow(
+    final row = _buildRow(
       id: 'nextUp',
       title: _l10n.nextUp,
       response: response,
       serverId: serverId,
       rowType: HomeRowType.nextUp,
     );
+    final enrichedItems = await _enrichNextUpItemsWithSeriesLastPlayed(row.items);
+    return row.copyWith(items: enrichedItems);
   }
 
   Future<HomeRow> loadResumeRelaxed(String serverId) async {
@@ -134,13 +136,15 @@ class RowDataSource {
     final response = await getNextUpRelaxed(
       limit: _defaultLimit,
     );
-    return _buildRow(
+    final row = _buildRow(
       id: 'nextUp',
       title: _l10n.nextUp,
       response: response,
       serverId: serverId,
       rowType: HomeRowType.nextUp,
     );
+    final enrichedItems = await _enrichNextUpItemsWithSeriesLastPlayed(row.items);
+    return row.copyWith(items: enrichedItems);
   }
 
   Future<HomeRow> loadLatestMedia(
@@ -521,13 +525,15 @@ class RowDataSource {
       parentId: parentId,
       limit: _defaultLimit,
     );
-    return _buildRow(
+    final row = _buildRow(
       id: 'nextUp_$parentId',
       title: _l10n.nextUp,
       response: response,
       serverId: serverId,
       rowType: HomeRowType.nextUp,
     );
+    final enrichedItems = await _enrichNextUpItemsWithSeriesLastPlayed(row.items);
+    return row.copyWith(items: enrichedItems);
   }
 
   Future<HomeRow> loadLibraryFavorites(
@@ -1660,6 +1666,97 @@ class RowDataSource {
         .map((e) => e.trim().toUpperCase())
         .where((e) => e.isNotEmpty)
         .toSet();
+  }
+
+  Future<List<AggregatedItem>> _enrichNextUpItemsWithSeriesLastPlayed(
+    List<AggregatedItem> items,
+  ) async {
+    final seriesIds = items
+        .map((item) => item.rawData['SeriesId'] as String?)
+        .where((id) => id != null && id.isNotEmpty)
+        .cast<String>()
+        .toSet()
+        .toList();
+
+    if (seriesIds.isEmpty) return items;
+
+    try {
+      // 1. Fetch 100 most recently played episodes
+      final recentPlayedResponse = await _client.itemsApi.getItems(
+        includeItemTypes: const ['Episode'],
+        filters: const ['IsPlayed'],
+        recursive: true,
+        sortBy: 'DatePlayed',
+        sortOrder: 'Descending',
+        limit: 100,
+        fields: 'UserData,SeriesId',
+      );
+
+      final recentItems = recentPlayedResponse['Items'] as List? ?? [];
+      final seriesLastPlayedMap = <String, String>{};
+      for (final item in recentItems) {
+        if (item is Map) {
+          final sId = item['SeriesId'] as String?;
+          final lastPlayed = item['UserData']?['LastPlayedDate'] as String?;
+          if (sId != null && lastPlayed != null && lastPlayed.isNotEmpty) {
+            seriesLastPlayedMap.putIfAbsent(sId, () => lastPlayed);
+          }
+        }
+      }
+
+      // 2. For any series not found in the top 100, fall back to batch querying the Series items directly
+      final missingSeriesIds = seriesIds.where((id) => !seriesLastPlayedMap.containsKey(id)).toList();
+      if (missingSeriesIds.isNotEmpty) {
+        final seriesResponse = await _client.itemsApi.getItems(
+          ids: missingSeriesIds,
+          fields: 'UserData',
+          recursive: true,
+          limit: missingSeriesIds.length,
+        );
+        final seriesItems = seriesResponse['Items'] as List? ?? [];
+        for (final s in seriesItems) {
+          if (s is Map) {
+            final id = s['Id'] as String?;
+            final lastPlayed = s['UserData']?['LastPlayedDate'] as String?;
+            if (id != null && lastPlayed != null && lastPlayed.isNotEmpty) {
+              seriesLastPlayedMap[id] = lastPlayed;
+            }
+          }
+        }
+      }
+
+      // 3. Determine the effective date
+      return items.map((item) {
+        final sId = item.rawData['SeriesId'] as String?;
+        final seriesLastPlayed = sId != null ? seriesLastPlayedMap[sId] : null;
+        final episodeDateCreated = item.rawData['DateCreated'] as String?;
+
+        final lastPlayedDate = seriesLastPlayed != null ? DateTime.tryParse(seriesLastPlayed) : null;
+        final dateCreated = episodeDateCreated != null ? DateTime.tryParse(episodeDateCreated) : null;
+
+        DateTime? effectiveDate;
+        if (lastPlayedDate != null && dateCreated != null) {
+          effectiveDate = lastPlayedDate.isAfter(dateCreated) ? lastPlayedDate : dateCreated;
+        } else {
+          effectiveDate = lastPlayedDate ?? dateCreated;
+        }
+
+        if (effectiveDate != null) {
+          final updatedRaw = Map<String, dynamic>.from(item.rawData);
+          final userData = Map<String, dynamic>.from(updatedRaw['UserData'] as Map? ?? {});
+          userData['LastPlayedDate'] = effectiveDate.toIso8601String();
+          updatedRaw['UserData'] = userData;
+          return AggregatedItem(
+            id: item.id,
+            serverId: item.serverId,
+            rawData: updatedRaw,
+          );
+        }
+        return item;
+      }).toList();
+    } catch (_) {
+      return items;
+    }
   }
 }
 

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -15,6 +15,7 @@ import '../models/home_row.dart';
 import '../utils/bounded_concurrency.dart';
 import '../utils/latest_media_row_normalizer.dart';
 import '../utils/genre_browse_utils.dart';
+import '../utils/next_up_enrichment.dart';
 import '../utils/playlist_utils.dart';
 
 class RowDataSource {
@@ -1670,94 +1671,8 @@ class RowDataSource {
 
   Future<List<AggregatedItem>> _enrichNextUpItemsWithSeriesLastPlayed(
     List<AggregatedItem> items,
-  ) async {
-    final seriesIds = items
-        .map((item) => item.rawData['SeriesId'] as String?)
-        .where((id) => id != null && id.isNotEmpty)
-        .cast<String>()
-        .toSet()
-        .toList();
-
-    if (seriesIds.isEmpty) return items;
-
-    try {
-      // 1. Fetch 100 most recently played episodes
-      final recentPlayedResponse = await _client.itemsApi.getItems(
-        includeItemTypes: const ['Episode'],
-        filters: const ['IsPlayed'],
-        recursive: true,
-        sortBy: 'DatePlayed',
-        sortOrder: 'Descending',
-        limit: 100,
-        fields: 'UserData,SeriesId',
-      );
-
-      final recentItems = recentPlayedResponse['Items'] as List? ?? [];
-      final seriesLastPlayedMap = <String, String>{};
-      for (final item in recentItems) {
-        if (item is Map) {
-          final sId = item['SeriesId'] as String?;
-          final lastPlayed = item['UserData']?['LastPlayedDate'] as String?;
-          if (sId != null && lastPlayed != null && lastPlayed.isNotEmpty) {
-            seriesLastPlayedMap.putIfAbsent(sId, () => lastPlayed);
-          }
-        }
-      }
-
-      // 2. For any series not found in the top 100, fall back to batch querying the Series items directly
-      final missingSeriesIds = seriesIds.where((id) => !seriesLastPlayedMap.containsKey(id)).toList();
-      if (missingSeriesIds.isNotEmpty) {
-        final seriesResponse = await _client.itemsApi.getItems(
-          ids: missingSeriesIds,
-          fields: 'UserData',
-          recursive: true,
-          limit: missingSeriesIds.length,
-        );
-        final seriesItems = seriesResponse['Items'] as List? ?? [];
-        for (final s in seriesItems) {
-          if (s is Map) {
-            final id = s['Id'] as String?;
-            final lastPlayed = s['UserData']?['LastPlayedDate'] as String?;
-            if (id != null && lastPlayed != null && lastPlayed.isNotEmpty) {
-              seriesLastPlayedMap[id] = lastPlayed;
-            }
-          }
-        }
-      }
-
-      // 3. Determine the effective date
-      return items.map((item) {
-        final sId = item.rawData['SeriesId'] as String?;
-        final seriesLastPlayed = sId != null ? seriesLastPlayedMap[sId] : null;
-        final episodeDateCreated = item.rawData['DateCreated'] as String?;
-
-        final lastPlayedDate = seriesLastPlayed != null ? DateTime.tryParse(seriesLastPlayed) : null;
-        final dateCreated = episodeDateCreated != null ? DateTime.tryParse(episodeDateCreated) : null;
-
-        DateTime? effectiveDate;
-        if (lastPlayedDate != null && dateCreated != null) {
-          effectiveDate = lastPlayedDate.isAfter(dateCreated) ? lastPlayedDate : dateCreated;
-        } else {
-          effectiveDate = lastPlayedDate ?? dateCreated;
-        }
-
-        if (effectiveDate != null) {
-          final updatedRaw = Map<String, dynamic>.from(item.rawData);
-          final userData = Map<String, dynamic>.from(updatedRaw['UserData'] as Map? ?? {});
-          userData['LastPlayedDate'] = effectiveDate.toIso8601String();
-          updatedRaw['UserData'] = userData;
-          return AggregatedItem(
-            id: item.id,
-            serverId: item.serverId,
-            rawData: updatedRaw,
-          );
-        }
-        return item;
-      }).toList();
-    } catch (_) {
-      return items;
-    }
-  }
+  ) =>
+      enrichNextUpItemsWithSeriesLastPlayed(items, _client);
 }
 
 class _ParsedStableId {

--- a/lib/data/utils/next_up_enrichment.dart
+++ b/lib/data/utils/next_up_enrichment.dart
@@ -1,0 +1,113 @@
+import 'package:server_core/server_core.dart';
+
+import '../models/aggregated_item.dart';
+
+/// Enriches a list of Next Up items with an accurate [LastPlayedDate] pulled
+/// from the parent Series, so that the continue-watching row sorts correctly
+/// when a user's most-recently-watched episode has an older [DateCreated].
+///
+/// Strategy:
+///  1. Fetch the 100 most recently played episodes and build a
+///     seriesId → lastPlayedDate map from their UserData.
+///  2. For any series still missing (i.e. beyond the top 100), batch-query
+///     the Series items directly by ID.
+///  3. Set each item's effective LastPlayedDate to
+///     max(seriesLastPlayed, episodeDateCreated).
+Future<List<AggregatedItem>> enrichNextUpItemsWithSeriesLastPlayed(
+  List<AggregatedItem> items,
+  MediaServerClient client,
+) async {
+  final seriesIds = items
+      .map((item) => item.rawData['SeriesId'] as String?)
+      .where((id) => id != null && id.isNotEmpty)
+      .cast<String>()
+      .toSet()
+      .toList();
+
+  if (seriesIds.isEmpty) return items;
+
+  try {
+    // 1. Fetch 100 most recently played episodes
+    final recentPlayedResponse = await client.itemsApi.getItems(
+      includeItemTypes: const ['Episode'],
+      filters: const ['IsPlayed'],
+      recursive: true,
+      sortBy: 'DatePlayed',
+      sortOrder: 'Descending',
+      limit: 100,
+      fields: 'UserData,SeriesId',
+    );
+
+    final recentItems = recentPlayedResponse['Items'] as List? ?? [];
+    final seriesLastPlayedMap = <String, String>{};
+    for (final item in recentItems) {
+      if (item is Map) {
+        final sId = item['SeriesId'] as String?;
+        final lastPlayed = item['UserData']?['LastPlayedDate'] as String?;
+        if (sId != null && lastPlayed != null && lastPlayed.isNotEmpty) {
+          seriesLastPlayedMap.putIfAbsent(sId, () => lastPlayed);
+        }
+      }
+    }
+
+    // 2. For any series not found in the top 100, batch-query directly.
+    //    Note: do NOT pass recursive=true when IDs are supplied — it has no
+    //    effect on ID-based lookups but can cause some servers to include
+    //    child items, eating into the limit.
+    final missingSeriesIds =
+        seriesIds.where((id) => !seriesLastPlayedMap.containsKey(id)).toList();
+    if (missingSeriesIds.isNotEmpty) {
+      final seriesResponse = await client.itemsApi.getItems(
+        ids: missingSeriesIds,
+        fields: 'UserData',
+        limit: missingSeriesIds.length,
+      );
+      final seriesItems = seriesResponse['Items'] as List? ?? [];
+      for (final s in seriesItems) {
+        if (s is Map) {
+          final id = s['Id'] as String?;
+          final lastPlayed = s['UserData']?['LastPlayedDate'] as String?;
+          if (id != null && lastPlayed != null && lastPlayed.isNotEmpty) {
+            seriesLastPlayedMap[id] = lastPlayed;
+          }
+        }
+      }
+    }
+
+    // 3. Determine the effective date for each item
+    return items.map((item) {
+      final sId = item.rawData['SeriesId'] as String?;
+      final seriesLastPlayed = sId != null ? seriesLastPlayedMap[sId] : null;
+      final episodeDateCreated = item.rawData['DateCreated'] as String?;
+
+      final lastPlayedDate =
+          seriesLastPlayed != null ? DateTime.tryParse(seriesLastPlayed) : null;
+      final dateCreated =
+          episodeDateCreated != null ? DateTime.tryParse(episodeDateCreated) : null;
+
+      DateTime? effectiveDate;
+      if (lastPlayedDate != null && dateCreated != null) {
+        effectiveDate =
+            lastPlayedDate.isAfter(dateCreated) ? lastPlayedDate : dateCreated;
+      } else {
+        effectiveDate = lastPlayedDate ?? dateCreated;
+      }
+
+      if (effectiveDate != null) {
+        final updatedRaw = Map<String, dynamic>.from(item.rawData);
+        final userData =
+            Map<String, dynamic>.from(updatedRaw['UserData'] as Map? ?? {});
+        userData['LastPlayedDate'] = effectiveDate.toIso8601String();
+        updatedRaw['UserData'] = userData;
+        return AggregatedItem(
+          id: item.id,
+          serverId: item.serverId,
+          rawData: updatedRaw,
+        );
+      }
+      return item;
+    }).toList();
+  } catch (_) {
+    return items;
+  }
+}

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -910,12 +910,12 @@ class HomeViewModel extends ChangeNotifier {
           for (final item in nextUpRow?.items ?? []) {
             mergedItemsMap.putIfAbsent(item.id, () => item);
           }
-          final sorted = mergedItemsMap.values.toList()
-            ..sort((a, b) {
-              final aDate = a.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
-              final bDate = b.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
-              return bDate.compareTo(aDate);
-            });
+          int byLastPlayedDate(AggregatedItem a, AggregatedItem b) {
+            final aDate = a.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+            final bDate = b.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+            return bDate.compareTo(aDate);
+          }
+          final sorted = mergedItemsMap.values.toList()..sort(byLastPlayedDate);
           _applyMergedResumeResult(sorted);
         } else {
           final results = await Future.wait([
@@ -929,12 +929,12 @@ class HomeViewModel extends ChangeNotifier {
           for (final item in results[1].items) {
             mergedItemsMap.putIfAbsent(item.id, () => item);
           }
-          final sorted = mergedItemsMap.values.toList()
-            ..sort((a, b) {
-              final aDate = a.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
-              final bDate = b.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
-              return bDate.compareTo(aDate);
-            });
+          int byLastPlayedDate(AggregatedItem a, AggregatedItem b) {
+            final aDate = a.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+            final bDate = b.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+            return bDate.compareTo(aDate);
+          }
+          final sorted = mergedItemsMap.values.toList()..sort(byLastPlayedDate);
           _applyMergedResumeResult(sorted);
         }
       } catch (_) {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -910,7 +910,13 @@ class HomeViewModel extends ChangeNotifier {
           for (final item in nextUpRow?.items ?? []) {
             mergedItemsMap.putIfAbsent(item.id, () => item);
           }
-          _applyMergedResumeResult(mergedItemsMap.values.toList());
+          final sorted = mergedItemsMap.values.toList()
+            ..sort((a, b) {
+              final aDate = a.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+              final bDate = b.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+              return bDate.compareTo(aDate);
+            });
+          _applyMergedResumeResult(sorted);
         } else {
           final results = await Future.wait([
             _dataSource.loadResume(_serverId),
@@ -923,7 +929,13 @@ class HomeViewModel extends ChangeNotifier {
           for (final item in results[1].items) {
             mergedItemsMap.putIfAbsent(item.id, () => item);
           }
-          _applyMergedResumeResult(mergedItemsMap.values.toList());
+          final sorted = mergedItemsMap.values.toList()
+            ..sort((a, b) {
+              final aDate = a.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+              final bDate = b.rawData['UserData']?['LastPlayedDate'] as String? ?? '';
+              return bDate.compareTo(aDate);
+            });
+          _applyMergedResumeResult(sorted);
         }
       } catch (_) {
       } finally {


### PR DESCRIPTION
# Refine logic for Continue Watching and Next Up Merger Row

## Summary
1. Use LastPlayedDate if available (partially played items where item.UserData?.LastPlayedDate is available)
2. If unavailable, check Series LastPlayedDate (retrieve series' active date via the recent episode lookup, with  series batch fallback)
3. If unavailable, falls  back to DateCreated - used when neither of the above exist OR if the episode's creation date is more recent than the last playback of the series (new episode emphasis).

## Related Issues
Jenn's request!

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Implemented a dual-lookup strategy to determine the last active date of parent series for unplayed Next Up episodes:
  1. Batch query the 100 most recently played episodes (`sortBy: 'DatePlayed', sortOrder: 'Descending', filters: ['IsPlayed']`) recursively across libraries to map active series to their exact last watched date.
  2. Fall back to batch-querying the Series items directly (with `recursive: true`) if a series is not found in the top 100 played list.
- Compared the retrieved series' last played date with the episode's creation date (`DateCreated`) and used the more recent of the two dates.
- Injected this effective timestamp into the episodes' `UserData['LastPlayedDate']` structure.
- Sorted the combined list of Continue Watching and Next Up items chronologically by `LastPlayedDate` descending in `HomeViewModel`.
- Integrated enrichment in `getAggregatedNextUp` (multi-server) and `loadNextUp`/`loadNextUpRelaxed`/`loadLibraryNextUp` (single-server).

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device - on Android 11 and Android TV
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Enable the "Merge Continue Watching and Next Up" setting.
2. Verified that partially watched movies/episodes and Next Up episodes are displayed in a single row sorted chronologically by last active time (with newly added episodes of active shows bubbling up correctly).

## Screenshots (if applicable)
It's the CW&NU. You know what it looks like.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
