### PR TITLE
Fixing Home Page Issues

### DIFF
--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -252,6 +252,7 @@ class SessionRepository {
         await _authStore.removeUser(serverId, userId);
       }
       _clientFactory.removeClient(serverId);
+      resetActiveStreamResolver();
     }
 
     await _authPrefs.setLastServerId('');

--- a/lib/data/services/media_server_client_factory.dart
+++ b/lib/data/services/media_server_client_factory.dart
@@ -27,7 +27,18 @@ class MediaServerClientFactory {
   }
 
   MediaServerClient? getClientIfExists(String serverId) {
-    return _clients[serverId];
+    final client = _clients[serverId];
+    if (client != null) return client;
+
+    final normalizedInput = normalizeServerBaseUrl(serverId);
+    if (normalizedInput.isNotEmpty) {
+      for (final activeClient in _clients.values) {
+        if (normalizeServerBaseUrl(activeClient.baseUrl) == normalizedInput) {
+          return activeClient;
+        }
+      }
+    }
+    return null;
   }
 
   MediaServerClient getActiveClient() {

--- a/lib/data/services/media_server_client_factory.dart
+++ b/lib/data/services/media_server_client_factory.dart
@@ -30,11 +30,13 @@ class MediaServerClientFactory {
     final client = _clients[serverId];
     if (client != null) return client;
 
-    final normalizedInput = normalizeServerBaseUrl(serverId);
-    if (normalizedInput.isNotEmpty) {
-      for (final activeClient in _clients.values) {
-        if (normalizeServerBaseUrl(activeClient.baseUrl) == normalizedInput) {
-          return activeClient;
+    if (serverId.contains('://')) {
+      final normalizedInput = normalizeServerBaseUrl(serverId);
+      if (normalizedInput.isNotEmpty) {
+        for (final activeClient in _clients.values) {
+          if (normalizeServerBaseUrl(activeClient.baseUrl) == normalizedInput) {
+            return activeClient;
+          }
         }
       }
     }

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -12,7 +12,7 @@ enum ItemDetailState { loading, ready, error }
 
 class ItemDetailViewModel extends ChangeNotifier {
   static const _episodeOverviewFields =
-  'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay';
+      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData';
 
   final MediaServerClient _client;
   final ItemMutationRepository _mutations;

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -501,7 +501,15 @@ void registerPlaybackModule() {
   );
 }
 
+MediaServerClient? _currentActiveResolverClient;
+
 void setActiveStreamResolver(MediaServerClient client) {
+  if (identical(client, _currentActiveResolverClient) &&
+      _getIt.isRegistered<MediaStreamResolver>() &&
+      _getIt.isRegistered<PlayerService>()) {
+    return;
+  }
+
   if (_getIt.isRegistered<MediaStreamResolver>()) {
     _getIt.unregister<MediaStreamResolver>();
   }
@@ -529,12 +537,14 @@ void setActiveStreamResolver(MediaServerClient client) {
   final manager = _getIt<PlaybackManager>();
   manager.setResolver(resolver);
   manager.setPlayerService(service);
+
+  _currentActiveResolverClient = client;
 }
 
 Future<void> _ensureResolverForItem(dynamic item) async {
   if (item is! AggregatedItem) return;
   final factory = _getIt<MediaServerClientFactory>();
-  final client = factory.getClientIfExists(item.serverId);
-  if (client == null || identical(client, _getIt<MediaServerClient>())) return;
+  final client = factory.getClientIfExists(item.serverId) ?? _getIt<MediaServerClient>();
   setActiveStreamResolver(client);
 }
+

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -503,6 +503,10 @@ void registerPlaybackModule() {
 
 MediaServerClient? _currentActiveResolverClient;
 
+void resetActiveStreamResolver() {
+  _currentActiveResolverClient = null;
+}
+
 void setActiveStreamResolver(MediaServerClient client) {
   if (identical(client, _currentActiveResolverClient) &&
       _getIt.isRegistered<MediaStreamResolver>() &&
@@ -544,7 +548,8 @@ void setActiveStreamResolver(MediaServerClient client) {
 Future<void> _ensureResolverForItem(dynamic item) async {
   if (item is! AggregatedItem) return;
   final factory = _getIt<MediaServerClientFactory>();
-  final client = factory.getClientIfExists(item.serverId) ?? _getIt<MediaServerClient>();
+  final client = factory.getClientIfExists(item.serverId);
+  if (client == null) return;
   setActiveStreamResolver(client);
 }
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4564,22 +4564,36 @@ class _ActionButtonsState extends State<_ActionButtons> {
       context.replace(Destinations.item(item.id, serverId: item.serverId));
 
       final isPhoto = item.type == 'Photo';
-      final isSeries = item.type == 'Series';
-      final totalEpisodes = isSeries
-          ? (item.recursiveItemCount ?? 0)
-          : (item.childCount ?? item.recursiveItemCount ?? 0);
-      final unplayed = item.unplayedItemCount ?? totalEpisodes;
-      final isFullyWatched = item.isPlayed || unplayed == 0;
-      final isFullyUnwatched = unplayed == totalEpisodes;
-      final isPartiallyWatched = !isFullyWatched && !isFullyUnwatched;
-
-      final hasProgress = isSeries
-          ? isPartiallyWatched
-          : ((item.playedPercentage ?? 0) > 0 ||
-             (item.playbackPosition?.inMilliseconds ?? 0) > 0);
-
-      _play(context, item, resume: !isPhoto && hasProgress);
+      final ws = _computeWatchState(item);
+      _play(context, item, resume: !isPhoto && ws.hasProgress);
     });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Watch-state helper — avoids repeating the same 6-line block in three places
+  // ---------------------------------------------------------------------------
+
+  ({bool isFullyWatched, bool isFullyUnwatched, bool isPartiallyWatched,
+    bool hasProgress})
+  _computeWatchState(AggregatedItem item) {
+    final isSeries = item.type == 'Series';
+    final totalEpisodes = isSeries
+        ? (item.recursiveItemCount ?? 0)
+        : (item.childCount ?? item.recursiveItemCount ?? 0);
+    final unplayed = item.unplayedItemCount ?? totalEpisodes;
+    final isFullyWatched = item.isPlayed || unplayed == 0;
+    final isFullyUnwatched = unplayed == totalEpisodes;
+    final isPartiallyWatched = !isFullyWatched && !isFullyUnwatched;
+    final hasProgress = isSeries
+        ? isPartiallyWatched
+        : ((item.playedPercentage ?? 0) > 0 ||
+           (item.playbackPosition?.inMilliseconds ?? 0) > 0);
+    return (
+      isFullyWatched: isFullyWatched,
+      isFullyUnwatched: isFullyUnwatched,
+      isPartiallyWatched: isPartiallyWatched,
+      hasProgress: hasProgress,
+    );
   }
 
   List<Map<String, dynamic>> _streamsForTrackSelectors(
@@ -4633,18 +4647,10 @@ class _ActionButtonsState extends State<_ActionButtons> {
     final isPhoto = item.type == 'Photo';
     final isBook = _isReadableBookItem(item);
     final isSeries = item.type == 'Series';
-    final totalEpisodes = item.type == 'Series'
-        ? (item.recursiveItemCount ?? 0)
-        : (item.childCount ?? item.recursiveItemCount ?? 0);
-    final unplayed = item.unplayedItemCount ?? totalEpisodes;
-    final isFullyWatched = item.isPlayed || unplayed == 0;
-    final isFullyUnwatched = unplayed == totalEpisodes;
-    final isPartiallyWatched = !isFullyWatched && !isFullyUnwatched;
-
-    final hasProgress = isSeries
-        ? isPartiallyWatched
-        : ((item.playedPercentage ?? 0) > 0 ||
-           (item.playbackPosition?.inMilliseconds ?? 0) > 0);
+    final ws = _computeWatchState(item);
+    final isFullyWatched = ws.isFullyWatched;
+    final isFullyUnwatched = ws.isFullyUnwatched;
+    final hasProgress = ws.hasProgress;
     final selectedSource = _selectedMediaSourceForItem(
       item,
       widget.selectedMediaSourceId,
@@ -4683,12 +4689,10 @@ class _ActionButtonsState extends State<_ActionButtons> {
           final s = nextUp.parentIndexNumber;
           final e = nextUp.indexNumber;
           if (s != null && e != null) {
-            if (_isCompact(context)) {
-              if (s == 1 && e == 1) {
-                playButtonLabel = l10n.play;
-              } else {
-                playButtonLabel = 'S${s}E$e';
-              }
+            if (s == 1 && e == 1) {
+              playButtonLabel = l10n.play;
+            } else if (_isCompact(context)) {
+              playButtonLabel = 'S${s}E$e';
             } else {
               playButtonLabel = 'Resume from S$s:E$e';
             }
@@ -5569,12 +5573,9 @@ class _ActionButtonsState extends State<_ActionButtons> {
               throw PlaybackStartupRecoveryAbortedException();
             }
 
-            final totalEpisodes = item.type == 'Series'
-                ? (item.recursiveItemCount ?? 0)
-                : (item.childCount ?? item.recursiveItemCount ?? 0);
-            final unplayed = item.unplayedItemCount ?? totalEpisodes;
-            final isFullyWatched = item.isPlayed || unplayed == 0;
-            final isFullyUnwatched = unplayed == totalEpisodes;
+            final ws = _computeWatchState(item);
+            final isFullyWatched = ws.isFullyWatched;
+            final isFullyUnwatched = ws.isFullyUnwatched;
 
             AggregatedItem targetEpisode;
             if (isFullyWatched || isFullyUnwatched) {

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4562,7 +4562,23 @@ class _ActionButtonsState extends State<_ActionButtons> {
       // Consume autoPlay from the current detail route so back navigation
       // doesn't re-trigger playback.
       context.replace(Destinations.item(item.id, serverId: item.serverId));
-      _play(context, item);
+
+      final isPhoto = item.type == 'Photo';
+      final isSeries = item.type == 'Series';
+      final totalEpisodes = isSeries
+          ? (item.recursiveItemCount ?? 0)
+          : (item.childCount ?? item.recursiveItemCount ?? 0);
+      final unplayed = item.unplayedItemCount ?? totalEpisodes;
+      final isFullyWatched = item.isPlayed || unplayed == 0;
+      final isFullyUnwatched = unplayed == totalEpisodes;
+      final isPartiallyWatched = !isFullyWatched && !isFullyUnwatched;
+
+      final hasProgress = isSeries
+          ? isPartiallyWatched
+          : ((item.playedPercentage ?? 0) > 0 ||
+             (item.playbackPosition?.inMilliseconds ?? 0) > 0);
+
+      _play(context, item, resume: !isPhoto && hasProgress);
     });
   }
 
@@ -4617,7 +4633,9 @@ class _ActionButtonsState extends State<_ActionButtons> {
     final isPhoto = item.type == 'Photo';
     final isBook = _isReadableBookItem(item);
     final isSeries = item.type == 'Series';
-    final totalEpisodes = item.childCount ?? item.recursiveItemCount ?? 0;
+    final totalEpisodes = item.type == 'Series'
+        ? (item.recursiveItemCount ?? 0)
+        : (item.childCount ?? item.recursiveItemCount ?? 0);
     final unplayed = item.unplayedItemCount ?? totalEpisodes;
     final isFullyWatched = item.isPlayed || unplayed == 0;
     final isFullyUnwatched = unplayed == totalEpisodes;
@@ -4665,7 +4683,15 @@ class _ActionButtonsState extends State<_ActionButtons> {
           final s = nextUp.parentIndexNumber;
           final e = nextUp.indexNumber;
           if (s != null && e != null) {
-            playButtonLabel = 'Resume from S$s:E$e';
+            if (_isCompact(context)) {
+              if (s == 1 && e == 1) {
+                playButtonLabel = l10n.play;
+              } else {
+                playButtonLabel = 'S${s}E$e';
+              }
+            } else {
+              playButtonLabel = 'Resume from S$s:E$e';
+            }
           } else {
             playButtonLabel = 'Resume';
           }
@@ -5518,7 +5544,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
         switch (item.type) {
           case 'Series':
             const episodeQueueFields =
-                'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay';
+                'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData';
             
             final client = _clientForItem(item);
             final data = await client.itemsApi.getEpisodes(
@@ -5543,7 +5569,9 @@ class _ActionButtonsState extends State<_ActionButtons> {
               throw PlaybackStartupRecoveryAbortedException();
             }
 
-            final totalEpisodes = item.childCount ?? item.recursiveItemCount ?? 0;
+            final totalEpisodes = item.type == 'Series'
+                ? (item.recursiveItemCount ?? 0)
+                : (item.childCount ?? item.recursiveItemCount ?? 0);
             final unplayed = item.unplayedItemCount ?? totalEpisodes;
             final isFullyWatched = item.isPlayed || unplayed == 0;
             final isFullyUnwatched = unplayed == totalEpisodes;
@@ -5643,7 +5671,29 @@ class _ActionButtonsState extends State<_ActionButtons> {
             );
 
           case 'Episode':
-            final episodes = viewModel.episodes;
+            var episodes = viewModel.episodes;
+            if (episodes.isEmpty || !episodes.any((e) => e.id == item.id)) {
+              final seriesId = item.seriesId;
+              final seasonId = item.seasonId;
+              if (seriesId != null && seriesId.isNotEmpty) {
+                try {
+                  const episodeQueueFields =
+                      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData';
+                  final client = _clientForItem(item);
+                  final data = await client.itemsApi.getEpisodes(
+                    seriesId,
+                    seasonId: seasonId,
+                    fields: episodeQueueFields,
+                  );
+                  episodes = _mapRawItemsForServer(
+                    data['Items'],
+                    item.serverId,
+                  );
+                } catch (_) {}
+              }
+            }
+            if (!context.mounted) return;
+
             if (episodes.length > 1) {
               final startIndex = episodes.indexWhere((e) => e.id == item.id);
               final idx = startIndex >= 0 ? startIndex : 0;

--- a/packages/server_jellyfin/lib/src/api/jellyfin_item_fields.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_item_fields.dart
@@ -1,2 +1,2 @@
 const kItemFields =
-    'Trickplay,Chapters,MediaSources,MediaStreams,People,Overview,Genres,RecursiveItemCount,ChildCount,SpecialFeatureCount';
+    'Trickplay,Chapters,MediaSources,MediaStreams,People,Overview,Genres,RecursiveItemCount,ChildCount';

--- a/packages/server_jellyfin/lib/src/api/jellyfin_item_fields.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_item_fields.dart
@@ -1,2 +1,2 @@
 const kItemFields =
-    'Trickplay,Chapters,MediaSources,MediaStreams,People,Overview,Genres';
+    'Trickplay,Chapters,MediaSources,MediaStreams,People,Overview,Genres,RecursiveItemCount,ChildCount,SpecialFeatureCount';

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -90,8 +90,9 @@ class JellyfinItemsApi implements ItemsApi {
 
   @override
   Future<Map<String, dynamic>> getItem(String itemId) async {
+    final userId = _getUserId();
     final response = await _dio.get(
-      '/Items/$itemId',
+      '/Users/$userId/Items/$itemId',
       queryParameters: {'Fields': kItemFields},
     );
     return response.data as Map<String, dynamic>;


### PR DESCRIPTION
# Resolving Media Detail Page Discrepancies

## Summary
This PR resolves metadata loading and play/resume state displays on show details pages, specifically for items navigated from or played via "Recent TV Shows", "Recent Movies", and "Continue Watching" rows. It addresses issue #388 by ensuring the details page correctly displays "Play" vs "Resume from SX:EX" and has the user-specific state needed to build the Next Up/resume episode queues.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #388 
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated `getItem(itemId)` to use the user-specific `/Users/$userId/Items/$itemId` endpoint instead of the public `/Items/$itemId` to load correct user-specific play and resume data.
- Added `RecursiveItemCount`, `ChildCount`, and `SpecialFeatureCount` to `kItemFields` to determine the accurate played and episode counts for show/season context.
- Added a fallback loop in `getClientIfExists` that normalizes base URLs to successfully look up client configurations by base URL when UUID lookups return `null`.
- Tracked active stream resolver/play session client via `_currentActiveResolverClient` and registered/restored active resolvers and player services during playback configuration in `_ensureResolverForItem`.
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device - tested on Android Mobile and Android TV
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a show details page from the home row ("Recent TV Shows" or "Continue Watching").
2. Verify that the details page displays "Play" (instead of "Resume from S1:E1") for new, never watched shows.
3. Verify that the details page correctly displays the next unwatched episode (e.g., "Resume from S1:E4") for partially watched shows.
4. Play an episode from the "Continue Watching" details page and verify that the next episode is queued properly.

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
