### PR TITLE
The one about phantom gaps on iOS

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2374,7 +2374,9 @@ class _ContentRowsState extends State<_ContentRows>
         : 0.0;
     final overlayBottom = _isHomeRowsStyleV2()
         ? navbarHeight
-        : infoTopPadding + infoAreaHeight;
+        : showInfoOverlay
+            ? infoTopPadding + infoAreaHeight
+            : 0.0;
     final rowExtents = _computeRowExtents(rows, posterSize, prefs);
     final rowTopOffsets = <double>[];
     var currentTop = listTopPadding + infoPlaceholderHeight;


### PR DESCRIPTION
# Removing the gaps from iOS Home Screen

## Summary
In Classic (v1) mode, overlayBottom was unconditionally computed as infoTopPadding + infoAreaHeight regardless of whether the info overlay was actually being shown (showInfoOverlay). When the overlay is off (the default, or after switching from Modern), infoPlaceholderHeight is 0 but overlayBottom was still a large value (200px+ on iPhone 15 Pro due to its safeArea inset). This oversized overlayBottom fed into neededBottomPadding and _buildShiftedRow, creating a visible gap between the carousel and the first home row that persisted across app restarts.

Fix: mirror the same showInfoOverlay guard already used for infoPlaceholderHeight so overlayBottom is 0.0 when the Classic info overlay is not shown.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #330 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- In _ContentRowsState.build(), guarded the Classic-mode overlayBottom calculation with showInfoOverlay, mirroring the same guard already used for infoPlaceholderHeight

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code (Symptom was iOS-specific due to larger safe-area insets, but the incorrect formula applied to any platform running Classic style with the info overlay disabled)

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Don't have an iOS device but logic should work.

### Test Steps (ask #330 to test):
1. Open the app in Modern (v2) row style — confirm home screen loads normally
2. Switch to Classic (v1) row style in Settings
3. Confirm the gap between the top area and the first row is gone immediately (no restart required)
4. Restart the app in Classic style — confirm no gap on cold open
5. Switch back to Modern — confirm no regression

## Screenshots (if applicable)
N/A — unable to reproduce on Android; reporter to validate on iPhone 15 Pro running iOS 26.6 Beta.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
