### PR TITLE
UI: Add 8.0 top padding to library browse screen header

### DIFF
--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -4374,7 +4374,7 @@ class _LibraryHeader extends StatelessWidget {
     final showInlineAlpha =
       !isBookBrowse && sortBy == LibrarySortBy.name && (!isMobile || isCompactLandscape);
     final showBelowAlpha = !isBookBrowse && sortBy == LibrarySortBy.name && isCompactPortrait;
-    final topPad = isMobile ? MediaQuery.of(context).padding.top : 0.0;
+    final topPad = (isMobile ? MediaQuery.of(context).padding.top : 0.0) + 8.0;
     final hPad = isMobile ? 16.0 : _horizontalPadding * desktopScale;
 
     return Padding(


### PR DESCRIPTION
# Pull Request

## Summary
This aligns the title text height on library browse screens (such as Home Movies and Playlists) with the music/audio browse screen header, resolving the issue where the library header was placed too high on TV and mobile layouts.

Add 8.0 top padding to library browse screen header to align it with the music/audio browse screen header, resolving the issue where the library header was placed too high on TV and mobile layouts.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #407 
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added a `+ 8.0` padding offset to `topPad` in `_LibraryHeader` inside `library_browse_screen.dart` to match `_MusicHeader` padding behavior.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):
    - Code analyzed and verified with `flutter analyze` (no issues found).
    - Matches padding behavior of `_MusicHeader` which has been visually verified.
    - I'm tired and haven't had coffee yet

### Test Steps
1. Navigate to a library page (Home Movies, Playlists, Movies, etc.) and check title height.
2. Verify alignment with the Audio page title.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
