### PR TITLE
bug//fix: Fix double rendering of subtitles during transcoding

### DIFF
--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -451,7 +451,7 @@ class Media3PlayerBackend implements PlayerBackend {
       audioFallbackToStereoAac:
           _prefs.resolveAudioFallbackCodec() == AudioFallbackCodec.aacStereo,
       maxResolution: maxResolution,
-      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay),
+      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay) && canRenderBitmapSubtitles,
       assDirectPlay: _prefs.get(UserPreferences.assDirectPlay),
       supportsAvc: PlatformDetection.supportsAvc,
       supportsAvcHigh10: PlatformDetection.supportsAvcHigh10,

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -450,7 +450,7 @@ class MediaKitPlayerBackend implements PlayerBackend {
       audioFallbackToStereoAac:
           _prefs.resolveAudioFallbackCodec() == AudioFallbackCodec.aacStereo,
       maxResolution: maxResolution,
-      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay),
+      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay) && canRenderBitmapSubtitles,
       assDirectPlay: _prefs.get(UserPreferences.assDirectPlay),
       supportsAvc: capabilities.supportsAvc,
       supportsAvcHigh10: capabilities.supportsAvcHigh10,

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -97,14 +97,6 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       url = url
           .replaceFirst(RegExp(r'\?StartTimeTicks=\d+&'), '?')
           .replaceFirst(RegExp(r'[&?]StartTimeTicks=\d+'), '');
-      if (!enableDirectPlay && subtitleStreamIndex != null && subtitleStreamIndex >= 0) {
-        final smRegex = RegExp(r'SubtitleMethod=\w+');
-        if (smRegex.hasMatch(url)) {
-          url = url.replaceFirst(smRegex, 'SubtitleMethod=Encode');
-        } else {
-          url = '$url&SubtitleMethod=Encode';
-        }
-      }
     }
 
     // Append auth token for mpv (which doesn't use our Dio interceptors).


### PR DESCRIPTION
# Fix double rendering of subtitles during transcoding

## Summary
Fixes an issue where subtitles were double-rendered (burned in and overlaid) when video playback transcodes.

## Related Issues
Discord report issue

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Restricted `pgsDirectPlay` in the `DeviceProfile` to only be enabled if `canRenderBitmapSubtitles` is supported by the active backend player.
- Removed the manual `SubtitleMethod=Encode` override in `JellyfinMediaStreamResolver` when `enableDirectPlay` is disabled. This lets the Jellyfin server automatically determine the correct subtitle method (e.g. external/soft subtitles for text tracks, and burn-in for unsupported bitmap tracks).

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Verified codebase compiles successfully and runs `flutter analyze` without warnings in the modified files. Will ask user with issue to verify fix is functional once build script finishes. Manual verification should show that standard text subtitle tracks (e.g. SRT, ASS) are no longer burned in by the server during transcoding (preventing double overlays), and PGS subtitles are correctly burned in only on platforms where the backend cannot render them (iOS/Tizen).

### Test Steps
1. Play a video file requiring transcoding (e.g. with a bitrate limit set in settings).
2. Enable a text subtitle track (e.g., SRT). Subtitles should overlay cleanly once without double rendering.
3. Play a video with PGS subtitles on an iOS device or simulator. Subtitles should burn in correctly.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced