### PR TITLE
fix(home): honour Show in Latest Media toggle for Books, Playlists and Boxsets

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -732,7 +732,6 @@ class MultiServerRepository {
           final id = data['Id'] as String;
           final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
           if (collectionType == 'music' ||
-              collectionType == 'books' ||
               collectionType == 'playlists' ||
               collectionType == 'boxsets' ||
               collectionType == 'livetv') {

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -732,8 +732,6 @@ class MultiServerRepository {
           final id = data['Id'] as String;
           final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
           if (collectionType == 'music' ||
-              collectionType == 'playlists' ||
-              collectionType == 'boxsets' ||
               collectionType == 'livetv') {
             continue;
           }

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -744,9 +744,7 @@ class HomeViewModel extends ChangeNotifier {
         .where((data) {
           final id = data['Id'] as String;
           final collectionType = data['CollectionType'] as String?;
-          if (collectionType == 'playlists' ||
-              collectionType == 'boxsets' ||
-              collectionType == 'livetv') {
+          if (collectionType == 'livetv') {
             return false;
           }
           return !latestExcludes.contains(id);


### PR DESCRIPTION
## Summary

The \Show in Latest Media\ toggle in Library Visibility was completely non-functional for Playlists and Boxsets on all platforms, and broken for Books on Windows (multi-server path). All three collection types were hardcoded into skip lists in the two Latest Media loading paths, meaning the toggle wrote correctly to the server config (\latestItemsExcludes\) but was never actually consulted.

## Related Issues
- Fixes #[issue number if applicable]

## Root Cause

Both \_loadLatestMediaRows()\ (single-server) and \getAggregatedLatestMediaRows()\ (multi-server) hardcode a collection type skip list that runs **before** the \latestExcludes.contains(id)\ preference check:

\\\dart
// Ran unconditionally, bypassing the user's toggle entirely
if (collectionType == 'playlists' || collectionType == 'boxsets' ...) continue;

// This check was never reached for the above types
if (latestExcludes.contains(id)) continue;
\\\

**Books** had an additional inconsistency: it was only hardcoded in the multi-server path, so the toggle worked on mobile/ATV (single-server) but not on Windows (multi-server).

## Changes Made

Removed \ooks\, \playlists\, and \oxsets\ from the hardcoded skip lists in both loading paths. The \latestExcludes.contains(id)\ check already handles user preference correctly via the server config — the hardcoded skips were the only thing preventing it from working.

**Retained hardcoded exclusions:**
- \music\ — has its own dedicated Latest Music section type; including it here would duplicate rows
- \livetv\ — \getLatestItems\ returns nothing meaningful for a LiveTV parent library

## Type of Change
- [x] Bug fix

## Platform
- [x] All / Shared code (both single-server and multi-server paths fixed)

## Testing
1. Go to Settings → Library Visibility
2. For a Books, Playlists, or Boxsets library, toggle **Show in Latest Media ON** — confirm its Latest row appears on the home screen
3. Toggle **OFF** — confirm the row disappears
4. Confirm Music and LiveTV are unaffected regardless of toggle state
5. Verify behaviour is consistent on Windows (multi-server path) and mobile/ATV (single-server path)

## Checklist
- [x] Code builds successfully
- [x] \lutter analyze\ passes with no issues
- [x] No unnecessary commented-out code
- [x] No new warnings introduced