### PR TITLE
The one about going less hard

### DIFF
--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -172,7 +172,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
     _youTubeRevealTimer?.cancel();
     _mainPlaybackSub?.cancel();
     _media3EventSub?.cancel();
-    _disposeTrailerPlayer();
+    unawaited(_disposeTrailerPlayer());
     widget.viewModel.removeListener(_onStateChanged);
     widget.prefs.removeListener(_onPrefsChanged);
     WidgetsBinding.instance.removeObserver(this);
@@ -417,7 +417,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
     if (trailerEngineChanged) {
       _lastUseMedia3TrailerEngine = useMedia3Trailer;
       _cancelTrailerPreview();
-      _disposeTrailerPlayer();
+      unawaited(_disposeTrailerPlayer());
     }
 
     final trailerPreviewEnabled = widget.prefs.get(
@@ -433,7 +433,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
     if (hardwareDecodingChanged) {
       _lastHardwareDecodingEnabled = hardwareDecodingEnabled;
       _cancelTrailerPreview();
-      _disposeTrailerPlayer();
+      unawaited(_disposeTrailerPlayer());
     }
 
     if (!trailerPreviewEnabled) {
@@ -1066,7 +1066,7 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
     return null;
   }
 
-  void _disposeTrailerPlayer() {
+  Future<void> _disposeTrailerPlayer() async {
     _clearSponsorBlockTracking();
     _trailerCompletedSub?.cancel();
     _trailerCompletedSub = null;
@@ -1076,10 +1076,15 @@ class _MediaBarState extends State<MediaBar> with WidgetsBindingObserver {
       _trailerUsingMedia3 = false;
       unawaited(_media3TrailerBackend!.stop());
     }
-    _trailerPlayer?.stop();
-    _trailerPlayer?.dispose();
+    // Capture and null fields before the await so any code that wakes during
+    // the async pause (e.g. a concurrent _loadTrailer call) sees null and
+    // creates a fresh player rather than grabbing this half-disposed one.
+    // This matches how the main video player already handles teardown.
+    final player = _trailerPlayer;
     _trailerPlayer = null;
     _trailerController = null;
+    await player?.stop();
+    player?.dispose();
   }
 
   void _clearSponsorBlockTracking() {


### PR DESCRIPTION
# Just say no to unknown hard errors

## Summary
_disposeTrailerPlayer() called player.stop() fire-and-forget then immediately player.dispose(). When the user closes Moonfin while a media bar trailer is actively playing, libmpv is still processing the stop command when dispose() tears down its native context. This race leaves libmpv in a corrupt state at process teardown, causing Windows to raise NtRaiseHardError which appears as the 'Unknown Hard Error' system dialog every time the app is closed (issue #387).

Fix: make _disposeTrailerPlayer async and await stop() before dispose() so libmpv has finished its internal state machine before its resources are released. All three call sites use unawaited() since they are in synchronous contexts (dispose(), _onPrefsChanged()) where we cannot await but still want the correct sequencing inside the async chain.

The bug is specific to the media bar trailer player and not the main playback player (which already awaits stop before dispose), explaining why the error only appears on machines where the media bar auto-plays trailers on startup.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #387 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Made _disposeTrailerPlayer() async and added await to player.stop() before player.dispose(), ensuring libmpv finishes its internal state machine before its resources are released
* Updated the three call sites in dispose() and _onPrefsChanged() to use unawaited() since those are synchronous contexts

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code (but bug is Windows specific because libmpv's ANGLE OpenGL teardown is more sensitive to out-of-order resource releases - the fix is correct on all platforms regardless)

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device - built on Windows and tested
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin on Windows with the media bar enabled and trailer preview on
2. Wait for a trailer to begin auto-playing in the media bar (a few seconds after launch)
3. Close the app with the X button
4. Confirm no "Unknown Hard Error" dialog appear

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
