### PR TITLE
fix(settings): Stop Focus Indicator from Cloning Itself All Over the Place

### DIFF
--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -450,20 +450,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       changed = true;
     }
 
-    // Migration: if Seerr rows exist before dynamic sections, move them to the end.
-    final lastDynamicIndex = _sections.lastIndexWhere((s) => s.isPluginDynamic);
-    if (lastDynamicIndex >= 0) {
-      final firstSeerrIndex =
-          _sections.indexWhere((s) => s.isBuiltin && _isSeerrSectionType(s.type));
-      if (firstSeerrIndex >= 0 && firstSeerrIndex < lastDynamicIndex) {
-        final seerrConfigs =
-            _sections.where((s) => s.isBuiltin && _isSeerrSectionType(s.type)).toList();
-        _sections.removeWhere((s) => s.isBuiltin && _isSeerrSectionType(s.type));
-        _sections.addAll(seerrConfigs);
-        changed = true;
-      }
-    }
-
     return changed;
   }
 

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -265,6 +265,11 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
       _focusNodes.insert(newIndex, node);
     });
     _save();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _focusNodes[newIndex].requestFocus();
+      }
+    });
   }
 }
 

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -220,6 +220,11 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
       _focusNodes.insert(newIndex, node);
     });
     _saveRows();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _focusNodes[newIndex].requestFocus();
+      }
+    });
   }
 
   String _rowLabel(SeerrRowType type, AppLocalizations l10n) => switch (type) {


### PR DESCRIPTION
# Stop Focus Indicator from Cloning Itself All Over the Place

## Summary
Fix focus selector loss and visual multi-selection highlights when reordering settings config tiles, and preserve custom home sections order layouts. Basically, in the Seerr and Ratings preference panes, moving an item would cause the selector to make a fake (duplicate). This eliminates the imposter.

## Related Issues
Fixed ATV-1

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- RatingsConfigScreen & SeerrConfigScreen: request focus on the reordered item's FocusNode inside a post-frame callback to prevent focus loss and duplicate visual highlights.
- HomeSectionsScreen: remove the overengineered migration block that forced Seerr rows to the end on init, overriding the user's manual reordering.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Opened the 3 menus that were impacted
2. Moved things around
3. Was satisfied with the lack of imposters

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
