### PR TITLE
Fix D-pad focus in settings preference tiles

### DIFF
--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -838,8 +838,8 @@ class _TvFocusHighlightState extends State<TvFocusHighlight> {
   Widget build(BuildContext context) {
     return Focus(
       focusNode: _focusNode,
-      canRequestFocus: widget.enabled,
-      skipTraversal: !widget.enabled,
+      canRequestFocus: false,
+      skipTraversal: true,
       descendantsAreFocusable: widget.enabled,
       onFocusChange: _onFocusChange,
       child: Padding(


### PR DESCRIPTION
# Pull Request 

## Summary
Fixes a bug where preference settings tiles (e.g., Media Bar, Navigation Style, Home Row Style, etc.) are not togglable or interactable via D-pad/TV remote navigation.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #406 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Set `canRequestFocus` to `false` and `skipTraversal` to `true` on the outer `Focus` node within `TvFocusHighlight`.
- This ensures D-pad navigation targets and focuses the inner `ListTile` or `SwitchListTile` directly, allowing standard Enter/Select key events to trigger their `onTap`/`onChanged` handlers, while preserving parent-bubbled focus highlight updates.

## Platform
- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to settings on Android TV or Nvidia Shield using D-pad.
2. Verify that focusing preference settings (such as Navigation Style or Home Row Style) and pressing Select/Enter toggles/opens their config dialogs.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
