### PR TITLE
feat(home-sections): fix focus, loading overlay, and layout nesting in Home Sections

### DIFF
--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -85,7 +85,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
   static final _nsfwPatterns =
       _nsfwKeywords.map((k) => RegExp(k, caseSensitive: false)).toList();
 
-  static const _popularNetworks = [
+  static const popularNetworks = [
     SeerrNetwork(id: 213, name: 'Netflix', logoPath: 'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/wwemzKWzjKYJFfCeiB57q3r4Bcm.png'),
     SeerrNetwork(id: 2739, name: 'Disney+', logoPath: 'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/gJ8VX6JSu3ciXHuC2dDGAo2lvwM.png'),
     SeerrNetwork(id: 1024, name: 'Prime Video', logoPath: 'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/ifhbNuuVnlwYy5oXA5VIb2YR8AZ.png'),
@@ -110,7 +110,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     SeerrNetwork(id: 3353, name: 'Peacock', logoPath: 'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/gIAcGTjKKr0KOHL5s4O36roJ8p7.png'),
   ];
 
-  static const _popularStudios = [
+  static const popularStudios = [
     SeerrStudio(id: 2, name: 'Disney', logoPath: 'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/wdrCwmRnLFJhEoH8GSfymY85KHT.png'),
     SeerrStudio(id: 127928, name: '20th Century Studios', logoPath: 'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/h0rjX5vjW5r8yEnUBStFarjcLT4.png'),
     SeerrStudio(id: 34, name: 'Sony Pictures', logoPath: 'https://image.tmdb.org/t/p/w780_filter(duotone,ffffff,bababa)/GagSvqWlyPdkFHMfQ3pNq6ix9P.png'),
@@ -235,12 +235,12 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
           await _loadGenres(index, isMovie: false);
         case SeerrRowType.networks:
           _updateRow(index, row.copyWith(
-            networks: _popularNetworks,
+            networks: popularNetworks,
             isLoading: false,
           ));
         case SeerrRowType.studios:
           _updateRow(index, row.copyWith(
-            studios: _popularStudios,
+            studios: popularStudios,
             isLoading: false,
           ));
         default:

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3736,6 +3736,10 @@
   "@showLibrariesInToolbar": {
     "description": "Setting for showing libraries in toolbar"
   },
+  "showSeerrButton": "Show Seerr Button",
+  "@showSeerrButton": {
+    "description": "Setting for showing Seerr button"
+  },
   "navbarOpacity": "Navbar Opacity",
   "@navbarOpacity": {
     "description": "Setting for navbar opacity"
@@ -6751,6 +6755,7 @@
   "settingsShowGenresButtonInNavigation": "Show the genres button in the navigation bar",
   "settingsShowFavoritesButtonInNavigation": "Show the favorites button in the navigation bar",
   "settingsShowLibrariesButtonInNavigation": "Show the libraries button in the navigation bar",
+  "settingsShowSeerrButtonInNavigation": "Show the Seerr button in the navigation bar",
   "settingsLibraryVisibilitySubtitle": "Toggle home page visibility per library. Restart Moonfin for changes to take effect.",
   "settingsMediaBarAndLocalPreviews": "Media Bar & Local Previews",
   "settingsVisualOverlays": "Visual Overlays",
@@ -7063,6 +7068,8 @@
   "displayPlaylistsRowsSubtitle": "Show Playlist rows in Home Sections.",
   "playlistsRowSorting": "Playlist Row Sorting",
   "playlistsRowSortingDescription": "Sort Playlist rows by date added, release date, alphabetically, and more.",
+  "displaySeerrRows": "Display Seerr Discovery Rows",
+  "displaySeerrRowsSubtitle": "Show Seerr discovery rows in Home Sections.",
   "appearance": "Appearance",
   "cardSize": "Card Size",
   "externalPlayerApp": "External player app",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4907,6 +4907,12 @@ abstract class AppLocalizations {
   /// **'Show Libraries in Toolbar'**
   String get showLibrariesInToolbar;
 
+  /// Setting for showing Seerr button
+  ///
+  /// In en, this message translates to:
+  /// **'Show Seerr Button'**
+  String get showSeerrButton;
+
   /// Setting for navbar opacity
   ///
   /// In en, this message translates to:
@@ -12257,6 +12263,12 @@ abstract class AppLocalizations {
   /// **'Show the libraries button in the navigation bar'**
   String get settingsShowLibrariesButtonInNavigation;
 
+  /// No description provided for @settingsShowSeerrButtonInNavigation.
+  ///
+  /// In en, this message translates to:
+  /// **'Show the Seerr button in the navigation bar'**
+  String get settingsShowSeerrButtonInNavigation;
+
   /// No description provided for @settingsLibraryVisibilitySubtitle.
   ///
   /// In en, this message translates to:
@@ -13264,6 +13276,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sort Playlist rows by date added, release date, alphabetically, and more.'**
   String get playlistsRowSortingDescription;
+
+  /// No description provided for @displaySeerrRows.
+  ///
+  /// In en, this message translates to:
+  /// **'Display Seerr Discovery Rows'**
+  String get displaySeerrRows;
+
+  /// No description provided for @displaySeerrRowsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Seerr discovery rows in Home Sections.'**
+  String get displaySeerrRowsSubtitle;
 
   /// No description provided for @appearance.
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -2692,6 +2692,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get showLibrariesInToolbar => 'Wys biblioteke in Toolbar';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Ondeursigtigheid';
 
   @override
@@ -6881,6 +6884,10 @@ class AppLocalizationsAf extends AppLocalizations {
       'Wys die biblioteke-knoppie in die navigasiebalk';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Wissel tuisbladsigbaarheid per biblioteek. Herbegin Moonfin vir veranderinge om in werking te tree.';
 
@@ -7465,6 +7472,13 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Voorkoms';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2679,6 +2679,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get showLibrariesInToolbar => 'إظهار المكتبات في شريط الأدوات';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'عتامة نافبار';
 
   @override
@@ -6836,6 +6839,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'إظهار زر المكتبات في شريط التنقل';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'تبديل رؤية الصفحة الرئيسية لكل مكتبة. أعد تشغيل Moonfin لتصبح التغييرات سارية المفعول.';
 
@@ -7415,6 +7422,13 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'مظهر';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -2692,6 +2692,9 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказаць бібліятэкі на панэлі інструментаў';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Непразрыстасць панэлі навігацыі';
 
   @override
@@ -6889,6 +6892,10 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказаць кнопку бібліятэк на панэлі навігацыі';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Пераключыць бачнасць хатняй старонкі для кожнай бібліятэкі. Перазапусціце Moonfin, каб змены ўступілі ў сілу.';
 
@@ -7488,6 +7495,13 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Знешні выгляд';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2705,6 +2705,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на библиотеки в лентата с инструменти';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Непрозрачност на навигационната лента';
 
   @override
@@ -6933,6 +6936,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на бутона за библиотеки в лентата за навигация';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Превключване на видимостта на началната страница за библиотека. Рестартирайте Moonfin, за да влязат в сила промените.';
 
@@ -7531,6 +7538,13 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Външен вид';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -2682,6 +2682,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get showLibrariesInToolbar => 'টুলবারে লাইব্রেরি দেখান';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'নববার অস্বচ্ছতা';
 
   @override
@@ -6866,6 +6869,10 @@ class AppLocalizationsBn extends AppLocalizations {
       'নেভিগেশন বারে লাইব্রেরি বোতামটি দেখান';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'লাইব্রেরি প্রতি হোম পেজ দৃশ্যমানতা টগল করুন। পরিবর্তনগুলি কার্যকর করার জন্য Moonfin পুনরায় চালু করুন৷';
 
@@ -7452,6 +7459,13 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'চেহারা';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -2721,6 +2721,9 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra les biblioteques a la barra d\'eines';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opacitat de la barra de navegació';
 
   @override
@@ -6976,6 +6979,10 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra el botó de biblioteques a la barra de navegació';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Commuta la visibilitat de la pàgina d\'inici per biblioteca. Reinicieu Moonfin perquè els canvis tinguin efecte.';
 
@@ -7570,6 +7577,13 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Aparença';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2690,6 +2690,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showLibrariesInToolbar => 'Zobrazit knihovny na liště Toolbar';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Neprůhlednost navigační lišty';
 
   @override
@@ -6881,6 +6884,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zobrazit tlačítko knihoven v navigační liště';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Přepnout viditelnost domovské stránky podle knihovny. Restartujte Moonfin, aby se změny projevily.';
 
@@ -7469,6 +7476,13 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Vzhled';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -2698,6 +2698,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get showLibrariesInToolbar => 'Dangos Llyfrgelloedd yn y Bar Offer';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Anhryloywder Navbar';
 
   @override
@@ -6893,6 +6896,10 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dangoswch y botwm llyfrgelloedd yn y bar llywio';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Toglo gwelededd tudalen gartref fesul llyfrgell. Ailgychwyn Moonfin i newidiadau ddod i rym.';
 
@@ -7483,6 +7490,13 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Ymddangosiad';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showLibrariesInToolbar => 'Vis biblioteker i værktøjslinjen';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Opacitet';
 
   @override
@@ -6871,6 +6874,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Vis biblioteksknappen i navigationslinjen';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Skift startsidesynlighed pr. bibliotek. Genstart Moonfin for at ændringerne træder i kraft.';
 
@@ -7457,6 +7464,13 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Udseende';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bibliotheken in der Symbolleiste anzeigen';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navigationsleisten-Transparenz';
 
   @override
@@ -6930,6 +6933,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Zeigen Sie die Schaltfläche „Bibliotheken“ in der Navigationsleiste an';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Schalten Sie die Sichtbarkeit der Startseite pro Bibliothek um. Starten Sie Moonfin neu, damit die Änderungen wirksam werden.';
 
@@ -7525,6 +7532,13 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Aussehen';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2720,6 +2720,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Εμφάνιση βιβλιοθηκών στο Toolbar';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Αδιαφάνεια γραμμής πλοήγησης';
 
   @override
@@ -6974,6 +6977,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Εμφάνιση του κουμπιού βιβλιοθήκες στη γραμμή πλοήγησης';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Εναλλαγή ορατότητας αρχικής σελίδας ανά βιβλιοθήκη. Επανεκκινήστε το Moonfin για να τεθούν σε ισχύ οι αλλαγές.';
 
@@ -7574,6 +7581,13 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Εμφάνιση';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2677,6 +2677,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showLibrariesInToolbar => 'Show Libraries in Toolbar';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Opacity';
 
   @override
@@ -6824,6 +6827,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Show the libraries button in the navigation bar';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Toggle home page visibility per library. Restart Moonfin for changes to take effect.';
 
@@ -7402,6 +7409,13 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -2685,6 +2685,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get showLibrariesInToolbar => 'Montru Bibliotekojn en Ilobreto';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Opakeco';
 
   @override
@@ -6860,6 +6863,10 @@ class AppLocalizationsEo extends AppLocalizations {
       'Montru la butonon de bibliotekoj en la navigadbreto';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Ŝaltu hejmpaĝan videblecon per biblioteko. Rekomencu Moonfin por ke ŝanĝoj efektiviĝu.';
 
@@ -7448,6 +7455,13 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Aspekto';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar bibliotecas en la barra de herramientas';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opacidad de la barra de navegación';
 
   @override
@@ -6941,6 +6944,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar el botón de bibliotecas en la barra de navegación';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Alternar la visibilidad de la página de inicio por biblioteca. Reinicie Moonfin para que los cambios surtan efecto.';
 
@@ -7534,6 +7541,13 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Apariencia';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2697,6 +2697,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get showLibrariesInToolbar => 'Näita teeke tööriistaribal';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbari läbipaistmatus';
 
   @override
@@ -6882,6 +6885,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kuvage navigeerimisribal teekide nupp';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Avalehe nähtavuse sisse- ja väljalülitamine teegi kaupa. Muudatuste jõustumiseks taaskäivitage Moonfin.';
 
@@ -7472,6 +7479,13 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Välimus';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -2674,6 +2674,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showLibrariesInToolbar => 'نمایش کتابخانه ها در نوار ابزار';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'کدورت نوار ناوبری';
 
   @override
@@ -6836,6 +6839,10 @@ class AppLocalizationsFa extends AppLocalizations {
       'نمایش دکمه کتابخانه ها در نوار پیمایش';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'قابلیت مشاهده صفحه اصلی در هر کتابخانه را تغییر دهید. برای اعمال تغییرات Moonfin را مجددا راه اندازی کنید.';
 
@@ -7420,6 +7427,13 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'ظاهر';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2701,6 +2701,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showLibrariesInToolbar => 'Näytä kirjastot työkalupalkissa';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbarin läpinäkyvyys';
 
   @override
@@ -6899,6 +6902,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Näytä kirjastot-painike navigointipalkissa';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Vaihda etusivun näkyvyys kirjastoittain. Käynnistä Moonfin uudelleen, jotta muutokset tulevat voimaan.';
 
@@ -7484,6 +7491,13 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Ulkonäkö';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2718,6 +2718,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les bibliothèques dans la barre d’outils';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opacité de la barre de navigation';
 
   @override
@@ -6951,6 +6954,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher le bouton des bibliothèques dans la barre de navigation';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Basculez la visibilité de la page d\'accueil par bibliothèque. Redémarrez Moonfin pour que les modifications prennent effet.';
 
@@ -7543,6 +7550,13 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Apparence';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -2722,6 +2722,9 @@ class AppLocalizationsGl extends AppLocalizations {
       'Mostrar bibliotecas na barra de ferramentas';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opacidade da barra de navegación';
 
   @override
@@ -6966,6 +6969,10 @@ class AppLocalizationsGl extends AppLocalizations {
       'Mostra o botón de bibliotecas na barra de navegación';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Alterna a visibilidade da páxina de inicio por biblioteca. Reinicia Moonfin para que os cambios teñan efecto.';
 
@@ -7557,6 +7564,13 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2663,6 +2663,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get showLibrariesInToolbar => 'הצג ספריות בסרגל הכלים';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'אטימות Navbar';
 
   @override
@@ -6781,6 +6784,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'הצג את לחצן הספריות בסרגל הניווט';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'החלף את נראות דף הבית לכל ספריה. הפעל מחדש את Moonfin כדי שהשינויים ייכנסו לתוקף.';
 
@@ -7356,6 +7363,13 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2680,6 +2680,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showLibrariesInToolbar => 'टूलबार में लाइब्रेरी दिखाएं';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'नेवबार अपारदर्शिता';
 
   @override
@@ -6855,6 +6858,10 @@ class AppLocalizationsHi extends AppLocalizations {
       'नेविगेशन बार में लाइब्रेरीज़ बटन दिखाएँ';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'प्रति लाइब्रेरी होम पेज दृश्यता टॉगल करें। परिवर्तनों को प्रभावी करने के लिए Moonfin को पुनः आरंभ करें।';
 
@@ -7438,6 +7445,13 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2694,6 +2694,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showLibrariesInToolbar => 'Prikaži biblioteke na alatnoj traci';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Neprozirnost navigacijske trake';
 
   @override
@@ -6893,6 +6896,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Prikaži gumb knjižnica na navigacijskoj traci';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Promjena vidljivosti početne stranice po knjižnici. Ponovno pokrenite Moonfin kako bi promjene stupile na snagu.';
 
@@ -7482,6 +7489,13 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2703,6 +2703,9 @@ class AppLocalizationsHu extends AppLocalizations {
       'Könyvtárak megjelenítése az Eszköztárban';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Opacitás';
 
   @override
@@ -6936,6 +6939,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Jelenítse meg a könyvtárak gombot a navigációs sávban';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'A kezdőlap láthatóságának váltása könyvtáronként. Indítsa újra a Moonfin alkalmazást, hogy a változtatások életbe lépjenek.';
 
@@ -7525,6 +7532,13 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2693,6 +2693,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get showLibrariesInToolbar => 'Tampilkan Perpustakaan di Toolbar';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opasitas Navbar';
 
   @override
@@ -6889,6 +6892,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Tampilkan tombol perpustakaan di bilah navigasi';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Alihkan visibilitas halaman beranda per perpustakaan. Mulai ulang Moonfin agar perubahan diterapkan.';
 
@@ -7470,6 +7477,13 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2702,6 +2702,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showLibrariesInToolbar => 'Mostra Librerie nella Barra Strumenti';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opacità Barra Navigazione';
 
   @override
@@ -6911,6 +6914,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mostra il pulsante delle librerie nella barra di navigazione';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Attiva/disattiva la visibilità della home page per libreria. Riavvia Moonfin affinché le modifiche abbiano effetto.';
 
@@ -7501,6 +7508,13 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2641,6 +2641,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showLibrariesInToolbar => 'ツールバーにライブラリを表示';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'ナビゲーションバーの不透明度';
 
   @override
@@ -6704,6 +6707,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'ナビゲーション バーにライブラリ ボタンを表示する';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'ライブラリごとにホームページの表示を切り替えます。変更を有効にするには、Moonfin を再起動します。';
 
@@ -7264,6 +7271,13 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -2700,6 +2700,9 @@ class AppLocalizationsKk extends AppLocalizations {
       'Құралдар тақтасында кітапханаларды көрсету';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Шарлау тақтасының мөлдірлігі';
 
   @override
@@ -6904,6 +6907,10 @@ class AppLocalizationsKk extends AppLocalizations {
       'Шарлау жолағында кітапханалар түймесін көрсетіңіз';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Әрбір кітапхананың басты бетінің көріну мүмкіндігін ауыстырып-қосқыш. Өзгерістердің күшіне енуі үшін Moonfin қолданбасын қайта іске қосыңыз.';
 
@@ -7493,6 +7500,13 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -2702,6 +2702,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showLibrariesInToolbar => 'ಟೂಲ್‌ಬಾರ್‌ನಲ್ಲಿ ಲೈಬ್ರರಿಗಳನ್ನು ತೋರಿಸಿ';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'ನವಬಾರ್ ಅಪಾರದರ್ಶಕತೆ';
 
   @override
@@ -6921,6 +6924,10 @@ class AppLocalizationsKn extends AppLocalizations {
       'ನ್ಯಾವಿಗೇಶನ್ ಬಾರ್‌ನಲ್ಲಿ ಲೈಬ್ರರೀಸ್ ಬಟನ್ ಅನ್ನು ತೋರಿಸಿ';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'ಪ್ರತಿ ಲೈಬ್ರರಿಗೆ ಮುಖಪುಟದ ಗೋಚರತೆಯನ್ನು ಟಾಗಲ್ ಮಾಡಿ. ಬದಲಾವಣೆಗಳು ಕಾರ್ಯರೂಪಕ್ಕೆ ಬರಲು Moonfin ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ.';
 
@@ -7509,6 +7516,13 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2635,6 +2635,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showLibrariesInToolbar => '툴바에 라이브러리 표시';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => '탐색바 불투명도';
 
   @override
@@ -6695,6 +6698,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsShowLibrariesButtonInNavigation => '탐색 모음에 라이브러리 버튼 표시';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       '라이브러리별로 홈 페이지 가시성을 전환합니다. 변경 사항을 적용하려면 Moonfin을 다시 시작하세요.';
 
@@ -7259,6 +7266,13 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2690,6 +2690,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showLibrariesInToolbar => 'Rodyti bibliotekas įrankių juostoje';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navigacijos juostos neskaidrumas';
 
   @override
@@ -6894,6 +6897,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Rodyti bibliotekų mygtuką naršymo juostoje';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Perjungti pagrindinio puslapio matomumą pagal biblioteką. Iš naujo paleiskite „Moonfin“, kad pakeitimai įsigaliotų.';
 
@@ -7488,6 +7495,13 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Išvaizda';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2701,6 +2701,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showLibrariesInToolbar => 'Rādīt bibliotēkas rīkjoslā';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navigācijas joslas necaurredzamība';
 
   @override
@@ -6906,6 +6909,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Parādiet bibliotēkas pogu navigācijas joslā';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Pārslēgt mājas lapas redzamību katrai bibliotēkai. Restartējiet Moonfin, lai izmaiņas stātos spēkā.';
 
@@ -7496,6 +7503,13 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Izskats';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsMk extends AppLocalizations {
       'Прикажи библиотеки во лентата со алатки';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Непроѕирност на навигација';
 
   @override
@@ -6920,6 +6923,10 @@ class AppLocalizationsMk extends AppLocalizations {
       'Прикажи го копчето за библиотеки во лентата за навигација';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Вклучете ја видливоста на почетната страница по библиотека. Рестартирајте го Moonfin за да стапат на сила промените.';
 
@@ -7511,6 +7518,13 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get showLibrariesInToolbar => 'ടൂൾബാറിൽ ലൈബ്രറികൾ കാണിക്കുക';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'നവബാർ അതാര്യത';
 
   @override
@@ -6957,6 +6960,10 @@ class AppLocalizationsMl extends AppLocalizations {
       'നാവിഗേഷൻ ബാറിലെ ലൈബ്രറികളുടെ ബട്ടൺ കാണിക്കുക';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'ഓരോ ലൈബ്രറിയിലും ഹോം പേജ് ദൃശ്യപരത ടോഗിൾ ചെയ്യുക. മാറ്റങ്ങൾ പ്രാബല്യത്തിൽ വരുന്നതിന് Moonfin പുനരാരംഭിക്കുക.';
 
@@ -7554,6 +7561,13 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'രൂപഭാവം';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -2691,6 +2691,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get showLibrariesInToolbar => 'Хэрэгслийн самбарт номын санг харуулах';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar-ийн тунгалаг байдал';
 
   @override
@@ -6896,6 +6899,10 @@ class AppLocalizationsMn extends AppLocalizations {
       'Навигацийн талбар дахь номын сангийн товчийг харуул';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Номын сан бүрийн нүүр хуудасны харагдах байдлыг асаах/унтраах. Өөрчлөлтүүд хүчин төгөлдөр болохын тулд Moonfin-г дахин эхлүүлнэ үү.';
 
@@ -7488,6 +7495,13 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Гадаад төрх';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2686,6 +2686,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get showLibrariesInToolbar => 'Vis biblioteker i verktøylinjen';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar opasitet';
 
   @override
@@ -6873,6 +6876,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Vis bibliotek-knappen i navigasjonslinjen';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Slå av og på hjemmesidens synlighet per bibliotek. Start Moonfin på nytt for at endringer skal tre i kraft.';
 
@@ -7461,6 +7468,13 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2700,6 +2700,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Bibliotheken weergeven in de werkbalk';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navigatiebalkdekking';
 
   @override
@@ -6903,6 +6906,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Toon de bibliothekenknop in de navigatiebalk';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Schakel de zichtbaarheid van de startpagina per bibliotheek in. Start Moonfin opnieuw op zodat de wijzigingen van kracht worden.';
 
@@ -7492,6 +7499,13 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -2685,6 +2685,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get showLibrariesInToolbar => 'ਟੂਲਬਾਰ ਵਿੱਚ ਲਾਇਬ੍ਰੇਰੀਆਂ ਦਿਖਾਓ';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'ਨਵਬਾਰ ਧੁੰਦਲਾਪਨ';
 
   @override
@@ -6862,6 +6865,10 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਨੈਵੀਗੇਸ਼ਨ ਪੱਟੀ ਵਿੱਚ ਲਾਇਬ੍ਰੇਰੀਆਂ ਬਟਨ ਦਿਖਾਓ';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'ਪ੍ਰਤੀ ਲਾਇਬ੍ਰੇਰੀ ਹੋਮ ਪੇਜ ਦੀ ਦਿੱਖ ਨੂੰ ਟੌਗਲ ਕਰੋ। ਤਬਦੀਲੀਆਂ ਨੂੰ ਲਾਗੂ ਕਰਨ ਲਈ Moonfin ਨੂੰ ਮੁੜ ਚਾਲੂ ਕਰੋ।';
 
@@ -7441,6 +7448,13 @@ class AppLocalizationsPa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2700,6 +2700,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Pokaż biblioteki na pasku narzędzi';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Nieprzezroczystość paska nawigacyjnego';
 
   @override
@@ -6912,6 +6915,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Pokaż przycisk bibliotek na pasku nawigacyjnym';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Przełącz widoczność strony głównej dla każdej biblioteki. Uruchom ponownie Moonfin, aby zmiany odniosły skutek.';
 
@@ -7503,6 +7510,13 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2701,6 +2701,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar Bibliotecas na Barra de Ferramentas';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opacidade da Barra de Navegação';
 
   @override
@@ -6921,6 +6924,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar o botão de bibliotecas na barra de navegação';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Alternar a visibilidade da página inicial por biblioteca. Reinicie Moonfin para que as alterações tenham efeito.';
 
@@ -7515,6 +7522,13 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Aparência';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2703,6 +2703,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Afișați bibliotecile în bara de instrumente';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opacitatea barei de navigare';
 
   @override
@@ -6916,6 +6919,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Afișați butonul biblioteci în bara de navigare';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Comutați vizibilitatea paginii de pornire pentru fiecare bibliotecă. Reporniți Moonfin pentru ca modificările să intre în vigoare.';
 
@@ -7506,6 +7513,13 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2703,6 +2703,9 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показать библиотеки на панели инструментов';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Непрозрачность панели навигации';
 
   @override
@@ -6920,6 +6923,10 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показать кнопку «Библиотеки» на панели навигации.';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Переключить видимость домашней страницы для каждой библиотеки. Перезапустите Moonfin, чтобы изменения вступили в силу.';
 
@@ -7512,6 +7519,13 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -2685,6 +2685,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get showLibrariesInToolbar => 'මෙවලම් තීරුවේ පුස්තකාල පෙන්වන්න';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar පාරාන්ධතාව';
 
   @override
@@ -6864,6 +6867,10 @@ class AppLocalizationsSi extends AppLocalizations {
       'සංචාලන තීරුවේ පුස්තකාල බොත්තම පෙන්වන්න';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'පුස්තකාලයකට මුල් පිටුව දෘශ්‍යතාව ටොගල් කරන්න. වෙනස්කම් බලාත්මක වීමට Moonfin නැවත ආරම්භ කරන්න.';
 
@@ -7449,6 +7456,13 @@ class AppLocalizationsSi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2697,6 +2697,9 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zobraziť knižnice na paneli s nástrojmi';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Nepriehľadnosť navigačnej lišty';
 
   @override
@@ -6904,6 +6907,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zobraziť tlačidlo knižnice na navigačnom paneli';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Prepnúť viditeľnosť domovskej stránky podľa knižnice. Reštartujte Moonfin, aby sa zmeny prejavili.';
 
@@ -7493,6 +7500,13 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2699,6 +2699,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Prikaži knjižnice v orodni vrstici';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Neprosojnost krmarne vrstice';
 
   @override
@@ -6900,6 +6903,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Prikažite gumb za knjižnice v navigacijski vrstici';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Preklopi vidnost domače strani na knjižnico. Znova zaženite Moonfin, da spremembe začnejo veljati.';
 
@@ -7490,6 +7497,13 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsSq extends AppLocalizations {
       'Shfaq bibliotekat në shiritin e veglave';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Opaciteti i Navbarit';
 
   @override
@@ -6931,6 +6934,10 @@ class AppLocalizationsSq extends AppLocalizations {
       'Shfaq butonin e bibliotekave në shiritin e navigimit';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Ndrysho dukshmërinë e faqes kryesore për bibliotekë. Rinisni Moonfin që ndryshimet të hyjnë në fuqi.';
 
@@ -7521,6 +7528,13 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -2697,6 +2697,9 @@ class AppLocalizationsSr extends AppLocalizations {
       'Прикажи библиотеке на траци са алаткама';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Прозирност навигационе траке';
 
   @override
@@ -6896,6 +6899,10 @@ class AppLocalizationsSr extends AppLocalizations {
       'Прикажите дугме библиотеке на траци за навигацију';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Укључите/искључите видљивост почетне странице по библиотеци. Поново покрените __АРБ_ТЕРМ_0__ да би промене ступиле на снагу.';
 
@@ -7486,6 +7493,13 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2695,6 +2695,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showLibrariesInToolbar => 'Visa bibliotek i verktygsfältet';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Opacitet';
 
   @override
@@ -6883,6 +6886,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Visa biblioteksknappen i navigeringsfältet';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Växla hemsidans synlighet per bibliotek. Starta om Moonfin för att ändringarna ska träda i kraft.';
 
@@ -7472,6 +7479,13 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get showLibrariesInToolbar => 'Onyesha Maktaba kwenye Upauzana';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Uwazi wa Upau wa Urambazaji';
 
   @override
@@ -6921,6 +6924,10 @@ class AppLocalizationsSw extends AppLocalizations {
       'Onyesha kitufe cha maktaba kwenye upau wa kusogeza';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Geuza mwonekano wa ukurasa wa nyumbani kwa kila maktaba. Anzisha tena Moonfin ili mabadiliko yaanze kutumika.';
 
@@ -7513,6 +7520,13 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get showLibrariesInToolbar => 'கருவிப்பட்டியில் நூலகங்களைக் காட்டு';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'நவ்பார் ஒளிபுகா';
 
   @override
@@ -6927,6 +6930,10 @@ class AppLocalizationsTa extends AppLocalizations {
       'வழிசெலுத்தல் பட்டியில் நூலகங்கள் பொத்தானைக் காட்டு';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'ஒரு நூலகத்திற்கு முகப்புப் பக்கத் தெரிவுநிலையை நிலைமாற்று. மாற்றங்கள் நடைமுறைக்கு வர Moonfin ஐ மீண்டும் தொடங்கவும்.';
 
@@ -7516,6 +7523,13 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2701,6 +2701,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get showLibrariesInToolbar => 'టూల్‌బార్‌లో లైబ్రరీలను చూపండి';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'నవబార్ అస్పష్టత';
 
   @override
@@ -6913,6 +6916,10 @@ class AppLocalizationsTe extends AppLocalizations {
       'నావిగేషన్ బార్‌లో లైబ్రరీల బటన్‌ను చూపండి';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'లైబ్రరీకి హోమ్ పేజీ విజిబిలిటీని టోగుల్ చేయండి. మార్పులు అమలులోకి రావడానికి Moonfinని పునఃప్రారంభించండి.';
 
@@ -7509,6 +7516,13 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'స్వరూపం';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -2672,6 +2672,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showLibrariesInToolbar => 'แสดงไลบรารีในแถบเครื่องมือ';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'ความทึบของแถบนำทาง';
 
   @override
@@ -6831,6 +6834,10 @@ class AppLocalizationsTh extends AppLocalizations {
       'แสดงปุ่มไลบรารีในแถบนำทาง';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'สลับการเปิดเผยหน้าแรกต่อห้องสมุด รีสตาร์ท Moonfin เพื่อให้การเปลี่ยนแปลงมีผล';
 
@@ -7407,6 +7414,13 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'รูปร่าง';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -2714,6 +2714,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get showLibrariesInToolbar => 'Ipakita ang Mga Aklatan sa Toolbar';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Opacity';
 
   @override
@@ -6950,6 +6953,10 @@ class AppLocalizationsTl extends AppLocalizations {
       'Ipakita ang pindutan ng mga aklatan sa navigation bar';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'I-toggle ang visibility ng home page sa bawat library. I-restart ang Moonfin para magkabisa ang mga pagbabago.';
 
@@ -7541,6 +7548,13 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2688,6 +2688,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get showLibrariesInToolbar => 'Kitaplıkları Araç Çubuğunda Göster';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Gezinti Çubuğunun Opaklığı';
 
   @override
@@ -6875,6 +6878,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Gezinti çubuğunda kitaplıklar düğmesini göster';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Kitaplık başına ana sayfa görünürlüğünü değiştirin. Değişikliklerin etkili olması için Moonfin yeniden başlatın.';
 
@@ -7461,6 +7468,13 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -2691,6 +2691,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get showLibrariesInToolbar => 'قورالبالدىقىدا كۈتۈپخانىلارنى كۆرسەت';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Navbar Opacity';
 
   @override
@@ -6882,6 +6885,10 @@ class AppLocalizationsUg extends AppLocalizations {
       'يولباشچى ستونىدىكى كۈتۈپخانىلار كۇنۇپكىسىنى كۆرسەت';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'ھەر بىر كۈتۈپخانىنىڭ باش بېتىنىڭ كۆرۈنۈشىنى توغرىلاڭ. ئۆزگەرتىشنىڭ كۈچكە ئىگە بولۇشى ئۈچۈن Moonfin نى قايتا قوزغىتىڭ.';
 
@@ -7468,6 +7475,13 @@ class AppLocalizationsUg extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2698,6 +2698,9 @@ class AppLocalizationsUk extends AppLocalizations {
       'Показати бібліотеки на панелі інструментів';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Непрозорість навігаційної панелі';
 
   @override
@@ -6909,6 +6912,10 @@ class AppLocalizationsUk extends AppLocalizations {
       'Показати кнопку бібліотек на панелі навігації';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Перемикання видимості домашньої сторінки для кожної бібліотеки. Перезапустіть Moonfin, щоб зміни набули чинності.';
 
@@ -7506,6 +7513,13 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Зовнішній вигляд';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2693,6 +2693,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get showLibrariesInToolbar => 'Hiển thị Thư viện trong Thanh công cụ';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => 'Độ mờ của thanh điều hướng';
 
   @override
@@ -6881,6 +6884,10 @@ class AppLocalizationsVi extends AppLocalizations {
       'Hiển thị nút thư viện trong thanh điều hướng';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       'Chuyển đổi khả năng hiển thị trang chủ cho mỗi thư viện. Khởi động lại Moonfin để các thay đổi có hiệu lực.';
 
@@ -7468,6 +7475,13 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Vẻ bề ngoài';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2623,6 +2623,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showLibrariesInToolbar => '在工具列中顯示庫';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => '導覽列不透明度';
 
   @override
@@ -6661,6 +6664,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsShowLibrariesButtonInNavigation => '在導覽列中顯示庫按鈕';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       '切換每個庫的主頁可見性。重新啟動 Moonfin 以使變更生效。';
 
@@ -7216,6 +7223,13 @@ class AppLocalizationsYue extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2618,6 +2618,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showLibrariesInToolbar => '在工具栏中显示库';
 
   @override
+  String get showSeerrButton => 'Show Seerr Button';
+
+  @override
   String get navbarOpacity => '导航栏不透明度';
 
   @override
@@ -6656,6 +6659,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsShowLibrariesButtonInNavigation => '在导航栏中显示库按钮';
 
   @override
+  String get settingsShowSeerrButtonInNavigation =>
+      'Show the Seerr button in the navigation bar';
+
+  @override
   String get settingsLibraryVisibilitySubtitle =>
       '切换每个库的主页可见性。重新启动 Moonfin 以使更改生效。';
 
@@ -7197,6 +7204,13 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+
+  @override
+  String get displaySeerrRowsSubtitle =>
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => '外貌';

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -194,6 +194,17 @@ class HomeSectionConfig {
         HomeSectionConfig(type: HomeSectionType.favoriteSongs, enabled: false, order: 18),
         HomeSectionConfig(type: HomeSectionType.collections, enabled: false, order: 19),
         HomeSectionConfig(type: HomeSectionType.genres, enabled: false, order: 20),
+        HomeSectionConfig(type: HomeSectionType.seerrRecentRequests, enabled: false, order: 21),
+        HomeSectionConfig(type: HomeSectionType.seerrRecentlyAdded, enabled: false, order: 22),
+        HomeSectionConfig(type: HomeSectionType.seerrPopularMovies, enabled: false, order: 23),
+        HomeSectionConfig(type: HomeSectionType.seerrUpcomingMovies, enabled: false, order: 24),
+        HomeSectionConfig(type: HomeSectionType.seerrPopularSeries, enabled: false, order: 25),
+        HomeSectionConfig(type: HomeSectionType.seerrUpcomingSeries, enabled: false, order: 26),
+        HomeSectionConfig(type: HomeSectionType.seerrTrending, enabled: false, order: 27),
+        HomeSectionConfig(type: HomeSectionType.seerrMovieGenres, enabled: false, order: 28),
+        HomeSectionConfig(type: HomeSectionType.seerrStudios, enabled: false, order: 29),
+        HomeSectionConfig(type: HomeSectionType.seerrSeriesGenres, enabled: false, order: 30),
+        HomeSectionConfig(type: HomeSectionType.seerrNetworks, enabled: false, order: 31),
       ];
 
   static List<HomeSectionConfig> fromJsonString(String jsonString) {

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -218,6 +218,17 @@ enum HomeSectionType {
   collections('collections'),
   genres('genres'),
   liveTv('livetv'),
+  seerrRecentRequests('seerr_recent_requests'),
+  seerrRecentlyAdded('seerr_recently_added'),
+  seerrPopularMovies('seerr_popular_movies'),
+  seerrUpcomingMovies('seerr_upcoming_movies'),
+  seerrPopularSeries('seerr_popular_series'),
+  seerrUpcomingSeries('seerr_upcoming_series'),
+  seerrTrending('seerr_trending'),
+  seerrMovieGenres('seerr_movie_genres'),
+  seerrStudios('seerr_studios'),
+  seerrSeriesGenres('seerr_series_genres'),
+  seerrNetworks('seerr_networks'),
   none('none');
 
   const HomeSectionType(this.serializedName);

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -290,6 +290,11 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final displaySeerrRows = Preference(
+    key: 'pref_display_seerr_rows',
+    defaultValue: false,
+  );
+
   static final favoritesRowSortBy = EnumPreference(
     key: 'pref_favorites_row_sort_by',
     defaultValue: LibrarySortBy.name,
@@ -388,6 +393,11 @@ class UserPreferences extends ChangeNotifier {
 
   static final showLibrariesInToolbar = Preference(
     key: 'pref_show_libraries_in_toolbar',
+    defaultValue: true,
+  );
+
+  static final showSeerrButton = Preference(
+    key: 'pref_show_seerr_button',
     defaultValue: true,
   );
 

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2119,8 +2119,14 @@ class _ContentRowsState extends State<_ContentRows>
       return _libraryRowExtent(rowHeight, metadataScale: metadataScale);
     }
 
-    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2;
-    final rowImageType = isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs);
+    final isSeerrRowOverride = row.id == 'seerr_movie_genres' ||
+        row.id == 'seerr_series_genres' ||
+        row.id == 'seerr_studios' ||
+        row.id == 'seerr_networks';
+    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !isSeerrRowOverride;
+    final rowImageType = isSeerrRowOverride
+        ? ImageType.thumb
+        : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
     final platformScale = PlatformDetection.isTV ? 0.8 : desktopScale;
     var maxCardHeight = 220.0 * metadataScale;
     if (isRowsV2) {
@@ -2739,9 +2745,14 @@ class _ContentRowsState extends State<_ContentRows>
     required AppLocalizations l10n,
   }) {
     final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
-    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2;
-    final rowImageType =
-        isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs);
+    final isSeerrRowOverride = row.id == 'seerr_movie_genres' ||
+        row.id == 'seerr_series_genres' ||
+        row.id == 'seerr_studios' ||
+        row.id == 'seerr_networks';
+    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !isSeerrRowOverride;
+    final rowImageType = isSeerrRowOverride
+        ? ImageType.thumb
+        : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = PlatformDetection.useDesktopUi ? desktopScale : 1.0;
     final platformScale = PlatformDetection.isTV ? 0.8 : desktopScale;
@@ -2792,12 +2803,14 @@ class _ContentRowsState extends State<_ContentRows>
           posterSize.portraitHeight.toDouble() * platformScale + (46 * metadataScale);
     }
 
+    final isSeerrRow = row.id.startsWith('seerr_');
     return _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),
+      subtitle: isSeerrRow ? 'Seerr Discovery Rows' : null,
       rowIndex: rowIndex,
       hasItems: row.items.isNotEmpty,
-      height: maxCardHeight + (10 * metadataScale),
+      height: maxCardHeight + (10 * metadataScale) + (isSeerrRow ? 18.0 : 0.0),
       child: LockedFocusRow<AggregatedItem>(
         key: _rowKey(rowIndex),
         items: row.items,
@@ -2850,6 +2863,29 @@ class _ContentRowsState extends State<_ContentRows>
             _navigateToLibrary(context, item);
           } else if (row.rowType == HomeRowType.genres && row.id == 'genres') {
             context.push(Destinations.genre(item.name, genreId: item.id));
+          } else if (item.serverId == 'seerr') {
+            final filterType = item.rawData['FilterType'] as String?;
+            if (filterType != null) {
+              final mediaType = item.rawData['MediaType'] as String? ?? 'movie';
+              final filterId = item.id;
+              final filterName = item.rawData['FilterName'] as String? ?? item.name;
+              final uri = Uri(
+                path: Destinations.seerrBrowse,
+                queryParameters: {
+                  'filterId': filterId,
+                  'filterName': filterName,
+                  'mediaType': mediaType,
+                  'filterType': filterType,
+                },
+              );
+              context.push(uri.toString());
+            } else {
+              final mediaType = item.type == 'Series' || item.type == 'tv' ? 'tv' : 'movie';
+              context.push(
+                Destinations.seerrMedia(item.id),
+                extra: {'mediaType': mediaType},
+              );
+            }
           } else {
             context.push(Destinations.itemOrPhoto(
               item.id,
@@ -2941,6 +2977,29 @@ class _ContentRowsState extends State<_ContentRows>
               _navigateToLibrary(context, item);
             } else if (row.rowType == HomeRowType.genres && row.id == 'genres') {
               context.push(Destinations.genre(item.name, genreId: item.id));
+            } else if (item.serverId == 'seerr') {
+              final filterType = item.rawData['FilterType'] as String?;
+              if (filterType != null) {
+                final mediaType = item.rawData['MediaType'] as String? ?? 'movie';
+                final filterId = item.id;
+                final filterName = item.rawData['FilterName'] as String? ?? item.name;
+                final uri = Uri(
+                  path: Destinations.seerrBrowse,
+                  queryParameters: {
+                    'filterId': filterId,
+                    'filterName': filterName,
+                    'mediaType': mediaType,
+                    'filterType': filterType,
+                  },
+                );
+                context.push(uri.toString());
+              } else {
+                final mediaType = item.type == 'Series' || item.type == 'tv' ? 'tv' : 'movie';
+                context.push(
+                  Destinations.seerrMedia(item.id),
+                  extra: {'mediaType': mediaType},
+                );
+              }
             } else {
               context.push(Destinations.itemOrPhoto(
                 item.id,
@@ -3230,6 +3289,7 @@ class _ContentRowsState extends State<_ContentRows>
   Widget _buildTitledRow({
     Key? key,
     required String title,
+    String? subtitle,
     required int rowIndex,
     required bool hasItems,
     required double height,
@@ -3255,12 +3315,27 @@ class _ContentRowsState extends State<_ContentRows>
           child: Row(
             children: [
               Expanded(
-                child: Text(
-                  title,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: AppColorScheme.onSurface,
-                        fontWeight: FontWeight.w600,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            color: AppColorScheme.onSurface,
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                    if (subtitle != null && subtitle.isNotEmpty) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+                            ),
                       ),
+                    ],
+                  ],
                 ),
               ),
               if (showHeaderControls) ...[
@@ -3402,6 +3477,19 @@ class _ContentRowsState extends State<_ContentRows>
     bool useSeriesThumbs,
     double requestScale,
   ) {
+    if (item.serverId == 'seerr') {
+      final backdrop = item.rawData['BackdropPath'] as String?;
+      if (backdrop != null && backdrop.isNotEmpty) {
+        if (backdrop.startsWith('http')) return backdrop;
+        return 'https://image.tmdb.org/t/p/w1280$backdrop';
+      }
+      final poster = item.rawData['PosterPath'] as String?;
+      if (poster != null && poster.isNotEmpty) {
+        if (poster.startsWith('http')) return poster;
+        return 'https://image.tmdb.org/t/p/w300$poster';
+      }
+      return null;
+    }
     final maxW = (height * 16 / 9 * requestScale).toInt();
     final maxH = (height * requestScale).toInt();
     if (!useSeriesThumbs) {
@@ -3470,6 +3558,12 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   static ImageType _homeRowImageTypeForRow(HomeRow row, UserPreferences prefs) {
+    if (row.id == 'seerr_movie_genres' ||
+        row.id == 'seerr_series_genres' ||
+        row.id == 'seerr_studios' ||
+        row.id == 'seerr_networks') {
+      return ImageType.thumb;
+    }
     if (row.rowType == HomeRowType.latestMedia && _isLatestMusicRow(row)) {
       return ImageType.poster;
     }
@@ -3522,6 +3616,12 @@ class _ContentRowsState extends State<_ContentRows>
     HomeRow row,
     ImageType imageType,
   ) {
+    if (row.id == 'seerr_movie_genres' ||
+        row.id == 'seerr_series_genres' ||
+        row.id == 'seerr_studios' ||
+        row.id == 'seerr_networks') {
+      return 16 / 9;
+    }
     double thumbAspectRatio() {
       return switch (item.type) {
         'MusicAlbum' || 'MusicArtist' || 'Audio' || 'Playlist' || 'Person' => 1,
@@ -3544,6 +3644,32 @@ class _ContentRowsState extends State<_ContentRows>
     double requestScale,
     {bool isMyMediaRow = false}
   ) {
+    if (item.serverId == 'seerr') {
+      if (imageType == ImageType.thumb || imageType == ImageType.banner) {
+        final backdrop = item.rawData['BackdropPath'] as String?;
+        if (backdrop != null && backdrop.isNotEmpty) {
+          if (backdrop.startsWith('http')) return backdrop;
+          return 'https://image.tmdb.org/t/p/w1280$backdrop';
+        }
+        final poster = item.rawData['PosterPath'] as String?;
+        if (poster != null && poster.isNotEmpty) {
+          if (poster.startsWith('http')) return poster;
+          return 'https://image.tmdb.org/t/p/w300$poster';
+        }
+      } else {
+        final poster = item.rawData['PosterPath'] as String?;
+        if (poster != null && poster.isNotEmpty) {
+          if (poster.startsWith('http')) return poster;
+          return 'https://image.tmdb.org/t/p/w300$poster';
+        }
+        final backdrop = item.rawData['BackdropPath'] as String?;
+        if (backdrop != null && backdrop.isNotEmpty) {
+          if (backdrop.startsWith('http')) return backdrop;
+          return 'https://image.tmdb.org/t/p/w1280$backdrop';
+        }
+      }
+      return null;
+    }
     final itemThumbTag = _tagForType(item, 'Thumb');
     final itemBannerTag = _tagForType(item, 'Banner');
     final parentThumbItemId = item.rawData['ParentThumbItemId'] as String?;

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -15,6 +15,11 @@ import '../../../l10n/current_app_localizations.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import 'package:get_it/get_it.dart';
+import '../../../data/repositories/seerr_repository.dart';
+import '../../../data/services/seerr/seerr_api_models.dart';
+import '../../../preference/seerr_preferences.dart';
+import '../../../data/viewmodels/seerr_discover_view_model.dart';
 
 class HomeViewModel extends ChangeNotifier {
   final RowDataSource _dataSource;
@@ -75,6 +80,20 @@ class HomeViewModel extends ChangeNotifier {
     return type == HomeSectionType.playlists;
   }
 
+  static bool _isSeerrSectionType(HomeSectionType type) {
+    return type == HomeSectionType.seerrRecentRequests ||
+        type == HomeSectionType.seerrRecentlyAdded ||
+        type == HomeSectionType.seerrPopularMovies ||
+        type == HomeSectionType.seerrUpcomingMovies ||
+        type == HomeSectionType.seerrPopularSeries ||
+        type == HomeSectionType.seerrUpcomingSeries ||
+        type == HomeSectionType.seerrTrending ||
+        type == HomeSectionType.seerrMovieGenres ||
+        type == HomeSectionType.seerrStudios ||
+        type == HomeSectionType.seerrSeriesGenres ||
+        type == HomeSectionType.seerrNetworks;
+  }
+
   ImageApi imageApiForServer(String serverId) {
     if (!_multiServerEnabled) return _dataSource.imageApi;
     return _multiServerRepo.getImageApiForServer(serverId);
@@ -131,6 +150,8 @@ class HomeViewModel extends ChangeNotifier {
           _prefs.get(UserPreferences.displayGenresRows);
       final showPlaylistsRows =
           _prefs.get(UserPreferences.displayPlaylistsRows);
+      final showSeerrRows =
+          _prefs.get(UserPreferences.displaySeerrRows);
 
       // Plugin-dynamic sections only make sense on the active server.
       final visibleConfigsRaw = configs
@@ -150,7 +171,8 @@ class HomeViewModel extends ChangeNotifier {
             (showPlaylistsRows ||
               !((c.isBuiltin && _isPlaylistsSectionType(c.type)) ||
                 (c.isPluginDynamic &&
-                  c.pluginSource == HomeSectionPluginSource.playlists))),
+                  c.pluginSource == HomeSectionPluginSource.playlists))) &&
+            (showSeerrRows || !_isSeerrSectionType(c.type)),
           )
           .toList(growable: false);
 
@@ -381,6 +403,28 @@ class HomeViewModel extends ChangeNotifier {
             row.rowType == HomeRowType.liveTvOnNow;
       case HomeSectionType.activeRecordings:
         return row.rowType == HomeRowType.activeRecordings;
+      case HomeSectionType.seerrRecentRequests:
+        return row.id == 'seerr_recent_requests';
+      case HomeSectionType.seerrRecentlyAdded:
+        return row.id == 'seerr_recently_added';
+      case HomeSectionType.seerrPopularMovies:
+        return row.id == 'seerr_popular_movies';
+      case HomeSectionType.seerrUpcomingMovies:
+        return row.id == 'seerr_upcoming_movies';
+      case HomeSectionType.seerrPopularSeries:
+        return row.id == 'seerr_popular_series';
+      case HomeSectionType.seerrUpcomingSeries:
+        return row.id == 'seerr_upcoming_series';
+      case HomeSectionType.seerrTrending:
+        return row.id == 'seerr_trending';
+      case HomeSectionType.seerrMovieGenres:
+        return row.id == 'seerr_movie_genres';
+      case HomeSectionType.seerrStudios:
+        return row.id == 'seerr_studios';
+      case HomeSectionType.seerrSeriesGenres:
+        return row.id == 'seerr_series_genres';
+      case HomeSectionType.seerrNetworks:
+        return row.id == 'seerr_networks';
       case HomeSectionType.mediaBar:
       case HomeSectionType.recentlyReleased:
       case HomeSectionType.resumeBook:
@@ -578,6 +622,28 @@ class HomeViewModel extends ChangeNotifier {
         return const {'genres'};
       case HomeSectionType.activeRecordings:
         return const {'activeRecordings'};
+      case HomeSectionType.seerrRecentRequests:
+        return const {'seerrRecentRequests'};
+      case HomeSectionType.seerrRecentlyAdded:
+        return const {'seerrRecentlyAdded'};
+      case HomeSectionType.seerrPopularMovies:
+        return const {'seerrPopularMovies'};
+      case HomeSectionType.seerrUpcomingMovies:
+        return const {'seerrUpcomingMovies'};
+      case HomeSectionType.seerrPopularSeries:
+        return const {'seerrPopularSeries'};
+      case HomeSectionType.seerrUpcomingSeries:
+        return const {'seerrUpcomingSeries'};
+      case HomeSectionType.seerrTrending:
+        return const {'seerrTrending'};
+      case HomeSectionType.seerrMovieGenres:
+        return const {'seerrMovieGenres'};
+      case HomeSectionType.seerrStudios:
+        return const {'seerrStudios'};
+      case HomeSectionType.seerrSeriesGenres:
+        return const {'seerrSeriesGenres'};
+      case HomeSectionType.seerrNetworks:
+        return const {'seerrNetworks'};
       case HomeSectionType.mediaBar:
       case HomeSectionType.none:
         return const <String>{};
@@ -751,6 +817,28 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.mediaBar:
         _mediaBarViewModel.load();
         return [];
+      case HomeSectionType.seerrRecentRequests:
+        return _loadSeerrRow(SeerrRowType.recentRequests, l10n.recentRequests, 'seerr_recent_requests');
+      case HomeSectionType.seerrRecentlyAdded:
+        return _loadSeerrRow(SeerrRowType.recentlyAdded, l10n.recentlyAdded, 'seerr_recently_added');
+      case HomeSectionType.seerrPopularMovies:
+        return _loadSeerrRow(SeerrRowType.popularMovies, l10n.popularMovies, 'seerr_popular_movies');
+      case HomeSectionType.seerrUpcomingMovies:
+        return _loadSeerrRow(SeerrRowType.upcomingMovies, l10n.upcomingMovies, 'seerr_upcoming_movies');
+      case HomeSectionType.seerrPopularSeries:
+        return _loadSeerrRow(SeerrRowType.popularSeries, l10n.popularSeries, 'seerr_popular_series');
+      case HomeSectionType.seerrUpcomingSeries:
+        return _loadSeerrRow(SeerrRowType.upcomingSeries, l10n.upcomingSeries, 'seerr_upcoming_series');
+      case HomeSectionType.seerrTrending:
+        return _loadSeerrRow(SeerrRowType.trending, l10n.trending, 'seerr_trending');
+      case HomeSectionType.seerrMovieGenres:
+        return _loadSeerrRow(SeerrRowType.movieGenres, l10n.movieGenres, 'seerr_movie_genres');
+      case HomeSectionType.seerrStudios:
+        return _loadSeerrRow(SeerrRowType.studios, l10n.studios, 'seerr_studios');
+      case HomeSectionType.seerrSeriesGenres:
+        return _loadSeerrRow(SeerrRowType.seriesGenres, l10n.seriesGenres, 'seerr_series_genres');
+      case HomeSectionType.seerrNetworks:
+        return _loadSeerrRow(SeerrRowType.networks, l10n.networks, 'seerr_networks');
       case HomeSectionType.recentlyReleased:
       case HomeSectionType.resumeBook:
       case HomeSectionType.none:
@@ -872,6 +960,61 @@ class HomeViewModel extends ChangeNotifier {
           id: 'libraryTilesSmall', title: l10n.myMedia,
           rowType: HomeRowType.libraryTilesSmall, isLoading: true,
         );
+      case HomeSectionType.seerrRecentRequests:
+        return HomeRow(
+          id: 'seerr_recent_requests', title: l10n.recentRequests,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrRecentlyAdded:
+        return HomeRow(
+          id: 'seerr_recently_added', title: l10n.recentlyAdded,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrPopularMovies:
+        return HomeRow(
+          id: 'seerr_popular_movies', title: l10n.popularMovies,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrUpcomingMovies:
+        return HomeRow(
+          id: 'seerr_upcoming_movies', title: l10n.upcomingMovies,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrPopularSeries:
+        return HomeRow(
+          id: 'seerr_popular_series', title: l10n.popularSeries,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrUpcomingSeries:
+        return HomeRow(
+          id: 'seerr_upcoming_series', title: l10n.upcomingSeries,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrTrending:
+        return HomeRow(
+          id: 'seerr_trending', title: l10n.trending,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrMovieGenres:
+        return HomeRow(
+          id: 'seerr_movie_genres', title: l10n.movieGenres,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrStudios:
+        return HomeRow(
+          id: 'seerr_studios', title: l10n.studios,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrSeriesGenres:
+        return HomeRow(
+          id: 'seerr_series_genres', title: l10n.seriesGenres,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
+      case HomeSectionType.seerrNetworks:
+        return HomeRow(
+          id: 'seerr_networks', title: l10n.networks,
+          rowType: HomeRowType.pluginDynamic, isLoading: true,
+        );
       case HomeSectionType.liveTv:
       case HomeSectionType.activeRecordings:
       case HomeSectionType.mediaBar:
@@ -988,6 +1131,320 @@ class HomeViewModel extends ChangeNotifier {
       );
     }
     notifyListeners();
+  }
+
+  Future<List<HomeRow>> _loadSeerrRow(SeerrRowType type, String title, String rowId) async {
+    try {
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      final seerrPrefs = GetIt.instance<SeerrPreferences>();
+      await repo.ensureInitialized();
+      if (!repo.isAvailable) {
+        return [];
+      }
+
+      final blockNsfw = seerrPrefs.blockNsfw;
+      final limit = seerrPrefs.fetchLimit.limit;
+
+      List<SeerrDiscoverItem> rawItems = [];
+
+      if (type == SeerrRowType.movieGenres) {
+        final genres = await repo.getGenreSliderMovies();
+        final aggregatedItems = genres.map((genre) {
+          final backdrop = genre.backdrops.isNotEmpty ? genre.backdrops.first : '';
+          return AggregatedItem(
+            id: genre.id.toString(),
+            serverId: 'seerr',
+            rawData: {
+              'Name': genre.name,
+              'Type': 'Genre',
+              'Overview': '',
+              'PosterPath': backdrop,
+              'BackdropPath': backdrop,
+              'MediaType': 'movie',
+              'FilterType': 'genre',
+              'FilterName': genre.name,
+            },
+          );
+        }).toList();
+        return [
+          HomeRow(
+            id: rowId,
+            title: title,
+            rowType: HomeRowType.pluginDynamic,
+            items: aggregatedItems,
+          )
+        ];
+      } else if (type == SeerrRowType.seriesGenres) {
+        final genres = await repo.getGenreSliderTv();
+        final aggregatedItems = genres.map((genre) {
+          final backdrop = genre.backdrops.isNotEmpty ? genre.backdrops.first : '';
+          return AggregatedItem(
+            id: genre.id.toString(),
+            serverId: 'seerr',
+            rawData: {
+              'Name': genre.name,
+              'Type': 'Genre',
+              'Overview': '',
+              'PosterPath': backdrop,
+              'BackdropPath': backdrop,
+              'MediaType': 'tv',
+              'FilterType': 'genre',
+              'FilterName': genre.name,
+            },
+          );
+        }).toList();
+        return [
+          HomeRow(
+            id: rowId,
+            title: title,
+            rowType: HomeRowType.pluginDynamic,
+            items: aggregatedItems,
+          )
+        ];
+      } else if (type == SeerrRowType.networks) {
+        final networks = SeerrDiscoverViewModel.popularNetworks;
+        final aggregatedItems = networks.map((network) {
+          return AggregatedItem(
+            id: network.id.toString(),
+            serverId: 'seerr',
+            rawData: {
+              'Name': network.name,
+              'Type': 'Network',
+              'Overview': '',
+              'PosterPath': network.logoPath ?? '',
+              'BackdropPath': network.logoPath ?? '',
+              'MediaType': 'tv',
+              'FilterType': 'network',
+              'FilterName': network.name,
+            },
+          );
+        }).toList();
+        return [
+          HomeRow(
+            id: rowId,
+            title: title,
+            rowType: HomeRowType.pluginDynamic,
+            items: aggregatedItems,
+          )
+        ];
+      } else if (type == SeerrRowType.studios) {
+        final studios = SeerrDiscoverViewModel.popularStudios;
+        final aggregatedItems = studios.map((studio) {
+          return AggregatedItem(
+            id: studio.id.toString(),
+            serverId: 'seerr',
+            rawData: {
+              'Name': studio.name,
+              'Type': 'Studio',
+              'Overview': '',
+              'PosterPath': studio.logoPath ?? '',
+              'BackdropPath': studio.logoPath ?? '',
+              'MediaType': 'movie',
+              'FilterType': 'studio',
+              'FilterName': studio.name,
+            },
+          );
+        }).toList();
+        return [
+          HomeRow(
+            id: rowId,
+            title: title,
+            rowType: HomeRowType.pluginDynamic,
+            items: aggregatedItems,
+          )
+        ];
+      } else if (type == SeerrRowType.recentRequests) {
+        final user = await repo.getCurrentUser();
+        final response = await repo.getRequests(
+          requestedBy: user.canViewAllRequests ? null : user.id,
+          limit: limit,
+        );
+        final mapped = response.results
+            .where((r) => r.media != null)
+            .map((r) {
+              final media = r.media!;
+              return SeerrDiscoverItem(
+                id: media.tmdbId ?? media.id,
+                title: media.title ?? media.name,
+                name: media.name ?? media.title,
+                overview: media.overview,
+                releaseDate: media.releaseDate,
+                firstAirDate: media.firstAirDate,
+                mediaType: r.type,
+                posterPath: media.posterPath,
+                backdropPath: media.backdropPath,
+                mediaInfo: SeerrMediaInfo(
+                  id: media.id,
+                  tmdbId: media.tmdbId,
+                  status: media.status,
+                ),
+              );
+            })
+            .toList();
+        rawItems = await Future.wait(mapped.map((item) => _enrichSeerrItem(repo, item)));
+      } else if (type == SeerrRowType.recentlyAdded) {
+        final media = await repo.getRecentlyAdded(limit: limit);
+        final mapped = media.map((m) => SeerrDiscoverItem(
+          id: m.tmdbId ?? m.id,
+          title: m.title,
+          name: m.name,
+          overview: m.overview,
+          releaseDate: m.releaseDate,
+          firstAirDate: m.firstAirDate,
+          mediaType: m.mediaType,
+          posterPath: m.posterPath,
+          backdropPath: m.backdropPath,
+          mediaInfo: SeerrMediaInfo(
+            id: m.id,
+            tmdbId: m.tmdbId,
+            status: m.status,
+          ),
+        )).toList();
+        rawItems = await Future.wait(mapped.map((item) => _enrichSeerrItem(repo, item)));
+      } else {
+        final page = await _loadSeerrPage(repo, type, limit);
+        if (page != null) {
+          rawItems = page.results;
+        }
+      }
+
+      final nsfwKeywords = [
+        r'\bsex\b', 'sexual', r'\bporn\b', 'erotic', r'\bnude\b', 'nudity',
+        r'\bxxx\b', 'adult film', 'prostitute', 'stripper', r'\bescort\b',
+        'seduction', r'\baffair\b', 'threesome', r'\borgy\b', 'kinky',
+        'fetish', r'\bbdsm\b', 'dominatrix',
+      ];
+      final nsfwPatterns = nsfwKeywords.map((k) => RegExp(k, caseSensitive: false)).toList();
+
+      final filtered = rawItems.where((item) {
+        if (type != SeerrRowType.recentlyAdded && type != SeerrRowType.recentRequests) {
+          if (item.isAvailable || item.isBlacklisted) return false;
+        }
+        if (blockNsfw) {
+          if (item.adult) return false;
+          final text = '${item.displayTitle} ${item.overview ?? ''}';
+          if (nsfwPatterns.any((p) => p.hasMatch(text))) return false;
+        }
+        return true;
+      }).toList();
+
+      final aggregatedItems = filtered.map((item) {
+        return AggregatedItem(
+          id: item.id.toString(),
+          serverId: 'seerr',
+          rawData: {
+            'Name': item.displayTitle,
+            'Type': item.mediaType == 'tv' ? 'Series' : 'Movie',
+            'Overview': item.overview ?? '',
+            'PosterPath': item.posterPath ?? '',
+            'BackdropPath': item.backdropPath ?? '',
+            'ProductionYear': _extractYear(item.releaseDate ?? item.firstAirDate),
+          },
+        );
+      }).toList();
+
+      return [
+        HomeRow(
+          id: rowId,
+          title: title,
+          rowType: HomeRowType.pluginDynamic,
+          items: aggregatedItems,
+        )
+      ];
+    } catch (e) {
+      debugPrint('[SeerrHomeRow] Failed to load Seerr row $type: $e');
+      return [];
+    }
+  }
+
+  Future<SeerrDiscoverPage?> _loadSeerrPage(SeerrRepository repo, SeerrRowType type, int limit) async {
+    switch (type) {
+      case SeerrRowType.trending:
+        return repo.getTrending(limit: limit, offset: 0);
+      case SeerrRowType.popularMovies:
+        return repo.getTrendingMovies(limit: limit, offset: 0);
+      case SeerrRowType.popularSeries:
+        return repo.getTrendingTv(limit: limit, offset: 0);
+      case SeerrRowType.upcomingMovies:
+        return repo.getUpcomingMovies();
+      case SeerrRowType.upcomingSeries:
+        return repo.getUpcomingTv();
+      default:
+        return null;
+    }
+  }
+
+  Future<SeerrDiscoverItem> _enrichSeerrItem(SeerrRepository repo, SeerrDiscoverItem item) async {
+    if (item.backdropPath != null && item.voteAverage != null && (item.releaseDate != null || item.firstAirDate != null)) {
+      return item;
+    }
+    final tmdbId = item.mediaInfo?.tmdbId ?? item.id;
+    if (tmdbId <= 0) return item;
+    try {
+      if (item.mediaType == 'tv') {
+        final details = await repo.getTvDetails(tmdbId);
+        return SeerrDiscoverItem(
+          id: item.id,
+          mediaType: item.mediaType,
+          title: item.title ?? details.title,
+          name: item.name ?? details.name,
+          originalTitle: item.originalTitle,
+          originalName: item.originalName,
+          posterPath: details.posterPath ?? item.posterPath,
+          backdropPath: details.backdropPath ?? item.backdropPath,
+          overview: details.overview ?? item.overview,
+          releaseDate: item.releaseDate ?? details.firstAirDate,
+          firstAirDate: item.firstAirDate ?? details.firstAirDate,
+          originalLanguage: item.originalLanguage,
+          genreIds: item.genreIds,
+          voteAverage: details.voteAverage ?? item.voteAverage,
+          voteCount: item.voteCount,
+          popularity: item.popularity,
+          adult: item.adult,
+          mediaInfo: item.mediaInfo,
+          character: item.character,
+          job: item.job,
+          department: item.department,
+        );
+      }
+      final details = await repo.getMovieDetails(tmdbId);
+      return SeerrDiscoverItem(
+        id: item.id,
+        mediaType: item.mediaType,
+        title: item.title ?? details.title,
+        name: item.name,
+        originalTitle: item.originalTitle,
+        originalName: item.originalName,
+        posterPath: details.posterPath ?? item.posterPath,
+        backdropPath: details.backdropPath ?? item.backdropPath,
+        overview: details.overview ?? item.overview,
+        releaseDate: item.releaseDate ?? details.releaseDate,
+        firstAirDate: item.firstAirDate ?? details.releaseDate,
+        originalLanguage: item.originalLanguage,
+        genreIds: item.genreIds,
+        voteAverage: details.voteAverage ?? item.voteAverage,
+        voteCount: item.voteCount,
+        popularity: item.popularity,
+        adult: item.adult,
+        mediaInfo: item.mediaInfo,
+        character: item.character,
+        job: item.job,
+        department: item.department,
+      );
+    } catch (_) {
+      return item;
+    }
+  }
+
+  int? _extractYear(String? dateString) {
+    if (dateString == null || dateString.isEmpty) return null;
+    try {
+      final parts = dateString.split('-');
+      if (parts.isNotEmpty) {
+        return int.tryParse(parts[0]);
+      }
+    } catch (_) {}
+    return null;
   }
 }
 

--- a/lib/ui/screens/settings/home_rows_image_type_screen.dart
+++ b/lib/ui/screens/settings/home_rows_image_type_screen.dart
@@ -73,6 +73,17 @@ class _HomeRowsImageTypeScreenState extends State<HomeRowsImageTypeScreen> {
     HomeSectionType.collections => l10n.collections,
     HomeSectionType.genres => l10n.genres,
     HomeSectionType.liveTv => l10n.liveTV,
+    HomeSectionType.seerrRecentRequests => l10n.recentRequests,
+    HomeSectionType.seerrRecentlyAdded => l10n.recentlyAdded,
+    HomeSectionType.seerrPopularMovies => l10n.popularMovies,
+    HomeSectionType.seerrUpcomingMovies => l10n.upcomingMovies,
+    HomeSectionType.seerrPopularSeries => l10n.popularSeries,
+    HomeSectionType.seerrUpcomingSeries => l10n.upcomingSeries,
+    HomeSectionType.seerrTrending => l10n.trending,
+    HomeSectionType.seerrMovieGenres => l10n.movieGenres,
+    HomeSectionType.seerrStudios => l10n.studios,
+    HomeSectionType.seerrSeriesGenres => l10n.seriesGenres,
+    HomeSectionType.seerrNetworks => l10n.networks,
     HomeSectionType.none => l10n.none,
   };
 

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -15,6 +15,7 @@ import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/poster_size_settings_dialog.dart';
+import '../../widgets/playback/player_loading_overlay.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import '../../widgets/settings/preference_tiles.dart';
 import '../../../l10n/app_localizations.dart';
@@ -84,6 +85,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   late List<HomeSectionConfig> _sections;
   HomeSectionConfig? _mediaBarConfig;
   final _focusNodes = <FocusNode>[];
+  final Map<String, FocusNode> _focusNodesByStableId = {};
+  bool _isLoading = true;
+  bool _showOverlay = true;
 
   final Set<String> _emptySectionIds = {};
 
@@ -303,16 +307,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           ..clear()
           ..addAll(newEmptyIds);
       });
-      if (PlatformDetection.isTV) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          if (FocusManager.instance.primaryFocus?.hasPrimaryFocus ?? false) {
-            return;
-          }
-          final first = _visibleSectionIndices().firstOrNull;
-          if (first != null) _focusSectionAndEnsureVisible(first);
-        });
-      }
     }
   }
 
@@ -342,12 +336,36 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     return type == HomeSectionType.playlists;
   }
 
+  bool _isSeerrSectionType(HomeSectionType type) {
+    return type == HomeSectionType.seerrRecentRequests ||
+        type == HomeSectionType.seerrRecentlyAdded ||
+        type == HomeSectionType.seerrPopularMovies ||
+        type == HomeSectionType.seerrUpcomingMovies ||
+        type == HomeSectionType.seerrPopularSeries ||
+        type == HomeSectionType.seerrUpcomingSeries ||
+        type == HomeSectionType.seerrTrending ||
+        type == HomeSectionType.seerrMovieGenres ||
+        type == HomeSectionType.seerrStudios ||
+        type == HomeSectionType.seerrSeriesGenres ||
+        type == HomeSectionType.seerrNetworks;
+  }
+
+  void _addSection(HomeSectionConfig cfg) {
+    final insertIdx = _sections.indexWhere((s) => s.isBuiltin && _isSeerrSectionType(s.type));
+    if (insertIdx >= 0) {
+      _sections.insert(insertIdx, cfg);
+    } else {
+      _sections.add(cfg);
+    }
+  }
+
   bool _isHiddenByRowVisibilityGates(HomeSectionConfig section) {
     final showFavoritesRows = _prefs.get(UserPreferences.displayFavoritesRows);
     final showCollectionsRows =
         _prefs.get(UserPreferences.displayCollectionsRows);
     final showGenresRows = _prefs.get(UserPreferences.displayGenresRows);
     final showPlaylistsRows = _prefs.get(UserPreferences.displayPlaylistsRows);
+    final showSeerrRows = _prefs.get(UserPreferences.displaySeerrRows);
 
     final hiddenByFavorites =
       !showFavoritesRows && _isFavoriteSectionType(section.type);
@@ -363,7 +381,12 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       ((section.isBuiltin && _isPlaylistsSectionType(section.type)) ||
         (section.isPluginDynamic &&
           section.pluginSource == HomeSectionPluginSource.playlists));
-    return hiddenByFavorites || hiddenByCollections || hiddenByGenres || hiddenByPlaylists;
+    final hiddenBySeerr = !showSeerrRows && _isSeerrSectionType(section.type);
+    return hiddenByFavorites ||
+        hiddenByCollections ||
+        hiddenByGenres ||
+        hiddenByPlaylists ||
+        hiddenBySeerr;
   }
 
   List<int> _visibleSectionIndices() {
@@ -409,16 +432,36 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         continue;
       }
       if (existingTypes.contains(type)) continue;
+
+      final isSeerr = _isSeerrSectionType(type);
+      final idx = isSeerr ? _sections.length : insertIndex;
+
       _sections.insert(
-        insertIndex,
+        idx,
         HomeSectionConfig(
           type: type,
           enabled: false,
           order: nextOrder++,
         ),
       );
-      insertIndex++;
+      if (!isSeerr) {
+        insertIndex++;
+      }
       changed = true;
+    }
+
+    // Migration: if Seerr rows exist before dynamic sections, move them to the end.
+    final lastDynamicIndex = _sections.lastIndexWhere((s) => s.isPluginDynamic);
+    if (lastDynamicIndex >= 0) {
+      final firstSeerrIndex =
+          _sections.indexWhere((s) => s.isBuiltin && _isSeerrSectionType(s.type));
+      if (firstSeerrIndex >= 0 && firstSeerrIndex < lastDynamicIndex) {
+        final seerrConfigs =
+            _sections.where((s) => s.isBuiltin && _isSeerrSectionType(s.type)).toList();
+        _sections.removeWhere((s) => s.isBuiltin && _isSeerrSectionType(s.type));
+        _sections.addAll(seerrConfigs);
+        changed = true;
+      }
     }
 
     return changed;
@@ -427,40 +470,64 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   /// Probes for newly discovered plugin sections in the background and
   /// re-merges the result into the visible list.
   Future<void> _refreshPluginSections() async {
-    final futures = <Future<void>>[];
-    if (GetIt.instance.isRegistered<HomeScreenSectionsService>()) {
-      futures.add(GetIt.instance<HomeScreenSectionsService>().refreshAll());
-    }
-    if (GetIt.instance.isRegistered<KefinTweaksService>()) {
-      futures.add(GetIt.instance<KefinTweaksService>().refreshAll());
-    }
-    if (futures.isNotEmpty) {
-      await Future.wait(futures);
-    }
-    final collectionsFuture = _fetchCollectionsForHomeSections();
-    final genresFuture = _fetchGenresForHomeSections();
-    final playlistsFuture = _fetchPlaylistsForHomeSections();
-    final discoveredCollections = await collectionsFuture;
-    final discoveredGenres = await genresFuture;
-    final discoveredPlaylists = await playlistsFuture;
-    if (!mounted) return;
-    var changed = false;
     setState(() {
-      final mergedPluginSections = _mergeDiscoveredPluginSections();
-      final mergedCollectionSections = _mergeCollectionSections(discoveredCollections);
-      final mergedGenreSections = _mergeGenreSections(discoveredGenres);
-      final mergedPlaylistSections = _mergePlaylistSections(discoveredPlaylists);
-      changed =
-          mergedPluginSections ||
-          mergedCollectionSections ||
-          mergedGenreSections ||
-          mergedPlaylistSections;
-      _rebuildFocusNodes();
+      _isLoading = true;
+      _showOverlay = true;
     });
-    if (changed) {
-      _persistSections(pushSync: false);
+    try {
+      final futures = <Future<void>>[];
+      if (GetIt.instance.isRegistered<HomeScreenSectionsService>()) {
+        futures.add(GetIt.instance<HomeScreenSectionsService>().refreshAll());
+      }
+      if (GetIt.instance.isRegistered<KefinTweaksService>()) {
+        futures.add(GetIt.instance<KefinTweaksService>().refreshAll());
+      }
+      if (futures.isNotEmpty) {
+        try {
+          await Future.wait(futures);
+        } catch (_) {}
+      }
+      final collectionsFuture = _fetchCollectionsForHomeSections();
+      final genresFuture = _fetchGenresForHomeSections();
+      final playlistsFuture = _fetchPlaylistsForHomeSections();
+      final discoveredCollections = await collectionsFuture;
+      final discoveredGenres = await genresFuture;
+      final discoveredPlaylists = await playlistsFuture;
+      if (!mounted) return;
+      var changed = false;
+      setState(() {
+        final mergedPluginSections = _mergeDiscoveredPluginSections();
+        final mergedCollectionSections = _mergeCollectionSections(discoveredCollections);
+        final mergedGenreSections = _mergeGenreSections(discoveredGenres);
+        final mergedPlaylistSections = _mergePlaylistSections(discoveredPlaylists);
+        changed =
+            mergedPluginSections ||
+            mergedCollectionSections ||
+            mergedGenreSections ||
+            mergedPlaylistSections;
+        _rebuildFocusNodes();
+      });
+      if (changed) {
+        _persistSections(pushSync: false);
+      }
+      await _checkEmptyStates();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        if (PlatformDetection.isTV) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            if (FocusManager.instance.primaryFocus?.hasPrimaryFocus ?? false) {
+              return;
+            }
+            final first = _visibleSectionIndices().firstOrNull;
+            if (first != null) _focusSectionAndEnsureVisible(first);
+          });
+        }
+      }
     }
-    unawaited(_checkEmptyStates());
   }
 
   /// Adds plugin-dynamic sections discovered by the Home Screen Sections
@@ -561,7 +628,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           changed = true;
         }
       } else {
-        _sections.add(cfg);
+        _addSection(cfg);
         changed = true;
       }
     }
@@ -718,7 +785,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           changed = true;
         }
       } else {
-        _sections.add(cfg);
+        _addSection(cfg);
         changed = true;
       }
     }
@@ -773,7 +840,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           changed = true;
         }
       } else {
-        _sections.add(cfg);
+        _addSection(cfg);
         changed = true;
       }
     }
@@ -831,7 +898,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
             changed = true;
           }
         } else {
-          _sections.add(cfg);
+          _addSection(cfg);
           changed = true;
         }
       }
@@ -890,7 +957,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
             changed = true;
           }
         } else {
-          _sections.add(cfg);
+          _addSection(cfg);
           changed = true;
         }
       }
@@ -909,20 +976,35 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   }
 
   void _rebuildFocusNodes() {
-    for (final n in _focusNodes) {
-      n.dispose();
+    final activeIds = _sections.map((s) => s.stableId).toSet();
+
+    final inactiveIds = _focusNodesByStableId.keys.where((id) => !activeIds.contains(id)).toList();
+    for (final id in inactiveIds) {
+      _focusNodesByStableId[id]?.dispose();
+      _focusNodesByStableId.remove(id);
     }
+
+    for (final section in _sections) {
+      if (!_focusNodesByStableId.containsKey(section.stableId)) {
+        _focusNodesByStableId[section.stableId] = FocusNode(
+          debugLabel: 'section_${section.stableId}',
+        );
+      }
+    }
+
     _focusNodes.clear();
-    for (var i = 0; i < _sections.length; i++) {
-      _focusNodes.add(FocusNode(debugLabel: 'section_$i'));
+    for (final section in _sections) {
+      _focusNodes.add(_focusNodesByStableId[section.stableId]!);
     }
   }
 
   @override
   void dispose() {
-    for (final n in _focusNodes) {
+    for (final n in _focusNodesByStableId.values) {
       n.dispose();
     }
+    _focusNodesByStableId.clear();
+    _focusNodes.clear();
     super.dispose();
   }
 
@@ -1032,6 +1114,17 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     HomeSectionType.collections => l10n.collections,
     HomeSectionType.genres => l10n.genres,
     HomeSectionType.liveTv => l10n.liveTV,
+    HomeSectionType.seerrRecentRequests => l10n.recentRequests,
+    HomeSectionType.seerrRecentlyAdded => l10n.recentlyAdded,
+    HomeSectionType.seerrPopularMovies => l10n.popularMovies,
+    HomeSectionType.seerrUpcomingMovies => l10n.upcomingMovies,
+    HomeSectionType.seerrPopularSeries => l10n.popularSeries,
+    HomeSectionType.seerrUpcomingSeries => l10n.upcomingSeries,
+    HomeSectionType.seerrTrending => l10n.trending,
+    HomeSectionType.seerrMovieGenres => l10n.movieGenres,
+    HomeSectionType.seerrStudios => l10n.studios,
+    HomeSectionType.seerrSeriesGenres => l10n.seriesGenres,
+    HomeSectionType.seerrNetworks => l10n.networks,
     HomeSectionType.none => l10n.none,
   };
 
@@ -1055,6 +1148,32 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         PosterSizeSettingsDialog(
           prefs: _prefs,
           onChanged: () => setState(() {}),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadingOverlay(BuildContext context) {
+    final theme = Theme.of(context);
+    return Positioned.fill(
+      child: AnimatedOpacity(
+        opacity: _isLoading ? 1.0 : 0.0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+        onEnd: () {
+          if (!_isLoading && mounted) {
+            setState(() {
+              _showOverlay = false;
+            });
+          }
+        },
+        child: Container(
+          color: theme.colorScheme.surface,
+          alignment: Alignment.center,
+          child: const PlayerLoadingOverlay(
+            logoSize: 80,
+            labelSpacing: 20,
+          ),
         ),
       ),
     );
@@ -1087,9 +1206,21 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
             ),
           ],
         ),
-        body: PlatformDetection.isTV
-            ? _buildTvList(l10n)
-            : _buildReorderableList(l10n),
+        body: ExcludeFocus(
+          excluding: _isLoading,
+          child: IgnorePointer(
+            ignoring: _isLoading,
+            child: Stack(
+              children: [
+                PlatformDetection.isTV
+                    ? _buildTvList(l10n)
+                    : _buildReorderableList(l10n),
+                if (_showOverlay)
+                  _buildLoadingOverlay(context),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -1227,7 +1358,16 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                           color: AppColorScheme.onSurface.withValues(alpha: 0.7),
                         ),
                       )
-                    : null,
+                    : (_isSeerrSectionType(section.type)
+                        ? Text(
+                            'Seerr Discovery Rows',
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontFamily: kCleanSettingsFontFamily,
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                            ),
+                          )
+                        : null),
                 onTap: isEmpty
                     ? null
                     : () {
@@ -1260,6 +1400,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   Widget _buildTvList(AppLocalizations l10n) {
     final visibleIndices = _visibleSectionIndices();
     return ListView.builder(
+      cacheExtent: 3000.0,
       itemCount: visibleIndices.length + (widget.showGeneralOptions ? 1 : 0),
       itemBuilder: (context, index) {
         if (widget.showGeneralOptions && index == 0) {
@@ -1276,7 +1417,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           label: _labelFor(section, l10n),
           subtitle: section.isPluginDynamic
               ? _pluginSubtitle(section)
-              : null,
+              : (_isSeerrSectionType(section.type)
+                  ? 'Seerr Discovery Rows'
+                  : null),
           enabled: section.enabled,
           isFirst: visibleIndex == 0,
           isLast: visibleIndex == visibleIndices.length - 1,

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -29,6 +29,7 @@ import '../../../playback/audio_capability_profile.dart';
 import '../../../playback/external_player_service.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../preference/seerr_preferences.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/settings/preference_binding.dart';
@@ -768,6 +769,7 @@ class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final seerrEnabledOnAccount = GetIt.instance<SeerrPreferences>().enabled;
     final availableNavbarPositions = NavigationLayout.availableNavbarPositions;
     final prefs = GetIt.instance<UserPreferences>();
     final currentNavbarPosition = prefs.get(UserPreferences.navbarPosition);
@@ -849,6 +851,18 @@ class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
               icon: Icons.video_library,
               onChanged: _pushPersonalizationSync,
             ),
+            if (seerrEnabledOnAccount)
+              SwitchPreferenceTile(
+                preference: UserPreferences.showSeerrButton,
+                title: l10n.showSeerrButton,
+                subtitle: l10n.settingsShowSeerrButtonInNavigation,
+                iconBuilder: (size, color) => Image.asset(
+                  'assets/icons/seerr.png',
+                  width: size,
+                  height: size,
+                ),
+                onChanged: _pushPersonalizationSync,
+              ),
           ],
         ),
       ),
@@ -922,6 +936,12 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
     setState(() {});
   }
 
+  void _onSeerrRowsToggleChanged() {
+    _pushPersonalizationSync();
+    if (!mounted) return;
+    setState(() {});
+  }
+
   void _onPlaylistsSortChanged() {
     _pushPersonalizationSync();
     _reloadHomeRows();
@@ -936,6 +956,7 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
     );
     final showGenresRows = _prefs.get(UserPreferences.displayGenresRows);
     final showPlaylistsRows = _prefs.get(UserPreferences.displayPlaylistsRows);
+    final seerrEnabledOnAccount = GetIt.instance<SeerrPreferences>().enabled;
     final rowsStyle = _prefs.get(UserPreferences.homeRowsStyle);
     return Scaffold(
       appBar: buildSettingsAppBar(context, Text(l10n.homeScreen)),
@@ -1027,23 +1048,37 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
               labelOf: (v) => v.displayName,
               onChanged: _onGenresItemFilterChanged,
             ),
-            SwitchPreferenceTile(
-              preference: UserPreferences.displayPlaylistsRows,
-              title: l10n.displayPlaylistsRows,
-              subtitle: l10n.displayPlaylistsRowsSubtitle,
-              icon: Icons.playlist_play,
-              onChanged: _onPlaylistsRowsToggleChanged,
-            ),
-            if (showPlaylistsRows)
-              EnumPreferenceTile<LibrarySortBy>(
-                preference: UserPreferences.playlistsRowSortBy,
-                title: l10n.playlistsRowSorting,
-                description: l10n.playlistsRowSortingDescription,
-                icon: Icons.sort,
-                labelOf: (v) => v.displayName,
-                onChanged: _onPlaylistsSortChanged,
-              ),
           ],
+          SwitchPreferenceTile(
+            preference: UserPreferences.displayPlaylistsRows,
+            title: l10n.displayPlaylistsRows,
+            subtitle: l10n.displayPlaylistsRowsSubtitle,
+            icon: Icons.playlist_play,
+            onChanged: _onPlaylistsRowsToggleChanged,
+          ),
+          if (showPlaylistsRows)
+            EnumPreferenceTile<LibrarySortBy>(
+              preference: UserPreferences.playlistsRowSortBy,
+              title: l10n.playlistsRowSorting,
+              description: l10n.playlistsRowSortingDescription,
+              icon: Icons.sort,
+              labelOf: (v) => v.displayName,
+              onChanged: _onPlaylistsSortChanged,
+            ),
+          SwitchPreferenceTile(
+            preference: UserPreferences.displaySeerrRows,
+            title: l10n.displaySeerrRows,
+            subtitle: seerrEnabledOnAccount
+                ? l10n.displaySeerrRowsSubtitle
+                : '${l10n.displaySeerrRowsSubtitle} (Requires Seerr login in Plugins)',
+            enabled: seerrEnabledOnAccount,
+            iconBuilder: (size, color) => Image.asset(
+              'assets/icons/seerr.png',
+              width: size,
+              height: size,
+            ),
+            onChanged: _onSeerrRowsToggleChanged,
+          ),
 
           _SectionHeader(l10n.appearance),
           SwitchPreferenceTile(

--- a/lib/ui/util/home_row_title_localizer.dart
+++ b/lib/ui/util/home_row_title_localizer.dart
@@ -32,6 +32,28 @@ String localizeHomeRowTitle({
       return l10n.onNow;
     case 'activeRecordings':
       return l10n.activeRecordings;
+    case 'seerr_recent_requests':
+      return l10n.recentRequests;
+    case 'seerr_recently_added':
+      return l10n.recentlyAdded;
+    case 'seerr_popular_movies':
+      return l10n.popularMovies;
+    case 'seerr_upcoming_movies':
+      return l10n.upcomingMovies;
+    case 'seerr_popular_series':
+      return l10n.popularSeries;
+    case 'seerr_upcoming_series':
+      return l10n.upcomingSeries;
+    case 'seerr_trending':
+      return l10n.trending;
+    case 'seerr_movie_genres':
+      return l10n.movieGenres;
+    case 'seerr_studios':
+      return l10n.studios;
+    case 'seerr_series_genres':
+      return l10n.seriesGenres;
+    case 'seerr_networks':
+      return l10n.networks;
   }
 
   if (row.id.startsWith('resume_')) return l10n.continueWatching;

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -124,6 +124,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
     _userSub = _userRepo.currentUserStream.listen((_) => _loadUserImage());
     _prefs.addListener(_onPrefsChanged);
     _viewsRepo.addListener(_onUserViewsChanged);
+    GetIt.instance<PluginSyncService>().addListener(_onPrefsChanged);
     _loadLibraries();
     FocusManager.instance.addListener(_trackPreviousFocus);
     if (PlatformDetection.isTV || (PlatformDetection.isDesktop || (PlatformDetection.isWeb && !PlatformDetection.useMobileUi))) {
@@ -168,6 +169,9 @@ class _LeftSidebarState extends State<LeftSidebar> {
     _userSub?.cancel();
     try {
       _viewsRepo.removeListener(_onUserViewsChanged);
+    } catch (_) {}
+    try {
+      GetIt.instance<PluginSyncService>().removeListener(_onPrefsChanged);
     } catch (_) {}
     _prefs.removeListener(_onPrefsChanged);
     _currentTime.dispose();
@@ -686,10 +690,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
     final showSyncPlay =
         _prefs.get(UserPreferences.syncPlayEnabled) &&
         _prefs.get(UserPreferences.showSyncPlayButton);
-    final pluginSync = GetIt.instance<PluginSyncService>();
     final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final seerrEnabledLocally =
-        seerrPrefs.enabled && _prefs.get(UserPreferences.seerrEnabled);
     final seerrDisplayName = seerrPrefs.moonfinDisplayName.trim();
     final seerrNavLabel = seerrDisplayName.isNotEmpty
       ? seerrDisplayName
@@ -828,9 +829,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                       );
                     },
                   ),
-                if (pluginSync.pluginAvailable &&
-                    pluginSync.seerrInfoAvailable &&
-                    seerrEnabledLocally)
+                if (_prefs.get(UserPreferences.showSeerrButton))
                   _SidebarItem(
                     baseColor: nextSidebarColor(),
                     iconBuilder: (size, color) => seerrPrefs.isSeerrVariant

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -242,7 +242,7 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
             if (widget.subtitleWidget != null) ...[
               SizedBox(height: widget.title != null ? 2 : 6),
               widget.subtitleWidget!,
-            ] else if (widget.subtitle != null)
+            ] else if (widget.subtitle != null && widget.subtitle!.isNotEmpty)
               SizedBox(
                 height: subtitleLineHeight,
                 child: showMarquee
@@ -409,9 +409,15 @@ class _CardImage extends StatelessWidget {
               children: [
                 Container(
                   color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                  padding: (itemType == 'Network' || itemType == 'Studio')
+                      ? const EdgeInsets.all(8.0)
+                      : EdgeInsets.zero,
                   child: imageUrl != null
                       ? BoundedNetworkImage(
                           imageUrl: imageUrl!,
+                          fit: (itemType == 'Network' || itemType == 'Studio')
+                              ? BoxFit.contain
+                              : BoxFit.cover,
                           fadeInDuration: Duration.zero,
                           scale: isCircular ? 0.8 : 0.9,
                           maxWidth: aspectRatio > 1.2 ? 960 : 640,

--- a/lib/ui/widgets/mediabar/gallery_active_card.dart
+++ b/lib/ui/widgets/mediabar/gallery_active_card.dart
@@ -3,6 +3,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/models/gallery_detail.dart';
 import '../../../data/models/media_bar_slide_item.dart';
+import '../../../util/platform_detection.dart';
 
 class GalleryActiveCard extends StatelessWidget {
   final MediaBarSlideItem item;
@@ -46,7 +47,8 @@ class GalleryActiveCard extends StatelessWidget {
     }
     return LayoutBuilder(
       builder: (context, constraints) {
-        final wide = constraints.maxWidth > 720;
+        final wide =
+            !PlatformDetection.useMobileUi || constraints.maxWidth > 720;
         final left = _LeftColumn(item: item, accent: accent, ratings: ratings);
         final right = _RightCard(detail: detail, accent: accent);
 

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -50,6 +50,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
     super.initState();
     _prefs.addListener(_onPrefsChanged);
     _viewsRepo.addListener(_onViewsChanged);
+    GetIt.instance<PluginSyncService>().addListener(_onPrefsChanged);
     _userSub = _userRepo.currentUserStream.listen((_) => _loadUserImage());
     _loadUserImage();
     _loadLibraries();
@@ -57,6 +58,9 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
 
   @override
   void dispose() {
+    try {
+      GetIt.instance<PluginSyncService>().removeListener(_onPrefsChanged);
+    } catch (_) {}
     _prefs.removeListener(_onPrefsChanged);
     try {
       _viewsRepo.removeListener(_onViewsChanged);
@@ -277,12 +281,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
 
   bool _seerrEnabled() {
     try {
-      final seerrPrefs = GetIt.instance<SeerrPreferences>();
-      final pluginSync = GetIt.instance<PluginSyncService>();
-      return seerrPrefs.enabled &&
-          _prefs.get(UserPreferences.seerrEnabled) &&
-          pluginSync.pluginAvailable &&
-          pluginSync.seerrInfoAvailable;
+      return _prefs.get(UserPreferences.showSeerrButton);
     } catch (_) {
       return false;
     }

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -205,6 +205,7 @@ class SwitchPreferenceTile extends StatefulWidget {
   final VoidCallback? onChanged;
 
   final bool inverted;
+  final bool enabled;
 
   const SwitchPreferenceTile({
     super.key,
@@ -215,6 +216,7 @@ class SwitchPreferenceTile extends StatefulWidget {
     this.iconBuilder,
     this.onChanged,
     this.inverted = false,
+    this.enabled = true,
   });
 
   @override
@@ -242,6 +244,7 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
   @override
   Widget build(BuildContext context) {
     return TvFocusHighlight(
+      enabled: widget.enabled,
       builder: (context, focused) {
         final iconColor = focused
             ? AppColors.black.withValues(alpha: 0.54)
@@ -271,10 +274,12 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
                 ? Text(widget.subtitle!, style: _kSettingsSubtitleTextStyle)
                 : null,
             value: widget.inverted ? !value : value,
-            onChanged: (v) {
-              _binding.value = widget.inverted ? !v : v;
-              widget.onChanged?.call();
-            },
+            onChanged: widget.enabled
+                ? (v) {
+                    _binding.value = widget.inverted ? !v : v;
+                    widget.onChanged?.call();
+                  }
+                : null,
           ),
         );
       },
@@ -794,8 +799,13 @@ class _IntPickerPreferenceTileState extends State<IntPickerPreferenceTile> {
 
 class TvFocusHighlight extends StatefulWidget {
   final Widget Function(BuildContext context, bool focused) builder;
+  final bool enabled;
 
-  const TvFocusHighlight({super.key, required this.builder});
+  const TvFocusHighlight({
+    super.key,
+    required this.builder,
+    this.enabled = true,
+  });
 
   @override
   State<TvFocusHighlight> createState() => _TvFocusHighlightState();
@@ -828,26 +838,29 @@ class _TvFocusHighlightState extends State<TvFocusHighlight> {
   Widget build(BuildContext context) {
     return Focus(
       focusNode: _focusNode,
-      canRequestFocus: true,
-      skipTraversal: true,
-      descendantsAreFocusable: true,
+      canRequestFocus: widget.enabled,
+      skipTraversal: !widget.enabled,
+      descendantsAreFocusable: widget.enabled,
       onFocusChange: _onFocusChange,
       child: Padding(
         padding: _settingsTileOuterPadding(context),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 90),
-          curve: Curves.easeOut,
-          decoration: _settingsTileDecoration(context, focused: _focused),
-          child: ListTileTheme.merge(
-            textColor: _focused
-                ? AppColors.black.withValues(alpha: 0.87)
-                : AppColorScheme.onSurface,
-            iconColor: _focused
-                ? AppColors.black.withValues(alpha: 0.54)
-                : AppColorScheme.onSurface.withValues(alpha: 0.7),
-            titleTextStyle: _kSettingsTitleTextStyle,
-            subtitleTextStyle: _kSettingsSubtitleTextStyle,
-            child: Builder(builder: (ctx) => widget.builder(ctx, _focused)),
+        child: Opacity(
+          opacity: widget.enabled ? 1.0 : 0.45,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 90),
+            curve: Curves.easeOut,
+            decoration: _settingsTileDecoration(context, focused: _focused),
+            child: ListTileTheme.merge(
+              textColor: _focused
+                  ? AppColors.black.withValues(alpha: 0.87)
+                  : AppColorScheme.onSurface,
+              iconColor: _focused
+                  ? AppColors.black.withValues(alpha: 0.54)
+                  : AppColorScheme.onSurface.withValues(alpha: 0.7),
+              titleTextStyle: _kSettingsTitleTextStyle,
+              subtitleTextStyle: _kSettingsSubtitleTextStyle,
+              child: Builder(builder: (ctx) => widget.builder(ctx, _focused)),
+            ),
           ),
         ),
       ),

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -116,6 +116,7 @@ class _TopToolbarState extends State<TopToolbar> {
     _userSub = _userRepo.currentUserStream.listen((_) => _loadUserImage());
     _prefs.addListener(_onPrefsChanged);
     _viewsRepo.addListener(_onUserViewsChanged);
+    GetIt.instance<PluginSyncService>().addListener(_onPrefsChanged);
     _loadLibraries();
   }
 
@@ -145,6 +146,9 @@ class _TopToolbarState extends State<TopToolbar> {
     _userSub?.cancel();
     try {
       _viewsRepo.removeListener(_onUserViewsChanged);
+    } catch (_) {}
+    try {
+      GetIt.instance<PluginSyncService>().removeListener(_onPrefsChanged);
     } catch (_) {}
     _prefs.removeListener(_onPrefsChanged);
     _currentTime.dispose();
@@ -617,14 +621,8 @@ class _TopToolbarState extends State<TopToolbar> {
     final showSyncPlay =
         _prefs.get(UserPreferences.syncPlayEnabled) &&
         _prefs.get(UserPreferences.showSyncPlayButton);
-    final pluginSync = GetIt.instance<PluginSyncService>();
     final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final seerrEnabledLocally =
-        seerrPrefs.enabled && _prefs.get(UserPreferences.seerrEnabled);
-    final showSeerr =
-        seerrEnabledLocally &&
-        pluginSync.pluginAvailable &&
-        pluginSync.seerrInfoAvailable;
+    final showSeerr = _prefs.get(UserPreferences.showSeerrButton);
     final l10n = AppLocalizations.of(context);
     final seerrDisplayName = seerrPrefs.moonfinDisplayName.trim();
     final seerrNavLabel = seerrDisplayName.isNotEmpty

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -52,10 +52,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.1"
   audio_service:
     dependency: "direct main"
     description:
@@ -156,10 +156,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9"
+      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.4"
+    version: "8.12.6"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   cli_util:
     dependency: transitive
     description:
@@ -224,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   code_builder:
     dependency: transitive
     description:
@@ -292,10 +300,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "942a4791cd385a68ccb3b32c71c427aba508a1bb949b86dff2adbe4049f16239"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.3.5+2"
   crypto:
     dependency: "direct main"
     description:
@@ -355,10 +363,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.14"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -589,10 +597,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: c2fe1001710127dfa7da89977a08d591398370d099aacdaa6d44da7eb14b8476
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.31"
+    version: "2.0.35"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -605,26 +613,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: da922f2aab2d733db7e011a6bcc4a825b844892d4edd6df83ff156b09a9b2e40
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "8878c25136a79def1668c75985e8e193d9d7d095453ec28730da0315dc69aee3"
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda"
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -645,10 +653,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: "6a1137df62b84b54261dca582c1c09ea72f4f9a4b2fcee21b025964132d5d0c3"
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
@@ -735,10 +743,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "08b742eef4f71c9df5af543751cd0b7f1c679c4088488f4223ecaddc1a813b79"
+      sha256: "5922b2861e2235a3504896f0d6fa07d84141b480cf52eecd2f42cd25585a9e8a"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.2"
+    version: "17.3.0"
   graphs:
     dependency: transitive
     description:
@@ -747,6 +755,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   html:
     dependency: transitive
     description:
@@ -826,14 +842,30 @@ packages:
       relative: true
     source: path
     version: "0.1.0"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -1022,6 +1054,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.16.13"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.6"
   nm:
     dependency: transitive
     description:
@@ -1030,6 +1070,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.3.0"
   octo_image:
     dependency: transitive
     description:
@@ -1098,18 +1146,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "3b4c1fc3aa55ddc9cd4aa6759984330d5c8e66aa7702a6223c61540dc6380c37"
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.19"
+    version: "2.3.1"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1146,50 +1194,42 @@ packages:
     dependency: transitive
     description:
       name: pdfium_dart
-      sha256: f1683b9070ddc5c9189c6ee008c285791da66328ce1b882c7162d3393f3a4a74
+      sha256: b536c19a10f8c86c160274a54ca6f29bc4c88001324ddcda4cca316033f2dc96
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.4"
   pdfium_flutter:
     dependency: transitive
     description:
       name: pdfium_flutter
-      sha256: "0c8b7d5d11d20a1486eade599648e907067568955bd14a1b06de076a968b60a1"
+      sha256: "97ccb5cf207b66ba5549f09047e935376d967c6311ec3c5314405d1d04569fd2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.9"
+    version: "0.2.1"
   pdfrx:
     dependency: "direct main"
     description:
       name: pdfrx
-      sha256: e32e0c786528eec2b3c56b43f59ef1debce3a27c7accd862b95413f949afcfa9
+      sha256: "6b3571565fb412fb7d0a325a76154d0685bd0a0659c3f41ee007f408d48cfd46"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.24"
+    version: "2.4.3"
   pdfrx_engine:
     dependency: transitive
     description:
       name: pdfrx_engine
-      sha256: a8914433d1f6188b903c53d36b9d7dc908bfa89131591a9db22f1a22470d3a48
+      sha256: a201b11e13b6c729d731ddc96ce06394cce8503c39e4c7e9d2fa51b3e7b351a5
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.9"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
+    version: "0.4.2"
   permission_handler:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.3"
   permission_handler_android:
     dependency: transitive
     description:
@@ -1202,10 +1242,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.7"
+    version: "9.4.9"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1242,10 +1282,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -1346,6 +1386,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   riverpod:
     dependency: transitive
     description:
@@ -1491,18 +1539,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      sha256: a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.25"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.6"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1515,10 +1563,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   shared_preferences_tizen:
     dependency: "direct main"
     description:
@@ -1584,74 +1632,74 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   speech_to_text:
     dependency: "direct main"
     description:
       name: speech_to_text
-      sha256: c07557664974afa061f221d0d4186935bea4220728ea9446702825e8b988db04
+      sha256: "75587f7400f485fdf166beacd471549d98fe5d58e634f708916bb65dec05d6a4"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.4.0"
   speech_to_text_platform_interface:
     dependency: transitive
     description:
       name: speech_to_text_platform_interface
-      sha256: a1935847704e41ee468aad83181ddd2423d0833abe55d769c59afca07adb5114
+      sha256: a7e16e02853853ed7534ac2bde9a1c4f39c8879970a7974ac6ff832d4bdaa4b0
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   speech_to_text_windows:
     dependency: transitive
     description:
       name: speech_to_text_windows
-      sha256: "2c9846d18253c7bbe059a276297ef9f27e8a2745dead32192525beb208195072"
+      sha256: "2d1d10565b23262386b453b33656299608dc7a66784453735d6c1318f13f44d7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+beta.8"
+    version: "1.0.1"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
-      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
+      sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      sha256: cce558075afe2a83f3fd7fc123acd6b090683e4f23910d44fbb31ecd7800b014
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.5.9"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      sha256: "164a5d73ab87a134566057219988bafde837029a64264e61f1f04376ef3cfcd2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   sqflite_platform_interface:
     dependency: transitive
     description:
       name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   sqflite_tizen:
     dependency: "direct main"
     description:
@@ -1824,34 +1872,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "81777b08c498a292d93ff2feead633174c386291e35612f8da438d6e92c4447e"
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.20"
+    version: "6.3.32"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.4"
+    version: "6.4.1"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1872,18 +1920,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:
@@ -1912,10 +1960,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e
+      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.5"
   vector_math:
     dependency: transitive
     description:
@@ -1936,10 +1984,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      sha256: "5d18d04084cc0cfc7afde39d0a308d4041e8ae6e9d5255bc086c263998dd1201"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.5"
+    version: "2.9.6"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -1976,10 +2024,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.2.0"
   volume_controller:
     dependency: "direct main"
     description:
@@ -2000,18 +2048,18 @@ packages:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
+      sha256: b13f99e992e7ae6a152e16c5559d3c07ff445b13330192662494e614ca3e7d7b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.1"
   wakelock_plus_tizen:
     dependency: "direct main"
     description:
       name: wakelock_plus_tizen
-      sha256: "12bb99ccc5503bdc98d850b6fb01ac424e05d78c9805dc1c80d01c5d73a70a00"
+      sha256: "02366093ac0d9bcf41f0f932ba56b433e89b43751a8eff31917945c7f32e412c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   watcher:
     dependency: transitive
     description:
@@ -2056,10 +2104,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_android
-      sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
+      sha256: a97db7a44f8e71af2f3971c45550a08cce1fb60059c1b8e534251e6cfb753490
       url: "https://pub.dev"
     source: hosted
-    version: "4.12.0"
+    version: "4.13.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -2072,10 +2120,10 @@ packages:
     dependency: "direct main"
     description:
       name: webview_flutter_wkwebview
-      sha256: "82648217f537573e1ca9ae9952d3eacedca6ab5aee69dc84445fc763766dcea2"
+      sha256: c879dd64b87c452aa84381b244d5469da57ba7e8cca6884c7b1e0d406372c12d
       url: "https://pub.dev"
     source: hosted
-    version: "3.25.1"
+    version: "3.26.0"
   webview_win_floating:
     dependency: "direct main"
     description:
@@ -2088,10 +2136,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "5.15.0"
   win32_registry:
     dependency: transitive
     description:
@@ -2120,10 +2168,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
@@ -2136,18 +2184,18 @@ packages:
     dependency: "direct main"
     description:
       name: youtube_player_iframe
-      sha256: e74ce6a33293fdd0eb0fb25f65935afa8ee33eeb6d89bff69ff9371665af1408
+      sha256: "8488d3fd3ce10286356a3e40036cc9ab296c19f399a3141acb70dc18a5231dab"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.2"
   youtube_player_iframe_web:
     dependency: transitive
     description:
       name: youtube_player_iframe_web
-      sha256: "333901d008634f2ea67ef27aba8d597567e4ff45f393290b948a739654ab6dca"
+      sha256: "405fccd8b7ae467835fc713bc86a3182470106098eec9aad0c178aec5395efa8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.1"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,7 +107,7 @@ dependencies:
   webview_flutter_android: ^4.12.0
   webview_flutter_wkwebview: ^3.25.1
   youtube_player_iframe: ^6.0.0
-  pdfrx: ^2.2.24
+  pdfrx: ^2.4.3
   flutter_widget_from_html_core: ^0.16.1
   archive: ^4.0.9
   rar:


### PR DESCRIPTION
# Home Renovations & Seerr Integration

## Summary
The Home Sections screen was somewhat fragile due to loading extensive content. This PR protects it from interaction during load states, preserves D-pad focus, resolves nested toggles, and impatient people.

In addition, this pull request introduces the foundations and refinements for Seerr integrations, introducing independent settings toggles for Seerr home screen rows and navigation buttons, as well as layout, typography, and meta-data updates.

- Resolves D-pad focus loss when scrolling back up the settings rows.
- Fixes nested Playlists toggles visibility bug.
- Adds a dedicated toggle under Personalization -> Navigation to show/hide the Seerr button in the Top Toolbar, Left Sidebar, and Mobile Bottom Navbar.
- Adds a main "Display Seerr Discovery Rows" toggle under Personalization -> Home Screen to display/hide Seerr discovery rows on the home page.
- Fetches and supports all Seerr row types: Recent Requests, Recently Added, Trending, Popular Movies, Upcoming Movies, Popular Series, Upcoming Series, Movie Genres, Studios, Series Genres, and Networks.
- Overrides row styles for Genres, Studios, and Networks to render in classic landscape (16/9 aspect ratio) with logo padding, resolving awkward scaling and lack of backdrop image for these rows.
- Corrects date enrichment mapping to ensure release years display properly on new seerr rows.

## Related Issues
No issue yet because it is for a new feature!

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
### Home Sections Refactoring (PR #406)
- Unnested "Display Playlists Rows" toggle and its sort option from `displayGenresRows` in `settings_side_panel.dart`.
- Added `_isLoading` and `_showOverlay` states with `ExcludeFocus` and `IgnorePointer` to prevent interaction during data loading.
- Added an `AnimatedOpacity` loading overlay with `PlayerLoadingOverlay` (rotating Moonfin logo) centered.
- Updated `_rebuildFocusNodes` to map and reuse `FocusNodes` by `stableId` to prevent focus loss on reload.
- Added `scrollCacheExtent: 3000` to `ListView.builder` in `_buildTvList` to prevent off-screen widgets from disposing, resolving D-pad focus loss when scrolling back up.
### Seerr Integrations & Layout Tweaks
- Capitalized "Seerr" across settings pages, subtitles, and translation source files (`app_en.arb`).
- Registered `showSeerrButton` boolean preference in `user_preferences.dart` and decoupled it from the main `displaySeerrRows` toggle in `settings_side_panel.dart` to allow independent control.
- Simplified top, left, and bottom navigation widgets (`top_toolbar.dart`, `left_sidebar.dart`, `mobile_bottom_nav_bar.dart`) to render the Seerr link solely based on `showSeerrButton`.
- Exposed Seerr Movie Genres, Series Genres, Studios, and Networks rows, sorting them cleanly at the end of the Home Sections options.
- Bypassed V2 (modern shifting) layout inside `home_screen.dart` for Seerr Movie/Series Genres, Studios, and Networks. They now render as landscape (16/9 aspect ratio) thumbnail rows.
- Updated `media_card.dart` to apply a small (`8.0`px) padding and `BoxFit.contain` for brand logo cards (Studios and Networks) so they are not cropped.
- Fixed `_enrichSeerrItem` in `home_view_model.dart` to correctly map TMDB date results back to the discover models, resolving missing release years.

## Platform
- [X] Android (Android TV focus changes)
- [ ] iOS
- [ ] macOS
- [X] Windows (Desktop testing)
- [ ] Linux
- [X] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Configured row styles and verified Playlists toggle is visible even when Genres is disabled.
2. Verified that opening the Home Sections screen displays a loading spinner and blocks input.
3. Verified that once loaded, focus starts correctly on the first visible item.
4. Scrolled down past the visible viewport into dynamic collections, then successfully navigated back up to "Live TV" without losing D-pad focus.
5. Logged into Seerr under Plugins, enabled the Seerr integration, and verified that both settings toggles under Navigation ("Show Seerr Button") and Home Screen ("Display Seerr Discovery Rows") work completely independently.
6. Verified that when Seerr rows are toggled on, years display correctly in "Recent Requests" and "Recently Added" rows.
7. Verified that Genres, Studios, and Networks rows render in 16:9 classic format and that logos (like Netflix or Disney) fit neatly inside their cards.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="350" alt="2026-06-06_23-10-02_explorer" src="https://github.com/user-attachments/assets/d7d72eec-a576-42c9-a3ae-95c8c81c2ab4" />
<img width="200" alt="2026-06-06_23-08-23_brave" src="https://github.com/user-attachments/assets/49b735b9-16c0-4fbc-a6cb-fab986534b29" />
<img width="300" alt="2026-06-06_23-08-48_moonfin" src="https://github.com/user-attachments/assets/ceb08c79-3915-43fe-90fa-b59a366b4572" />
<img width="400" alt="2026-06-06_23-09-03_moonfin" src="https://github.com/user-attachments/assets/3220951e-21f6-47ff-a395-d3b0eb613afc" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced

