### PR TITLE
feat(favorites): Fix Loading Issues and Add New Display View

### DIFF
--- a/lib/data/viewmodels/favorites_view_model.dart
+++ b/lib/data/viewmodels/favorites_view_model.dart
@@ -36,8 +36,9 @@ class FavoritesViewModel extends ChangeNotifier {
   Map<FavoriteTypeFilter, List<AggregatedItem>> _rowItems = {};
   Map<FavoriteTypeFilter, List<AggregatedItem>> get rowItems => _rowItems;
 
-  int get totalCount =>
-      _rowItems.values.fold(0, (sum, list) => sum + list.length);
+  int get totalCount => _viewStyle == FavoritesViewStyle.home
+      ? _rowItems.values.fold(0, (sum, list) => sum + list.length)
+      : _gridTotalCount;
 
   late LibrarySortBy _sortBy;
   LibrarySortBy get sortBy => _sortBy;
@@ -64,6 +65,23 @@ class FavoritesViewModel extends ChangeNotifier {
 
   ImageApi get imageApi => _client.imageApi;
 
+  late FavoritesViewStyle _viewStyle;
+  FavoritesViewStyle get viewStyle => _viewStyle;
+
+  List<AggregatedItem> _gridItems = const [];
+  List<AggregatedItem> get gridItems => _gridItems;
+
+  int _gridTotalCount = 0;
+  int get gridTotalCount => _gridTotalCount;
+
+  bool _loadingMoreGrid = false;
+  bool get loadingMoreGrid => _loadingMoreGrid;
+
+  bool get hasMoreGrid => _gridItems.length < _gridTotalCount;
+
+  final Map<FavoriteTypeFilter, int> _rowTotalCounts = {};
+  final Set<FavoriteTypeFilter> _inFlightPagingRowTypes = {};
+
   FavoritesViewModel({
     required MediaServerClient client,
     required UserPreferences prefs,
@@ -75,6 +93,7 @@ class FavoritesViewModel extends ChangeNotifier {
     _sortDirection = _prefs.get(UserPreferences.librarySortDirection(_prefKey));
     _imageType = _prefs.get(UserPreferences.libraryImageType(_prefKey));
     _posterSize = _prefs.resolveLibraryPosterSize();
+    _viewStyle = _prefs.get(UserPreferences.favoritesViewStyle);
   }
 
   void setFocusedItem(AggregatedItem? item) {
@@ -82,6 +101,13 @@ class FavoritesViewModel extends ChangeNotifier {
     _focusedRatings = const {};
     notifyListeners();
     if (item != null) _loadFocusedRatings(item);
+  }
+
+  Future<void> setViewStyle(FavoritesViewStyle value) async {
+    if (_viewStyle == value) return;
+    _viewStyle = value;
+    await _prefs.set(UserPreferences.favoritesViewStyle, value);
+    await load();
   }
 
   Future<void> _loadFocusedRatings(AggregatedItem item) async {
@@ -117,18 +143,28 @@ class FavoritesViewModel extends ChangeNotifier {
   Future<void> load() async {
     _state = FavoritesState.loading;
     _rowItems = {};
+    _rowTotalCounts.clear();
+    _gridItems = const [];
+    _gridTotalCount = 0;
     _tmdbIdByItemId.clear();
     notifyListeners();
 
     try {
-      final results = await Future.wait(
-        rowTypes.map((type) => _fetchRowItems(type)),
-      );
-      final map = <FavoriteTypeFilter, List<AggregatedItem>>{};
-      for (var i = 0; i < rowTypes.length; i++) {
-        if (results[i].isNotEmpty) map[rowTypes[i]] = results[i];
+      if (_viewStyle == FavoritesViewStyle.home) {
+        final results = await Future.wait(
+          rowTypes.map((type) => _fetchRowItems(type, startIndex: 0)),
+        );
+        final map = <FavoriteTypeFilter, List<AggregatedItem>>{};
+        for (var i = 0; i < rowTypes.length; i++) {
+          if (results[i].$1.isNotEmpty) {
+            map[rowTypes[i]] = results[i].$1;
+            _rowTotalCounts[rowTypes[i]] = results[i].$2;
+          }
+        }
+        _rowItems = map;
+      } else {
+        await _fetchGridPage(0);
       }
-      _rowItems = map;
       _state = FavoritesState.ready;
     } catch (e) {
       _errorMessage = e.toString();
@@ -137,7 +173,10 @@ class FavoritesViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<List<AggregatedItem>> _fetchRowItems(FavoriteTypeFilter type) async {
+  Future<(List<AggregatedItem>, int)> _fetchRowItems(
+    FavoriteTypeFilter type, {
+    int startIndex = 0,
+  }) async {
     try {
       final sortValue = _sortBy.apiValue;
       final sortOrder = _sortDirection == SortDirection.ascending
@@ -148,6 +187,7 @@ class FavoritesViewModel extends ChangeNotifier {
         response = await _client.itemsApi.getItems(
           sortBy: sortValue,
           sortOrder: sortOrder,
+          startIndex: startIndex,
           limit: _rowLimit,
           recursive: true,
           isFavorite: true,
@@ -163,6 +203,7 @@ class FavoritesViewModel extends ChangeNotifier {
         response = await _client.itemsApi.getItems(
           sortBy: fallbackSort,
           sortOrder: sortOrder,
+          startIndex: startIndex,
           limit: _rowLimit,
           recursive: true,
           isFavorite: true,
@@ -172,7 +213,7 @@ class FavoritesViewModel extends ChangeNotifier {
         );
       }
       final rawItems = (response['Items'] as List?) ?? [];
-      return rawItems
+      final items = rawItems
           .cast<Map<String, dynamic>>()
           .map(
             (raw) => AggregatedItem(
@@ -182,9 +223,109 @@ class FavoritesViewModel extends ChangeNotifier {
             ),
           )
           .toList();
+      final totalCount = response['TotalRecordCount'] as int? ?? items.length;
+      return (items, totalCount);
     } catch (_) {
-      return const [];
+      return (const <AggregatedItem>[], 0);
     }
+  }
+
+  Future<void> loadMoreForType(FavoriteTypeFilter type) async {
+    final items = _rowItems[type];
+    if (items == null || items.isEmpty) return;
+    final total = _rowTotalCounts[type] ?? 0;
+    if (items.length >= total) return;
+    if (_inFlightPagingRowTypes.contains(type)) return;
+
+    _inFlightPagingRowTypes.add(type);
+    try {
+      final currentOffset = items.length;
+      final (newItems, totalCount) = await _fetchRowItems(type, startIndex: currentOffset);
+      _rowTotalCounts[type] = totalCount;
+
+      if (newItems.isNotEmpty) {
+        _rowItems[type] = [...items, ...newItems];
+        notifyListeners();
+      }
+    } catch (_) {
+    } finally {
+      _inFlightPagingRowTypes.remove(type);
+    }
+  }
+
+  Future<void> _fetchGridPage(int startIndex) async {
+    final sortValue = _sortBy.apiValue;
+    final sortOrder = _sortDirection == SortDirection.ascending
+        ? 'Ascending'
+        : 'Descending';
+    final pageSize = startIndex == 0 ? 75 : 48;
+
+    Map<String, dynamic> response;
+    try {
+      response = await _client.itemsApi.getItems(
+        sortBy: sortValue,
+        sortOrder: sortOrder,
+        startIndex: startIndex,
+        limit: pageSize,
+        recursive: true,
+        isFavorite: true,
+        fields: _browseFields,
+      );
+    } on DioException catch (e) {
+      final statusCode = e.response?.statusCode ?? 0;
+      if (statusCode < 500) rethrow;
+      final fallbackSort = sortValue.toLowerCase().contains('isfolder')
+          ? 'SortName'
+          : sortValue;
+      response = await _client.itemsApi.getItems(
+        sortBy: fallbackSort,
+        sortOrder: sortOrder,
+        startIndex: startIndex,
+        limit: pageSize,
+        recursive: true,
+        isFavorite: true,
+        fields: _browseFields,
+        enableTotalRecordCount: false,
+      );
+    }
+
+    final rawItems = (response['Items'] as List?) ?? [];
+    final totalFromServer = response['TotalRecordCount'] as int?;
+    if (totalFromServer != null) {
+      _gridTotalCount = totalFromServer;
+    } else {
+      _gridTotalCount = startIndex + rawItems.length + (rawItems.length == pageSize ? 1 : 0);
+    }
+
+    final mapped = rawItems
+        .cast<Map<String, dynamic>>()
+        .map(
+          (raw) => AggregatedItem(
+            id: raw['Id'] as String,
+            serverId: _client.baseUrl,
+            rawData: raw,
+          ),
+        )
+        .toList();
+
+    if (startIndex == 0) {
+      _gridItems = mapped;
+    } else {
+      _gridItems = [..._gridItems, ...mapped];
+    }
+  }
+
+  Future<void> loadMoreGrid() async {
+    if (_loadingMoreGrid || !hasMoreGrid) return;
+    _loadingMoreGrid = true;
+    notifyListeners();
+
+    try {
+      await _fetchGridPage(_gridItems.length);
+    } catch (_) {}
+
+    _loadingMoreGrid = false;
+    notifyListeners();
   }
 
   Future<void> setSortBy(LibrarySortBy value) async {

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -71,6 +71,11 @@ enum PosterSize {
   final int landscapeHeight;
 }
 
+enum FavoritesViewStyle {
+  home,
+  library,
+}
+
 enum HomeRowsStyle {
   v1,
   v2,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -272,6 +272,12 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: PlatformDetection.isTV,
   );
 
+  static final favoritesViewStyle = EnumPreference(
+    key: 'pref_favorites_view_style',
+    defaultValue: FavoritesViewStyle.home,
+    values: FavoritesViewStyle.values,
+  );
+
   static final displayFavoritesRows = Preference(
     key: 'pref_display_favorites_rows',
     defaultValue: false,

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -13,15 +13,18 @@ import '../../../data/viewmodels/favorites_view_model.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
+import '../../../util/focus/grid_focus_node_mixin.dart';
+import '../../../util/focus/dpad_keys.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/focus/focusable_toolbar_button.dart';
+import '../../widgets/focus/locked_focus_row.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/fullscreen_backdrop_switcher.dart';
-import '../../widgets/library_row.dart';
 import '../../widgets/media_card.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/rating_display.dart';
+import '../../widgets/horizontal_scroll_section.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
@@ -46,7 +49,7 @@ class FavoritesScreen extends StatefulWidget {
   State<FavoritesScreen> createState() => _FavoritesScreenState();
 }
 
-class _FavoritesScreenState extends State<FavoritesScreen> {
+class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMixin<FavoritesScreen> {
   late final FavoritesViewModel _vm;
   final _scrollController = ScrollController();
   final _prefs = GetIt.instance<UserPreferences>();
@@ -54,6 +57,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   StreamSubscription<String?>? _backgroundSub;
   String? _backdropUrl;
   bool _topSnapScheduled = false;
+  final Map<FavoriteTypeFilter, GlobalKey<LockedFocusRowState>> _rowKeys = {};
 
   @override
   void initState() {
@@ -65,6 +69,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     );
     _vm.addListener(_onChanged);
     _vm.load();
+    _scrollController.addListener(_onScroll);
     _backgroundSub = _backgroundService.backgroundStream.listen((url) {
       if (mounted) setState(() => _backdropUrl = url);
     });
@@ -79,16 +84,79 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     _vm.removeListener(_onChanged);
     _prefs.removeListener(_onChanged);
     _vm.dispose();
+    disposeGridFocusNodes();
     super.dispose();
+  }
+
+  int _lastGridItemsLength = 0;
+  Object? _lastGridFirstItemId;
+
+  void _maybeBumpGridVersion() {
+    if (_vm.viewStyle != FavoritesViewStyle.library) return;
+    final length = _vm.gridItems.length;
+    final firstId = length == 0 ? null : _vm.gridItems.first.id;
+    if (length != _lastGridItemsLength || firstId != _lastGridFirstItemId) {
+      _lastGridItemsLength = length;
+      _lastGridFirstItemId = firstId;
+      gridContentVersion++;
+      cleanupGridFocusNodes(length);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) restoreGridFocusIfNeeded();
+      });
+    }
   }
 
   void _onChanged() {
     if (mounted) setState(() {});
+    _maybeBumpGridVersion();
   }
 
   void _onItemFocused(AggregatedItem item) {
     _vm.setFocusedItem(item);
     _backgroundService.setBackground(item, context: BlurContext.browsing);
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    if (_vm.viewStyle != FavoritesViewStyle.library) return;
+    final pos = _scrollController.position;
+    if (pos.pixels > pos.maxScrollExtent - 400) {
+      _vm.loadMoreGrid();
+    }
+  }
+
+  double _cardWidth() {
+    final desktopScale = _desktopUiScaleFactor();
+    final posterSize = _vm.posterSize;
+    final baseWidth = switch (_vm.imageType) {
+      ImageType.thumb => posterSize.landscapeHeight * (16 / 9),
+      ImageType.banner => posterSize.landscapeHeight * (16 / 9),
+      ImageType.poster => posterSize.portraitHeight * (2 / 3),
+    };
+    return baseWidth * desktopScale;
+  }
+
+  double _gridBaseAspectRatio() {
+    return switch (_vm.imageType) {
+      ImageType.thumb => 16 / 9,
+      ImageType.banner => 16 / 9,
+      ImageType.poster => 2 / 3,
+    };
+  }
+
+  double _itemAspectRatio(AggregatedItem item) {
+    return switch (_vm.imageType) {
+      ImageType.thumb => switch (item.type) {
+        'MusicAlbum' ||
+        'MusicArtist' ||
+        'Audio' ||
+        'Playlist' ||
+        'Person' => 1.0,
+        _ => 16 / 9,
+      },
+      ImageType.banner => 16 / 9,
+      ImageType.poster => MediaCard.aspectRatioForType(item.type),
+    };
   }
 
   void _snapRowsToTop() {
@@ -104,6 +172,40 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
         curve: Curves.easeOut,
       );
     });
+  }
+
+  bool _onRowVerticalNavigation(
+    List<FavoriteTypeFilter> visibleTypes,
+    FavoriteTypeFilter currentType,
+    bool isUp,
+  ) {
+    final currentIndex = visibleTypes.indexOf(currentType);
+    final targetIndex = currentIndex + (isUp ? -1 : 1);
+    if (targetIndex >= 0 && targetIndex < visibleTypes.length) {
+      final targetType = visibleTypes[targetIndex];
+      final targetKey = _rowKeys[targetType];
+      if (targetKey != null) {
+        final state = targetKey.currentState;
+        if (state != null) {
+          state.requestFocusFromMemory();
+        } else {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _rowKeys[targetType]?.currentState?.requestFocusFromMemory();
+          });
+        }
+        final ctx = targetKey.currentContext;
+        if (ctx != null) {
+          Scrollable.ensureVisible(
+            ctx,
+            duration: const Duration(milliseconds: 300),
+            alignment: 0.5,
+            curve: Curves.easeInOut,
+          );
+        }
+      }
+      return true;
+    }
+    return false;
   }
 
   double _imageHeight(double aspectRatio) {
@@ -199,7 +301,9 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
           ],
         ),
       ),
-      FavoritesState.ready => _buildRows(),
+      FavoritesState.ready => _vm.viewStyle == FavoritesViewStyle.home
+          ? _buildRows()
+          : _buildGrid(),
     };
   }
 
@@ -217,19 +321,29 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     final navbarIsLeft = _prefs.get(UserPreferences.navbarPosition) == NavbarPosition.left;
     final rowLeftInset = (!isMobile && navbarIsLeft) ? 56.0 : 0.0;
     final focusColor = Color(_prefs.get(UserPreferences.focusColor).colorValue);
-    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final cardFocusExpansion = _prefs.get(UserPreferences.cardFocusExpansion);
     final watchedBehavior = _prefs.get(UserPreferences.watchedIndicatorBehavior);
+    final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
+    final desktopScale = _desktopUiScaleFactor();
 
-    final rows = <Widget>[];
+    final visibleTypes = <FavoriteTypeFilter>[];
     for (final type in FavoritesViewModel.rowTypes) {
       final items = _vm.rowItems[type];
-      if (items == null || items.isEmpty) continue;
+      if (items != null && items.isNotEmpty) {
+        visibleTypes.add(type);
+      }
+    }
+
+    final rows = <Widget>[];
+    for (final type in visibleTypes) {
+      final items = _vm.rowItems[type]!;
       final isTopRow = rows.isEmpty;
 
       final ar = MediaCard.aspectRatioForType(type.itemTypes?.first);
       final imageH = _imageHeight(ar);
       final rowHeight = imageH + 102;
+
+      _rowKeys.putIfAbsent(type, () => GlobalKey<LockedFocusRowState>());
 
       rows.add(
         Padding(
@@ -237,55 +351,97 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
             left: rowLeftInset,
             top: 4,
           ),
-          child: LibraryRow(
+          child: HorizontalScrollSection(
             title: type.displayName,
-            rowHeight: rowHeight,
-            children: items.map((item) {
-              final width = imageH * ar;
-              return MediaCard(
-                title: item.name,
-                subtitle: _cardSubtitle(item),
-                imageUrl: _imageUrl(
-                  item,
-                  maxWidth: width.toInt(),
-                  maxHeight: imageH.toInt(),
+            titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
+              color: AppColorScheme.onSurface,
+              fontWeight: FontWeight.w700,
+            ),
+            headerPadding: EdgeInsets.fromLTRB(
+              16 * desktopScale,
+              16 * desktopScale,
+              8 * desktopScale,
+              8 * desktopScale,
+            ),
+            contentSpacing: 0,
+            showControls: !isMobile && PlatformDetection.useDesktopUi,
+            builder: (context, scrollController) => LockedFocusRow<AggregatedItem>(
+              key: _rowKeys[type],
+              items: items,
+              hubKey: 'favorites_row_${type.name}',
+              controller: scrollController,
+              height: rowHeight,
+              itemExtent: imageH * ar,
+              itemSpacing: 12 * desktopScale,
+              padding: EdgeInsets.fromLTRB(
+                20 * desktopScale,
+                5 * desktopScale,
+                20 * desktopScale,
+                5 * desktopScale,
+              ),
+              onIndexChanged: (index, item) {
+                _onItemFocused(item);
+                if (index >= items.length - 8) {
+                  _vm.loadMoreForType(type);
+                }
+              },
+              onVerticalNavigation: (isUp) {
+                return _onRowVerticalNavigation(visibleTypes, type, isUp);
+              },
+              onLongPress: (index, item) => showContextMenu(
+                context,
+                item,
+                onChanged: () => setState(() {}),
+              ),
+              onTap: (index, item) => context.push(
+                Destinations.itemOrPhoto(
+                  item.id,
+                  serverId: item.serverId,
+                  type: item.type,
                 ),
-                width: width,
-                aspectRatio: ar,
-                isFavorite: item.isFavorite,
-                isPlayed: item.isPlayed,
-                unplayedCount: item.unplayedItemCount,
-                playedPercentage: item.playedPercentage,
-                watchedBehavior: watchedBehavior,
-                itemType: item.type,
-                focusColor: focusColor,
-                cardFocusExpansion: cardFocusExpansion,
-                suppressImageFocusBorder: isNeon,
-                suppressFocusGlow: isNeon,
-                onFocus: isMobile
-                    ? null
-                    : () {
-                        _onItemFocused(item);
-                        if (isTopRow && PlatformDetection.isTV) {
-                          _snapRowsToTop();
-                        }
-                      },
-                onHoverStart: isMobile ? null : () => _onItemFocused(item),
-                onHoverEnd: isMobile ? null : () => _vm.setFocusedItem(null),
-                onLongPress: () => showContextMenu(
-                  context,
-                  item,
-                  onChanged: () => setState(() {}),
-                ),
-                onTap: () => context.push(
-                  Destinations.itemOrPhoto(
-                    item.id,
-                    serverId: item.serverId,
-                    type: item.type,
+              ),
+              itemBuilder: (context, item, index, isFocused) {
+                final width = imageH * ar;
+                return MediaCard(
+                  title: item.name,
+                  subtitle: _cardSubtitle(item),
+                  imageUrl: _imageUrl(
+                    item,
+                    maxWidth: width.toInt(),
+                    maxHeight: imageH.toInt(),
                   ),
-                ),
-              );
-            }).toList(),
+                  width: width,
+                  aspectRatio: ar,
+                  isFavorite: item.isFavorite,
+                  isPlayed: item.isPlayed,
+                  unplayedCount: item.unplayedItemCount,
+                  playedPercentage: item.playedPercentage,
+                  watchedBehavior: watchedBehavior,
+                  itemType: item.type,
+                  focusColor: focusColor,
+                  cardFocusExpansion: cardFocusExpansion,
+                  suppressFocusGlow: suppressFocusGlow,
+                  externalIsFocused: isFocused,
+                  onFocus: isMobile
+                      ? null
+                      : () {
+                          _onItemFocused(item);
+                          if (isTopRow && PlatformDetection.isTV) {
+                            _snapRowsToTop();
+                          }
+                        },
+                  onHoverStart: isMobile ? null : () => _onItemFocused(item),
+                  onHoverEnd: isMobile ? null : () => _vm.setFocusedItem(null),
+                  onTap: () => context.push(
+                    Destinations.itemOrPhoto(
+                      item.id,
+                      serverId: item.serverId,
+                      type: item.type,
+                    ),
+                  ),
+                );
+              },
+            ),
           ),
         ),
       );
@@ -298,6 +454,158 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
         bottom: 32,
       ),
       children: rows,
+    );
+  }
+
+  Widget _buildGrid() {
+    if (_vm.gridItems.isEmpty) {
+      return Center(
+        child: Text(
+          AppLocalizations.of(context).noFavoritesYet,
+          style: const TextStyle(color: Colors.white70),
+        ),
+      );
+    }
+
+    final cardWidth = _cardWidth();
+    final spacing = 12.0;
+    final watchedBehavior = _prefs.get(
+      UserPreferences.watchedIndicatorBehavior,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isMobile = _isCompact(context);
+        final gridPadding = isMobile ? 16.0 : _horizontalPadding;
+        final crossAxisCount =
+            ((constraints.maxWidth - gridPadding * 2 + spacing) /
+                    (cardWidth + spacing))
+                .floor()
+                .clamp(2, 20);
+
+        final cellWidth =
+            (constraints.maxWidth -
+                gridPadding * 2 -
+                (crossAxisCount - 1) * spacing) /
+            crossAxisCount;
+        final ar = _gridBaseAspectRatio();
+        final hasSubtitles = _vm.gridItems.any(
+          (item) => (_cardSubtitle(item)?.isNotEmpty ?? false),
+        );
+        final desktopTextScale = PlatformDetection.useDesktopUi
+            ? MediaQuery.textScalerOf(context).scale(1.0)
+            : 1.0;
+        final textHeight = (hasSubtitles ? 42.0 : 24.0) * desktopTextScale;
+        final childAspectRatio = cellWidth / (cellWidth / ar + textHeight);
+        final focusColor = Color(
+          _prefs.get(UserPreferences.focusColor).colorValue,
+        );
+        final focusExpansion = _prefs.get(UserPreferences.cardFocusExpansion);
+        final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
+
+        return CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverPadding(
+              padding: EdgeInsets.fromLTRB(gridPadding, 8, gridPadding, 16),
+              sliver: SliverGrid(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: crossAxisCount,
+                  mainAxisSpacing: 8,
+                  crossAxisSpacing: spacing,
+                  childAspectRatio: childAspectRatio,
+                ),
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  final item = _vm.gridItems[index];
+                  final itemAspectRatio = _itemAspectRatio(item);
+
+                  Widget card = MediaCard(
+                    title: item.name,
+                    subtitle: _cardSubtitle(item),
+                    imageUrl: _imageUrl(
+                      item,
+                      maxWidth: (cellWidth * 2).toInt(),
+                      maxHeight: (cellWidth * 2 / itemAspectRatio).toInt(),
+                    ),
+                    width: double.infinity,
+                    aspectRatio: itemAspectRatio,
+                    focusColor: focusColor,
+                    focusNode: getGridItemFocusNode(index),
+                    cardFocusExpansion: focusExpansion,
+                    suppressFocusGlow: suppressFocusGlow,
+                    isPlayed: item.isPlayed,
+                    isFavorite: item.isFavorite,
+                    unplayedCount: item.unplayedItemCount,
+                    playedPercentage: item.playedPercentage,
+                    watchedBehavior: watchedBehavior,
+                    itemType: item.type,
+                    onFocus: isMobile
+                      ? null
+                      : () {
+                          _onItemFocused(item);
+                        },
+                    onHoverStart: isMobile ? null : () => _onItemFocused(item),
+                    onHoverEnd: isMobile
+                        ? null
+                        : () => _vm.setFocusedItem(null),
+                    onKeyEvent: (_, event) {
+                      if (event.isActionable && event.logicalKey.isRightKey) {
+                        final isLastColumn =
+                            (index % crossAxisCount) == crossAxisCount - 1;
+                        final isLastItem = index == _vm.gridItems.length - 1;
+                        if (isLastColumn || isLastItem) {
+                          return KeyEventResult.handled;
+                        }
+                      }
+
+                      if (!_vm.hasMoreGrid && !_vm.loadingMoreGrid) {
+                        return KeyEventResult.ignored;
+                      }
+                      if (!event.isActionable ||
+                          !event.logicalKey.isDownKey) {
+                        return KeyEventResult.ignored;
+                      }
+
+                      final nextRowIndex = index + crossAxisCount;
+                      final atBottomLoadedRow = nextRowIndex >= _vm.gridItems.length;
+                      if (!atBottomLoadedRow) {
+                        return KeyEventResult.ignored;
+                      }
+
+                      _vm.loadMoreGrid();
+                      return KeyEventResult.handled;
+                    },
+                    onLongPress: () => showContextMenu(
+                      context,
+                      item,
+                      onChanged: () => setState(() {}),
+                    ),
+                    onTap: () => context.push(
+                      Destinations.itemOrPhoto(
+                        item.id,
+                        serverId: item.serverId,
+                        type: item.type,
+                      ),
+                    ),
+                  );
+                  return card;
+                }, childCount: _vm.gridItems.length),
+              ),
+            ),
+            if (_vm.loadingMoreGrid)
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 24),
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      color: AppColorScheme.accent,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 
@@ -843,12 +1151,42 @@ class _DisplaySettingsDialogState extends State<_DisplaySettingsDialog> {
               ),
             ),
             Divider(color: dividerColor),
+            _sectionHeader('Switch View'),
+            _viewStyleRadioTile(vm, FavoritesViewStyle.home, 'Home View'),
+            _viewStyleRadioTile(vm, FavoritesViewStyle.library, 'Library View'),
+            Divider(color: dividerColor),
             _sectionHeader(AppLocalizations.of(context).imageType),
             for (final type in ImageType.values) _imageTypeRadioTile(vm, type),
             Divider(color: dividerColor),
             _sectionHeader(AppLocalizations.of(context).posterSize),
             for (final size in PosterSize.values)
               _posterSizeRadioTile(vm, size),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _viewStyleRadioTile(FavoritesViewModel vm, FavoritesViewStyle style, String label) {
+    final selected = vm.viewStyle == style;
+    final onSurface = AppColorScheme.onSurface;
+    return InkWell(
+      onTap: () => vm.setViewStyle(style),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        child: Row(
+          children: [
+            _radioCircle(selected),
+            const SizedBox(width: 12),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 15,
+                color: selected
+                    ? onSurface
+                    : onSurface.withValues(alpha: 0.72),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/ui/widgets/focus/locked_focus_row.dart
+++ b/lib/ui/widgets/focus/locked_focus_row.dart
@@ -259,12 +259,12 @@ class LockedFocusRowState<T> extends State<LockedFocusRow<T>> {
       return KeyEventResult.handled;
     }
     if (key.isUpKey) {
-      widget.onVerticalNavigation?.call(true);
-      return KeyEventResult.handled;
+      final handled = widget.onVerticalNavigation?.call(true) ?? false;
+      return handled ? KeyEventResult.handled : KeyEventResult.ignored;
     }
     if (key.isDownKey) {
-      widget.onVerticalNavigation?.call(false);
-      return KeyEventResult.handled;
+      final handled = widget.onVerticalNavigation?.call(false) ?? false;
+      return handled ? KeyEventResult.handled : KeyEventResult.ignored;
     }
     if (key.isContextMenuKey && widget.onLongPress != null) {
       final idx = _focusedIndex;


### PR DESCRIPTION
# feat(favorites): Fix Loading Issues and Add New Display View

## Summary
This PR implements several enhancements to the **Favorites** screen, introducing dynamic view style switching (Home/Rows vs Library/Grid views), restoring key focus feedback, implementing smooth row-to-row vertical jumping, and extending lazy loading support.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #392 
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
1. Added a setting under the cog settings dialog on the Favorites page that allows users to toggle the view between **Home View** (categorized rows; default) and **Library View** (flat grid of all favorites). The preference is persisted in user preferences.
2. Removed the logic that suppressed the focus indicator borders on `MediaCard`s, restoring visible border feedback (essential for TV/D-pad navigation layouts like Neon Pulse).
3. Updated `LockedFocusRow` key event handling to bubble unhandled vertical D-pad navigation key events (up/down) up to the system rather than trapping them. Implemented custom row-to-row jump tracking (`onVerticalNavigation`) in the Favorites home view to shift focus and center the viewport on the active row using `Scrollable.ensureVisible`. Focus bubbles back up to header buttons (Home, Sort, Settings cog) naturally when navigating UP from the top row.
4. Added lazy loading/pagination support to both views (categorized rows and flat grid) to lazy load media items when scrolling near limits to fix the original issue reported (got there in the end).

## Files Changed
* **`lib/preference/preference_constants.dart`**: Introduced `FavoritesViewStyle` enum (`home` and `library`).
* **`lib/preference/user_preferences.dart`**: Registered the `favoritesViewStyle` user preference.
* **`lib/data/viewmodels/favorites_view_model.dart`**: Implemented fetching pagination offsets for flat grid paging (`loadMoreGrid`) and row category paging (`loadMoreForType`).
* **`lib/ui/widgets/focus/locked_focus_row.dart`**: Updated `isUpKey` and `isDownKey` event logic to respect the vertical navigation handler's return state and bubble unhandled key presses.
* **`lib/ui/screens/browse/favorites_screen.dart`**: `_buildGrid()`, `_onRowVerticalNavigation`, and added view switching UI selection tiles inside Display Settings.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the **Favorites** screen.
2. Verify that focused items correctly draw the focus border indicators.
3. Open display settings (cog icon) and switch view to **Library View**. Confirm the layout displays as a grid and that scrolling to the bottom lazy-loads additional cards.
4. Switch view back to **Home View**. Use the D-pad to navigate left/right within a row and verify that focus does not escape the row edges horizontally.
5. Press D-pad **Down** or **Up** to navigate between Movie and TV Show rows; verify that focus transitions smoothly and centers the active row in the viewport.
6. From the top row, press D-pad **Up** to confirm focus exits the row and targets the toolbar header actions (Home/Sort/Settings).

## Screenshots (if applicable)
### OLD LIBRARY VIEW
<img width="400" alt="fav-old1" src="https://github.com/user-attachments/assets/69bea655-3660-4b42-bfe9-3f86efebaa5d" />
<img width="400" alt="fav-old2" src="https://github.com/user-attachments/assets/84cb1233-b8b2-4a18-b0f6-272ac59af355" />

### NEW LIBRARY VIEW

<img width="400" alt="2026-06-07_13-17-23_moonfin" src="https://github.com/user-attachments/assets/4ef2166a-76ca-427b-b541-344594ed6e84" />
<img width="400" alt="2026-06-07_13-17-38_moonfin" src="https://github.com/user-attachments/assets/c17b0191-29fa-47bb-b65c-ab9a81f934ef" />
<img width="400" alt="2026-06-07_13-18-04_moonfin" src="https://github.com/user-attachments/assets/6ea5a118-41d7-4c60-8a9a-ba6de19af0c3" />
<img width="400" alt="2026-06-07_13-18-11_moonfin" src="https://github.com/user-attachments/assets/23108742-5896-4771-acc0-c0c58e1e8f2f" />
<img width="400" alt="2026-06-07_13-18-24_moonfin" src="https://github.com/user-attachments/assets/aa2369f0-c452-4ca6-ae23-93c5f8d38627" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
