### PR TITLE
The one about Mobile Cast Pages

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -995,8 +995,11 @@ class _DetailContentState extends State<_DetailContent> {
                           _isCompact(context) ? 16 : 48,
                           0,
                         )
-                      : EdgeInsets.symmetric(
-                          horizontal: _isCompact(context) ? 16 : 48,
+                      : EdgeInsets.fromLTRB(
+                          _isCompact(context) ? 16 : 48,
+                          0,
+                          _isCompact(context) ? 16 : 48,
+                          MediaQuery.of(context).padding.bottom + 32,
                         ),
                   sliver: SliverList(
                     delegate: SliverChildListDelegate(
@@ -9627,7 +9630,7 @@ class _FilmographyRow extends StatelessWidget {
         ? (isEpisode ? 160.0 : 120.0)
         : cardHeight * cardAspectRatio;
     final rowHeight = isMobile
-        ? 220.0
+        ? 240.0
         : cardHeight + (56 * metadataScale);
 
     return SizedBox(
@@ -9723,7 +9726,7 @@ class _SeerrAppearancesRow extends StatelessWidget {
     final cardHeight = posterSize.portraitHeight.toDouble() * platformScale * rowScale;
     
     final cardWidth = isMobile ? 120.0 : cardHeight * (2 / 3);
-    final rowHeight = isMobile ? 220.0 : cardHeight + (56 * metadataScale);
+    final rowHeight = isMobile ? 240.0 : cardHeight + (56 * metadataScale);
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
     final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
 


### PR DESCRIPTION
# Give the actors some room to breathe

## Summary
On mobile, the cast/person detail page had two layout issues causing the bottom of the screen to be clipped. It was sad times.

## Related Issues
I see it, I fix it.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* The `SliverPadding` for non-book content was using `EdgeInsets.symmetric(horizontal)` with no bottom inset, leaving the last row flush against the navigation bar. Changed to `EdgeInsets.fromLTRB` with `MediaQuery.padding.bottom + 32` as the bottom to respect the system nav bar and give comfortable scroll room.
* The fixed `220px` mobile row height in both `_FilmographyRow` and `_SeerrAppearancesRow` was too short to display the subtitle (role/character name) beneath each card even with new skinny kid typeface. Increased to `240px` to prevent text clipping.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Verified on Android phone (mobile-beta flavor) — role names fully visible on all filmography rows, and the page scrolls comfortably past the last section.

## Screenshots (if applicable)
OLD:
<img width="350" alt="Screenshot_20260606-082912" src="https://github.com/user-attachments/assets/2cf65b7d-7cbe-4c19-baca-d61a31656866" />
NEW:
<img width="350" alt="Screenshot_20260606-085339" src="https://github.com/user-attachments/assets/70be2c05-11d9-4749-993b-7ac655409ba0" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
