### PR TITLE
The one about the Starting Line

### DIFF
--- a/lib/ui/screens/auth/startup_screen.dart
+++ b/lib/ui/screens/auth/startup_screen.dart
@@ -73,14 +73,20 @@ class _StartupScreenState extends State<StartupScreen>
     }
 
     final behavior = authPrefs.loginBehavior;
-    String? targetServerId;
     String? targetUserId;
 
+    // Always start with the last-used server as a universal fallback so that
+    // any edge case where a behavior-specific ID is not set still lands on
+    // the correct server's user-select page rather than the Add Server screen.
+    String? targetServerId = authPrefs.savedLastServerId.isNotEmpty
+        ? authPrefs.savedLastServerId
+        : null;
+
     if (behavior == UserSelectBehavior.lastUser) {
-      targetServerId = authPrefs.savedLastServerId;
       targetUserId = authPrefs.savedLastUserId;
     } else if (behavior == UserSelectBehavior.currentUser) {
-      targetServerId = authPrefs.savedAutoLoginServerId;
+      final autoServerId = authPrefs.savedAutoLoginServerId;
+      if (autoServerId.isNotEmpty) targetServerId = autoServerId;
       targetUserId = authPrefs.savedAutoLoginUserId;
     }
 
@@ -125,7 +131,9 @@ class _StartupScreenState extends State<StartupScreen>
       if (mounted) context.go(Destinations.home);
     } else {
       if (mounted) {
-        if (pinEnabledForAutoLoginUser && targetServerId != null && targetServerId.isNotEmpty) {
+        if (targetServerId != null && targetServerId.isNotEmpty) {
+          // A previously-used server is known — go straight to user selection
+          // for that server rather than the Add Server page.
           context.go('${Destinations.server}?serverId=$targetServerId');
         } else {
           context.go(Destinations.serverSelect);


### PR DESCRIPTION
# Smarter Start-Up Logic for All

## Summary
With auto-login disabled, launching the app incorrectly routed to the Add Server screen instead of the user selection page for the previously-used server.

The server ID was already stored in preferences correctly, but was only used for navigation in the PIN-protected user case. This change seeds targetServerId from savedLastServerId as a universal fallback for all UserSelectBehavior values, so any previously-configured server always lands on the correct user-select page. The Add Server screen is now only shown on launch when no server has been configured.

## Related Issues
* Issue raised on Discord

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- `lib/ui/screens/auth/startup_screen.dart`: Restructured server ID resolution in `_initialize()` to always seed `targetServerId` from `savedLastServerId` as a universal fallback, regardless of the configured login behavior. The `currentUser` behavior can still override this with its explicit auto-login server ID when set.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Configure a server and log in at least once.
2. Set Login Behaviour to Disabled or Last User (auto-login off).
3. Force-close the app and relaunch.
4. Confirm the app navigates to the user selection page for the previously-used server, not the Add Server screen.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced