### PR TITLE
Play theme music on Collection (BoxSet) detail pages

### DIFF
--- a/lib/data/services/theme_music_service.dart
+++ b/lib/data/services/theme_music_service.dart
@@ -26,7 +26,7 @@ class ThemeMusicService {
 
   static const _fadeDurationMs = 2000;
   static const _fadeStepMs = 50;
-  static const _validTypes = {'Series', 'Movie', 'Season', 'Episode'};
+  static const _validTypes = {'Series', 'Movie', 'Season', 'Episode', 'BoxSet'};
 
   ThemeMusicService(this._client, this._prefs, this._playbackManager) {
     _mainPlaybackSub = _playbackManager.state.playingStream.listen((isPlaying) {


### PR DESCRIPTION
# The one about Collection Themes

## Summary
BoxSet was not included in _validTypes in ThemeMusicService, causing the service to immediately call fadeOutAndStop() when a Collection detail page was opened. Adding 'BoxSet' to the set is sufficient since the Jellyfin /Items/{id}/ThemeMedia endpoint works for any item type and the existing themeItemId resolution already falls through to item.id for non-Episode/Season types, which is correct for BoxSets.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #393 
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added 'BoxSet' to _validTypes in ThemeMusicService so Collection detail pages are no longer excluded from theme music playback

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Simple change and I don't have any collections with theme music. And I'm tired, boss.

### Test Steps
1. Open the app and navigate to any Movie Collection (BoxSet) detail page
2. Confirm theme music begins playing (with fade-in) if a theme.mp3 is present in that collection on the server
3. Navigate away from the Collection — confirm theme music fades out
4. Verify Movie and Series detail pages still play theme music as before (no regression)
5. Verify that navigating to a Collection with no theme.mp3 plays silence as expected

## Screenshots (if applicable)
Picture theme music. From collections.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
