### PR TITLE
remove 'streaming from airplay' label that was bothering users

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -4051,7 +4051,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     ),
                     const SizedBox(width: 8),
                     Text(
-                      '$label$stateLabel$positionLabel',
+                      '$stateLabel$positionLabel',
                       style: const TextStyle(
                         color: Colors.white,
                         fontSize: AppTypography.fontSizeXs,


### PR DESCRIPTION
# Pull Request

## Summary
No longer displays the text "streaming from airplay" or equivalent for other platforms. Users reported it sometimes stayed on screen, disrupting the media watching experience. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

Discord

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- remove "label" from _buildCastMiniBar

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Not seeing the label anymore

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
