### PR TITLE
Bugfix/library visibility latest media

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -732,7 +732,6 @@ class MultiServerRepository {
           final id = data['Id'] as String;
           final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
           if (collectionType == 'music' ||
-              collectionType == 'books' ||
               collectionType == 'playlists' ||
               collectionType == 'boxsets' ||
               collectionType == 'livetv') {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -235,20 +235,40 @@ class HomeViewModel extends ChangeNotifier {
               .toList();
           final placeholder = _placeholderForConfig(cfg);
           final loadedIds = loadedRows.map((r) => r.id).toSet();
-          _rows = List.of(_rows);
-          int insertIndex = -1;
-          if (placeholder != null) {
-            insertIndex = _rows.indexWhere((r) => r.id == placeholder.id);
-          }
-          if (insertIndex < 0 && loadedIds.isNotEmpty) {
-            insertIndex = _rows.indexWhere((r) => loadedIds.contains(r.id));
+          // Find the row that immediately follows this section's placeholder /
+          // existing rows, so we can re-anchor after removals.
+
+          String? anchorId;
+          {
+            // Walk forward past the section's current rows to find the next
+            // sibling row that won't be removed.
+            bool pastSection = false;
+            for (final r in _rows) {
+              final willRemove = (placeholder != null && r.id == placeholder.id) ||
+                  loadedIds.contains(r.id) ||
+                  _rowBelongsToConfig(r, cfg);
+              if (willRemove) {
+                pastSection = true;
+              } else if (pastSection) {
+                anchorId = r.id;
+                break;
+              }
+            }
           }
           _rows.removeWhere((r) =>
               (placeholder != null && r.id == placeholder.id) ||
-              loadedIds.contains(r.id));
+              loadedIds.contains(r.id) ||
+              // Also clear any stale rows that belonged to this section from a
+              // prior load but were not included in the fresh result. This
+              // prevents phantom rows when the section's row-set changes
+              // (e.g. library added/removed, latestItemsExcludes updated).
+              _rowBelongsToConfig(r, cfg));
 
           if (loadedRows.isNotEmpty) {
-            if (insertIndex < 0 || insertIndex > _rows.length) {
+            final insertIndex = anchorId != null
+                ? _rows.indexWhere((r) => r.id == anchorId)
+                : -1;
+            if (insertIndex < 0) {
               _rows.addAll(loadedRows);
             } else {
               _rows.insertAll(insertIndex, loadedRows);
@@ -325,7 +345,11 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.nextUp:
         return row.rowType == HomeRowType.nextUp;
       case HomeSectionType.latestMedia:
-        return row.rowType == HomeRowType.latestMedia;
+        // Only claim rows that belong to the built-in latest-media section.
+        // Plugin-dynamic rows (per-collection, per-playlist, etc.) have IDs
+        // starting with 'pluginDynamic:' and must NOT be claimed here.
+        return row.rowType == HomeRowType.latestMedia &&
+            !row.id.startsWith('pluginDynamic:');
       case HomeSectionType.favoriteMovies:
       case HomeSectionType.favoriteSeries:
       case HomeSectionType.favoriteEpisodes:
@@ -337,15 +361,21 @@ class HomeViewModel extends ChangeNotifier {
         return row.rowType == HomeRowType.favorites &&
             row.id == _favoriteRowIdForSection(cfg.type);
       case HomeSectionType.collections:
-        return row.rowType == HomeRowType.collections;
+        // Only claim the single aggregated collections row (id == 'collections').
+        // Individual per-collection plugin rows have stableId-based IDs and
+        // must NOT be claimed by the built-in section.
+        return row.rowType == HomeRowType.collections &&
+            !row.id.startsWith('pluginDynamic:');
       case HomeSectionType.genres:
-        return row.rowType == HomeRowType.genres;
+        return row.rowType == HomeRowType.genres &&
+            !row.id.startsWith('pluginDynamic:');
       case HomeSectionType.libraryTilesSmall:
         return row.rowType == HomeRowType.libraryTiles;
       case HomeSectionType.libraryButtons:
         return row.rowType == HomeRowType.libraryTilesSmall;
       case HomeSectionType.playlists:
-        return row.rowType == HomeRowType.playlists;
+        return row.rowType == HomeRowType.playlists &&
+            !row.id.startsWith('pluginDynamic:');
       case HomeSectionType.liveTv:
         return row.rowType == HomeRowType.liveTv ||
             row.rowType == HomeRowType.liveTvOnNow;
@@ -743,8 +773,9 @@ class HomeViewModel extends ChangeNotifier {
         .cast<Map<String, dynamic>>()
         .where((data) {
           final id = data['Id'] as String;
-          final collectionType = data['CollectionType'] as String?;
-          if (collectionType == 'playlists' ||
+          final collectionType = (data['CollectionType'] as String?)?.toLowerCase();
+          if (collectionType == 'music' ||
+              collectionType == 'playlists' ||
               collectionType == 'boxsets' ||
               collectionType == 'livetv') {
             return false;

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -306,6 +306,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       if (PlatformDetection.isTV) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!mounted) return;
+          if (FocusManager.instance.primaryFocus?.hasPrimaryFocus ?? false) {
+            return;
+          }
           final first = _visibleSectionIndices().firstOrNull;
           if (first != null) _focusSectionAndEnsureVisible(first);
         });
@@ -420,8 +423,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
     return changed;
   }
-
-  static const _noLatestMediaSupport = {'playlists', 'boxsets'};
 
   /// Probes for newly discovered plugin sections in the background and
   /// re-merges the result into the visible list.

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -86,7 +86,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   final _focusNodes = <FocusNode>[];
 
   final Set<String> _emptySectionIds = {};
-  bool _isLoadingEmptyStates = false;
 
   static FavoriteTypeFilter _favoriteFilterForSection(HomeSectionType type) {
     return switch (type) {
@@ -104,9 +103,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
   Future<void> _checkEmptyStates() async {
     if (!mounted) return;
-    setState(() {
-      _isLoadingEmptyStates = true;
-    });
 
     final client = GetIt.instance<MediaServerClient>();
     final userId = client.userId;
@@ -306,8 +302,14 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         _emptySectionIds
           ..clear()
           ..addAll(newEmptyIds);
-        _isLoadingEmptyStates = false;
       });
+      if (PlatformDetection.isTV) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          final first = _visibleSectionIndices().firstOrNull;
+          if (first != null) _focusSectionAndEnsureVisible(first);
+        });
+      }
     }
   }
 
@@ -383,7 +385,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       _persistSections(pushSync: false);
     }
     _refreshPluginSections();
-    unawaited(_checkEmptyStates());
+    // Empty-state check is driven entirely by _refreshPluginSections;
+    // no separate call here avoids a double-spinner flash on open.
   }
 
   bool _ensureBuiltinSectionsPresent() {
@@ -417,6 +420,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
     return changed;
   }
+
+  static const _noLatestMediaSupport = {'playlists', 'boxsets'};
 
   /// Probes for newly discovered plugin sections in the background and
   /// re-merges the result into the visible list.
@@ -1064,19 +1069,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           context,
           Text(l10n.homeSections),
           actions: [
-            if (_isLoadingEmptyStates)
-              const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 12),
-                child: Center(
-                  child: SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                    ),
-                  ),
-                ),
-              ),
             IconButton(
               icon: const Icon(Icons.restore),
               tooltip: l10n.resetToDefaults,

--- a/lib/ui/screens/settings/library_settings_screen.dart
+++ b/lib/ui/screens/settings/library_settings_screen.dart
@@ -147,27 +147,38 @@ class _LibraryVisibilityScreenState extends State<LibraryVisibilityScreen> {
             onChanged: (v) => _toggleExclude(lib.id, !v, isLatest: false),
           ),
         ),
-        TvFocusHighlight(
-          builder: (_, focused) => SwitchListTile(
-            secondary: Icon(Icons.new_releases,
-                color: focused
-                    ? AppColors.black.withValues(alpha: 0.54)
-                    : null),
-            title: Text(
-              l10n.showInLatestMedia,
-              style: TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-                color: focused
-                    ? AppColors.black.withValues(alpha: 0.87)
-                    : AppColorScheme.onSurface,
+        // Playlists and boxsets use a different API path for their row content
+        // (getItems with type filtering rather than getLatestItems on a parent).
+        // Until a dedicated Latest row type exists for these, hide the toggle
+        // to avoid surfacing a setting that has no effect.
+        if (!_noLatestMediaSupport.contains(lib.collectionType.toLowerCase()))
+          TvFocusHighlight(
+            builder: (_, focused) => SwitchListTile(
+              secondary: Icon(Icons.new_releases,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.54)
+                      : null),
+              title: Text(
+                l10n.showInLatestMedia,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.87)
+                      : AppColorScheme.onSurface,
+                ),
               ),
+              value: !config.latestItemsExcludes.contains(lib.id),
+              onChanged: (v) => _toggleExclude(lib.id, !v, isLatest: true),
             ),
-            value: !config.latestItemsExcludes.contains(lib.id),
-            onChanged: (v) => _toggleExclude(lib.id, !v, isLatest: true),
           ),
-        ),
       ],
     ];
   }
+
+  /// Collection types whose 'Show in Latest Media' toggle is not yet functional.
+  /// getLatestItems on these parents returns container contents (movies, episodes)
+  /// rather than the container items themselves, which causes duplicate rows.
+  static const _noLatestMediaSupport = {'playlists', 'boxsets'};
+
 }


### PR DESCRIPTION
##  Fixes several bugs in Library Visibility settings and home-screen row logic.

## Summary 

With all of the work on new home row types, a few errors in logic slipped in and were causing things to auto-populate while unselected (e.g., particular collections, books). This PR focuses on fixing those issues. It also addresses hiding a few setting toggles that currently serve no purpose (e.g., recently added playlists).

## Related Issues
Bug testing

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

### Library Visibility — "Show in Latest Media" toggle
- **Playlists and Boxsets**: the toggle is now hidden for these collection types. Jellyfin's `getLatestItems` API returns individual track/movie items rather than the container, which caused duplicate rows. Hiding the toggle is cleaner than surfacing a non-functional control.
- **Books**: the toggle is present and is now working correctly — Jellyfin's `latestItemsExcludes` mechanism correctly controls Books visibility. Main fix was to stop it from always appearing.

### Home screen — Latest Media row deduplication
- Added `music` to the collection-type exclusion list in both the single-server (`home_view_model.dart`) and multi-server (`multi_server_repository.dart`) paths. Music libraries do not produce meaningful "latest" rows and were causing noise.
- `CollectionType` comparison is now case-insensitive (`.toLowerCase()`) to match Jellyfin server variants.

### Home screen — row ownership / phantom rows
- Built-in section types (`latestMedia`, `collections`, `genres`, `playlists`) now only claim rows whose IDs do **not** start with `pluginDynamic:`. Previously, plugin-dynamic rows (per-collection, per-playlist, etc.) were being incorrectly claimed by the built-in section type, causing those rows to vanish or duplicate on the home screen.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Installed on Shield and Windows
2. Turned on all combinations of custom library and home rows.
3. Make sure the ones we want show up and the ones we don't... don't.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
