### PR TITLE
feat(seerr): Remembering the Badges of Honor

### DIFF
--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -139,6 +139,8 @@ class AggregatedItem {
   String? get parentThumbImageTag =>
       rawData['ParentThumbImageTag'] as String?;
   String? get status => rawData['Status'] as String?;
+  String? get seerrMediaType => rawData['SeerrMediaType'] as String?;
+  int? get seerrStatus => _toInt(rawData['SeerrStatus']);
   int? get childCount => _toInt(rawData['ChildCount']);
 
   DateTime? get premiereDate {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3105,6 +3105,8 @@ class _ContentRowsState extends State<_ContentRows>
             playedPercentage: item.playedPercentage,
             watchedBehavior: watchedBehavior,
             itemType: item.type,
+            seerrMediaType: item.seerrMediaType,
+            seerrStatus: item.seerrStatus,
             focusColor: focusColor,
             cardFocusExpansion: isRowsV2 ? false : cardExpansion && !showPreviewVideo,
             externalIsFocused: effectiveV2Focused,

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -1299,6 +1299,8 @@ class HomeViewModel extends ChangeNotifier {
             'PosterPath': item.posterPath ?? '',
             'BackdropPath': item.backdropPath ?? '',
             'ProductionYear': _extractYear(item.releaseDate ?? item.firstAirDate),
+            'SeerrMediaType': item.mediaType,
+            'SeerrStatus': item.mediaInfo?.status,
           },
         );
       }).toList();


### PR DESCRIPTION
# Remembering the Badges of Honor

## Summary
Implements support for Seerr status overlays (Requested, Available, Pending) and media type badges (Movie/Series) directly on the Home Screen Seerr discovery rows to mirror their appearance on the dedicated Seerr page.

## Related Issues
Link related issues or tickets separated by commas.

Future issues have been quelled.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `seerrMediaType` and `seerrStatus` getters to `AggregatedItem`.
- Populated `SeerrMediaType` and `SeerrStatus` in the `rawData` map when mapping Seerr row items.
- Passed `seerrMediaType` and `seerrStatus` from `AggregatedItem` to `MediaCard` view components.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code (applies to all screens using Seerr rows)

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots (if applicable)
<img width="400" alt="2026-06-08_00-11-21_moonfin" src="https://github.com/user-attachments/assets/939d458f-8bd8-4b98-8db4-b3da03ca064f" />

### Test Steps
1. Launched the compiled release build on Windows.
2. Verified that the Seerr discovery rows on the Home screen display status overlays (e.g., Requested, Available) and media type badges (e.g., Movie, Series) on the posters.
 
## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

