### PR TITLE
Crabwalking - Bringing back horizontal library navigation

### DIFF
--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -84,6 +84,9 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   late PosterSize _posterSize;
   PosterSize get posterSize => _posterSize;
 
+  late LibraryScrollDirection _scrollDirection;
+  LibraryScrollDirection get scrollDirection => _scrollDirection;
+
   String? _errorMessage;
   String? get errorMessage => _errorMessage;
 
@@ -167,6 +170,9 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     _letterFilter = '';
     _imageType = _prefs.get(UserPreferences.libraryImageType(_imagePrefKey));
     _posterSize = _readScopedPosterSize();
+    _scrollDirection = _prefs.get(
+      UserPreferences.libraryScrollDirection(_imagePrefKey),
+    );
   }
 
   String get _prefKey => genreId ?? libraryId;
@@ -640,6 +646,16 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     } else {
       await _prefs.set(UserPreferences.libraryPosterSize, value);
     }
+    notifyListeners();
+  }
+
+  Future<void> setScrollDirection(LibraryScrollDirection value) async {
+    if (_scrollDirection == value) return;
+    _scrollDirection = value;
+    await _prefs.set(
+      UserPreferences.libraryScrollDirection(_imagePrefKey),
+      value,
+    );
     notifyListeners();
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -472,6 +472,18 @@
   "@extraLarge": {
     "description": "Poster size option"
   },
+  "scrollDirection": "Scroll Direction",
+  "@scrollDirection": {
+    "description": "Section header for scroll direction selection in library display settings"
+  },
+  "scrollDirectionVertical": "Vertical",
+  "@scrollDirectionVertical": {
+    "description": "Library scroll direction option: vertical grid (default)"
+  },
+  "scrollDirectionHorizontal": "Horizontal",
+  "@scrollDirectionHorizontal": {
+    "description": "Library scroll direction option: horizontal grid for ultrawide displays"
+  },
   "libraryGenresTitle": "{name} \u2014 Genres",
   "@libraryGenresTitle": {
     "description": "Header title showing library name with genres suffix",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -857,6 +857,24 @@ abstract class AppLocalizations {
   /// **'Extra Large'**
   String get extraLarge;
 
+  /// Section header for scroll direction selection in library display settings
+  ///
+  /// In en, this message translates to:
+  /// **'Scroll Direction'**
+  String get scrollDirection;
+
+  /// Library scroll direction option: vertical grid (default)
+  ///
+  /// In en, this message translates to:
+  /// **'Vertical'**
+  String get scrollDirectionVertical;
+
+  /// Library scroll direction option: horizontal grid for ultrawide displays
+  ///
+  /// In en, this message translates to:
+  /// **'Horizontal'**
+  String get scrollDirectionHorizontal;
+
   /// Header title showing library name with genres suffix
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -360,6 +360,15 @@ class AppLocalizationsAf extends AppLocalizations {
   String get extraLarge => 'Ekstra groot';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -356,6 +356,15 @@ class AppLocalizationsAr extends AppLocalizations {
   String get extraLarge => 'كبير جدا';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — الأنواع';
   }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -360,6 +360,15 @@ class AppLocalizationsBe extends AppLocalizations {
   String get extraLarge => 'Вельмі вялікі';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Жанры';
   }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -359,6 +359,15 @@ class AppLocalizationsBg extends AppLocalizations {
   String get extraLarge => 'Изключително голям';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Жанрове';
   }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -359,6 +359,15 @@ class AppLocalizationsBn extends AppLocalizations {
   String get extraLarge => 'অতিরিক্ত বড়';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — ধরন';
   }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -365,6 +365,15 @@ class AppLocalizationsCa extends AppLocalizations {
   String get extraLarge => 'Extragran';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Gèneres';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -361,6 +361,15 @@ class AppLocalizationsCs extends AppLocalizations {
   String get extraLarge => 'Extra velké';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Žánry';
   }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -361,6 +361,15 @@ class AppLocalizationsCy extends AppLocalizations {
   String get extraLarge => 'Mawr Ychwanegol';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -360,6 +360,15 @@ class AppLocalizationsDa extends AppLocalizations {
   String get extraLarge => 'Ekstra stor';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genrer';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -363,6 +363,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get extraLarge => 'Sehr groß';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name – Genres';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -364,6 +364,15 @@ class AppLocalizationsEl extends AppLocalizations {
   String get extraLarge => 'Πολύ μεγάλο';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Είδη';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -360,6 +360,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get extraLarge => 'Extra Large';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -359,6 +359,15 @@ class AppLocalizationsEo extends AppLocalizations {
   String get extraLarge => 'Ekstra Granda';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Ĝenroj';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -362,6 +362,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get extraLarge => 'Muy grande';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Géneros';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -361,6 +361,15 @@ class AppLocalizationsEt extends AppLocalizations {
   String get extraLarge => 'Eriti suur';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Žanrid';
   }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -358,6 +358,15 @@ class AppLocalizationsFa extends AppLocalizations {
   String get extraLarge => 'فوق العاده بزرگ';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name - ​​ژانرها';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -362,6 +362,15 @@ class AppLocalizationsFi extends AppLocalizations {
   String get extraLarge => 'Erittäin suuri';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genret';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -361,6 +361,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get extraLarge => 'Très grand';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -364,6 +364,15 @@ class AppLocalizationsGl extends AppLocalizations {
   String get extraLarge => 'Extra grande';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Xéneros';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -355,6 +355,15 @@ class AppLocalizationsHe extends AppLocalizations {
   String get extraLarge => 'גדול במיוחד';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -360,6 +360,15 @@ class AppLocalizationsHi extends AppLocalizations {
   String get extraLarge => 'एक्स्ट्रा लार्ज';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -360,6 +360,15 @@ class AppLocalizationsHr extends AppLocalizations {
   String get extraLarge => 'Iznimno velik';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -360,6 +360,15 @@ class AppLocalizationsHu extends AppLocalizations {
   String get extraLarge => 'Extra nagy';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -360,6 +360,15 @@ class AppLocalizationsId extends AppLocalizations {
   String get extraLarge => 'Ekstra besar';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -361,6 +361,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get extraLarge => 'Extra Grande';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -351,6 +351,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get extraLarge => '特大';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -361,6 +361,15 @@ class AppLocalizationsKk extends AppLocalizations {
   String get extraLarge => 'Өте үлкен';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -360,6 +360,15 @@ class AppLocalizationsKn extends AppLocalizations {
   String get extraLarge => 'ಹೆಚ್ಚುವರಿ ದೊಡ್ಡದು';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -351,6 +351,15 @@ class AppLocalizationsKo extends AppLocalizations {
   String get extraLarge => '특대';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -359,6 +359,15 @@ class AppLocalizationsLt extends AppLocalizations {
   String get extraLarge => 'Itin didelis';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -361,6 +361,15 @@ class AppLocalizationsLv extends AppLocalizations {
   String get extraLarge => 'Īpaši liels';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Žanri';
   }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -360,6 +360,15 @@ class AppLocalizationsMk extends AppLocalizations {
   String get extraLarge => 'Екстра голем';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -362,6 +362,15 @@ class AppLocalizationsMl extends AppLocalizations {
   String get extraLarge => 'എക്സ്ട്രാ ലാർജ്';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -361,6 +361,15 @@ class AppLocalizationsMn extends AppLocalizations {
   String get extraLarge => 'Хэт том';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Төрөл';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -359,6 +359,15 @@ class AppLocalizationsNb extends AppLocalizations {
   String get extraLarge => 'Ekstra stor';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -362,6 +362,15 @@ class AppLocalizationsNl extends AppLocalizations {
   String get extraLarge => 'Extra groot';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -360,6 +360,15 @@ class AppLocalizationsPa extends AppLocalizations {
   String get extraLarge => 'ਵਾਧੂ ਵੱਡਾ';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -361,6 +361,15 @@ class AppLocalizationsPl extends AppLocalizations {
   String get extraLarge => 'Bardzo duży';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -360,6 +360,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get extraLarge => 'Extra Grande';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Gêneros';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -360,6 +360,15 @@ class AppLocalizationsRo extends AppLocalizations {
   String get extraLarge => 'Extra Large';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genuri';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -360,6 +360,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get extraLarge => 'Очень большой';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -359,6 +359,15 @@ class AppLocalizationsSi extends AppLocalizations {
   String get extraLarge => 'අති විශාල';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -360,6 +360,15 @@ class AppLocalizationsSk extends AppLocalizations {
   String get extraLarge => 'Extra veľké';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -363,6 +363,15 @@ class AppLocalizationsSl extends AppLocalizations {
   String get extraLarge => 'Zelo velik';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -363,6 +363,15 @@ class AppLocalizationsSq extends AppLocalizations {
   String get extraLarge => 'Extra Large';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -360,6 +360,15 @@ class AppLocalizationsSr extends AppLocalizations {
   String get extraLarge => 'Ектра Ларге';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -358,6 +358,15 @@ class AppLocalizationsSv extends AppLocalizations {
   String get extraLarge => 'Extra large';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -364,6 +364,15 @@ class AppLocalizationsSw extends AppLocalizations {
   String get extraLarge => 'Kubwa Zaidi';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -360,6 +360,15 @@ class AppLocalizationsTa extends AppLocalizations {
   String get extraLarge => 'கூடுதல் பெரியது';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -360,6 +360,15 @@ class AppLocalizationsTe extends AppLocalizations {
   String get extraLarge => 'అదనపు పెద్దది';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -360,6 +360,15 @@ class AppLocalizationsTh extends AppLocalizations {
   String get extraLarge => 'ใหญ่พิเศษ';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — ประเภท';
   }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -362,6 +362,15 @@ class AppLocalizationsTl extends AppLocalizations {
   String get extraLarge => 'Extra Large';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Mga Genre';
   }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -359,6 +359,15 @@ class AppLocalizationsTr extends AppLocalizations {
   String get extraLarge => 'Ekstra Büyük';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -360,6 +360,15 @@ class AppLocalizationsUg extends AppLocalizations {
   String get extraLarge => 'قوشۇمچە چوڭ';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -360,6 +360,15 @@ class AppLocalizationsUk extends AppLocalizations {
   String get extraLarge => 'Дуже великий';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -363,6 +363,15 @@ class AppLocalizationsVi extends AppLocalizations {
   String get extraLarge => 'Cực lớn';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Thể loại';
   }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -348,6 +348,15 @@ class AppLocalizationsYue extends AppLocalizations {
   String get extraLarge => '特大號';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -348,6 +348,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get extraLarge => '特大号';
 
   @override
+  String get scrollDirection => 'Scroll Direction';
+
+  @override
+  String get scrollDirectionVertical => 'Vertical';
+
+  @override
+  String get scrollDirectionHorizontal => 'Horizontal';
+
+  @override
   String libraryGenresTitle(String name) {
     return '$name — Genres';
   }

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -274,6 +274,11 @@ enum SeriesStatusFilter {
   ended,
 }
 
+enum LibraryScrollDirection {
+  vertical,
+  horizontal,
+}
+
 enum FavoriteTypeFilter {
   all,
   movie,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1137,6 +1137,14 @@ class UserPreferences extends ChangeNotifier {
         values: ImageType.values,
       );
 
+  static EnumPreference<LibraryScrollDirection> libraryScrollDirection(
+    String libraryId,
+  ) => EnumPreference(
+    key: 'library_scroll_dir_$libraryId',
+    defaultValue: LibraryScrollDirection.vertical,
+    values: LibraryScrollDirection.values,
+  );
+
   static final allGenresImageType = EnumPreference(
     key: 'all_genres_image_type',
     defaultValue: ImageType.thumb,

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -3956,6 +3956,13 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       );
     }
 
+    if (_vm.scrollDirection == LibraryScrollDirection.horizontal) {
+      return _buildHorizontalGrid();
+    }
+    return _buildVerticalGrid();
+  }
+
+  Widget _buildVerticalGrid() {
     final cardWidth = _cardWidth();
     final spacing = _vm.isBookLibrary ? 16.0 : 12.0;
     final watchedBehavior = _prefs.get(
@@ -4045,7 +4052,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                             (index % crossAxisCount) == crossAxisCount - 1;
                         final isLastItem = index == _vm.items.length - 1;
                         if (isLastColumn || isLastItem) {
-                          // Keep focus in the current grid row at the right edge.
                           return KeyEventResult.handled;
                         }
                       }
@@ -4082,6 +4088,123 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
               SliverToBoxAdapter(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(vertical: 24),
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      color: _vm.isBookLibrary ? _bookAccent : _jellyfinBlue,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildHorizontalGrid() {
+    final cardWidth = _cardWidth();
+    final spacing = 12.0;
+    final watchedBehavior = _prefs.get(UserPreferences.watchedIndicatorBehavior);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final gridPadding = _horizontalPadding;
+        final ar = _gridBaseAspectRatio();
+        final hasSubtitles = _vm.items.any(
+          (item) => (_cardSubtitle(item)?.isNotEmpty ?? false),
+        );
+        final textHeight = hasSubtitles ? 42.0 : 24.0;
+        // Cell height in the horizontal view = card width + text
+        final cellHeight = cardWidth / ar + textHeight;
+        // How many rows fit in the available vertical height
+        final rowCount =
+            ((constraints.maxHeight - gridPadding * 2 + spacing) /
+                    (cellHeight + spacing))
+                .floor()
+                .clamp(1, 10);
+
+        final availableHeight =
+            constraints.maxHeight - gridPadding * 2;
+        final actualCellHeight =
+            (availableHeight - (rowCount - 1) * spacing) / rowCount;
+        final actualCellWidth = (actualCellHeight - textHeight) * ar;
+        final childAspectRatio = actualCellWidth / actualCellHeight;
+
+        return CustomScrollView(
+          controller: _scrollController,
+          scrollDirection: Axis.horizontal,
+          slivers: [
+            SliverPadding(
+              padding: EdgeInsets.fromLTRB(gridPadding, gridPadding, 16, gridPadding),
+              sliver: SliverGrid(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: rowCount,
+                  mainAxisSpacing: spacing,
+                  crossAxisSpacing: spacing,
+                  childAspectRatio: childAspectRatio,
+                ),
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) {
+                    final item = _vm.items[index];
+                    final itemAspectRatio = _itemAspectRatio(item);
+                    final focusColor = Color(
+                      _prefs.get(UserPreferences.focusColor).colorValue,
+                    );
+                    final isNeon =
+                        ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+                    return MediaCard(
+                      title: item.name,
+                      subtitle: _cardSubtitle(item),
+                      imageUrl: _imageUrl(item),
+                      width: double.infinity,
+                      aspectRatio: itemAspectRatio,
+                      focusColor: focusColor,
+                      focusNode: getGridItemFocusNode(index),
+                      cardFocusExpansion: _prefs.get(
+                        UserPreferences.cardFocusExpansion,
+                      ),
+                      suppressFocusGlow: isNeon,
+                      isPlayed: item.isPlayed,
+                      isFavorite: item.isFavorite,
+                      unplayedCount: item.unplayedItemCount,
+                      playedPercentage: _displayPlayedPercentage(item),
+                      watchedBehavior: watchedBehavior,
+                      itemType: item.type,
+                      onFocus: () => _onItemFocused(item),
+                      onHoverStart: () => _onItemFocused(item),
+                      onHoverEnd: () => _vm.setFocusedItem(null),
+                      onKeyEvent: (_, event) {
+                        if (!_vm.hasMore && !_vm.loadingMore) {
+                          return KeyEventResult.ignored;
+                        }
+                        if (!event.isActionable ||
+                            !event.logicalKey.isRightKey) {
+                          return KeyEventResult.ignored;
+                        }
+                        // Last item in its column — trigger load more
+                        final col = index ~/ rowCount;
+                        final isLastCol =
+                            (col + 1) * rowCount >= _vm.items.length;
+                        if (!isLastCol) return KeyEventResult.ignored;
+                        _vm.loadMore();
+                        return KeyEventResult.handled;
+                      },
+                      onLongPress: () => showContextMenu(
+                        context,
+                        item,
+                        onChanged: () => setState(() {}),
+                      ),
+                      onTap: () => _onItemTap(item),
+                    );
+                  },
+                  childCount: _vm.items.length,
+                ),
+              ),
+            ),
+            if (_vm.loadingMore)
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
                   child: Center(
                     child: CircularProgressIndicator(
                       color: _vm.isBookLibrary ? _bookAccent : _jellyfinBlue,
@@ -5145,7 +5268,29 @@ class _SettingsDialogState extends State<_SettingsDialog> {
               ),
             ),
             Divider(color: dividerColor),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
+              child: Text(
+                l10n.scrollDirection,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: sectionColor,
+                ),
+              ),
+            ),
+            _scrollDirectionRadioTile(
+              vm,
+              LibraryScrollDirection.vertical,
+              l10n.scrollDirectionVertical,
+            ),
+            _scrollDirectionRadioTile(
+              vm,
+              LibraryScrollDirection.horizontal,
+              l10n.scrollDirectionHorizontal,
+            ),
             if (!vm.isPlaylistBrowse) ...[
+              Divider(color: dividerColor),
               Padding(
                 padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
                 child: Text(
@@ -5173,6 +5318,35 @@ class _SettingsDialogState extends State<_SettingsDialog> {
             ),
             for (final size in PosterSize.values)
               _posterSizeRadioTile(vm, size),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _scrollDirectionRadioTile(
+    LibraryBrowseViewModel vm,
+    LibraryScrollDirection direction,
+    String label,
+  ) {
+    final selected = vm.scrollDirection == direction;
+    final accent = vm.isBookLibrary ? _bookAccent : _jellyfinBlue;
+    final onSurface = AppColorScheme.onSurface;
+    return InkWell(
+      onTap: () => vm.setScrollDirection(direction),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        child: Row(
+          children: [
+            _radioCircle(selected, accent),
+            const SizedBox(width: 12),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 15,
+                color: selected ? onSurface : onSurface.withValues(alpha: 0.72),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -3926,28 +3926,85 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
   Widget _buildBody() {
     final spinnerColor = _vm.isBookLibrary ? _bookAccent : _jellyfinBlue;
-    return switch (_vm.state) {
-      LibraryBrowseState.loading => Center(
-        child: CircularProgressIndicator(color: spinnerColor),
-      ),
-      LibraryBrowseState.error => Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              _vm.errorMessage ?? AppLocalizations.of(context).failedToLoadLibrary,
-              style: TextStyle(
-                color: _vm.isBookLibrary ? const Color(0xFFF4E6D5) : Colors.white,
-              ),
+    final showHorizChevrons =
+        _vm.scrollDirection == LibraryScrollDirection.horizontal &&
+        PlatformDetection.useDesktopUi &&
+        !PlatformDetection.isTV;
+    return Column(
+      children: [
+        if (showHorizChevrons)
+          // Chevron row matching home-screen style — sits just below the toolbar,
+          // flush with the right edge at _horizontalPadding inset.
+          Padding(
+            padding: EdgeInsets.fromLTRB(_horizontalPadding, 0, _horizontalPadding, 0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Focus(
+                  canRequestFocus: false,
+                  skipTraversal: true,
+                  descendantsAreFocusable: false,
+                  child: IconButton(
+                    icon: const Icon(Icons.chevron_left),
+                    onPressed: () {
+                      if (_scrollController.hasClients) {
+                        _scrollController.animateTo(
+                          (_scrollController.offset - 480).clamp(0, double.infinity),
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeInOut,
+                        );
+                      }
+                    },
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+                Focus(
+                  canRequestFocus: false,
+                  skipTraversal: true,
+                  descendantsAreFocusable: false,
+                  child: IconButton(
+                    icon: const Icon(Icons.chevron_right),
+                    onPressed: () {
+                      if (_scrollController.hasClients) {
+                        _scrollController.animateTo(
+                          _scrollController.offset + 480,
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeInOut,
+                        );
+                      }
+                    },
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: 16),
-            ElevatedButton(onPressed: _vm.load, child: Text(AppLocalizations.of(context).retry)),
-          ],
+          ),
+        Expanded(
+          child: switch (_vm.state) {
+            LibraryBrowseState.loading => Center(
+                child: CircularProgressIndicator(color: spinnerColor),
+              ),
+            LibraryBrowseState.error => Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      _vm.errorMessage ?? AppLocalizations.of(context).failedToLoadLibrary,
+                      style: TextStyle(
+                        color: _vm.isBookLibrary ? const Color(0xFFF4E6D5) : Colors.white,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton(onPressed: _vm.load, child: Text(AppLocalizations.of(context).retry)),
+                  ],
+                ),
+              ),
+            LibraryBrowseState.ready =>
+              _vm.isBookLibrary ? _buildBookGrid() : _buildGrid(),
+          },
         ),
-      ),
-      LibraryBrowseState.ready =>
-        _vm.isBookLibrary ? _buildBookGrid() : _buildGrid(),
-    };
+      ],
+    );
   }
 
   Widget _buildGrid() {
@@ -4115,11 +4172,9 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         );
         final textHeight = hasSubtitles ? 42.0 : 24.0;
 
-        // Fix #1 — use _cardWidth() as the TARGET CELL HEIGHT so that the
-        // poster-size preference controls card size regardless of aspect ratio.
-        // (Previously it was used as image width, causing posters to fill the
-        // entire viewport height because their tall aspect ratio produced 1 row.)
-        final targetCellHeight = _cardWidth();
+        final targetImageHeight = _cardWidth() / ar;
+        final targetCellHeight = targetImageHeight + textHeight;
+
         final rowCount =
             ((constraints.maxHeight - gridPadding * 2 + spacing) /
                     (targetCellHeight + spacing))
@@ -4129,21 +4184,18 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         final availableHeight = constraints.maxHeight - gridPadding * 2;
         final actualCellHeight =
             (availableHeight - (rowCount - 1) * spacing) / rowCount;
-        final actualCellWidth = (actualCellHeight - textHeight) * ar;
-        final childAspectRatio = actualCellWidth / actualCellHeight;
+        final actualImageHeight = actualCellHeight - textHeight;
+        final actualCellWidth = actualImageHeight * ar;
 
-        final showDesktopChevrons =
-            PlatformDetection.useDesktopUi && !PlatformDetection.isTV;
+        final childAspectRatio = actualCellHeight / actualCellWidth;
 
-        // Fix #2 — redirect vertical mouse-wheel delta to horizontal scroll.
-        // Fix #4 — ClampingScrollPhysics prevents the view from rubber-banding
-        //          past position 0 which caused the leading padding to vanish.
-        final scrollView = Listener(
+        return Listener(
           onPointerSignal: (signal) {
             if (signal is PointerScrollEvent) {
               final pos = _scrollController.position;
-              final newOffset = (_scrollController.offset + signal.scrollDelta.dy)
-                  .clamp(pos.minScrollExtent, pos.maxScrollExtent);
+              final newOffset =
+                  (_scrollController.offset + signal.scrollDelta.dy)
+                      .clamp(pos.minScrollExtent, pos.maxScrollExtent);
               _scrollController.jumpTo(newOffset);
             }
           },
@@ -4153,7 +4205,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
             physics: const ClampingScrollPhysics(),
             slivers: [
               SliverPadding(
-                // Fix #4 — explicit leading padding preserved by Clamping physics.
                 padding: EdgeInsets.fromLTRB(
                   gridPadding, gridPadding, 16, gridPadding,
                 ),
@@ -4235,107 +4286,9 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
             ],
           ),
         );
-
-        // Fix #3 — overlay left/right chevron buttons on desktop (non-TV),
-        // matching the home-screen row pattern.
-        if (!showDesktopChevrons) return scrollView;
-
-        const chevronScrollStep = 480.0;
-        return Stack(
-          children: [
-            scrollView,
-            // Left chevron
-            Positioned(
-              left: 0,
-              top: 0,
-              bottom: 0,
-              child: Focus(
-                canRequestFocus: false,
-                skipTraversal: true,
-                descendantsAreFocusable: false,
-                child: Center(
-                  child: AnimatedBuilder(
-                    animation: _scrollController,
-                    builder: (context, _) {
-                      final canScrollLeft = _scrollController.hasClients &&
-                          _scrollController.offset > 0;
-                      return Opacity(
-                        opacity: canScrollLeft ? 1.0 : 0.0,
-                        child: _HorizontalScrollChevron(
-                          icon: Icons.chevron_left_rounded,
-                          onPressed: canScrollLeft
-                              ? () => _scrollController.animateTo(
-                                    (_scrollController.offset - chevronScrollStep)
-                                        .clamp(0, double.infinity),
-                                    duration: const Duration(milliseconds: 300),
-                                    curve: Curves.easeInOut,
-                                  )
-                              : null,
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ),
-            ),
-            // Right chevron
-            Positioned(
-              right: 0,
-              top: 0,
-              bottom: 0,
-              child: Focus(
-                canRequestFocus: false,
-                skipTraversal: true,
-                descendantsAreFocusable: false,
-                child: Center(
-                  child: AnimatedBuilder(
-                    animation: _scrollController,
-                    builder: (context, _) {
-                      final canScrollRight = _scrollController.hasClients &&
-                          _scrollController.offset <
-                              _scrollController.position.maxScrollExtent;
-                      return Opacity(
-                        opacity: canScrollRight ? 1.0 : 0.0,
-                        child: _HorizontalScrollChevron(
-                          icon: Icons.chevron_right_rounded,
-                          onPressed: canScrollRight
-                              ? () => _scrollController.animateTo(
-                                    _scrollController.offset + chevronScrollStep,
-                                    duration: const Duration(milliseconds: 300),
-                                    curve: Curves.easeInOut,
-                                  )
-                              : null,
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ),
-            ),
-          ],
-        );
       },
     );
   }
-
-  // Reusable chevron button for the horizontal library grid.
-  // Wrapped in a semi-transparent pill so it's visible over any poster art.
-  static Widget _HorizontalScrollChevron({
-    required IconData icon,
-    required VoidCallback? onPressed,
-  }) =>
-      Container(
-        margin: const EdgeInsets.symmetric(horizontal: 4),
-        decoration: BoxDecoration(
-          color: Colors.black54,
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: IconButton(
-          icon: Icon(icon, color: Colors.white),
-          onPressed: onPressed,
-          visualDensity: VisualDensity.compact,
-        ),
-      );
 
   Widget _buildBookGrid() {
     final baseItems = _vm.items.where((item) => !_vm.isNavigableFolder(item));

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -6,6 +6,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -4102,7 +4103,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   }
 
   Widget _buildHorizontalGrid() {
-    final cardWidth = _cardWidth();
     final spacing = 12.0;
     final watchedBehavior = _prefs.get(UserPreferences.watchedIndicatorBehavior);
 
@@ -4114,109 +4114,228 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
           (item) => (_cardSubtitle(item)?.isNotEmpty ?? false),
         );
         final textHeight = hasSubtitles ? 42.0 : 24.0;
-        // Cell height in the horizontal view = card width + text
-        final cellHeight = cardWidth / ar + textHeight;
-        // How many rows fit in the available vertical height
+
+        // Fix #1 — use _cardWidth() as the TARGET CELL HEIGHT so that the
+        // poster-size preference controls card size regardless of aspect ratio.
+        // (Previously it was used as image width, causing posters to fill the
+        // entire viewport height because their tall aspect ratio produced 1 row.)
+        final targetCellHeight = _cardWidth();
         final rowCount =
             ((constraints.maxHeight - gridPadding * 2 + spacing) /
-                    (cellHeight + spacing))
+                    (targetCellHeight + spacing))
                 .floor()
                 .clamp(1, 10);
 
-        final availableHeight =
-            constraints.maxHeight - gridPadding * 2;
+        final availableHeight = constraints.maxHeight - gridPadding * 2;
         final actualCellHeight =
             (availableHeight - (rowCount - 1) * spacing) / rowCount;
         final actualCellWidth = (actualCellHeight - textHeight) * ar;
         final childAspectRatio = actualCellWidth / actualCellHeight;
 
-        return CustomScrollView(
-          controller: _scrollController,
-          scrollDirection: Axis.horizontal,
-          slivers: [
-            SliverPadding(
-              padding: EdgeInsets.fromLTRB(gridPadding, gridPadding, 16, gridPadding),
-              sliver: SliverGrid(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: rowCount,
-                  mainAxisSpacing: spacing,
-                  crossAxisSpacing: spacing,
-                  childAspectRatio: childAspectRatio,
+        final showDesktopChevrons =
+            PlatformDetection.useDesktopUi && !PlatformDetection.isTV;
+
+        // Fix #2 — redirect vertical mouse-wheel delta to horizontal scroll.
+        // Fix #4 — ClampingScrollPhysics prevents the view from rubber-banding
+        //          past position 0 which caused the leading padding to vanish.
+        final scrollView = Listener(
+          onPointerSignal: (signal) {
+            if (signal is PointerScrollEvent) {
+              final pos = _scrollController.position;
+              final newOffset = (_scrollController.offset + signal.scrollDelta.dy)
+                  .clamp(pos.minScrollExtent, pos.maxScrollExtent);
+              _scrollController.jumpTo(newOffset);
+            }
+          },
+          child: CustomScrollView(
+            controller: _scrollController,
+            scrollDirection: Axis.horizontal,
+            physics: const ClampingScrollPhysics(),
+            slivers: [
+              SliverPadding(
+                // Fix #4 — explicit leading padding preserved by Clamping physics.
+                padding: EdgeInsets.fromLTRB(
+                  gridPadding, gridPadding, 16, gridPadding,
                 ),
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    final item = _vm.items[index];
-                    final itemAspectRatio = _itemAspectRatio(item);
-                    final focusColor = Color(
-                      _prefs.get(UserPreferences.focusColor).colorValue,
-                    );
-                    final isNeon =
-                        ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
-                    return MediaCard(
-                      title: item.name,
-                      subtitle: _cardSubtitle(item),
-                      imageUrl: _imageUrl(item),
-                      width: double.infinity,
-                      aspectRatio: itemAspectRatio,
-                      focusColor: focusColor,
-                      focusNode: getGridItemFocusNode(index),
-                      cardFocusExpansion: _prefs.get(
-                        UserPreferences.cardFocusExpansion,
-                      ),
-                      suppressFocusGlow: isNeon,
-                      isPlayed: item.isPlayed,
-                      isFavorite: item.isFavorite,
-                      unplayedCount: item.unplayedItemCount,
-                      playedPercentage: _displayPlayedPercentage(item),
-                      watchedBehavior: watchedBehavior,
-                      itemType: item.type,
-                      onFocus: () => _onItemFocused(item),
-                      onHoverStart: () => _onItemFocused(item),
-                      onHoverEnd: () => _vm.setFocusedItem(null),
-                      onKeyEvent: (_, event) {
-                        if (!_vm.hasMore && !_vm.loadingMore) {
-                          return KeyEventResult.ignored;
-                        }
-                        if (!event.isActionable ||
-                            !event.logicalKey.isRightKey) {
-                          return KeyEventResult.ignored;
-                        }
-                        // Last item in its column — trigger load more
-                        final col = index ~/ rowCount;
-                        final isLastCol =
-                            (col + 1) * rowCount >= _vm.items.length;
-                        if (!isLastCol) return KeyEventResult.ignored;
-                        _vm.loadMore();
-                        return KeyEventResult.handled;
-                      },
-                      onLongPress: () => showContextMenu(
-                        context,
-                        item,
-                        onChanged: () => setState(() {}),
-                      ),
-                      onTap: () => _onItemTap(item),
-                    );
-                  },
-                  childCount: _vm.items.length,
-                ),
-              ),
-            ),
-            if (_vm.loadingMore)
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: Center(
-                    child: CircularProgressIndicator(
-                      color: _vm.isBookLibrary ? _bookAccent : _jellyfinBlue,
-                    ),
+                sliver: SliverGrid(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: rowCount,
+                    mainAxisSpacing: spacing,
+                    crossAxisSpacing: spacing,
+                    childAspectRatio: childAspectRatio,
+                  ),
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      final item = _vm.items[index];
+                      final itemAspectRatio = _itemAspectRatio(item);
+                      final focusColor = Color(
+                        _prefs.get(UserPreferences.focusColor).colorValue,
+                      );
+                      final isNeon =
+                          ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+                      return MediaCard(
+                        title: item.name,
+                        subtitle: _cardSubtitle(item),
+                        imageUrl: _imageUrl(item),
+                        width: double.infinity,
+                        aspectRatio: itemAspectRatio,
+                        focusColor: focusColor,
+                        focusNode: getGridItemFocusNode(index),
+                        cardFocusExpansion: _prefs.get(
+                          UserPreferences.cardFocusExpansion,
+                        ),
+                        suppressFocusGlow: isNeon,
+                        isPlayed: item.isPlayed,
+                        isFavorite: item.isFavorite,
+                        unplayedCount: item.unplayedItemCount,
+                        playedPercentage: _displayPlayedPercentage(item),
+                        watchedBehavior: watchedBehavior,
+                        itemType: item.type,
+                        onFocus: () => _onItemFocused(item),
+                        onHoverStart: () => _onItemFocused(item),
+                        onHoverEnd: () => _vm.setFocusedItem(null),
+                        onKeyEvent: (_, event) {
+                          if (!_vm.hasMore && !_vm.loadingMore) {
+                            return KeyEventResult.ignored;
+                          }
+                          if (!event.isActionable ||
+                              !event.logicalKey.isRightKey) {
+                            return KeyEventResult.ignored;
+                          }
+                          final col = index ~/ rowCount;
+                          final isLastCol =
+                              (col + 1) * rowCount >= _vm.items.length;
+                          if (!isLastCol) return KeyEventResult.ignored;
+                          _vm.loadMore();
+                          return KeyEventResult.handled;
+                        },
+                        onLongPress: () => showContextMenu(
+                          context,
+                          item,
+                          onChanged: () => setState(() {}),
+                        ),
+                        onTap: () => _onItemTap(item),
+                      );
+                    },
+                    childCount: _vm.items.length,
                   ),
                 ),
               ),
+              if (_vm.loadingMore)
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    child: Center(
+                      child: CircularProgressIndicator(
+                        color: _vm.isBookLibrary ? _bookAccent : _jellyfinBlue,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+
+        // Fix #3 — overlay left/right chevron buttons on desktop (non-TV),
+        // matching the home-screen row pattern.
+        if (!showDesktopChevrons) return scrollView;
+
+        const chevronScrollStep = 480.0;
+        return Stack(
+          children: [
+            scrollView,
+            // Left chevron
+            Positioned(
+              left: 0,
+              top: 0,
+              bottom: 0,
+              child: Focus(
+                canRequestFocus: false,
+                skipTraversal: true,
+                descendantsAreFocusable: false,
+                child: Center(
+                  child: AnimatedBuilder(
+                    animation: _scrollController,
+                    builder: (context, _) {
+                      final canScrollLeft = _scrollController.hasClients &&
+                          _scrollController.offset > 0;
+                      return Opacity(
+                        opacity: canScrollLeft ? 1.0 : 0.0,
+                        child: _HorizontalScrollChevron(
+                          icon: Icons.chevron_left_rounded,
+                          onPressed: canScrollLeft
+                              ? () => _scrollController.animateTo(
+                                    (_scrollController.offset - chevronScrollStep)
+                                        .clamp(0, double.infinity),
+                                    duration: const Duration(milliseconds: 300),
+                                    curve: Curves.easeInOut,
+                                  )
+                              : null,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+            // Right chevron
+            Positioned(
+              right: 0,
+              top: 0,
+              bottom: 0,
+              child: Focus(
+                canRequestFocus: false,
+                skipTraversal: true,
+                descendantsAreFocusable: false,
+                child: Center(
+                  child: AnimatedBuilder(
+                    animation: _scrollController,
+                    builder: (context, _) {
+                      final canScrollRight = _scrollController.hasClients &&
+                          _scrollController.offset <
+                              _scrollController.position.maxScrollExtent;
+                      return Opacity(
+                        opacity: canScrollRight ? 1.0 : 0.0,
+                        child: _HorizontalScrollChevron(
+                          icon: Icons.chevron_right_rounded,
+                          onPressed: canScrollRight
+                              ? () => _scrollController.animateTo(
+                                    _scrollController.offset + chevronScrollStep,
+                                    duration: const Duration(milliseconds: 300),
+                                    curve: Curves.easeInOut,
+                                  )
+                              : null,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
           ],
         );
       },
     );
   }
+
+  // Reusable chevron button for the horizontal library grid.
+  // Wrapped in a semi-transparent pill so it's visible over any poster art.
+  static Widget _HorizontalScrollChevron({
+    required IconData icon,
+    required VoidCallback? onPressed,
+  }) =>
+      Container(
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        decoration: BoxDecoration(
+          color: Colors.black54,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: IconButton(
+          icon: Icon(icon, color: Colors.white),
+          onPressed: onPressed,
+          visualDensity: VisualDensity.compact,
+        ),
+      );
 
   Widget _buildBookGrid() {
     final baseItems = _vm.items.where((item) => !_vm.isNavigableFolder(item));


### PR DESCRIPTION
# Re-incorporates horizontal library views for people with those wide monitors.

## Summary
Reintroduces horizontal scroll direction as a per-library display option. Each library independently remembers its scroll direction preference. When horizontal mode is active, the grid scrolls left-to-right (columns fill top-to-bottom first), the mouse wheel is remapped to horizontal, and desktop users get ‹/› chevron controls matching the home-screen row style. And I remembered localization!

## Related Issues
Link related issues or tickets separated by commas.

Discord observation.
- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Added LibraryScrollDirection enum (vertical / horizontal) to preference_constants.dart
* Added libraryScrollDirection(libraryId) per-library EnumPreference factory to user_preferences.dart (key: library_scroll_dir_<libraryId>, default: vertical)
* Wired _scrollDirection field, getter, constructor init, and setScrollDirection() into LibraryBrowseViewModel
* Added Scroll Direction as the first section in the library Display Settings cog (above Image Type), with Vertical/Horizontal radio tiles styled to match existing options
* Split _buildGrid() into _buildVerticalGrid() (unchanged behaviour) and _buildHorizontalGrid() (new horizontal CustomScrollView):
    * Card dimensions match vertical mode exactly (_cardWidth() / ar for image height, correct childAspectRatio = height/width for horizontal SliverGrid)
    * Mouse wheel vertical delta is remapped to horizontal scroll via a Listener
    * ClampingScrollPhysics preserves the leading padding when scrolling back to the start
   * Desktop (non-TV) shows ‹/› IconButton chevrons above the grid, right-aligned, matching the home-screen row pattern
* Added scrollDirection, scrollDirectionVertical, scrollDirectionHorizontal l10n keys to app_en.arb; all locale stubs auto-generated

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Tested via Windows installer build on desktop.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open any non-book, non-music library → tap the ⚙️ gear icon → confirm Scroll Direction appears as the first section with Vertical selected by default
2. Select Horizontal
3. Scroll right with the mouse wheel and should scroll horizontally
4. Scroll back left and confirm the left padding is preserved
5. Confirm ‹ and › chevron buttons appear in the upper-right area above the grid and scroll the view in 480 px increments
6. Open a different library — confirm it independently defaults to Vertical (setting is per-library, not global)
7. Switch back to Vertical — confirm normal grid resumes with no visual artifacts

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="500" alt="2026-06-06_11-23-55_moonfin" src="https://github.com/user-attachments/assets/555080eb-283f-4b68-bda6-89e940ba06b9" />
<img width="500" alt="2026-06-06_11-23-47_moonfin" src="https://github.com/user-attachments/assets/0c7c008d-1062-4c94-a499-6129e4550117" />
<img width="500" alt="2026-06-06_11-24-01_moonfin" src="https://github.com/user-attachments/assets/cfe6bb4c-565a-4966-b93e-1db415e0cd9b" />
<img width="500" alt="2026-06-06_11-24-18_moonfin" src="https://github.com/user-attachments/assets/f15a5192-ae2d-4edc-b947-b663818ab483" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
