### PR TITLE
Correct European Portuguese (pt-PT) translations

### DIFF
--- a/lib/l10n/app_pt-PT.arb
+++ b/lib/l10n/app_pt-PT.arb
@@ -1,11 +1,30 @@
 {
   "@@locale": "pt_PT",
+  "appTitle": "Moonfin",
   "@appTitle": {
     "description": "The application title"
   },
+  "accountPreferences": "PREFERÊNCIAS DA CONTA",
+  "@accountPreferences": {
+    "description": "Section header for account preferences settings"
+  },
+  "interfaceLanguage": "Idioma da interface",
+  "@interfaceLanguage": {
+    "description": "Label for the app interface language setting"
+  },
+  "systemLanguageDefault": "Predefinição do sistema",
+  "@systemLanguageDefault": {
+    "description": "Label for using the system default language in settings"
+  },
+  "signIn": "Iniciar sessão",
   "@signIn": {
     "description": "Sign in heading and button label"
   },
+  "empty": "Vazio",
+  "@empty": {
+    "description": "Label indicating a section or category is empty"
+  },
+  "connectingToServer": "A ligar a {serverName}",
   "@connectingToServer": {
     "description": "Subtitle showing which server the user is connecting to",
     "placeholders": {
@@ -14,30 +33,43 @@
       }
     }
   },
+  "quickConnect": "Ligação Rápida",
   "@quickConnect": {
     "description": "Quick Connect toggle button label"
   },
+  "password": "Palavra-passe",
   "@password": {
     "description": "Password field label and toggle button"
   },
+  "username": "Nome de utilizador",
   "@username": {
     "description": "Username field label"
   },
+  "email": "E-mail",
+  "@email": {
+    "description": "Email field label"
+  },
+  "quickConnectInstruction": "Introduz este código no painel web do teu servidor:",
   "@quickConnectInstruction": {
     "description": "Instruction text for Quick Connect code entry"
   },
+  "waitingForAuthorization": "A aguardar autorização...",
   "@waitingForAuthorization": {
     "description": "Quick Connect polling status text"
   },
+  "back": "Voltar",
   "@back": {
     "description": "Back button label"
   },
+  "serverUnavailable": "O servidor não está disponível",
   "@serverUnavailable": {
     "description": "Error message when server cannot be reached"
   },
+  "loginFailed": "Falha no início de sessão",
   "@loginFailed": {
     "description": "Generic login failure message"
   },
+  "quickConnectUnavailable": "QuickConnect indisponível: {detail}",
   "@quickConnectUnavailable": {
     "description": "Quick Connect generic error message",
     "placeholders": {
@@ -46,6 +78,7 @@
       }
     }
   },
+  "quickConnectUnavailableWithStatus": "QuickConnect indisponível ({status}): {detail}",
   "@quickConnectUnavailableWithStatus": {
     "description": "Quick Connect error message with HTTP status info",
     "placeholders": {
@@ -57,15 +90,19 @@
       }
     }
   },
+  "whosWatching": "Quem está a ver?",
   "@whosWatching": {
     "description": "Server user selection heading"
   },
+  "addUser": "Adicionar utilizador",
   "@addUser": {
     "description": "Button to add a new user on the server screen"
   },
+  "selectServer": "Selecionar servidor",
   "@selectServer": {
     "description": "Button to navigate back to server selection"
   },
+  "appVersionFooter": "Moonfin Versão {version}",
   "@appVersionFooter": {
     "description": "App version shown in footer",
     "placeholders": {
@@ -74,27 +111,35 @@
       }
     }
   },
+  "savedServers": "Servidores guardados",
   "@savedServers": {
     "description": "Section heading for previously saved servers"
   },
+  "discoveredServers": "Servidores descobertos",
   "@discoveredServers": {
     "description": "Section heading for auto-discovered local servers"
   },
+  "noneFound": "Nenhum encontrado",
   "@noneFound": {
     "description": "Shown when no servers are discovered on the network"
   },
+  "unableToConnectToServer": "Não foi possível ligar ao servidor",
   "@unableToConnectToServer": {
     "description": "Error when a server connection attempt fails"
   },
+  "addServer": "Adicionar servidor",
   "@addServer": {
     "description": "Button to manually add a server address"
   },
+  "embyConnect": "Emby Connect",
   "@embyConnect": {
     "description": "Emby Connect sign-in option label"
   },
+  "removeServer": "Remover servidor",
   "@removeServer": {
     "description": "Dialog title for removing a saved server"
   },
+  "removeServerConfirmation": "Remover \"{serverName}\" dos seus servidores?",
   "@removeServerConfirmation": {
     "description": "Confirmation message when removing a saved server",
     "placeholders": {
@@ -103,90 +148,127 @@
       }
     }
   },
+  "cancel": "Cancelar",
   "@cancel": {
     "description": "Generic cancel button label"
   },
+  "remove": "Remover",
   "@remove": {
     "description": "Remove button label in confirmation dialogs"
   },
+  "connectToServer": "Ligar ao servidor",
   "@connectToServer": {
     "description": "Dialog title for adding a server by address"
   },
+  "serverAddress": "Endereço do servidor",
   "@serverAddress": {
     "description": "Label for the server URL input field"
   },
+  "serverAddressHint": "https://seu-servidor.exemplo.com",
   "@serverAddressHint": {
     "description": "Hint text for the server URL input field"
   },
+  "connect": "Ligar",
   "@connect": {
     "description": "Button to initiate connection to a server"
   },
+  "secureStorageUnavailable": "Armazenamento seguro indisponível",
   "@secureStorageUnavailable": {
     "description": "Dialog title when system keyring is inaccessible"
   },
+  "secureStorageUnavailableMessage": "Moonfin não conseguiu aceder ao chaveiro do teu sistema. O início de sessão pode continuar, mas o armazenamento seguro de tokens pode ficar indisponível até que o chaveiro seja desbloqueado.",
   "@secureStorageUnavailableMessage": {
     "description": "Explanation when secure storage is not available"
   },
+  "ok": "OK",
   "@ok": {
     "description": "Generic OK button label"
   },
+  "settingsAppearanceTheme": "Tema da aplicação",
   "@settingsAppearanceTheme": {
     "description": "Title for the theme selection screen and theme settings entry"
   },
+  "settingsAppearanceThemeSubtitle": "Alterna entre Moonfin e Neon Pulse sem reiniciar a aplicação",
   "@settingsAppearanceThemeSubtitle": {
     "description": "Subtitle for the theme selection screen and theme settings entry"
   },
+  "keyboardPreferSystemIme": "Preferir o teclado do sistema",
+  "@keyboardPreferSystemIme": {
+    "description": "Settings label for preferring the native system keyboard instead of the custom TV keyboard"
+  },
+  "keyboardPreferSystemImeDescription": "Usa o método de entrada do teu dispositivo por predefinição para entrada de texto",
+  "@keyboardPreferSystemImeDescription": {
+    "description": "Settings subtitle for the system keyboard preference"
+  },
+  "themeMoonfin": "Moonfin",
   "@themeMoonfin": {
     "description": "Display name for the Moonfin theme"
   },
+  "themeMoonfinSubtitle": "O visual atual do Moonfin que todos adoram",
   "@themeMoonfinSubtitle": {
     "description": "Preview description for the Moonfin theme"
   },
+  "themeNeonPulse": "Neon Pulse",
   "@themeNeonPulse": {
     "description": "Display name for the Neon Pulse theme"
   },
+  "themeNeonPulseSubtitle": "Estilo Synthwave com brilho magenta, texto ciano e contraste cromado mais forte",
   "@themeNeonPulseSubtitle": {
     "description": "Preview description for the Neon Pulse theme"
   },
+  "embyConnectSignInSubtitle": "Inicia sessão com a tua conta Emby Connect",
   "@embyConnectSignInSubtitle": {
     "description": "Subtitle on the Emby Connect sign-in screen"
   },
+  "emailOrUsername": "E-mail ou nome de utilizador",
   "@emailOrUsername": {
     "description": "Label for the Emby Connect username/email field"
   },
+  "selectAServer": "Selecionar um servidor",
   "@selectAServer": {
     "description": "Heading for the Emby Connect server list"
   },
+  "tryAgain": "Tentar novamente",
   "@tryAgain": {
     "description": "Button to retry a failed operation"
   },
+  "noLinkedServers": "Nenhum servidor associado a esta conta Emby Connect",
   "@noLinkedServers": {
     "description": "Error when Emby Connect account has no linked servers"
   },
+  "invalidEmbyConnectCredentials": "Credenciais Emby Connect inválidas",
   "@invalidEmbyConnectCredentials": {
     "description": "Error when Emby Connect auth response is invalid"
   },
+  "invalidEmbyConnectLogin": "Nome de utilizador ou palavra-passe do Emby Connect inválidos",
   "@invalidEmbyConnectLogin": {
     "description": "Error for wrong Emby Connect credentials"
   },
+  "embyConnectExchangeNotSupported": "O servidor não suporta a troca Emby Connect",
   "@embyConnectExchangeNotSupported": {
     "description": "Error when server lacks Emby Connect exchange endpoint"
   },
+  "embyConnectNetworkError": "Erro de rede ao contactar o Emby Connect ou o servidor selecionado",
   "@embyConnectNetworkError": {
     "description": "Generic network error during Emby Connect flow"
   },
+  "loadingLinkedServers": "A carregar servidores associados...",
   "@loadingLinkedServers": {
     "description": "Status text while fetching Emby Connect server list"
   },
+  "connectingToServerEllipsis": "A ligar ao servidor...",
   "@connectingToServerEllipsis": {
     "description": "Status text while connecting to a selected server"
   },
+  "noReachableAddress": "Nenhum endereço acessível fornecido",
   "@noReachableAddress": {
     "description": "Shown when a discovered server has no usable address"
   },
+  "invalidServerExchangeResponse": "Resposta inválida do endpoint de troca do servidor",
   "@invalidServerExchangeResponse": {
     "description": "Error when server exchange returns invalid data"
   },
+  "unableToConnectTo": "Não foi possível ligar a {target}",
   "@unableToConnectTo": {
     "description": "Error when connection to a specific server or address fails",
     "placeholders": {
@@ -195,81 +277,107 @@
       }
     }
   },
+  "exitApp": "Sair do Moonfin?",
   "@exitApp": {
     "description": "Title of exit confirmation dialog"
   },
+  "exitAppConfirmation": "Tens a certeza de que queres sair?",
   "@exitAppConfirmation": {
     "description": "Body text of exit confirmation dialog"
   },
+  "exit": "Sair",
   "@exit": {
     "description": "Exit button label"
   },
+  "noHomeRowsLoaded": "Nenhuma linha inicial pôde ser carregada",
   "@noHomeRowsLoaded": {
     "description": "Heading when home screen has no rows to display"
   },
+  "noHomeRowsHint": "Tenta atualizar ou reduzir as secções iniciais ativas.",
   "@noHomeRowsHint": {
     "description": "Hint text below the no-home-rows heading"
   },
+  "retryHomeRows": "Tentar novamente as linhas iniciais",
   "@retryHomeRows": {
     "description": "Button to retry loading home rows after failure"
   },
+  "guide": "Guia",
   "@guide": {
     "description": "Live TV guide button label"
   },
+  "recordings": "Gravações",
   "@recordings": {
     "description": "Live TV recordings button label"
   },
+  "schedule": "Agendamentos",
   "@schedule": {
     "description": "Live TV schedule button label"
   },
+  "series": "Séries",
   "@series": {
     "description": "Section header for TV series"
   },
+  "noItemsFound": "Nenhum item encontrado",
   "@noItemsFound": {
     "description": "Empty state when no items match the current view"
   },
+  "home": "Início",
   "@home": {
     "description": "Home navigation tooltip"
   },
+  "browseAll": "Navegar por tudo",
   "@browseAll": {
     "description": "Button to browse all items in a library"
   },
+  "genres": "Géneros",
   "@genres": {
     "description": "Genres navigation label"
   },
+  "collectionPlaceholder": "Os itens da coleção aparecerão aqui",
   "@collectionPlaceholder": {
     "description": "Placeholder text for empty collection screen"
   },
+  "browseByLetter": "Navegar por letra",
   "@browseByLetter": {
     "description": "Title for alphabetical browse screen"
   },
+  "alphabeticalBrowsePlaceholder": "A navegação alfabética aparecerá aqui",
   "@alphabeticalBrowsePlaceholder": {
     "description": "Placeholder text for alphabetical browse screen"
   },
+  "suggestions": "Sugestões",
   "@suggestions": {
     "description": "Title for suggestions screen"
   },
+  "suggestionsPlaceholder": "Itens sugeridos aparecerão aqui",
   "@suggestionsPlaceholder": {
     "description": "Placeholder text for suggestions screen"
   },
+  "failedToLoadLibraries": "Falha ao carregar bibliotecas",
   "@failedToLoadLibraries": {
     "description": "Error when library list cannot be loaded"
   },
+  "noLibrariesFound": "Nenhuma biblioteca encontrada",
   "@noLibrariesFound": {
     "description": "Empty state when no libraries are available"
   },
+  "library": "Biblioteca",
   "@library": {
     "description": "Library label used in navigation and fallback subtitle"
   },
+  "displaySettings": "Definições de visualização",
   "@displaySettings": {
     "description": "Tooltip for display settings button"
   },
+  "allGenres": "Todos os géneros",
   "@allGenres": {
     "description": "Title for the all genres screen"
   },
+  "noGenresFound": "Nenhum género encontrado",
   "@noGenresFound": {
     "description": "Empty state when no genres are available"
   },
+  "failedToLoadFolderError": "Falha ao carregar pasta: {error}",
   "@failedToLoadFolderError": {
     "description": "Error when a folder cannot be loaded",
     "placeholders": {
@@ -278,9 +386,11 @@
       }
     }
   },
+  "thisFolderIsEmpty": "Esta pasta está vazia",
   "@thisFolderIsEmpty": {
     "description": "Empty state for folder browse screen"
   },
+  "itemCountLabel": "{count} itens",
   "@itemCountLabel": {
     "description": "Subtitle showing number of items in a folder or collection",
     "placeholders": {
@@ -289,18 +399,23 @@
       }
     }
   },
+  "failedToLoadFavorites": "Falha ao carregar favoritos",
   "@failedToLoadFavorites": {
     "description": "Error when favorites cannot be loaded"
   },
+  "retry": "Tentar novamente",
   "@retry": {
     "description": "Button label to retry a failed operation"
   },
+  "noFavoritesYet": "Ainda não há favoritos",
   "@noFavoritesYet": {
     "description": "Empty state when user has no favorites"
   },
+  "favorites": "Favoritos",
   "@favorites": {
     "description": "Favorites section heading and filter label"
   },
+  "totalCountItems": "{count} itens",
   "@totalCountItems": {
     "description": "Header showing total item count",
     "placeholders": {
@@ -309,42 +424,55 @@
       }
     }
   },
+  "continuing": "Em continuação",
   "@continuing": {
     "description": "Series status badge for ongoing series"
   },
+  "ended": "Terminado",
   "@ended": {
     "description": "Series status badge for ended series"
   },
+  "sortAndFilter": "Classificar e filtrar",
   "@sortAndFilter": {
     "description": "Dialog title for sort and filter options"
   },
+  "type": "Tipo",
   "@type": {
     "description": "Stream info label for subtitle type"
   },
+  "sortBy": "Ordenar por",
   "@sortBy": {
     "description": "Section header for sort options"
   },
+  "display": "Mostrar",
   "@display": {
     "description": "Dialog title for display settings"
   },
+  "imageType": "Tipo de imagem",
   "@imageType": {
     "description": "Setting for image type"
   },
+  "posterSize": "Tamanho do pôster",
   "@posterSize": {
     "description": "Setting for poster size"
   },
+  "small": "Pequeno",
   "@small": {
     "description": "Poster size option"
   },
+  "medium": "Médio",
   "@medium": {
     "description": "Poster size option"
   },
+  "large": "Grande",
   "@large": {
     "description": "Poster size option"
   },
+  "extraLarge": "Extra Grande",
   "@extraLarge": {
     "description": "Size option: extra large"
   },
+  "libraryGenresTitle": "{name} — Géneros",
   "@libraryGenresTitle": {
     "description": "Header title showing library name with genres suffix",
     "placeholders": {
@@ -353,39 +481,51 @@
       }
     }
   },
+  "views": "Visualizações",
   "@views": {
     "description": "Section header for music browse view buttons"
   },
+  "albums": "Álbuns",
   "@albums": {
     "description": "Music browse view button label"
   },
+  "albumArtists": "Artistas do álbum",
   "@albumArtists": {
     "description": "Music browse view button label"
   },
+  "artists": "Artistas",
   "@artists": {
     "description": "Music browse view button label"
   },
+  "bookmarks": "Marcadores",
   "@bookmarks": {
     "description": "Bookmarks dialog title and navigation label"
   },
+  "noSavedBookmarks": "Ainda não há marcadores guardados para este título.",
   "@noSavedBookmarks": {
     "description": "Empty state in book bookmarks dialog"
   },
+  "openBook": "Abrir livro",
   "@openBook": {
     "description": "Button to open a book for reading"
   },
+  "chapter": "Capítulo",
   "@chapter": {
     "description": "Bookmark mode label for epub format"
   },
+  "page": "Página",
   "@page": {
     "description": "Bookmark mode label for pdf/comic format"
   },
+  "bookmark": "Marcador",
   "@bookmark": {
     "description": "Generic bookmark mode label"
   },
+  "justNow": "Agora mesmo",
   "@justNow": {
     "description": "Relative time for less than a minute ago"
   },
+  "minutesAgo": "{count}m atrás",
   "@minutesAgo": {
     "description": "Relative time in minutes",
     "placeholders": {
@@ -394,6 +534,7 @@
       }
     }
   },
+  "hoursAgo": "{count}h atrás",
   "@hoursAgo": {
     "description": "Relative time in hours",
     "placeholders": {
@@ -402,6 +543,7 @@
       }
     }
   },
+  "daysAgo": "{count}d atrás",
   "@daysAgo": {
     "description": "Relative time in days",
     "placeholders": {
@@ -410,33 +552,43 @@
       }
     }
   },
+  "discoverySubjects": "Assuntos de descoberta",
   "@discoverySubjects": {
     "description": "Title for the book discovery subject picker panel"
   },
+  "pickDiscoverySubjects": "Escolher quais feeds de assuntos serão apresentados no Discover.",
   "@pickDiscoverySubjects": {
     "description": "Instruction text in discovery subject picker"
   },
+  "apply": "Aplicar",
   "@apply": {
     "description": "Button label to apply selected options"
   },
+  "openLink": "Abrir link",
   "@openLink": {
     "description": "Action label to open a URL externally"
   },
+  "scanWithYourPhone": "Digitaliza com o teu telemóvel",
   "@scanWithYourPhone": {
     "description": "Instruction shown above a QR code"
   },
+  "audiobookGenres": "Géneros de audiolivros",
   "@audiobookGenres": {
     "description": "Title for audiobook genre picker panel"
   },
+  "pickAudiobookGenres": "Escolher quais géneros mostrar no Audiobook Discover.",
   "@pickAudiobookGenres": {
     "description": "Instruction text in audiobook genre picker"
   },
+  "discoverAudiobooks": "Descobre audiolivros",
   "@discoverAudiobooks": {
     "description": "Section title for audiobook discovery"
   },
+  "librivoxDescription": "Títulos populares de domínio público do LibriVox.",
   "@librivoxDescription": {
     "description": "Subtitle for audiobook discovery section"
   },
+  "titlesCount": "{count} títulos",
   "@titlesCount": {
     "description": "Label showing number of titles",
     "placeholders": {
@@ -445,81 +597,107 @@
       }
     }
   },
+  "scrollLeft": "Role para a esquerda",
   "@scrollLeft": {
     "description": "Tooltip for scroll left button"
   },
+  "scrollRight": "Role para a direita",
   "@scrollRight": {
     "description": "Tooltip for scroll right button"
   },
+  "couldNotLoadGenre": "Não foi possível carregar este género de momento.",
   "@couldNotLoadGenre": {
     "description": "Error when a genre row fails to load"
   },
+  "continueReading": "Continuar a ler",
   "@continueReading": {
     "description": "Section title for books in progress"
   },
+  "savedHighlights": "Destaques guardados",
   "@savedHighlights": {
     "description": "Section title for bookmarked content"
   },
+  "continueListening": "Continuar a ouvir",
   "@continueListening": {
     "description": "Section title for audiobooks in progress"
   },
+  "listen": "Ouvir",
   "@listen": {
     "description": "Primary action label for audiobooks"
   },
+  "resume": "Retomar",
   "@resume": {
     "description": "Primary action label for resuming reading"
   },
+  "failedToLoadLibrary": "Falha ao carregar a biblioteca",
   "@failedToLoadLibrary": {
     "description": "Error when a library cannot be loaded"
   },
+  "popularNow": "Popular agora",
   "@popularNow": {
     "description": "Book rail title for popular items"
   },
+  "savedForLater": "Guardar para mais tarde",
   "@savedForLater": {
     "description": "Book rail title for bookmarked items"
   },
+  "topListens": "Mais ouvidos",
   "@topListens": {
     "description": "Book rail title for popular audiobooks"
   },
+  "unreadDiscoveries": "Descobertas por ler",
   "@unreadDiscoveries": {
     "description": "Book rail title for unread items"
   },
+  "pickUpAgain": "Retomar",
   "@pickUpAgain": {
     "description": "Book rail title for in-progress bookmarked items"
   },
+  "bookHighlightsDescription": "Os teus livros com destaques, favoritos ou progresso de leitura.",
   "@bookHighlightsDescription": {
     "description": "Subtitle for saved highlights section"
   },
+  "handPickedFromLibrary": "Escolhido a dedo na tua biblioteca.",
   "@handPickedFromLibrary": {
     "description": "Subtitle for primary book rail from library"
   },
+  "handPickedFromListeningQueue": "Escolhido a dedo na tua fila de escuta.",
   "@handPickedFromListeningQueue": {
     "description": "Subtitle for primary book rail from audiobooks"
   },
+  "booksWithHighlights": "Livros com destaques, favoritos ou progresso de leitura.",
   "@booksWithHighlights": {
     "description": "Subtitle for bookmarks secondary rail"
   },
+  "jumpBackNarration": "Volta para a narração sem procurar o teu lugar.",
   "@jumpBackNarration": {
     "description": "Subtitle for audiobook continue listening rail"
   },
+  "unreadBooksReady": "Livros não lidos prontos para a próxima hora tranquila.",
   "@unreadBooksReady": {
     "description": "Subtitle for unread discoveries rail"
   },
+  "quickAccessFavorites": "Acesso rápido aos livros que sempre consultas.",
   "@quickAccessFavorites": {
     "description": "Subtitle for favorites book rail"
   },
+  "searchAudiobooks": "Pesquisar audiolivros",
   "@searchAudiobooks": {
     "description": "Placeholder text in audiobook search bar"
   },
+  "searchYourLibrary": "Pesquisa na tua biblioteca",
   "@searchYourLibrary": {
     "description": "Placeholder text in library search bar"
   },
+  "pickUpStory": "Continua a história de onde paraste",
   "@pickUpStory": {
     "description": "Hero card subtitle for library and audiobook sections"
   },
+  "savedPlacesChapters": "Os teus lugares guardados e capítulos por acabar",
   "@savedPlacesChapters": {
     "description": "Hero card subtitle for bookmarks section"
   },
+  "authorsCount": "{count} autores",
   "@authorsCount": {
     "description": "Metric pill showing author count",
     "placeholders": {
@@ -528,6 +706,7 @@
       }
     }
   },
+  "genresCount": "{count} géneros",
   "@genresCount": {
     "description": "Metric pill showing genre count",
     "placeholders": {
@@ -536,6 +715,7 @@
       }
     }
   },
+  "percentCompleted": "{percent}% concluído",
   "@percentCompleted": {
     "description": "Reading progress percentage label",
     "placeholders": {
@@ -544,18 +724,23 @@
       }
     }
   },
+  "readyWhenYouAre": "Pronto quando estiveres",
   "@readyWhenYouAre": {
     "description": "Label shown when no reading progress exists"
   },
+  "details": "Detalhes",
   "@details": {
     "description": "Button and title label for detail views"
   },
+  "listeningRoom": "Sala de escuta",
   "@listeningRoom": {
     "description": "Panel header for audiobook section"
   },
+  "bookmarksAndProgress": "Marcadores e progresso",
   "@bookmarksAndProgress": {
     "description": "Panel header for bookmarks section"
   },
+  "titlesArrangedForBrowsing": "{count} títulos organizados para navegação com leitura inicial.",
   "@titlesArrangedForBrowsing": {
     "description": "Panel subtitle showing total titles",
     "placeholders": {
@@ -564,36 +749,47 @@
       }
     }
   },
+  "titles": "Títulos",
   "@titles": {
     "description": "Stat card label for total titles"
   },
+  "allTitles": "Todos os títulos",
   "@allTitles": {
     "description": "Collection picker dialog title for all titles"
   },
+  "authors": "Autores",
   "@authors": {
     "description": "Stat card label for author count"
   },
+  "browseByAuthor": "Navegar por autor",
   "@browseByAuthor": {
     "description": "Collection picker dialog title for author browse"
   },
+  "browseByGenre": "Navegar por género",
   "@browseByGenre": {
     "description": "Collection picker dialog title for genre browse"
   },
+  "discover": "Descobrir",
   "@discover": {
     "description": "Section title for book discovery"
   },
+  "trendingTitlesOpenLibrary": "Títulos populares por assunto da Open Library.",
   "@trendingTitlesOpenLibrary": {
     "description": "Subtitle for book discovery section"
   },
+  "noBookmarkedItems": "Ainda não há itens marcados como favoritos",
   "@noBookmarkedItems": {
     "description": "Empty state for bookmarks grid"
   },
+  "nothingMatchesSection": "Nada corresponde a esta secção ainda. Tenta outra guia ou volta após o término da sincronização da biblioteca.",
   "@nothingMatchesSection": {
     "description": "Empty state for book experience when no items match"
   },
+  "audiobooks": "Audiolivros",
   "@audiobooks": {
     "description": "Audiobooks navigation and tab label"
   },
+  "noLabelFound": "Nenhum {label} encontrado",
   "@noLabelFound": {
     "description": "Empty state with dynamic label like books or audiobooks",
     "placeholders": {
@@ -602,72 +798,95 @@
       }
     }
   },
+  "folder": "Pasta",
   "@folder": {
     "description": "Fallback subtitle for navigable folder items"
   },
+  "filters": "Filtros",
   "@filters": {
     "description": "Section header for filter options"
   },
+  "readingStatus": "Estado de leitura",
   "@readingStatus": {
     "description": "Section header for book reading status filter"
   },
+  "playedStatus": "Estado reproduzido",
   "@playedStatus": {
     "description": "Section header for played status filter"
   },
+  "readStatus": "Lido",
   "@readStatus": {
     "description": "Filter label for read/watched items in book libraries"
   },
+  "watched": "Visto",
   "@watched": {
     "description": "Filter label for watched items"
   },
+  "unread": "Não lido",
   "@unread": {
     "description": "Status label for an unread book"
   },
+  "unwatched": "Não vistos",
   "@unwatched": {
     "description": "Filter label for unwatched items"
   },
+  "seriesStatus": "Estado da série",
   "@seriesStatus": {
     "description": "Section header for series status filter"
   },
+  "allLibraries": "Todas as bibliotecas",
   "@allLibraries": {
     "description": "Label when all libraries are selected"
   },
+  "books": "Livros",
   "@books": {
     "description": "Book media tab label"
   },
+  "author": "Autor",
   "@author": {
     "description": "Organize mode label for grouping by author"
   },
+  "unknownAuthor": "Autor desconhecido",
   "@unknownAuthor": {
     "description": "Fallback text when book author is not available"
   },
+  "uncategorized": "Sem categoria",
   "@uncategorized": {
     "description": "Fallback text when genre is not available"
   },
+  "overview": "Visão geral",
   "@overview": {
     "description": "Section header for content overview/description"
   },
+  "noLibrivoxDescription": "Nenhuma descrição fornecida pelo LibriVox para este título ainda.",
   "@noLibrivoxDescription": {
     "description": "Fallback when LibriVox title has no description"
   },
+  "readers": "Leitores",
   "@readers": {
     "description": "Section header for LibriVox audiobook readers"
   },
+  "openLinks": "Ligações externas",
   "@openLinks": {
     "description": "Section header for external links"
   },
+  "librivoxPage": "Página LibriVox",
   "@librivoxPage": {
     "description": "Button label for LibriVox external link"
   },
+  "internetArchive": "Arquivo da Internet",
   "@internetArchive": {
     "description": "Button label for Internet Archive external link"
   },
+  "rssFeed": "Feed RSS",
   "@rssFeed": {
     "description": "Button label for RSS feed external link"
   },
+  "downloadZip": "Transferir Zip",
   "@downloadZip": {
     "description": "Button label for zip download external link"
   },
+  "sectionCountLabel": "Secções: {count}",
   "@sectionCountLabel": {
     "description": "Detail chip showing number of sections in audiobook",
     "placeholders": {
@@ -676,6 +895,7 @@
       }
     }
   },
+  "firstPublished": "Publicado pela primeira vez {year}",
   "@firstPublished": {
     "description": "Publication year for a book",
     "placeholders": {
@@ -684,15 +904,19 @@
       }
     }
   },
+  "noOpenLibraryOverview": "Nenhuma visão geral disponível na Open Library para este título ainda.",
   "@noOpenLibraryOverview": {
     "description": "Fallback when Open Library has no description"
   },
+  "subjects": "Assuntos",
   "@subjects": {
     "description": "Section header for Open Library subjects"
   },
+  "all": "Todos",
   "@all": {
     "description": "Filter option for showing all items"
   },
+  "booksCount": "{count} livros",
   "@booksCount": {
     "description": "Label showing number of books in a discover row",
     "placeholders": {
@@ -701,12 +925,15 @@
       }
     }
   },
+  "couldNotLoadSubject": "Não foi possível carregar este assunto agora.",
   "@couldNotLoadSubject": {
     "description": "Error when a discover subject row fails to load"
   },
+  "audiobookDetails": "Detalhes do audiolivro",
   "@audiobookDetails": {
     "description": "AppBar title for LibriVox audiobook detail screen"
   },
+  "authorsCountTitle": "{count} autores",
   "@authorsCountTitle": {
     "description": "AppBar title for LibriVox authors list screen",
     "placeholders": {
@@ -715,6 +942,7 @@
       }
     }
   },
+  "audiobookCountLabel": "{count, plural, =1{1 audiolivro} other{{count} audiolivros}}",
   "@audiobookCountLabel": {
     "description": "Subtitle showing number of audiobooks by an author",
     "placeholders": {
@@ -723,84 +951,124 @@
       }
     }
   },
+  "trackList": "Lista de faixas",
   "@trackList": {
     "description": "AppBar title for the item list screen"
   },
+  "itemListPlaceholder": "A lista de itens aparecerá aqui",
   "@itemListPlaceholder": {
     "description": "Placeholder text for an empty item list screen"
   },
+  "favoriteTracksPlaceholder": "As faixas favoritas aparecerão aqui",
   "@favoriteTracksPlaceholder": {
     "description": "Placeholder text for an empty music favorites screen"
   },
+  "failedToLoad": "Falha ao carregar",
   "@failedToLoad": {
     "description": "Error message when item detail fails to load"
   },
+  "delete": "Eliminar",
   "@delete": {
     "description": "Delete action button label"
   },
+  "save": "Guardar",
   "@save": {
     "description": "Save action button label"
   },
+  "moreLikeThis": "Mais como este",
   "@moreLikeThis": {
     "description": "Section header for similar items"
   },
+  "castAndCrew": "Elenco e equipa",
   "@castAndCrew": {
     "description": "Section header for cast and crew section"
   },
+  "collection": "Coleção",
   "@collection": {
     "description": "Section header for collection items"
   },
+  "episodes": "Episódios",
   "@episodes": {
     "description": "Section header for episodes"
   },
+  "nextUp": "Próximo",
   "@nextUp": {
     "description": "Home section: next up"
   },
+  "seasons": "Temporadas",
   "@seasons": {
     "description": "Section header for seasons"
   },
+  "chapters": "Capítulos",
   "@chapters": {
     "description": "Section header for chapters"
   },
+  "features": "Características",
   "@features": {
     "description": "Section header for special features"
   },
+  "movies": "Filmes",
   "@movies": {
     "description": "Section header for movies"
   },
+  "musicVideos": "Vídeos musicais",
+  "@musicVideos": {
+    "description": "Section header for music videos filmography row"
+  },
+  "other": "Outro",
   "@other": {
     "description": "Section header for other items"
   },
+  "discography": "Discografia",
   "@discography": {
     "description": "Section header for artist discography"
   },
+  "similarArtists": "Artistas semelhantes",
   "@similarArtists": {
     "description": "Section header for similar artists"
   },
+  "tableOfContents": "Índice",
   "@tableOfContents": {
     "description": "Section header for audiobook chapters"
   },
+  "tracklist": "Lista de faixas",
   "@tracklist": {
     "description": "Section header for album track listing"
   },
+  "discNumber": "Disco {number}",
+  "@discNumber": {
+    "description": "Label for an album disc section in a multi-disc track list",
+    "placeholders": {
+      "number": {
+        "type": "int"
+      }
+    }
+  },
+  "biography": "Biografia",
   "@biography": {
     "description": "Section header for person biography"
   },
+  "authorDetails": "Detalhes do Autor",
   "@authorDetails": {
     "description": "AppBar title for author detail screen"
   },
+  "noOverviewAvailable": "Nenhuma visão geral disponível para este título ainda.",
   "@noOverviewAvailable": {
     "description": "Placeholder when no overview text is available"
   },
+  "noBiographyAvailable": "Nenhuma biografia disponível para este autor.",
   "@noBiographyAvailable": {
     "description": "Placeholder when no biography text is available"
   },
+  "noBooksFound": "Nenhum livro encontrado deste autor.",
   "@noBooksFound": {
     "description": "Placeholder when no books are found for an author"
   },
+  "unableToLoadAuthorDetails": "Não é possível carregar os detalhes do autor no momento.",
   "@unableToLoadAuthorDetails": {
     "description": "Error message when author details fail to load"
   },
+  "published": "Publicado {year}",
   "@published": {
     "description": "Publication year for an author book tile",
     "placeholders": {
@@ -809,9 +1077,11 @@
       }
     }
   },
+  "publicationDateUnknown": "Data de publicação desconhecida",
   "@publicationDateUnknown": {
     "description": "Placeholder when publication date is unknown"
   },
+  "seasonCount": "{count, plural, =1{1 Temporada} other{{count} Temporadas}}",
   "@seasonCount": {
     "description": "Number of seasons for a series",
     "placeholders": {
@@ -820,6 +1090,7 @@
       }
     }
   },
+  "endsAt": "Termina em {time}",
   "@endsAt": {
     "description": "Label showing when media will end",
     "placeholders": {
@@ -828,15 +1099,28 @@
       }
     }
   },
+  "endsIn": "Termina em {time}",
+  "@endsIn": {
+    "description": "Label showing remaining time for segment or timeout",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "view": "Visualizar",
   "@view": {
     "description": "Action button label for viewing a photo"
   },
+  "resumeReading": "Retomar leitura",
   "@resumeReading": {
     "description": "Action button label to resume reading a book"
   },
+  "read": "Ler",
   "@read": {
     "description": "Action button label to start reading a book"
   },
+  "resumeFrom": "Retomar de {position}",
   "@resumeFrom": {
     "description": "Action button label showing resume position",
     "placeholders": {
@@ -845,99 +1129,131 @@
       }
     }
   },
+  "play": "Reproduzir",
   "@play": {
     "description": "Action button label to play media"
   },
+  "startOver": "Recomeçar",
   "@startOver": {
     "description": "Action button label to restart reading a book"
   },
+  "restart": "Reiniciar",
   "@restart": {
     "description": "Action button label to restart playing media"
   },
+  "readOffline": "Ler offline",
   "@readOffline": {
     "description": "Action button label to read offline"
   },
+  "playOffline": "Reproduzir offline",
   "@playOffline": {
     "description": "Action button label to play offline"
   },
+  "audio": "Áudio",
   "@audio": {
     "description": "Action button label for audio track selection"
   },
+  "subtitles": "Legendas",
   "@subtitles": {
     "description": "Action button label for subtitle selection"
   },
+  "version": "Versão",
   "@version": {
     "description": "Action button label for version/media source selection"
   },
+  "cast": "Transmitir",
   "@cast": {
     "description": "Action button label for casting to a device"
   },
+  "trailer": "Trailer",
   "@trailer": {
     "description": "Action button label for trailer playback"
   },
+  "finished": "Finalizado",
   "@finished": {
     "description": "Status label for a finished book"
   },
+  "favorited": "Favorito",
   "@favorited": {
     "description": "Status label for a favorited item"
   },
+  "favorite": "Favorito",
   "@favorite": {
     "description": "Action button label to favorite an item"
   },
+  "playlist": "Lista de reprodução",
   "@playlist": {
     "description": "Action button label for adding to a playlist"
   },
+  "downloaded": "Transferido",
   "@downloaded": {
     "description": "Status label for a downloaded item"
   },
+  "downloadAll": "Transferir tudo",
   "@downloadAll": {
     "description": "Action button label to download all items"
   },
+  "download": "Transferir",
   "@download": {
     "description": "Action button label to download an item"
   },
+  "deleteDownloaded": "Eliminar transferido",
   "@deleteDownloaded": {
     "description": "Action button label to delete downloaded album tracks"
   },
+  "goToSeries": "Ir para a série",
   "@goToSeries": {
     "description": "Action button label to navigate to the parent series"
   },
+  "editMetadata": "Editar metadados",
   "@editMetadata": {
     "description": "Action button label to edit item metadata"
   },
+  "less": "Menos",
   "@less": {
     "description": "Action button label to collapse extra buttons"
   },
+  "more": "Mais",
   "@more": {
     "description": "Action button label to expand extra buttons"
   },
+  "deleteItem": "Eliminar item",
   "@deleteItem": {
     "description": "Dialog title for deleting an item"
   },
+  "deletePlaylist": "Eliminar lista de reprodução",
   "@deletePlaylist": {
     "description": "Dialog title for deleting a playlist"
   },
+  "deletePlaylistMessage": "Eliminar esta lista de reprodução do servidor?",
   "@deletePlaylistMessage": {
     "description": "Confirmation message for deleting a playlist"
   },
+  "deleteItemMessage": "Eliminar este item do servidor?",
   "@deleteItemMessage": {
     "description": "Confirmation message for deleting an item"
   },
+  "failedToDeletePlaylist": "Falha ao eliminar a lista de reprodução",
   "@failedToDeletePlaylist": {
     "description": "Error message when playlist deletion fails"
   },
+  "failedToDeleteItem": "Falha ao eliminar item",
   "@failedToDeleteItem": {
     "description": "Error message when item deletion fails"
   },
+  "renamePlaylist": "Renomear lista de reprodução",
   "@renamePlaylist": {
     "description": "Dialog title for renaming a playlist"
   },
+  "playlistName": "Nome da lista de reprodução",
   "@playlistName": {
     "description": "Hint text for playlist name input field"
   },
+  "deleteDownloadedAlbum": "Eliminar álbum transferido",
   "@deleteDownloadedAlbum": {
     "description": "Dialog title for deleting downloaded album tracks"
   },
+  "deleteDownloadedTracksMessage": "Eliminar faixas transferidas de \"{title}\"?",
   "@deleteDownloadedTracksMessage": {
     "description": "Confirmation message for deleting downloaded album tracks",
     "placeholders": {
@@ -946,15 +1262,19 @@
       }
     }
   },
+  "downloadedTracksDeleted": "Faixas transferidas eliminadas",
   "@downloadedTracksDeleted": {
     "description": "Success message after deleting downloaded tracks"
   },
+  "downloadedTracksDeleteFailed": "Algumas faixas transferidas não puderam ser eliminadas",
   "@downloadedTracksDeleteFailed": {
     "description": "Error message when some downloaded tracks could not be deleted"
   },
+  "noTracksLoaded": "Nenhuma faixa carregada",
   "@noTracksLoaded": {
     "description": "Message when no tracks are available"
   },
+  "noItemsLoaded": "Nenhum {itemLabel} carregado",
   "@noItemsLoaded": {
     "description": "Message when no items are loaded for download",
     "placeholders": {
@@ -963,6 +1283,7 @@
       }
     }
   },
+  "downloadingTitle": "A transferir {title} ({count} itens)...",
   "@downloadingTitle": {
     "description": "Snackbar message when downloading album tracks",
     "placeholders": {
@@ -974,6 +1295,7 @@
       }
     }
   },
+  "deleteConfirmMessage": "Tens a certeza de que queres eliminar \"{name}\" do servidor? Esta ação não pode ser desfeita.",
   "@deleteConfirmMessage": {
     "description": "Confirmation message for permanently deleting an item",
     "placeholders": {
@@ -982,12 +1304,15 @@
       }
     }
   },
+  "itemDeleted": "Item eliminado",
   "@itemDeleted": {
     "description": "Success message after deleting an item"
   },
+  "noPlayableTrailerFound": "Nenhum trailer reproduzível encontrado.",
   "@noPlayableTrailerFound": {
     "description": "Error message when no trailer can be played"
   },
+  "unsupportedBookFormat": "Formato de livro não suportado: .{extension}",
   "@unsupportedBookFormat": {
     "description": "Error message for unsupported book file format",
     "placeholders": {
@@ -996,27 +1321,35 @@
       }
     }
   },
+  "audioTrack": "Faixa de áudio",
   "@audioTrack": {
     "description": "Dialog title for audio track selection"
   },
+  "subtitleTrack": "Faixa de legenda",
   "@subtitleTrack": {
     "description": "Dialog title for subtitle track selection"
   },
+  "none": "Nenhum",
   "@none": {
     "description": "Option label for no subtitle selected"
   },
+  "downloadSubtitlesLabel": "Transferir legendas...",
   "@downloadSubtitlesLabel": {
     "description": "Label for the download subtitles option"
   },
+  "searchOpenSubtitlesPlugin": "Pesquisa usando o plugin OpenSubtitles",
   "@searchOpenSubtitlesPlugin": {
     "description": "Subtitle for the download subtitles option"
   },
+  "downloadSubtitles": "Transferir legendas",
   "@downloadSubtitles": {
     "description": "Dialog title for downloading remote subtitles"
   },
+  "selectedSubtitleInvalid": "A legenda selecionada é inválida.",
   "@selectedSubtitleInvalid": {
     "description": "Error message when a selected subtitle is invalid"
   },
+  "subtitleDownloadedSelected": "Legenda transferida e selecionada: {name}",
   "@subtitleDownloadedSelected": {
     "description": "Success message after downloading and selecting a subtitle",
     "placeholders": {
@@ -1025,9 +1358,11 @@
       }
     }
   },
+  "subtitleDownloadedPending": "Legenda transferida. Pode demorar um pouco a aparecer enquanto o Jellyfin atualiza o item.",
   "@subtitleDownloadedPending": {
     "description": "Message when subtitle was downloaded but not yet visible"
   },
+  "noRemoteSubtitlesFound": "Nenhuma legenda remota encontrada para {language}.",
   "@noRemoteSubtitlesFound": {
     "description": "Message when no remote subtitles were found",
     "placeholders": {
@@ -1036,9 +1371,11 @@
       }
     }
   },
+  "selectVersion": "Selecionar a versão",
   "@selectVersion": {
     "description": "Dialog title for selecting a media version"
   },
+  "versionNumber": "Versão {number}",
   "@versionNumber": {
     "description": "Default label for a media version",
     "placeholders": {
@@ -1047,21 +1384,27 @@
       }
     }
   },
+  "downloadAllQuality": "Transferir tudo - qualidade",
   "@downloadAllQuality": {
     "description": "Title for download quality picker when downloading all"
   },
+  "downloadQuality": "Qualidade de transferência",
   "@downloadQuality": {
     "description": "Title for download quality picker for a single item"
   },
+  "originalFileNoReencoding": "Ficheiro original, sem recodificação",
   "@originalFileNoReencoding": {
     "description": "Subtitle for original quality download option"
   },
+  "originalFilesNoReencoding": "Ficheiros originais, sem recodificação",
   "@originalFilesNoReencoding": {
     "description": "Subtitle for original quality batch download option"
   },
+  "noEpisodesLoaded": "Nenhum episódio carregado",
   "@noEpisodesLoaded": {
     "description": "Message when no episodes are available for download"
   },
+  "downloadingItem": "A transferir {name} ({quality})...",
   "@downloadingItem": {
     "description": "Snackbar message when downloading an item",
     "placeholders": {
@@ -1073,9 +1416,11 @@
       }
     }
   },
+  "deleteDownloadedFiles": "Eliminar ficheiros transferidos",
   "@deleteDownloadedFiles": {
     "description": "Dialog title for deleting downloaded files"
   },
+  "deleteLocalFilesMessage": "Eliminar ficheiros locais para {typeLabel}?\n\nIsto irá libertar espaço de armazenamento. Podes transferir novamente mais tarde.",
   "@deleteLocalFilesMessage": {
     "description": "Confirmation message for deleting local downloaded files",
     "placeholders": {
@@ -1084,24 +1429,31 @@
       }
     }
   },
+  "downloadedFilesDeleted": "Ficheiros transferidos eliminados",
   "@downloadedFilesDeleted": {
     "description": "Success message after deleting downloaded files"
   },
+  "failedToDeleteFiles": "Falha ao eliminar ficheiros",
   "@failedToDeleteFiles": {
     "description": "Error message when file deletion fails"
   },
+  "deleteFiles": "Eliminar ficheiros",
   "@deleteFiles": {
     "description": "Action button label for deleting downloaded files"
   },
+  "director": "REALIZAÇÃO",
   "@director": {
     "description": "Metadata label for director"
   },
+  "writers": "AUTORIA",
   "@writers": {
     "description": "Metadata label for writers"
   },
+  "studio": "ESTÚDIO",
   "@studio": {
     "description": "Metadata label for studio"
   },
+  "studioMoreCount": "+{count} mais",
   "@studioMoreCount": {
     "description": "Label showing additional studio count",
     "placeholders": {
@@ -1110,6 +1462,7 @@
       }
     }
   },
+  "totalEpisodes": "{count} Episódios",
   "@totalEpisodes": {
     "description": "Season progress label showing total episodes",
     "placeholders": {
@@ -1118,6 +1471,7 @@
       }
     }
   },
+  "episodeProgress": "{watched} / {total}",
   "@episodeProgress": {
     "description": "Season progress label showing watched vs total",
     "placeholders": {
@@ -1129,6 +1483,7 @@
       }
     }
   },
+  "episodeLabel": "Episódio {number}",
   "@episodeLabel": {
     "description": "Label for an episode number",
     "placeholders": {
@@ -1137,6 +1492,7 @@
       }
     }
   },
+  "chapterNumber": "Capítulo {number}",
   "@chapterNumber": {
     "description": "Default name for a chapter",
     "placeholders": {
@@ -1145,6 +1501,7 @@
       }
     }
   },
+  "trackCount": "{count, plural, =1{1 Faixa} other{{count} Faixas}}",
   "@trackCount": {
     "description": "Label showing number of tracks in an album",
     "placeholders": {
@@ -1153,6 +1510,7 @@
       }
     }
   },
+  "chapterCount": "{count, plural, =1{1 Capítulo} other{{count} Capítulos}}",
   "@chapterCount": {
     "description": "Label showing number of chapters in an audiobook",
     "placeholders": {
@@ -1161,6 +1519,7 @@
       }
     }
   },
+  "born": "Nasceu {date}",
   "@born": {
     "description": "Person birth date label",
     "placeholders": {
@@ -1169,6 +1528,7 @@
       }
     }
   },
+  "died": "Morreu {date}",
   "@died": {
     "description": "Person death date label",
     "placeholders": {
@@ -1177,6 +1537,7 @@
       }
     }
   },
+  "age": "Idade {age}",
   "@age": {
     "description": "Person age label",
     "placeholders": {
@@ -1185,15 +1546,19 @@
       }
     }
   },
+  "showLess": "Mostrar menos",
   "@showLess": {
     "description": "Toggle label to collapse expanded biography"
   },
+  "readMore": "Lê mais",
   "@readMore": {
     "description": "Toggle label to expand biography"
   },
+  "shuffle": "Baralhar",
   "@shuffle": {
     "description": "Action button label for shuffle playback"
   },
+  "downloadsCount": "{count} transferências",
   "@downloadsCount": {
     "description": "Subtitle showing number of downloads for a remote subtitle",
     "placeholders": {
@@ -1202,9 +1567,11 @@
       }
     }
   },
+  "perfectMatch": "Combinação perfeita",
   "@perfectMatch": {
     "description": "Label for a subtitle that is a hash match"
   },
+  "channelsCount": "{count}ch",
   "@channelsCount": {
     "description": "Audio channel count label",
     "placeholders": {
@@ -1213,12 +1580,15 @@
       }
     }
   },
+  "mono": "Mono",
   "@mono": {
     "description": "Audio channel layout label for mono"
   },
+  "stereo": "Estéreo",
   "@stereo": {
     "description": "Audio channel layout label for stereo"
   },
+  "remoteSubtitlePermissionError": "A legenda remota {action} requer a permissão de gestão de legendas Jellyfin para este utilizador.",
   "@remoteSubtitlePermissionError": {
     "description": "Error message when user lacks subtitle management permission",
     "placeholders": {
@@ -1227,6 +1597,7 @@
       }
     }
   },
+  "remoteSubtitleNotFoundError": "Este item não foi encontrado no servidor para legenda remota {action}.",
   "@remoteSubtitleNotFoundError": {
     "description": "Error message when item not found for subtitle operation",
     "placeholders": {
@@ -1235,6 +1606,7 @@
       }
     }
   },
+  "remoteSubtitleDetailError": "Legenda remota {action} falhou: {detail}",
   "@remoteSubtitleDetailError": {
     "description": "Error message with detail for subtitle operation",
     "placeholders": {
@@ -1246,6 +1618,7 @@
       }
     }
   },
+  "remoteSubtitleHttpError": "A legenda remota {action} falhou (HTTP {status}).",
   "@remoteSubtitleHttpError": {
     "description": "Error message with HTTP status for subtitle operation",
     "placeholders": {
@@ -1257,6 +1630,7 @@
       }
     }
   },
+  "remoteSubtitleGenericError": "Falha ao {action} legendas remotas.",
   "@remoteSubtitleGenericError": {
     "description": "Generic error message for subtitle operation",
     "placeholders": {
@@ -1265,6 +1639,7 @@
       }
     }
   },
+  "deleteSeriesFiles": "todos os episódios transferidos de \"{name}\"",
   "@deleteSeriesFiles": {
     "description": "Type label for series file deletion",
     "placeholders": {
@@ -1273,21 +1648,27 @@
       }
     }
   },
+  "deleteSeasonFiles": "todos os episódios transferidos nesta temporada",
   "@deleteSeasonFiles": {
     "description": "Type label for season file deletion"
   },
+  "stillWatching": "Ainda está a ver?",
   "@stillWatching": {
     "description": "Title for the still watching screen"
   },
+  "unableToLoadTrailerStream": "Não foi possível carregar o fluxo do trailer.",
   "@unableToLoadTrailerStream": {
     "description": "Error when trailer stream cannot be loaded"
   },
+  "trailerTimedOut": "O tempo limite do trailer expirou durante o carregamento.",
   "@trailerTimedOut": {
     "description": "Error when trailer loading times out"
   },
+  "playbackFailedForTrailer": "Falha na reprodução deste trailer.",
   "@playbackFailedForTrailer": {
     "description": "Error when trailer playback fails"
   },
+  "photoCountOf": "{current} / {total}",
   "@photoCountOf": {
     "description": "Photo counter showing current and total",
     "placeholders": {
@@ -1299,9 +1680,11 @@
       }
     }
   },
+  "castingUnavailableOffline": "A transmissão não está disponível durante a reprodução offline.",
   "@castingUnavailableOffline": {
     "description": "Snackbar message when casting is unavailable offline"
   },
+  "castActionFailed": "{label} ação falhou: {error}",
   "@castActionFailed": {
     "description": "Error when a cast action fails",
     "placeholders": {
@@ -1313,6 +1696,7 @@
       }
     }
   },
+  "failedToSetCastVolume": "Falha ao definir o volume de transmissão: {error}",
   "@failedToSetCastVolume": {
     "description": "Error when setting cast volume fails",
     "placeholders": {
@@ -1321,6 +1705,7 @@
       }
     }
   },
+  "castControlsTitle": "{label} Controlos",
   "@castControlsTitle": {
     "description": "Title for cast controls dialog",
     "placeholders": {
@@ -1329,18 +1714,23 @@
       }
     }
   },
+  "deviceVolume": "Volume do dispositivo",
   "@deviceVolume": {
     "description": "Label for device volume control in cast dialog"
   },
+  "unavailable": "Indisponível",
   "@unavailable": {
     "description": "Label when a feature is unavailable"
   },
+  "pause": "Pausa",
   "@pause": {
     "description": "Pause action label"
   },
+  "syncPosition": "Posição de sincronização",
   "@syncPosition": {
     "description": "Cast control action to sync playback position"
   },
+  "stopCast": "Pare {label}",
   "@stopCast": {
     "description": "Cast control action to stop casting",
     "placeholders": {
@@ -1349,9 +1739,11 @@
       }
     }
   },
+  "queueIsEmpty": "A fila está vazia",
   "@queueIsEmpty": {
     "description": "Empty state text for playback queue"
   },
+  "trackNumber": "Rastrear {number}",
   "@trackNumber": {
     "description": "Fallback track name in queue",
     "placeholders": {
@@ -1360,18 +1752,23 @@
       }
     }
   },
+  "remotePlayback": "Reprodução Remota",
   "@remotePlayback": {
     "description": "Label for Jellyfin session remote playback"
   },
+  "castingToGoogleCast": "Transmitindo para o Google Cast",
   "@castingToGoogleCast": {
     "description": "Cast mini bar label for Google Cast"
   },
+  "castingViaAirPlay": "Transmissão via AirPlay",
   "@castingViaAirPlay": {
     "description": "Cast mini bar label for AirPlay"
   },
+  "castingViaDlna": "Transmissão via DLNA",
   "@castingViaDlna": {
     "description": "Cast mini bar label for DLNA"
   },
+  "secondsCount": "{seconds} segundos",
   "@secondsCount": {
     "description": "Double-tap skip overlay duration label",
     "placeholders": {
@@ -1380,12 +1777,15 @@
       }
     }
   },
+  "longPressToUnlock": "Pressiona e segura para desbloquear",
   "@longPressToUnlock": {
     "description": "OSD lock overlay hint"
   },
+  "off": "Desligado",
   "@off": {
     "description": "Label for subtitle off option"
   },
+  "streamTypeFallback": "{streamType} {number}",
   "@streamTypeFallback": {
     "description": "Fallback label for unnamed audio or subtitle stream",
     "placeholders": {
@@ -1397,9 +1797,11 @@
       }
     }
   },
+  "auto": "Auto",
   "@auto": {
     "description": "Label for automatic bitrate selection"
   },
+  "bitrateValueMbps": "{mbps}Mbps",
   "@bitrateValueMbps": {
     "description": "Bitrate option label in Mbps",
     "placeholders": {
@@ -1408,12 +1810,15 @@
       }
     }
   },
+  "bitrateOverride": "Substituição de taxa de bits",
   "@bitrateOverride": {
     "description": "Label shown in stream info when a manual bitrate override is active"
   },
+  "audioDelay": "Atraso de áudio",
   "@audioDelay": {
     "description": "Title for audio delay adjuster"
   },
+  "delayMinusMs": "-{value}ms",
   "@delayMinusMs": {
     "description": "Label for decreasing playback delay in milliseconds",
     "placeholders": {
@@ -1422,6 +1827,7 @@
       }
     }
   },
+  "delayPlusMs": "+{value}ms",
   "@delayPlusMs": {
     "description": "Label for increasing playback delay in milliseconds",
     "placeholders": {
@@ -1430,81 +1836,107 @@
       }
     }
   },
+  "subtitleDelay": "Atraso de legenda",
   "@subtitleDelay": {
     "description": "Title for subtitle delay adjuster"
   },
+  "reset": "Reiniciar",
   "@reset": {
     "description": "Button label to reset a value"
   },
+  "unknown": "Desconhecido",
   "@unknown": {
     "description": "Fallback label for unknown items"
   },
+  "playbackInformation": "Informações de reprodução",
   "@playbackInformation": {
     "description": "Title for stream info sheet"
   },
+  "playback": "Reprodução",
   "@playback": {
     "description": "Section header in stream info"
   },
+  "playMethod": "Método de reprodução",
   "@playMethod": {
     "description": "Stream info label for play method"
   },
+  "directPlay": "Reprodução direta",
   "@directPlay": {
     "description": "Play method label"
   },
+  "directStream": "Transmissão direta",
   "@directStream": {
     "description": "Audio option: direct stream"
   },
+  "transcoding": "Transcodificação",
   "@transcoding": {
     "description": "Play method label"
   },
+  "transcodeReasons": "Razões de transcodificação",
   "@transcodeReasons": {
     "description": "Stream info label for transcode reasons"
   },
+  "player": "Reprodutor",
   "@player": {
     "description": "Stream info label for player engine"
   },
+  "container": "Contentor",
   "@container": {
     "description": "Stream info label for media container"
   },
+  "bitrate": "Taxa de bits",
   "@bitrate": {
     "description": "Stream info label for bitrate"
   },
+  "video": "Vídeo",
   "@video": {
     "description": "Section header for video stream info"
   },
+  "resolution": "Resolução",
   "@resolution": {
     "description": "Stream info label for video resolution"
   },
+  "hdr": "HDR",
   "@hdr": {
     "description": "Stream info label for HDR type"
   },
+  "codec": "Codec",
   "@codec": {
     "description": "Stream info label for codec"
   },
+  "videoBitrate": "Taxa de bits de vídeo",
   "@videoBitrate": {
     "description": "Stream info label for video bitrate"
   },
+  "track": "Faixa",
   "@track": {
     "description": "Stream info label for track name"
   },
+  "channels": "Canais",
   "@channels": {
     "description": "Stream info label for audio channels"
   },
+  "audioBitrate": "Taxa de bits de áudio",
   "@audioBitrate": {
     "description": "Stream info label for audio bitrate"
   },
+  "sampleRate": "Taxa de amostragem",
   "@sampleRate": {
     "description": "Stream info label for audio sample rate"
   },
+  "format": "Formato",
   "@format": {
     "description": "Stream info label for subtitle format"
   },
+  "external": "Externo",
   "@external": {
     "description": "Subtitle type label for external subtitles"
   },
+  "embedded": "Integrado",
   "@embedded": {
     "description": "Subtitle type label for embedded subtitles"
   },
+  "castSessionError": "Erro de sessão {protocol}",
   "@castSessionError": {
     "description": "Fallback error message for cast session errors",
     "placeholders": {
@@ -1513,6 +1945,7 @@
       }
     }
   },
+  "failedToLoadBookDetails": "Falha ao carregar detalhes do livro: {error}",
   "@failedToLoadBookDetails": {
     "description": "Error when loading book details fails",
     "placeholders": {
@@ -1521,9 +1954,11 @@
       }
     }
   },
+  "epubUnavailableOnPlatform": "A renderização de EPUB na aplicação ainda não está disponível nesta plataforma.",
   "@epubUnavailableOnPlatform": {
     "description": "Fallback message when EPUB cannot render on current platform"
   },
+  "formatCannotRenderInApp": "Este formato (.{extension}) ainda não pode ser renderizado na aplicação.",
   "@formatCannotRenderInApp": {
     "description": "Fallback message for unsupported document format",
     "placeholders": {
@@ -1532,12 +1967,15 @@
       }
     }
   },
+  "embeddedRenderingUnavailable": "A renderização de documentos incorporados não está disponível nesta plataforma.",
   "@embeddedRenderingUnavailable": {
     "description": "Fallback message when embedded renderer unavailable"
   },
+  "couldNotOpenExternalViewer": "Não foi possível abrir o visualizador externo.",
   "@couldNotOpenExternalViewer": {
     "description": "Error when external viewer fails to open"
   },
+  "failedToOpenInAppReader": "Falha ao abrir o leitor na aplicação: {error}",
   "@failedToOpenInAppReader": {
     "description": "Error when in-app reader fails to open",
     "placeholders": {
@@ -1546,6 +1984,7 @@
       }
     }
   },
+  "bookmarkAlreadySaved": "Marcador já guardado em {label}.",
   "@bookmarkAlreadySaved": {
     "description": "Snackbar when bookmark already exists",
     "placeholders": {
@@ -1554,6 +1993,7 @@
       }
     }
   },
+  "bookmarkAdded": "Marcador adicionado: {label}",
   "@bookmarkAdded": {
     "description": "Snackbar confirming bookmark was added",
     "placeholders": {
@@ -1562,12 +2002,15 @@
       }
     }
   },
+  "noBookmarksYet": "Ainda não há marcadores.\nToca no ícone de marcador durante a leitura para guardar a tua posição.",
   "@noBookmarksYet": {
     "description": "Empty state for bookmarks sheet"
   },
+  "noTableOfContentsAvailable": "Nenhum índice disponível",
   "@noTableOfContentsAvailable": {
     "description": "Empty state for table of contents panel"
   },
+  "pageLabel": "Página {number}",
   "@pageLabel": {
     "description": "Page number label in TOC or position",
     "placeholders": {
@@ -1576,12 +2019,15 @@
       }
     }
   },
+  "position": "Posição",
   "@position": {
     "description": "Generic position label"
   },
+  "bookReader": "Leitor de livros",
   "@bookReader": {
     "description": "Default title for book reader screen"
   },
+  "formatExtension": "Formato: .{extension}",
   "@formatExtension": {
     "description": "Chip label showing file format",
     "placeholders": {
@@ -1590,6 +2036,7 @@
       }
     }
   },
+  "percentRead": "{percent}% lido",
   "@percentRead": {
     "description": "Chip label showing reading progress",
     "placeholders": {
@@ -1598,24 +2045,31 @@
       }
     }
   },
+  "updating": "A atualizar...",
   "@updating": {
     "description": "Button label while updating"
   },
+  "markUnread": "Marcar como não lido",
   "@markUnread": {
     "description": "Button or menu item to mark as unread"
   },
+  "markAsRead": "Marcar como lido",
   "@markAsRead": {
     "description": "Button or menu item to mark as read"
   },
+  "reloadReader": "Recarregar leitor",
   "@reloadReader": {
     "description": "Button or menu item to reload the reader"
   },
+  "noPagesFound": "Nenhuma página encontrada.",
   "@noPagesFound": {
     "description": "Empty state for comic reader"
   },
+  "failedToDecodePageImage": "Falha ao decodificar a imagem da página.",
   "@failedToDecodePageImage": {
     "description": "Error when comic page image cannot be decoded"
   },
+  "resetZoom": "Redefinir zoom ({zoom}x)",
   "@resetZoom": {
     "description": "Tooltip for reset zoom button",
     "placeholders": {
@@ -1624,24 +2078,31 @@
       }
     }
   },
+  "singlePage": "Página única",
   "@singlePage": {
     "description": "Tooltip for single page spread mode"
   },
+  "twoPageSpread": "Vista de duas páginas",
   "@twoPageSpread": {
     "description": "Tooltip for two-page spread mode"
   },
+  "addBookmark": "Adicionar marcador",
   "@addBookmark": {
     "description": "Tooltip for add bookmark button"
   },
+  "bookmarksEllipsis": "Marcadores...",
   "@bookmarksEllipsis": {
     "description": "Menu item to view bookmarks"
   },
+  "markedAsRead": "Marcado como lido",
   "@markedAsRead": {
     "description": "Snackbar confirming item marked as read"
   },
+  "markedAsUnread": "Marcado como não lido",
   "@markedAsUnread": {
     "description": "Snackbar confirming item marked as unread"
   },
+  "failedToUpdateReadState": "Falha ao atualizar o estado de leitura: {error}",
   "@failedToUpdateReadState": {
     "description": "Error when marking read/unread fails",
     "placeholders": {
@@ -1650,33 +2111,43 @@
       }
     }
   },
+  "themeSystem": "Tema: Sistema",
   "@themeSystem": {
     "description": "Reader theme option for system default"
   },
+  "themeLight": "Tema: Luz",
   "@themeLight": {
     "description": "Reader theme option for light mode"
   },
+  "themeDark": "Tema: Escuro",
   "@themeDark": {
     "description": "Reader theme option for dark mode"
   },
+  "themeSepia": "Tema: Sépia",
   "@themeSepia": {
     "description": "Reader theme option for sepia mode"
   },
+  "invertColorsFixedLayout": "Inverter cores (layout fixo)",
   "@invertColorsFixedLayout": {
     "description": "Menu item to invert colors for fixed layout"
   },
+  "invertColorsPdf": "Inverter cores (PDF)",
   "@invertColorsPdf": {
     "description": "Menu item to invert colors for PDF"
   },
+  "preparingInAppReader": "A preparar leitor na aplicação...",
   "@preparingInAppReader": {
     "description": "Loading text while reader is being prepared"
   },
+  "pdfDataNotAvailable": "Dados PDF não disponíveis.",
   "@pdfDataNotAvailable": {
     "description": "Error when PDF data cannot be loaded"
   },
+  "readerFallbackModeActive": "Modo alternativo do leitor ativo",
   "@readerFallbackModeActive": {
     "description": "Title for fallback reader mode"
   },
+  "platformCannotHostDocumentEngine": "Esta plataforma não pode alojar o mecanismo de documento incorporado para ficheiros {extension}.",
   "@platformCannotHostDocumentEngine": {
     "description": "Fallback description when platform lacks document engine",
     "placeholders": {
@@ -1685,39 +2156,51 @@
       }
     }
   },
+  "reloadReaderPlatformHint": "Usa o Reload Reader depois de mudar para uma plataforma compatível (Android, iOS, macOS).",
   "@reloadReaderPlatformHint": {
     "description": "Hint text in fallback reader mode"
   },
+  "openExternally": "Abrir externamente",
   "@openExternally": {
     "description": "Button to open document in external viewer"
   },
+  "noEpubChaptersFound": "Nenhum capítulo do EPUB encontrado.",
   "@noEpubChaptersFound": {
     "description": "Error when no EPUB chapters are found"
   },
+  "readerNotReady": "Leitor não está pronto.",
   "@readerNotReady": {
     "description": "Error when reader has not finished initializing"
   },
+  "seriesRecordings": "Gravações de séries",
   "@seriesRecordings": {
     "description": "Live TV series recordings label"
   },
+  "now": "Agora",
   "@now": {
     "description": "Button label to jump to current time in guide"
   },
+  "sports": "Desportos",
   "@sports": {
     "description": "Sports category filter label"
   },
+  "news": "Notícias",
   "@news": {
     "description": "News category filter label"
   },
+  "kids": "Infantil",
   "@kids": {
     "description": "Kids category filter label"
   },
+  "premiere": "Estreia",
   "@premiere": {
     "description": "Premiere category filter label"
   },
+  "guideTimeline": "Linha temporal do guia",
   "@guideTimeline": {
     "description": "Section title for the TV guide timeline"
   },
+  "failedToLoadGuide": "Falha ao carregar o guia: {error}",
   "@failedToLoadGuide": {
     "description": "Error when guide data fails to load",
     "placeholders": {
@@ -1726,36 +2209,67 @@
       }
     }
   },
+  "noChannelsFound": "Nenhum canal encontrado",
   "@noChannelsFound": {
     "description": "Empty state when no TV channels match the filter"
   },
+  "liveBadge": "AO VIVO",
   "@liveBadge": {
     "description": "Badge label shown on currently airing programs"
   },
+  "movie": "Filme",
   "@movie": {
     "description": "Movie category chip label"
   },
+  "removedFromFavoriteChannels": "Removido dos canais favoritos",
   "@removedFromFavoriteChannels": {
     "description": "Snackbar confirmation after removing a channel from favorites"
   },
+  "addedToFavoriteChannels": "Adicionado aos canais favoritos",
   "@addedToFavoriteChannels": {
     "description": "Snackbar confirmation after adding a channel to favorites"
   },
+  "failedToUpdateFavoriteChannel": "Falha ao atualizar canal favorito",
   "@failedToUpdateFavoriteChannel": {
     "description": "Error when toggling channel favorite fails"
   },
+  "unfavoriteChannel": "Canal não favorito",
   "@unfavoriteChannel": {
     "description": "Button label to remove a channel from favorites"
   },
+  "favoriteChannel": "Canal favorito",
   "@favoriteChannel": {
     "description": "Button label to add a channel to favorites"
   },
+  "record": "Registro",
+  "@record": {
+    "description": "Button label to schedule a live TV recording"
+  },
+  "cancelRecordingAction": "Cancelar gravação",
+  "@cancelRecordingAction": {
+    "description": "Button label to cancel a scheduled live TV recording"
+  },
+  "programSetToRecord": "Programa pronto para gravar",
+  "@programSetToRecord": {
+    "description": "Snackbar confirmation after scheduling a live TV program recording"
+  },
+  "recordingCancelled": "Gravação cancelada",
+  "@recordingCancelled": {
+    "description": "Snackbar confirmation after cancelling a live TV recording"
+  },
+  "unableToCreateRecording": "Não foi possível criar a gravação",
+  "@unableToCreateRecording": {
+    "description": "Error when creating a live TV recording fails"
+  },
+  "watch": "Ver",
   "@watch": {
     "description": "Button label to start watching a channel"
   },
+  "close": "Fechar",
   "@close": {
     "description": "Button label to close a dialog"
   },
+  "failedToPlayChannel": "Falha ao reproduzir {name}",
   "@failedToPlayChannel": {
     "description": "Error when live TV channel playback fails",
     "placeholders": {
@@ -1764,27 +2278,35 @@
       }
     }
   },
+  "failedToLoadRecordings": "Falha ao carregar gravações",
   "@failedToLoadRecordings": {
     "description": "Error when recordings fail to load"
   },
+  "scheduledInNext24Hours": "Agendado para as próximas 24 horas",
   "@scheduledInNext24Hours": {
     "description": "Section title for upcoming scheduled recordings"
   },
+  "recentRecordings": "Gravações recentes",
   "@recentRecordings": {
     "description": "Section title for recently completed recordings"
   },
+  "tvSeries": "Série de TV",
   "@tvSeries": {
     "description": "Section title for TV series recordings"
   },
+  "failedToLoadSchedule": "Falha ao carregar agendamentos",
   "@failedToLoadSchedule": {
     "description": "Error when schedule fails to load"
   },
+  "noScheduledRecordings": "Nenhuma gravação agendada",
   "@noScheduledRecordings": {
     "description": "Empty state when no recordings are scheduled"
   },
+  "cancelRecording": "Cancelar gravação?",
   "@cancelRecording": {
     "description": "Dialog title for cancelling a recording"
   },
+  "cancelScheduledRecordingOf": "Cancelar a gravação agendada de \"{name}\"?",
   "@cancelScheduledRecordingOf": {
     "description": "Confirmation message for cancelling a scheduled recording",
     "placeholders": {
@@ -1793,27 +2315,35 @@
       }
     }
   },
+  "no": "Não",
   "@no": {
     "description": "Negative dialog button label"
   },
+  "yesCancel": "Sim, cancelar",
   "@yesCancel": {
     "description": "Confirmation button to cancel a recording"
   },
+  "failedToCancelRecording": "Falha ao cancelar a gravação",
   "@failedToCancelRecording": {
     "description": "Error when cancelling a recording fails"
   },
+  "failedToLoadSeriesRecordings": "Falha ao carregar gravações da série",
   "@failedToLoadSeriesRecordings": {
     "description": "Error when series recordings fail to load"
   },
+  "noSeriesRecordings": "Sem gravações de série",
   "@noSeriesRecordings": {
     "description": "Empty state when no series recordings exist"
   },
+  "cancelSeriesRecording": "Cancelar gravação de série",
   "@cancelSeriesRecording": {
     "description": "Button label to cancel a series recording"
   },
+  "cancelSeriesRecordingQuestion": "Cancelar a gravação da série?",
   "@cancelSeriesRecordingQuestion": {
     "description": "Dialog title for cancelling a series recording"
   },
+  "stopRecordingName": "Parar de gravar \"{name}\"?",
   "@stopRecordingName": {
     "description": "Confirmation message for stopping a series recording",
     "placeholders": {
@@ -1822,15 +2352,19 @@
       }
     }
   },
+  "failedToCancelSeriesRecording": "Falha ao cancelar a gravação da série",
   "@failedToCancelSeriesRecording": {
     "description": "Error when cancelling a series recording fails"
   },
+  "searchThisLibrary": "Pesquisar nesta biblioteca...",
   "@searchThisLibrary": {
     "description": "Search hint when scoped to a specific library"
   },
+  "searchEllipsis": "Pesquisar...",
   "@searchEllipsis": {
     "description": "Search hint placeholder"
   },
+  "noResultsForQuery": "Nenhum resultado para \"{query}\"",
   "@noResultsForQuery": {
     "description": "Shown when search returns no results",
     "placeholders": {
@@ -1839,6 +2373,7 @@
       }
     }
   },
+  "searchFailedError": "Falha na pesquisa: {error}",
   "@searchFailedError": {
     "description": "Shown when search encounters an error",
     "placeholders": {
@@ -1847,33 +2382,55 @@
       }
     }
   },
+  "seerr": "Seerr",
   "@seerr": {
     "description": "Seerr brand name"
   },
+  "seerrAccountType": "Tipo de conta Seerr",
+  "@seerrAccountType": {
+    "description": "Header for selecting Seerr authentication account type"
+  },
+  "jellyfinAccount": "Jellyfin",
+  "@jellyfinAccount": {
+    "description": "Auth option label for Seerr sign in using Jellyfin credentials"
+  },
+  "localAccount": "Local",
+  "@localAccount": {
+    "description": "Auth option label for Seerr sign in using local Seerr credentials"
+  },
+  "savedMedia": "Conteúdo guardado",
   "@savedMedia": {
     "description": "Header title for saved/downloaded media screen"
   },
+  "tvShows": "Programas de TV",
   "@tvShows": {
     "description": "Filter label for TV shows"
   },
+  "music": "Música",
   "@music": {
     "description": "Filter label for music"
   },
+  "musicAlbums": "Álbuns de música",
   "@musicAlbums": {
     "description": "Section title for downloaded music albums"
   },
+  "noMediaInFilter": "Nenhum conteúdo neste filtro",
   "@noMediaInFilter": {
     "description": "Shown when no items match the selected filter"
   },
+  "noDownloadedMediaYet": "Nenhum conteúdo transferido ainda",
   "@noDownloadedMediaYet": {
     "description": "Shown when no media has been downloaded"
   },
+  "browseLibrary": "Navegar na biblioteca",
   "@browseLibrary": {
     "description": "Button to navigate to the library"
   },
+  "deleteDownload": "Eliminar transferência",
   "@deleteDownload": {
     "description": "Dialog title for deleting a download"
   },
+  "removeItemAndFiles": "Remover \"{name}\" e os seus ficheiros?",
   "@removeItemAndFiles": {
     "description": "Confirmation to delete a downloaded item and its files",
     "placeholders": {
@@ -1882,6 +2439,7 @@
       }
     }
   },
+  "tracksCount": "{count} faixas",
   "@tracksCount": {
     "description": "Number of tracks in an album",
     "placeholders": {
@@ -1890,12 +2448,15 @@
       }
     }
   },
+  "album": "Álbum",
   "@album": {
     "description": "Fallback name for an album"
   },
+  "playAlbum": "Reproduzir álbum",
   "@playAlbum": {
     "description": "Button to play an album"
   },
+  "failedToLoadAlbum": "Falha ao carregar o álbum: {error}",
   "@failedToLoadAlbum": {
     "description": "Error when loading an album fails",
     "placeholders": {
@@ -1904,6 +2465,7 @@
       }
     }
   },
+  "noDownloadedTracksForAlbum": "Nenhuma faixa transferida encontrada para {name}.",
   "@noDownloadedTracksForAlbum": {
     "description": "Shown when an album has no downloaded tracks",
     "placeholders": {
@@ -1912,18 +2474,23 @@
       }
     }
   },
+  "season": "Temporada",
   "@season": {
     "description": "Fallback name for a season"
   },
+  "errorLoadingEpisodes": "Erro ao carregar episódios",
   "@errorLoadingEpisodes": {
     "description": "Error when loading episodes fails"
   },
+  "noDownloadedEpisodes": "Nenhum episódio transferido",
   "@noDownloadedEpisodes": {
     "description": "Shown when no episodes have been downloaded"
   },
+  "deleteEpisode": "Eliminar episódio",
   "@deleteEpisode": {
     "description": "Dialog title for deleting an episode"
   },
+  "removeName": "Remover \"{name}\"?",
   "@removeName": {
     "description": "Confirmation to remove an item by name",
     "placeholders": {
@@ -1932,6 +2499,7 @@
       }
     }
   },
+  "durationMinutes": "{minutes} min",
   "@durationMinutes": {
     "description": "Duration in minutes",
     "placeholders": {
@@ -1940,6 +2508,7 @@
       }
     }
   },
+  "seasonEpisodeLabel": "S{season} E{episode}",
   "@seasonEpisodeLabel": {
     "description": "Season and episode label like S1 E2",
     "placeholders": {
@@ -1951,6 +2520,7 @@
       }
     }
   },
+  "episodeNumber": "Episódio {number}",
   "@episodeNumber": {
     "description": "Episode label with number",
     "placeholders": {
@@ -1959,15 +2529,19 @@
       }
     }
   },
+  "seriesNotFound": "Série não encontrada",
   "@seriesNotFound": {
     "description": "Shown when a series cannot be found"
   },
+  "errorLoadingSeries": "Erro ao carregar a série",
   "@errorLoadingSeries": {
     "description": "Error when loading a series fails"
   },
+  "downloadedEpisodes": "Episódios transferidos",
   "@downloadedEpisodes": {
     "description": "Section title for downloaded episodes"
   },
+  "seasonNumber": "Temporada {number}",
   "@seasonNumber": {
     "description": "Season label with number",
     "placeholders": {
@@ -1976,6 +2550,7 @@
       }
     }
   },
+  "seasonChip": "S{number}",
   "@seasonChip": {
     "description": "Compact season chip label",
     "placeholders": {
@@ -1984,12 +2559,15 @@
       }
     }
   },
+  "specials": "Especiais",
   "@specials": {
     "description": "Label for special episodes"
   },
+  "deleteSeason": "Eliminar temporada",
   "@deleteSeason": {
     "description": "Dialog title for deleting a season"
   },
+  "deleteAllEpisodesInSeason": "Eliminar todos os episódios transferidos em {season}?",
   "@deleteAllEpisodesInSeason": {
     "description": "Confirmation to delete all episodes in a season",
     "placeholders": {
@@ -1998,6 +2576,7 @@
       }
     }
   },
+  "episodeCount": "{count, plural, =1{1 Episódio} other{{count} Episódios}}",
   "@episodeCount": {
     "description": "Number of episodes with pluralization",
     "placeholders": {
@@ -2006,33 +2585,43 @@
       }
     }
   },
+  "storageManagement": "Gestão de armazenamento",
   "@storageManagement": {
     "description": "Title for the storage management screen"
   },
+  "storageBreakdown": "Divisão de armazenamento",
   "@storageBreakdown": {
     "description": "Section title for storage breakdown"
   },
+  "downloadedItems": "Itens transferidos",
   "@downloadedItems": {
     "description": "Section title for downloaded items list"
   },
+  "storageLimit": "Limite de armazenamento",
   "@storageLimit": {
     "description": "Setting for storage limit"
   },
+  "noLimit": "Sem limite",
   "@noLimit": {
     "description": "Option: no limit"
   },
+  "deleteAllDownloads": "Eliminar todas as transferências",
   "@deleteAllDownloads": {
     "description": "Button and dialog title for deleting all downloads"
   },
+  "deleteAllDownloadsWarning": "Isto removerá todos os ficheiros de conteúdo transferidos e não poderá ser desfeito.",
   "@deleteAllDownloadsWarning": {
     "description": "Warning message when deleting all downloads"
   },
+  "deleteAll": "Eliminar tudo",
   "@deleteAll": {
     "description": "Button to confirm deleting all items"
   },
+  "deleteSelected": "Eliminar selecionado",
   "@deleteSelected": {
     "description": "Dialog title for deleting selected items"
   },
+  "deleteSelectedCount": "Eliminar {count} itens transferidos?",
   "@deleteSelectedCount": {
     "description": "Confirmation to delete selected downloaded items",
     "placeholders": {
@@ -2041,15 +2630,19 @@
       }
     }
   },
+  "musicAndAudiobooks": "Música e audiolivros",
   "@musicAndAudiobooks": {
     "description": "Storage breakdown label for music and audiobooks"
   },
+  "images": "Imagens",
   "@images": {
     "description": "Storage breakdown label for images"
   },
+  "database": "Base de dados",
   "@database": {
     "description": "Storage breakdown label for database"
   },
+  "ofStorageLimit": "do limite {limit}",
   "@ofStorageLimit": {
     "description": "Text showing storage used of total limit",
     "placeholders": {
@@ -2058,81 +2651,107 @@
       }
     }
   },
+  "settings": "Definições",
   "@settings": {
     "description": "Settings screen title"
   },
+  "authentication": "Autenticação",
   "@authentication": {
     "description": "Auth settings section title"
   },
+  "autoLoginServerManagement": "Sessão automática, gestão de servidor",
   "@autoLoginServerManagement": {
     "description": "Auth settings description"
   },
+  "pinCode": "Código PIN",
   "@pinCode": {
     "description": "PIN code settings title"
   },
+  "setUpPinCodeProtection": "Configurar proteção por código PIN",
   "@setUpPinCodeProtection": {
     "description": "PIN code settings description"
   },
+  "parentalControls": "Controlo parental",
   "@parentalControls": {
     "description": "Parental controls settings title"
   },
+  "contentRatingRestrictions": "Restrições de classificação etária",
   "@contentRatingRestrictions": {
     "description": "Parental controls description"
   },
+  "bitRateResolutionBehavior": "Taxa de bits, resolução, comportamento",
   "@bitRateResolutionBehavior": {
     "description": "Playback settings description"
   },
+  "languageSizeAppearance": "Idioma, tamanho, aparência",
   "@languageSizeAppearance": {
     "description": "Subtitle settings description"
   },
+  "qualityStorage": "Qualidade, armazenamento",
   "@qualityStorage": {
     "description": "Download settings description"
   },
+  "serverSyncAndPluginStatus": "Sincronização do servidor e estado do plugin",
   "@serverSyncAndPluginStatus": {
     "description": "Plugin settings description"
   },
+  "mediaRequestIntegration": "Integração de pedido de conteúdo",
   "@mediaRequestIntegration": {
     "description": "Seerr settings description"
   },
+  "switchServer": "Trocar servidor",
   "@switchServer": {
     "description": "Button to switch to a different server"
   },
+  "signOut": "Terminar sessão",
   "@signOut": {
     "description": "Button to sign out"
   },
+  "versionLicenses": "Versão, licenças",
   "@versionLicenses": {
     "description": "About settings description"
   },
+  "account": "Conta",
   "@account": {
     "description": "Account section title"
   },
+  "signInAndSecurity": "Sessão e segurança",
   "@signInAndSecurity": {
     "description": "Account section description"
   },
+  "administration": "Administração",
   "@administration": {
     "description": "Administration section title"
   },
+  "serverSettingsUsersLibraries": "Definições do servidor, utilizadores, bibliotecas",
   "@serverSettingsUsersLibraries": {
     "description": "Administration section description"
   },
+  "customization": "Personalização",
   "@customization": {
     "description": "Customization section title"
   },
+  "themeAndLayout": "Tema e disposição",
   "@themeAndLayout": {
     "description": "Customization section description"
   },
+  "videoAndSubtitles": "Vídeo e legendas",
   "@videoAndSubtitles": {
     "description": "Playback section description variant"
   },
+  "integrations": "Integrações",
   "@integrations": {
     "description": "Integrations section title"
   },
+  "pluginAndRequests": "Plugins e pedidos",
   "@pluginAndRequests": {
     "description": "Integrations section description"
   },
+  "customizeAccountPlaybackInterface": "Personaliza a conta, a reprodução e o comportamento da interface",
   "@customizeAccountPlaybackInterface": {
     "description": "Settings screen subtitle"
   },
+  "optionsCount": "{count} opções",
   "@optionsCount": {
     "description": "Number of options in a settings section",
     "placeholders": {
@@ -2141,84 +2760,119 @@
       }
     }
   },
+  "themeAndAppearance": "Tema e aparência",
   "@themeAndAppearance": {
     "description": "Appearance settings title"
   },
+  "focusBorderColor": "Cor da borda do foco",
   "@focusBorderColor": {
     "description": "Setting for focus border color"
   },
+  "watchedIndicators": "Indicadores vistos",
   "@watchedIndicators": {
     "description": "Setting for watched indicator display"
   },
+  "always": "Sempre",
   "@always": {
     "description": "Option: always"
   },
+  "hideUnwatched": "Ocultar não vistos",
   "@hideUnwatched": {
     "description": "Option: hide unwatched indicators"
   },
+  "episodesOnly": "Apenas episódios",
   "@episodesOnly": {
     "description": "Option: episodes only"
   },
+  "never": "Nunca",
   "@never": {
     "description": "Option: never"
   },
+  "focusExpansionAnimation": "Animação de expansão de foco",
   "@focusExpansionAnimation": {
     "description": "Setting for focus expansion animation"
   },
+  "desktopUiScale": "Escala de UI de desktop",
+  "@desktopUiScale": {
+    "description": "Setting for desktop UI scale"
+  },
+  "scaleFocusedCards": "Dimensionar cartões e blocos focados ou com cursor sobre eles",
   "@scaleFocusedCards": {
     "description": "Description for focus expansion animation"
   },
+  "backgroundBackdrops": "Cenários de fundo",
   "@backgroundBackdrops": {
     "description": "Setting for background backdrops"
   },
+  "showBackdropImages": "Mostrar imagens de fundo por trás do conteúdo",
   "@showBackdropImages": {
     "description": "Description for background backdrops"
   },
+  "seriesThumbnails": "Miniaturas de séries",
   "@seriesThumbnails": {
     "description": "Setting for series thumbnails"
   },
+  "seriesThumbnailsDescription": "Apenas episódios: usa a arte da série que corresponda a cada tipo de imagem de linha",
   "@seriesThumbnailsDescription": {
     "description": "Description for series thumbnails setting"
   },
+  "homeRowInfoOverlay": "Sobreposição de informações da linha inicial",
   "@homeRowInfoOverlay": {
     "description": "Setting for home row info overlay"
   },
+  "showTitleMetadataOnHomeRows": "Mostrar título e metadados ao navegar nas linhas iniciais",
   "@showTitleMetadataOnHomeRows": {
     "description": "Description for home row info overlay"
   },
+  "clockDisplay": "Visualização do relógio",
   "@clockDisplay": {
     "description": "Setting for clock display"
   },
+  "inMenus": "Nos menus",
   "@inMenus": {
     "description": "Option: show in menus"
   },
+  "inVideo": "Em vídeo",
   "@inVideo": {
     "description": "Option: show in video"
   },
+  "seasonalEffects": "Efeitos sazonais",
   "@seasonalEffects": {
     "description": "Setting for seasonal visual effects"
   },
+  "seasonalEffectsDescription": "Efeitos visuais e decorações sazonais",
+  "@seasonalEffectsDescription": {
+    "description": "Description for seasonal effects settings"
+  },
+  "snow": "Neve",
   "@snow": {
     "description": "Seasonal effect: snow"
   },
+  "fireworks": "Fogos de artifício",
   "@fireworks": {
     "description": "Seasonal effect: fireworks"
   },
+  "confetti": "Confete",
   "@confetti": {
     "description": "Seasonal effect: confetti"
   },
+  "fallingLeaves": "Folhas caindo",
   "@fallingLeaves": {
     "description": "Seasonal effect: falling leaves"
   },
+  "themeMusic": "Música Temática",
   "@themeMusic": {
     "description": "Setting for theme music"
   },
+  "playThemeMusicOnDetailPages": "Reproduzir música tema nas páginas de detalhes",
   "@playThemeMusicOnDetailPages": {
     "description": "Description for theme music setting"
   },
+  "themeMusicVolume": "Volume da música temática",
   "@themeMusicVolume": {
     "description": "Setting for theme music volume"
   },
+  "percentValue": "{value}%",
   "@percentValue": {
     "description": "Percentage display",
     "placeholders": {
@@ -2227,15 +2881,19 @@
       }
     }
   },
+  "themeMusicOnHomeRows": "Música tema nas linhas iniciais",
   "@themeMusicOnHomeRows": {
     "description": "Setting for theme music on home rows"
   },
+  "playWhenBrowsingHomeScreen": "Reproduzir ao navegar no ecrã inicial",
   "@playWhenBrowsingHomeScreen": {
     "description": "Description for theme music on home rows"
   },
+  "detailsBackgroundBlur": "Detalhes do desfoque de fundo",
   "@detailsBackgroundBlur": {
     "description": "Setting for details background blur"
   },
+  "pixelValue": "{value}px",
   "@pixelValue": {
     "description": "Pixel value display",
     "placeholders": {
@@ -2244,177 +2902,432 @@
       }
     }
   },
+  "browsingBackgroundBlur": "Desfoque de fundo ao navegar",
   "@browsingBackgroundBlur": {
     "description": "Setting for browsing background blur"
   },
+  "maxStreamingBitrate": "Taxa máxima de bits de streaming",
   "@maxStreamingBitrate": {
     "description": "Setting for max streaming bitrate"
   },
+  "maxResolution": "Resolução máxima",
   "@maxResolution": {
     "description": "Setting for max resolution"
   },
+  "playerZoomMode": "Modo de zoom do reprodutor",
   "@playerZoomMode": {
     "description": "Setting for player zoom mode"
   },
+  "settingsScrollWheelAction": "Roda do rato",
+  "@settingsScrollWheelAction": {
+    "description": "Setting title for the mouse scroll wheel action during playback"
+  },
+  "settingsScrollWheelActionDescription": "Escolhe o que acontece ao girar a roda do rato sobre o vídeo durante a reprodução.",
+  "@settingsScrollWheelActionDescription": {
+    "description": "Description for the mouse scroll wheel action setting"
+  },
+  "scrollWheelActionOff": "Desligado",
+  "@scrollWheelActionOff": {
+    "description": "Scroll wheel action option: do nothing"
+  },
+  "scrollWheelActionSeek": "Procurar (avançar / retroceder)",
+  "@scrollWheelActionSeek": {
+    "description": "Scroll wheel action option: seek forward and back"
+  },
+  "scrollWheelActionVolume": "Volume",
+  "@scrollWheelActionVolume": {
+    "description": "Scroll wheel action option: adjust volume"
+  },
+  "playerTooltipVolume": "Volume",
+  "@playerTooltipVolume": {
+    "description": "Tooltip for the volume control button in the player OSD"
+  },
+  "fit": "Ajustar",
   "@fit": {
     "description": "Zoom mode: fit"
   },
+  "autoCrop": "Corte automático",
   "@autoCrop": {
     "description": "Zoom mode: auto crop"
   },
+  "stretch": "Esticar",
   "@stretch": {
     "description": "Zoom mode: stretch"
   },
+  "refreshRateSwitching": "Mudança de taxa de atualização",
   "@refreshRateSwitching": {
     "description": "Setting for refresh rate switching"
   },
+  "disabled": "Desativado",
   "@disabled": {
     "description": "Option: disabled"
   },
+  "scaleOnTv": "Escala na TV",
   "@scaleOnTv": {
     "description": "Refresh rate option: scale on TV"
   },
+  "scaleOnDevice": "Dimensionar no dispositivo",
   "@scaleOnDevice": {
     "description": "Refresh rate option: scale on device"
   },
+  "trickPlay": "Reprodução avançada",
   "@trickPlay": {
     "description": "Setting for trick play thumbnails"
   },
+  "showPreviewThumbnailsWhenSeeking": "Mostrar miniaturas de visualização ao procurar",
   "@showPreviewThumbnailsWhenSeeking": {
     "description": "Description for trick play"
   },
+  "showDescriptionOnPause": "Mostrar descrição em pausa",
   "@showDescriptionOnPause": {
     "description": "Setting for showing description on pause"
   },
+  "dimVideoShowOverview": "Escurece o vídeo e mostra o texto de visão geral durante a pausa",
   "@dimVideoShowOverview": {
     "description": "Description for show description on pause"
   },
+  "osdLockButton": "Botão de bloqueio OSD",
   "@osdLockButton": {
     "description": "Setting for OSD lock button"
   },
+  "osdLockButtonDescription": "Mostrar um botão de bloqueio que bloqueia a entrada por toque até ser premido durante muito tempo",
   "@osdLockButtonDescription": {
     "description": "Description for OSD lock button"
   },
+  "audioBehavior": "Comportamento de áudio",
   "@audioBehavior": {
     "description": "Setting for audio behavior"
   },
+  "downmixToStereo": "Downmix para estéreo",
   "@downmixToStereo": {
     "description": "Audio option: downmix to stereo"
   },
+  "defaultAudioLanguage": "Idioma de áudio predefinido",
   "@defaultAudioLanguage": {
     "description": "Setting for default audio language"
   },
+  "autoServerDefault": "Automático (predefinição do servidor)",
   "@autoServerDefault": {
     "description": "Option: auto server default"
   },
+  "english": "Inglês",
   "@english": {
     "description": "Language: English"
   },
+  "spanish": "Espanhol",
   "@spanish": {
     "description": "Language: Spanish"
   },
+  "french": "Francês",
   "@french": {
     "description": "Language: French"
   },
+  "german": "Alemão",
   "@german": {
     "description": "Language: German"
   },
+  "italian": "italiano",
   "@italian": {
     "description": "Language: Italian"
   },
+  "portuguese": "Português",
   "@portuguese": {
     "description": "Language: Portuguese"
   },
+  "japanese": "japonês",
   "@japanese": {
     "description": "Language: Japanese"
   },
+  "korean": "coreano",
   "@korean": {
     "description": "Language: Korean"
   },
+  "chinese": "chinês",
   "@chinese": {
     "description": "Language: Chinese"
   },
+  "russian": "russo",
   "@russian": {
     "description": "Language: Russian"
   },
+  "arabic": "árabe",
   "@arabic": {
     "description": "Language: Arabic"
   },
+  "hindi": "hindi",
   "@hindi": {
     "description": "Language: Hindi"
   },
+  "dutch": "Holandês",
   "@dutch": {
     "description": "Language: Dutch"
   },
+  "swedish": "sueco",
   "@swedish": {
     "description": "Language: Swedish"
   },
+  "norwegian": "norueguês",
   "@norwegian": {
     "description": "Language: Norwegian"
   },
+  "danish": "dinamarquês",
   "@danish": {
     "description": "Language: Danish"
   },
+  "finnish": "finlandês",
   "@finnish": {
     "description": "Language: Finnish"
   },
+  "polish": "polonês",
   "@polish": {
     "description": "Language: Polish"
   },
+  "ac3Passthrough": "Passagem AC3",
   "@ac3Passthrough": {
     "description": "Setting for AC3 passthrough"
   },
+  "dtsPassthrough": "Passagem DTS",
   "@dtsPassthrough": {
     "description": "Setting for DTS passthrough"
   },
+  "trueHdSupport": "Suporte TrueHD",
   "@trueHdSupport": {
     "description": "Setting for TrueHD support"
   },
+  "enableDtsPassthrough": "Áudio Bitstream DTS apenas para AVR; requer suporte de receptor e faixa de origem DTS",
   "@enableDtsPassthrough": {
     "description": "Description for DTS passthrough"
   },
+  "enableTrueHdAudio": "Ativa o áudio TrueHD (pode não funcionar em todas as plataformas)",
   "@enableTrueHdAudio": {
     "description": "Description for TrueHD support"
   },
+  "settingsAudioOutputMode": "Modo de saída de áudio",
+  "@settingsAudioOutputMode": {
+    "description": "Setting for audio output mode"
+  },
+  "settingsAudioOutputModeAvrPassthrough": "Passagem AVR",
+  "@settingsAudioOutputModeAvrPassthrough": {
+    "description": "Audio output mode option for AVR passthrough"
+  },
+  "settingsAudioFallbackCodec": "Codec substituto de áudio",
+  "@settingsAudioFallbackCodec": {
+    "description": "Setting for fallback audio codec"
+  },
+  "settingsAudioFallbackAacStereo": "Estéreo AAC",
+  "@settingsAudioFallbackAacStereo": {
+    "description": "Fallback codec option for AAC stereo"
+  },
+  "settingsAudioFallbackAc35_1": "AC3 5.1",
+  "@settingsAudioFallbackAc35_1": {
+    "description": "Fallback codec option for AC3 5.1"
+  },
+  "settingsAudioFallbackEac35_1": "EAC3 5.1",
+  "@settingsAudioFallbackEac35_1": {
+    "description": "Fallback codec option for EAC3 5.1"
+  },
+  "settingsAudioPassthroughAdvanced": "Passagem (avançado)",
+  "@settingsAudioPassthroughAdvanced": {
+    "description": "Section title for advanced passthrough controls"
+  },
+  "settingsAudioCodecPassthrough": "Passagem de codec",
+  "@settingsAudioCodecPassthrough": {
+    "description": "Title for codec passthrough settings group"
+  },
+  "settingsAudioCodecPassthroughDescription": "Ativa apenas os formatos suportados pelo recetor AVR ou HDMI.",
+  "@settingsAudioCodecPassthroughDescription": {
+    "description": "Description for codec passthrough settings group"
+  },
+  "settingsAudioEac3Passthrough": "Passagem EAC3",
+  "@settingsAudioEac3Passthrough": {
+    "description": "Setting for EAC3 passthrough"
+  },
+  "settingsAudioEac3JocPassthrough": "Passagem EAC3 JOC (Atmos)",
+  "@settingsAudioEac3JocPassthrough": {
+    "description": "Setting for EAC3 JOC Atmos passthrough"
+  },
+  "settingsAudioDtsCorePassthrough": "Passagem principal DTS",
+  "@settingsAudioDtsCorePassthrough": {
+    "description": "Setting for DTS core passthrough"
+  },
+  "settingsAudioDtsHdPassthrough": "Passagem DTS-HD MA",
+  "@settingsAudioDtsHdPassthrough": {
+    "description": "Setting for DTS-HD MA passthrough"
+  },
+  "settingsAudioTrueHdPassthrough": "Passagem TrueHD",
+  "@settingsAudioTrueHdPassthrough": {
+    "description": "Setting for TrueHD passthrough"
+  },
+  "settingsAudioTrueHdAtmosPassthrough": "Passagem TrueHD Atmos",
+  "@settingsAudioTrueHdAtmosPassthrough": {
+    "description": "Setting for TrueHD Atmos passthrough"
+  },
+  "settingsAudioBitstreamEac3ToExternalDecoder": "Bitstream Dolby Digital Plus (EAC3) para decodificador externo.",
+  "@settingsAudioBitstreamEac3ToExternalDecoder": {
+    "description": "Description for EAC3 passthrough"
+  },
+  "settingsAudioBitstreamEac3JocToExternalDecoder": "Bitstream Dolby Atmos sobre EAC3 (JOC) para decodificador externo.",
+  "@settingsAudioBitstreamEac3JocToExternalDecoder": {
+    "description": "Description for EAC3 JOC passthrough"
+  },
+  "settingsAudioBitstreamDtsHdToExternalDecoder": "Bitstream DTS-HD MA (inclui núcleo DTS) para decodificador externo.",
+  "@settingsAudioBitstreamDtsHdToExternalDecoder": {
+    "description": "Description for DTS-HD MA passthrough"
+  },
+  "settingsAudioBitstreamTrueHdAtmosToExternalDecoder": "Bitstream Dolby TrueHD com metadados Atmos para decodificador externo.",
+  "@settingsAudioBitstreamTrueHdAtmosToExternalDecoder": {
+    "description": "Description for TrueHD Atmos passthrough"
+  },
+  "settingsDetectedAudioCapabilities": "Capacidades de áudio detectadas",
+  "@settingsDetectedAudioCapabilities": {
+    "description": "Section title for detected runtime audio capabilities"
+  },
+  "settingsDetectedAudioCapabilitiesUnavailable": "Nenhum instantâneo de capacidade de tempo de execução disponível ainda.",
+  "@settingsDetectedAudioCapabilitiesUnavailable": {
+    "description": "Message shown when runtime audio capability snapshot is missing"
+  },
+  "settingsAudioRouteLabel": "Rota",
+  "@settingsAudioRouteLabel": {
+    "description": "Label for active audio route row"
+  },
+  "settingsAudioDecodeLabel": "Decodificar",
+  "@settingsAudioDecodeLabel": {
+    "description": "Label for audio decode capability row"
+  },
+  "settingsAudioPassthroughLabel": "Passagem",
+  "@settingsAudioPassthroughLabel": {
+    "description": "Label for audio passthrough capability row"
+  },
+  "settingsAudioHdRoute": "Rota de áudio HD",
+  "@settingsAudioHdRoute": {
+    "description": "Label indicating the active route supports HD audio"
+  },
+  "settingsAudioRouteHdmi": "HDMI",
+  "@settingsAudioRouteHdmi": {
+    "description": "Audio route type HDMI"
+  },
+  "settingsAudioRouteArc": "ARC",
+  "@settingsAudioRouteArc": {
+    "description": "Audio route type ARC"
+  },
+  "settingsAudioRouteEarc": "eARC",
+  "@settingsAudioRouteEarc": {
+    "description": "Audio route type eARC"
+  },
+  "settingsAudioRouteBluetooth": "Bluetooth",
+  "@settingsAudioRouteBluetooth": {
+    "description": "Audio route type Bluetooth"
+  },
+  "settingsAudioRouteSpeaker": "Palestrante",
+  "@settingsAudioRouteSpeaker": {
+    "description": "Audio route type speaker"
+  },
+  "settingsAudioPcmChannels": "{count}ch PCM",
+  "@settingsAudioPcmChannels": {
+    "description": "Audio route subtitle showing max PCM channels",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "settingsAudioDiagnostics": "Diagnóstico",
+  "@settingsAudioDiagnostics": {
+    "description": "Section title for playback diagnostics"
+  },
+  "settingsAudioDiagnosticsVideoLevel": "Nível de vídeo",
+  "@settingsAudioDiagnosticsVideoLevel": {
+    "description": "Diagnostics label for video level"
+  },
+  "settingsAudioDiagnosticsVideoRange": "Faixa de vídeo",
+  "@settingsAudioDiagnosticsVideoRange": {
+    "description": "Diagnostics label for video range"
+  },
+  "settingsAudioDiagnosticsSubtitleCodec": "Codec de legenda",
+  "@settingsAudioDiagnosticsSubtitleCodec": {
+    "description": "Diagnostics label for subtitle codec"
+  },
+  "settingsAudioDiagnosticsAllowedAudioCodecs": "Codecs de áudio permitidos",
+  "@settingsAudioDiagnosticsAllowedAudioCodecs": {
+    "description": "Diagnostics label for allowed audio codecs"
+  },
+  "settingsAudioDiagnosticsHlsMpegTsAudioCodecs": "Codecs de áudio HLS MPEG-TS",
+  "@settingsAudioDiagnosticsHlsMpegTsAudioCodecs": {
+    "description": "Diagnostics label for HLS MPEG-TS audio codecs"
+  },
+  "settingsAudioDiagnosticsHlsFmp4AudioCodecs": "Codecs de áudio HLS fMP4",
+  "@settingsAudioDiagnosticsHlsFmp4AudioCodecs": {
+    "description": "Diagnostics label for HLS fMP4 audio codecs"
+  },
+  "settingsAudioDiagnosticsAudioSpdifPassthrough": "passagem de áudio-spdif",
+  "@settingsAudioDiagnosticsAudioSpdifPassthrough": {
+    "description": "Diagnostics label for audio-spdif passthrough codecs"
+  },
+  "settingsAudioDiagnosticsActiveAudioRoute": "Rota de áudio ativa",
+  "@settingsAudioDiagnosticsActiveAudioRoute": {
+    "description": "Diagnostics label for active audio route"
+  },
+  "settingsAudioDiagnosticsRouteHdAudioSupport": "Suporte de áudio HD de rota",
+  "@settingsAudioDiagnosticsRouteHdAudioSupport": {
+    "description": "Diagnostics label for route HD audio support"
+  },
+  "nightMode": "Modo noturno",
   "@nightMode": {
     "description": "Setting for night mode"
   },
+  "compressDynamicRange": "Comprimir gama dinâmica",
   "@compressDynamicRange": {
     "description": "Description for night mode"
   },
+  "advancedMpv": "Avançado mpv",
   "@advancedMpv": {
     "description": "Section title for advanced mpv settings"
   },
+  "enableCustomMpvConf": "Ativar mpv.conf personalizado",
   "@enableCustomMpvConf": {
     "description": "Setting for custom mpv.conf"
   },
+  "applyMpvConfBeforePlayback": "Aplica um mpv.conf especificado pelo utilizador antes do início da reprodução",
   "@applyMpvConfBeforePlayback": {
     "description": "Description for custom mpv.conf"
   },
+  "unsafeAdvancedMpvOptions": "Opções avançadas de mpv inseguras",
   "@unsafeAdvancedMpvOptions": {
     "description": "Setting for unsafe mpv options"
   },
+  "unsafeMpvOptionsDescription": "Permite um conjunto mais amplo de opções de mpv. Pode interromper o comportamento de reprodução.",
   "@unsafeMpvOptionsDescription": {
     "description": "Description for unsafe mpv options"
   },
+  "hardwareDecoding": "Decodificação de hardware",
   "@hardwareDecoding": {
     "description": "Label for hardware decoding toggle"
   },
+  "hardwareDecodingSubtitle": "Pode melhorar o desempenho, mas pode causar problemas de reprodução em alguns dispositivos.",
   "@hardwareDecodingSubtitle": {
     "description": "Description for hardware decoding toggle"
   },
+  "nextUpAndQueuing": "Próximo e na fila",
   "@nextUpAndQueuing": {
     "description": "Section title for next up and queuing"
   },
+  "nextUpDisplay": "Próximo display",
+  "@nextUpDisplay": {
+    "description": "Setting for next up behavior"
+  },
+  "extended": "Estendido",
   "@extended": {
     "description": "Option: extended"
   },
+  "minimal": "Mínimo",
   "@minimal": {
     "description": "Option: minimal"
   },
+  "nextUpTimeout": "Próximo limite de tempo",
   "@nextUpTimeout": {
     "description": "Setting for next up timeout"
   },
+  "secondsValue": "{value}s",
   "@secondsValue": {
     "description": "Seconds value display",
     "placeholders": {
@@ -2423,15 +3336,19 @@
       }
     }
   },
+  "mediaQueuing": "Enfileiramento de conteúdo",
   "@mediaQueuing": {
     "description": "Setting for media queuing"
   },
+  "autoQueueNextEpisodes": "Colocar automaticamente os próximos episódios na fila",
   "@autoQueueNextEpisodes": {
     "description": "Description for media queuing"
   },
+  "stillWatchingPrompt": "Ainda está a ver?",
   "@stillWatchingPrompt": {
     "description": "Setting for still watching prompt"
   },
+  "afterEpisodesAndHours": "Depois de episódios de {episodes} / {hours}h",
   "@afterEpisodesAndHours": {
     "description": "Still watching prompt interval",
     "placeholders": {
@@ -2443,129 +3360,171 @@
       }
     }
   },
+  "resumeAndSkip": "Retomar e avançar",
   "@resumeAndSkip": {
     "description": "Section title for resume and skip settings"
   },
+  "resumeRewind": "Retomar retroceder",
   "@resumeRewind": {
     "description": "Setting for resume rewind"
   },
+  "unpauseRewind": "Retomar retroceder",
   "@unpauseRewind": {
     "description": "Setting for rewinding a little when resuming from pause"
   },
+  "fiveSeconds": "5 segundos",
   "@fiveSeconds": {
     "description": "Duration: 5 seconds"
   },
+  "tenSeconds": "10 segundos",
   "@tenSeconds": {
     "description": "Duration: 10 seconds"
   },
+  "fifteenSeconds": "15 segundos",
   "@fifteenSeconds": {
     "description": "Duration: 15 seconds"
   },
+  "thirtySeconds": "30 segundos",
   "@thirtySeconds": {
     "description": "Duration: 30 seconds"
   },
+  "skipBackLength": "Comprimento do salto para trás",
   "@skipBackLength": {
     "description": "Setting for skip back length"
   },
+  "skipForwardLength": "Comprimento do salto para a frente",
   "@skipForwardLength": {
     "description": "Setting for skip forward length"
   },
+  "customMpvConfPath": "Caminho mpv.conf personalizado",
   "@customMpvConfPath": {
     "description": "Setting for custom mpv.conf path"
   },
+  "notSetMpvConf": "Não definido. Moonfin tentará um mpv.conf padrão nas pastas app/data.",
   "@notSetMpvConf": {
     "description": "Description when no custom mpv.conf is set"
   },
+  "selectMpvConf": "Selecionar mpv.conf",
   "@selectMpvConf": {
     "description": "Dialog title for selecting mpv.conf"
   },
+  "pathToMpvConf": "/caminho/para/mpv.conf",
   "@pathToMpvConf": {
     "description": "Hint text for mpv.conf path input"
   },
+  "subtitleStyleDescription": "As definições de estilo (tamanho, cor, deslocamento) aplicam-se a legendas baseadas em texto (SRT, VTT, TTML). As legendas ASS/SSA usam o seu próprio estilo integrado, a menos que \"ASS/SSA Direct Play\" esteja desativado. Legendas de bitmap (PGS, DVB, VobSub) não podem ser reestilizadas.",
   "@subtitleStyleDescription": {
     "description": "Info text about subtitle styling"
   },
+  "defaultSubtitleLanguage": "Idioma de legenda predefinido",
   "@defaultSubtitleLanguage": {
     "description": "Setting for default subtitle language"
   },
+  "defaultToNoSubtitles": "Predefinido sem legendas",
   "@defaultToNoSubtitles": {
     "description": "Setting for defaulting to no subtitles"
   },
+  "turnOffSubtitlesByDefault": "Desativa as legendas por predefinição",
   "@turnOffSubtitlesByDefault": {
     "description": "Description for default to no subtitles"
   },
+  "subtitleSize": "Tamanho da legenda",
   "@subtitleSize": {
     "description": "Setting for subtitle size"
   },
+  "textFillColor": "Cor de preenchimento de texto",
   "@textFillColor": {
     "description": "Setting for subtitle text fill color"
   },
+  "backgroundColor": "Cor de fundo",
   "@backgroundColor": {
     "description": "Setting for background color"
   },
+  "textStrokeColor": "Cor do traço do texto",
   "@textStrokeColor": {
     "description": "Setting for subtitle text stroke color"
   },
+  "subtitleCustomization": "Personalização de legendas",
   "@subtitleCustomization": {
     "description": "Title of the subtitle customization screen"
   },
+  "subtitleCustomizationDescription": "Personalize a aparência das legendas",
   "@subtitleCustomizationDescription": {
     "description": "Subtitle for the subtitle customization tile"
   },
+  "subtitlePreviewText": "A rápida raposa castanha salta sobre o cão preguiçoso",
   "@subtitlePreviewText": {
     "description": "Sample text shown in the subtitle live preview"
   },
+  "verticalOffset": "Deslocamento vertical",
   "@verticalOffset": {
     "description": "Setting for vertical offset"
   },
+  "pgsDirectPlay": "Reprodução direta PGS",
   "@pgsDirectPlay": {
     "description": "Setting for PGS direct play"
   },
+  "directPlayPgsSubtitles": "Legendas PGS com reprodução direta",
   "@directPlayPgsSubtitles": {
     "description": "Description for PGS direct play"
   },
+  "assSsaDirectPlay": "Reprodução direta ASS/SSA",
   "@assSsaDirectPlay": {
     "description": "Setting for ASS/SSA direct play"
   },
+  "directPlayAssSsaSubtitles": "Legendas ASS/SSA com reprodução direta",
   "@directPlayAssSsaSubtitles": {
     "description": "Description for ASS/SSA direct play"
   },
+  "white": "Branco",
   "@white": {
     "description": "Color: white"
   },
+  "black": "Preto",
   "@black": {
     "description": "Color: black"
   },
+  "yellow": "Amarelo",
   "@yellow": {
     "description": "Color: yellow"
   },
+  "green": "Verde",
   "@green": {
     "description": "Color: green"
   },
+  "cyan": "Ciano",
   "@cyan": {
     "description": "Color: cyan"
   },
+  "red": "Vermelho",
   "@red": {
     "description": "Color: red"
   },
+  "transparent": "Transparente",
   "@transparent": {
     "description": "Color: transparent"
   },
+  "semiTransparentBlack": "Preto semitransparente",
   "@semiTransparentBlack": {
     "description": "Color: semi-transparent black"
   },
+  "global": "Global",
   "@global": {
     "description": "Profile: global"
   },
+  "desktop": "Ambiente de trabalho",
   "@desktop": {
     "description": "Profile: desktop"
   },
+  "mobile": "Móvel",
   "@mobile": {
     "description": "Profile: mobile"
   },
+  "tv": "TV",
   "@tv": {
     "description": "Profile: TV"
   },
+  "loadedProfileSettings": "Definições de perfil {profile} carregadas.",
   "@loadedProfileSettings": {
     "description": "Message when profile settings are loaded",
     "placeholders": {
@@ -2574,6 +3533,7 @@
       }
     }
   },
+  "failedToLoadProfileSettings": "Falha ao carregar as definições do perfil {profile}.",
   "@failedToLoadProfileSettings": {
     "description": "Error when profile settings fail to load",
     "placeholders": {
@@ -2582,6 +3542,7 @@
       }
     }
   },
+  "syncedSettingsToProfile": "Definições locais sincronizadas com o perfil {profile}.",
   "@syncedSettingsToProfile": {
     "description": "Message when settings are synced to a profile",
     "placeholders": {
@@ -2590,216 +3551,291 @@
       }
     }
   },
+  "customizationProfile": "Perfil de personalização",
   "@customizationProfile": {
     "description": "Setting for customization profile"
   },
+  "customizationProfileDescription": "Escolhe o perfil para carregar, editar e sincronizar. Global aplica-se a todos os locais, a menos que um perfil de dispositivo o substitua. O ponto verde marca o perfil do teu dispositivo atual.",
   "@customizationProfileDescription": {
     "description": "Description for customization profile"
   },
+  "loadProfile": "Carregar perfil",
   "@loadProfile": {
     "description": "Button to load a profile"
   },
+  "syncing": "A sincronizar...",
   "@syncing": {
     "description": "Label while syncing"
   },
+  "syncToProfile": "Sincronizar com perfil",
   "@syncToProfile": {
     "description": "Button to sync to a profile"
   },
+  "profileSyncHidden": "Sincronização de perfil oculta",
   "@profileSyncHidden": {
     "description": "Title when profile sync is hidden"
   },
+  "enablePluginSyncDescription": "Ativa a sincronização do plugin do servidor nas definições do plugin para mostrar os controlos do perfil aqui.",
   "@enablePluginSyncDescription": {
     "description": "Description when plugin sync is disabled"
   },
+  "quality": "Qualidade",
   "@quality": {
     "description": "Section title for quality settings"
   },
+  "defaultDownloadQuality": "Qualidade de transferência predefinida",
   "@defaultDownloadQuality": {
     "description": "Setting for default download quality"
   },
+  "network": "Rede",
   "@network": {
     "description": "Section title for network settings"
   },
+  "wifiOnlyDownloads": "Transferências apenas via Wi-Fi",
   "@wifiOnlyDownloads": {
     "description": "Setting for wifi-only downloads"
   },
+  "onlyDownloadOnWifi": "Transferir apenas quando ligado ao Wi-Fi",
   "@onlyDownloadOnWifi": {
     "description": "Description for wifi-only downloads"
   },
+  "storage": "Armazenamento",
   "@storage": {
     "description": "Section title for storage settings"
   },
+  "storageUsed": "Armazenamento usado",
   "@storageUsed": {
     "description": "Label for storage used"
   },
+  "manage": "Gerir",
   "@manage": {
     "description": "Button to manage storage"
   },
+  "calculating": "A calcular...",
   "@calculating": {
     "description": "Label while calculating"
   },
+  "downloadLocation": "Localização de transferência",
   "@downloadLocation": {
     "description": "Setting for download location"
   },
+  "defaultLabel": "Padrão",
   "@defaultLabel": {
     "description": "Option: default"
   },
+  "saveToDownloadsFolder": "Guardar na pasta Downloads",
   "@saveToDownloadsFolder": {
     "description": "Setting for saving to downloads folder"
   },
+  "downloadsVisibleToOtherApps": "Transferências/Moonfin – visível para outras aplicações",
   "@downloadsVisibleToOtherApps": {
     "description": "Description for downloads folder visibility"
   },
+  "dangerZone": "Zona de perigo",
   "@dangerZone": {
     "description": "Section title for dangerous actions"
   },
+  "clearAllDownloads": "Limpar todas as transferências",
   "@clearAllDownloads": {
     "description": "Button to clear all downloads"
   },
+  "original": "Original",
   "@original": {
     "description": "Quality option: original"
   },
+  "changeDownloadLocation": "Alterar localização de transferência",
   "@changeDownloadLocation": {
     "description": "Dialog title for changing download location"
   },
+  "changeDownloadLocationDescription": "Novas transferências serão guardadas na pasta selecionada. As transferências existentes permanecerão na sua localização atual e poderão ser geridas nas definições de armazenamento.",
   "@changeDownloadLocationDescription": {
     "description": "Description for changing download location"
   },
+  "confirm": "Confirmar",
   "@confirm": {
     "description": "Button to confirm an action"
   },
+  "cannotWriteToFolder": "Não é possível escrever na pasta selecionada. Escolhe um local diferente ou concede permissões de armazenamento.",
   "@cannotWriteToFolder": {
     "description": "Error when cannot write to selected folder"
   },
+  "saveToDownloadsFolderQuestion": "Guardar na pasta Downloads?",
   "@saveToDownloadsFolderQuestion": {
     "description": "Dialog title for saving to downloads folder"
   },
+  "saveToDownloadsFolderDescription": "O conteúdo transferido será guardado em Downloads/Moonfin no teu dispositivo. Esses ficheiros ficarão visíveis para outras aplicações, como a tua galeria ou reprodutor de música.\n\nAs transferências existentes permanecerão na localização atual.",
   "@saveToDownloadsFolderDescription": {
     "description": "Description for saving to downloads folder"
   },
+  "enable": "Ativar",
   "@enable": {
     "description": "Button to enable a feature"
   },
+  "clearAllDownloadsWarning": "Isto eliminará todo o conteúdo transferido e não poderá ser desfeito.",
   "@clearAllDownloadsWarning": {
     "description": "Warning when clearing all downloads"
   },
+  "clearAll": "Limpar tudo",
   "@clearAll": {
     "description": "Button to clear all"
   },
+  "navigationStyle": "Estilo de navegação",
   "@navigationStyle": {
     "description": "Setting for navigation style"
   },
+  "topBar": "Barra superior",
   "@topBar": {
     "description": "Navigation style: top bar"
   },
+  "leftSidebar": "Barra lateral esquerda",
   "@leftSidebar": {
     "description": "Navigation style: left sidebar"
   },
+  "showShuffleButton": "Mostrar botão aleatório",
   "@showShuffleButton": {
     "description": "Setting for showing shuffle button"
   },
+  "showGenresButton": "Botão Mostrar géneros",
   "@showGenresButton": {
     "description": "Setting for showing genres button"
   },
+  "showFavoritesButton": "Mostrar botão Favoritos",
   "@showFavoritesButton": {
     "description": "Setting for showing favorites button"
   },
+  "showLibrariesInToolbar": "Mostrar bibliotecas na barra de ferramentas",
   "@showLibrariesInToolbar": {
     "description": "Setting for showing libraries in toolbar"
   },
+  "showSeerrButton": "Mostrar botão Seerr",
+  "@showSeerrButton": {
+    "description": "Setting for showing Seerr button"
+  },
+  "navbarOpacity": "Opacidade da barra de navegação",
   "@navbarOpacity": {
     "description": "Setting for navbar opacity"
   },
+  "navbarColor": "Cor da barra de navegação",
   "@navbarColor": {
     "description": "Setting for navbar color"
   },
+  "gray": "Cinza",
   "@gray": {
     "description": "Color: gray"
   },
+  "darkBlue": "Azul escuro",
   "@darkBlue": {
     "description": "Color: dark blue"
   },
+  "purple": "Roxo",
   "@purple": {
     "description": "Color: purple"
   },
+  "teal": "Cerceta",
   "@teal": {
     "description": "Color: teal"
   },
+  "navy": "Marinha",
   "@navy": {
     "description": "Color: navy"
   },
+  "charcoal": "Carvão",
   "@charcoal": {
     "description": "Color: charcoal"
   },
+  "brown": "Castanho",
   "@brown": {
     "description": "Color: brown"
   },
+  "darkRed": "Vermelho Escuro",
   "@darkRed": {
     "description": "Color: dark red"
   },
+  "darkGreen": "Verde Escuro",
   "@darkGreen": {
     "description": "Color: dark green"
   },
+  "slate": "Ardósia",
   "@slate": {
     "description": "Color: slate"
   },
+  "indigo": "Índigo",
   "@indigo": {
     "description": "Color: indigo"
   },
+  "libraryDisplay": "Visualização da Biblioteca",
   "@libraryDisplay": {
     "description": "Section title for library display settings"
   },
+  "posterLabel": "Poster",
   "@posterLabel": {
     "description": "Image type: poster"
   },
+  "thumbnailLabel": "Miniatura",
   "@thumbnailLabel": {
     "description": "Image type: thumbnail"
   },
+  "bannerLabel": "Banner",
   "@bannerLabel": {
     "description": "Image type: banner"
   },
+  "overridePerLibrarySettings": "Substituir definições por biblioteca",
   "@overridePerLibrarySettings": {
     "description": "Setting for overriding per-library settings"
   },
+  "applyImageTypeToAllLibraries": "Aplicar tipo de imagem a todas as bibliotecas",
   "@applyImageTypeToAllLibraries": {
     "description": "Description for override per-library settings"
   },
+  "multiServerLibraries": "Bibliotecas multiservidor",
   "@multiServerLibraries": {
     "description": "Setting for multi-server libraries"
   },
+  "showLibrariesFromAllServers": "Mostrar bibliotecas de todos os servidores ligados",
   "@showLibrariesFromAllServers": {
     "description": "Description for multi-server libraries"
   },
+  "enableFolderView": "Ativar visualização de pasta",
   "@enableFolderView": {
     "description": "Setting for enabling folder view"
   },
+  "showFolderBrowsingOption": "Mostrar opção de navegação em pastas",
   "@showFolderBrowsingOption": {
     "description": "Description for folder view"
   },
+  "libraryVisibility": "Visibilidade da Biblioteca",
   "@libraryVisibility": {
     "description": "Section title for library visibility"
   },
+  "libraryVisibilityDescription": "Alternar a visibilidade da página inicial por biblioteca. Reinicia o Moonfin para que as alterações tenham efeito.",
   "@libraryVisibilityDescription": {
     "description": "Explanation shown on the library visibility settings screen"
   },
+  "showInNavigation": "Mostrar na navegação",
   "@showInNavigation": {
     "description": "Toggle for showing library in navigation"
   },
+  "showInLatestMedia": "Mostrar no conteúdo mais recente",
   "@showInLatestMedia": {
     "description": "Toggle for showing library in latest media"
   },
+  "sourceLibraries": "Bibliotecas de origem",
   "@sourceLibraries": {
     "description": "Setting for source libraries"
   },
+  "sourceCollections": "Coleções de origem",
   "@sourceCollections": {
     "description": "Setting for source collections"
   },
+  "excludedGenres": "Géneros eliminados",
   "@excludedGenres": {
     "description": "Setting for excluded genres"
   },
+  "selectAll": "Selecionar tudo",
   "@selectAll": {
     "description": "Button to select all items"
   },
+  "itemsSelected": "{count} selecionado",
   "@itemsSelected": {
     "description": "Number of selected items",
     "placeholders": {
@@ -2808,210 +3844,315 @@
       }
     }
   },
+  "mediaBar": "Barra de conteúdo",
   "@mediaBar": {
     "description": "Media bar section title"
   },
+  "mediaSources": "Fontes de conteúdo",
+  "@mediaSources": {
+    "description": "Section heading for media source options"
+  },
+  "behavior": "Comportamento",
+  "@behavior": {
+    "description": "Section heading for behavior options"
+  },
+  "seconds": "segundos",
+  "@seconds": {
+    "description": "Time unit label in seconds"
+  },
+  "localPreviews": "Visualizações locais",
+  "@localPreviews": {
+    "description": "Local previews settings screen title"
+  },
+  "localPreviewsDescription": "Configura visualizações de trailer, conteúdo e áudio.",
+  "@localPreviewsDescription": {
+    "description": "Description for local previews settings"
+  },
+  "mediaBarMode": "Estilo da barra de conteúdo",
   "@mediaBarMode": {
     "description": "Setting for choosing media bar style"
   },
+  "mediaBarModeDescription": "Escolhe entre Moonfin, MakD ou desliga a barra de conteúdo",
   "@mediaBarModeDescription": {
     "description": "Description for media bar style setting"
   },
+  "mediaBarModeMoonfin": "Moonfin",
   "@mediaBarModeMoonfin": {
     "description": "Media bar style option: Moonfin"
   },
+  "mediaBarModeMakd": "MakD",
   "@mediaBarModeMakd": {
     "description": "Media bar style option: MakD"
   },
+  "mediaBarModeOff": "Desligado",
   "@mediaBarModeOff": {
     "description": "Media bar style option: Off"
   },
+  "enableMediaBar": "Ativar barra de conteúdo",
   "@enableMediaBar": {
     "description": "Setting for enabling media bar"
   },
+  "showFeaturedContentSlideshow": "Mostrar apresentação de diapositivos de conteúdo em destaque na página inicial",
   "@showFeaturedContentSlideshow": {
     "description": "Description for enable media bar"
   },
+  "contentType": "Tipo de conteúdo",
   "@contentType": {
     "description": "Setting for content type"
   },
+  "moviesAndTvShows": "Filmes e séries de TV",
   "@moviesAndTvShows": {
     "description": "Content type: movies and TV shows"
   },
+  "moviesOnly": "Apenas filmes",
   "@moviesOnly": {
     "description": "Content type: movies only"
   },
+  "tvShowsOnly": "Apenas séries de TV",
   "@tvShowsOnly": {
     "description": "Content type: TV shows only"
   },
+  "itemCount": "Contagem de itens",
   "@itemCount": {
     "description": "Setting for item count"
   },
+  "noneSelected": "Nenhum selecionado",
   "@noneSelected": {
     "description": "Label when nothing is selected"
   },
+  "noneExcluded": "Nenhum eliminado",
   "@noneExcluded": {
     "description": "Label when no genres are excluded"
   },
+  "autoAdvance": "Avanço automático",
   "@autoAdvance": {
     "description": "Setting for auto advance"
   },
+  "autoAdvanceSlides": "Avançar automaticamente para o próximo slide",
   "@autoAdvanceSlides": {
     "description": "Description for auto advance"
   },
+  "autoAdvanceInterval": "Intervalo de avanço automático",
   "@autoAdvanceInterval": {
     "description": "Setting for auto advance interval"
   },
+  "trailerPreview": "Pré-visualização do trailer",
   "@trailerPreview": {
     "description": "Setting for trailer preview"
   },
+  "autoPlayTrailers": "Reproduz trailers automaticamente na barra de conteúdo após 3 segundos",
   "@autoPlayTrailers": {
     "description": "Description for trailer preview"
   },
+  "episodePreview": "Prévia do episódio",
   "@episodePreview": {
     "description": "Setting for episode preview"
   },
+  "mediaPreview": "Visualização de conteúdo",
+  "@mediaPreview": {
+    "description": "Setting for media preview"
+  },
+  "episodePreviewDescription": "Reproduz uma pré-visualização inline de 30 segundos em cartões focados, com cursor sobre eles ou premidos durante muito tempo",
   "@episodePreviewDescription": {
     "description": "Description for episode preview"
   },
+  "mediaPreviewDescription": "Reproduzir uma visualização in-line de 30 segundos em cartões focados, pairados ou pressionados por muito tempo",
+  "@mediaPreviewDescription": {
+    "description": "Description for media preview"
+  },
+  "previewAudio": "Pré-visualizar áudio",
   "@previewAudio": {
     "description": "Setting for preview audio"
   },
+  "enablePreviewAudio": "Ativar áudio para pré-visualizações de trailers e episódios",
   "@enablePreviewAudio": {
     "description": "Description for preview audio"
   },
+  "latestMedia": "Últimos conteúdos",
   "@latestMedia": {
     "description": "Home section: latest media"
   },
+  "recentlyReleased": "Lançado recentemente",
   "@recentlyReleased": {
     "description": "Home section: recently released"
   },
+  "myMedia": "O meu conteúdo",
   "@myMedia": {
     "description": "Home section: my media"
   },
+  "myMediaSmall": "O meu conteúdo (pequena)",
   "@myMediaSmall": {
     "description": "Home section: my media small"
   },
+  "continueWatching": "Continuar a ver",
   "@continueWatching": {
     "description": "Home section: continue watching"
   },
+  "resumeAudio": "Retomar áudio",
   "@resumeAudio": {
     "description": "Home section: resume audio"
   },
+  "resumeBooks": "Retomar livros",
   "@resumeBooks": {
     "description": "Home section: resume books"
   },
+  "activeRecordings": "Gravações Ativas",
   "@activeRecordings": {
     "description": "Home section: active recordings"
   },
+  "playlists": "Listas de reprodução",
   "@playlists": {
     "description": "Home section: playlists"
   },
+  "liveTV": "TV ao vivo",
   "@liveTV": {
     "description": "Home section: live TV"
   },
+  "homeSections": "Secções iniciais",
   "@homeSections": {
     "description": "Settings title for home sections"
   },
+  "resetToDefaults": "Repor predefinições",
   "@resetToDefaults": {
     "description": "Tooltip for reset to defaults button"
   },
+  "homeRowPosterSize": "Tamanho do pôster da linha inicial",
   "@homeRowPosterSize": {
     "description": "Setting for home row poster size"
   },
+  "perRowImageTypeSelection": "Seleção de tipo de imagem por linha",
   "@perRowImageTypeSelection": {
     "description": "Setting for per-row image type selection"
   },
+  "configureImageTypeForEachRow": "Configura o tipo de imagem para cada linha inicial ativada",
   "@configureImageTypeForEachRow": {
     "description": "Description for per-row image type selection"
   },
+  "mergeContinueWatchingAndNextUp": "Mesclar Continuar a Ver e Próximo",
   "@mergeContinueWatchingAndNextUp": {
     "description": "Setting for merging continue watching and next up"
   },
+  "combineBothRows": "Combine as duas linhas em uma única secção inicial",
   "@combineBothRows": {
     "description": "Description for merge continue watching and next up"
   },
+  "fullScreenRows": "Linhas iniciais expandidas",
+  "@fullScreenRows": {
+    "description": "Setting for full screen home rows"
+  },
+  "fullScreenRowsDescription": "Limitar as linhas iniciais a 1 linha por ecrã",
+  "@fullScreenRowsDescription": {
+    "description": "Description for full screen home rows"
+  },
+  "perRowImageType": "Tipo de imagem por linha",
   "@perRowImageType": {
     "description": "Title for per-row image type screen"
   },
+  "perRowSettings": "Definições por linha",
   "@perRowSettings": {
     "description": "Section title for per-row settings"
   },
+  "autoLogin": "Sessão automática",
   "@autoLogin": {
     "description": "Setting for auto login"
   },
+  "lastUser": "Último utilizador",
   "@lastUser": {
     "description": "Option: last user"
   },
-  "@specificUser": {
-    "description": "Option: specific user"
+  "currentUser": "Utilizador atual",
+  "@currentUser": {
+    "description": "Option: current user"
   },
+  "alwaysAuthenticate": "Sempre autenticar",
   "@alwaysAuthenticate": {
     "description": "Setting for always authenticate"
   },
+  "requirePasswordWithToken": "Exigir palavra-passe mesmo com token guardado",
   "@requirePasswordWithToken": {
     "description": "Description for always authenticate"
   },
+  "confirmExit": "Confirmar saída",
   "@confirmExit": {
     "description": "Setting for confirm exit"
   },
+  "showConfirmationBeforeExiting": "Mostrar confirmação antes de sair",
   "@showConfirmationBeforeExiting": {
     "description": "Description for confirm exit"
   },
+  "blockContentWithRatings": "Bloqueia conteúdo com as seguintes classificações:",
   "@blockContentWithRatings": {
     "description": "Label for parental controls rating selection"
   },
+  "noContentRatingsFound": "Nenhuma classificação de conteúdo foi encontrada neste servidor ainda.",
   "@noContentRatingsFound": {
     "description": "Shown when no ratings exist on server"
   },
+  "couldNotLoadServerRatings": "Não foi possível carregar as classificações do servidor. A mostrar apenas classificações guardadas.",
   "@couldNotLoadServerRatings": {
     "description": "Shown when ratings fail to load"
   },
+  "couldNotRefreshRatings": "Não foi possível atualizar as classificações do servidor. A mostrar classificações guardadas.",
   "@couldNotRefreshRatings": {
     "description": "Shown when ratings fail to refresh"
   },
+  "enablePinCode": "Ativar código PIN",
   "@enablePinCode": {
     "description": "Setting for enabling PIN code"
   },
+  "requirePinToAccess": "Exigir um PIN para aceder à tua conta",
   "@requirePinToAccess": {
     "description": "Description for enable PIN code"
   },
+  "changePin": "Alterar PIN",
   "@changePin": {
     "description": "Setting for changing PIN"
   },
+  "setNewPinCode": "Definir um novo código PIN",
   "@setNewPinCode": {
     "description": "Description for change PIN"
   },
+  "removePin": "Remover PIN",
   "@removePin": {
     "description": "Setting for removing PIN"
   },
+  "removePinProtection": "Remover proteção do código PIN",
   "@removePinProtection": {
     "description": "Description for remove PIN"
   },
+  "screensaver": "Protetor de ecrã",
   "@screensaver": {
     "description": "Settings title for screensaver"
   },
+  "inAppScreensaver": "Protetor de ecrã na aplicação",
   "@inAppScreensaver": {
     "description": "Setting for in-app screensaver"
   },
+  "enableBuiltInScreensaver": "Ativa o protetor de ecrã integrado",
   "@enableBuiltInScreensaver": {
     "description": "Description for in-app screensaver"
   },
+  "mode": "Modo",
   "@mode": {
     "description": "Setting for mode"
   },
+  "libraryArt": "Arte da Biblioteca",
   "@libraryArt": {
     "description": "Screensaver mode: library art"
   },
+  "logo": "Logotipo",
   "@logo": {
     "description": "Screensaver mode: logo"
   },
+  "clock": "Relógio",
   "@clock": {
     "description": "Screensaver mode: clock"
   },
+  "timeout": "Tempo esgotado",
   "@timeout": {
     "description": "Setting for timeout"
   },
+  "minutesShort": "{minutes} min",
   "@minutesShort": {
     "description": "Minutes duration short format",
     "placeholders": {
@@ -3020,15 +4161,19 @@
       }
     }
   },
+  "dimmingLevel": "Nível de escurecimento",
   "@dimmingLevel": {
     "description": "Setting for dimming level"
   },
+  "maxAgeRating": "Classificação etária máxima",
   "@maxAgeRating": {
     "description": "Setting for max age rating"
   },
+  "any": "Qualquer",
   "@any": {
     "description": "Option: any"
   },
+  "agePlusValue": "{age}+",
   "@agePlusValue": {
     "description": "Age rating display",
     "placeholders": {
@@ -3037,99 +4182,131 @@
       }
     }
   },
+  "requireAgeRating": "Exigir classificação etária",
   "@requireAgeRating": {
     "description": "Setting for requiring age rating"
   },
+  "onlyShowRatedContent": "Mostrar apenas conteúdo classificado",
   "@onlyShowRatedContent": {
     "description": "Description for require age rating"
   },
+  "showClock": "Mostrar relógio",
   "@showClock": {
     "description": "Setting for showing clock"
   },
+  "displayClockDuringScreensaver": "Mostrar relógio durante o protetor de ecrã",
   "@displayClockDuringScreensaver": {
     "description": "Description for show clock"
   },
+  "rottenTomatoesCritics": "Tomates podres (críticos)",
   "@rottenTomatoesCritics": {
     "description": "Rating source: Rotten Tomatoes Critics"
   },
+  "rottenTomatoesAudience": "Tomates podres (público)",
   "@rottenTomatoesAudience": {
     "description": "Rating source: Rotten Tomatoes Audience"
   },
+  "imdb": "IMDB",
   "@imdb": {
     "description": "Rating source: IMDb"
   },
+  "tmdb": "TMDB",
   "@tmdb": {
     "description": "Rating source: TMDB"
   },
+  "metacritic": "Metacrítico",
   "@metacritic": {
     "description": "Rating source: Metacritic"
   },
+  "metacriticUser": "Metacritic (utilizador)",
   "@metacriticUser": {
     "description": "Rating source: Metacritic User"
   },
+  "trakt": "Trakt",
   "@trakt": {
     "description": "Rating source: Trakt"
   },
+  "letterboxd": "Letterboxd",
   "@letterboxd": {
     "description": "Rating source: Letterboxd"
   },
+  "myAnimeList": "MyAnimeList",
   "@myAnimeList": {
     "description": "Rating source: MyAnimeList"
   },
+  "aniList": "AniList",
   "@aniList": {
     "description": "Rating source: AniList"
   },
+  "communityRating": "Classificação da comunidade",
   "@communityRating": {
     "description": "Rating source: Community Rating"
   },
+  "ratings": "Avaliações",
   "@ratings": {
     "description": "Settings title for ratings"
   },
+  "additionalRatings": "Classificações Adicionais",
   "@additionalRatings": {
     "description": "Setting for additional ratings"
   },
+  "showMdbListAndTmdbRatings": "Mostrar classificações MDBList e TMDB",
   "@showMdbListAndTmdbRatings": {
     "description": "Description for additional ratings"
   },
+  "ratingLabels": "Etiquetas de classificação",
   "@ratingLabels": {
     "description": "Setting for rating labels"
   },
+  "showLabelsNextToIcons": "Mostrar etiquetas ao lado dos ícones de classificação",
   "@showLabelsNextToIcons": {
     "description": "Description for rating labels"
   },
+  "ratingBadges": "Selos de classificação",
   "@ratingBadges": {
     "description": "Setting for rating badges"
   },
+  "showDecorativeBadges": "Mostrar emblemas decorativos atrás das classificações",
   "@showDecorativeBadges": {
     "description": "Description for rating badges"
   },
+  "episodeRatings": "Classificações de episódios",
   "@episodeRatings": {
     "description": "Setting for episode ratings"
   },
+  "showRatingsOnEpisodes": "Mostrar classificações em episódios individuais",
   "@showRatingsOnEpisodes": {
     "description": "Description for episode ratings"
   },
+  "ratingSources": "Fontes de classificação",
   "@ratingSources": {
     "description": "Section title for rating sources"
   },
+  "ratingSourcesDescription": "Ativa e reordena as fontes de classificação mostradas em toda a aplicação",
   "@ratingSourcesDescription": {
     "description": "Description for rating sources"
   },
+  "pluginLabel": "Plugin",
   "@pluginLabel": {
     "description": "Settings title for plugin"
   },
+  "pluginDetected": "Plugin detetado",
   "@pluginDetected": {
     "description": "Status when plugin is detected"
   },
+  "pluginNotDetected": "Plugin não detetado",
   "@pluginNotDetected": {
     "description": "Status when plugin is not detected"
   },
+  "pluginDetectedDescription": "Plugin de servidor detetado. A sincronização é ativada automaticamente na primeira vez que o plugin é encontrado.",
   "@pluginDetectedDescription": {
     "description": "Description when plugin is detected"
   },
+  "pluginNotDetectedDescription": "O plugin do servidor não foi detetado de momento. As definições locais ainda usam os seus valores guardados ou predefinições integradas.",
   "@pluginNotDetectedDescription": {
     "description": "Description when plugin is not detected"
   },
+  "pluginStatusVersion": "{status}\nVersão: {version}",
   "@pluginStatusVersion": {
     "description": "Plugin status with version",
     "placeholders": {
@@ -3141,72 +4318,99 @@
       }
     }
   },
+  "availableServices": "Serviços disponíveis",
   "@availableServices": {
     "description": "Section title for available services"
   },
+  "serverPluginSync": "Sincronização de plugin de servidor",
   "@serverPluginSync": {
     "description": "Setting for server plugin sync"
   },
+  "syncSettingsWithPlugin": "Sincronizar definições com o plugin do servidor",
   "@syncSettingsWithPlugin": {
     "description": "Description for server plugin sync"
   },
+  "whatSyncControls": "Quais controlos de sincronização",
   "@whatSyncControls": {
     "description": "Info title for sync explanation"
   },
+  "syncControlsDescription": "A sincronização controla apenas se as definições suportadas pelo plugin são enviadas e extraídas do servidor. A seleção de perfil e as ações de sincronização de perfil estão nas definições de personalização quando a sincronização do plugin está ativada.",
   "@syncControlsDescription": {
     "description": "Description of what sync controls"
   },
+  "recentRequests": "Pedidos recentes",
   "@recentRequests": {
     "description": "Seerr row: recent requests"
   },
+  "recentlyAdded": "Adicionado recentemente",
   "@recentlyAdded": {
     "description": "Seerr row: recently added"
   },
+  "trending": "Tendências",
   "@trending": {
     "description": "Seerr row: trending"
   },
+  "popularMovies": "Filmes populares",
   "@popularMovies": {
     "description": "Seerr row: popular movies"
   },
+  "movieGenres": "Géneros de filmes",
   "@movieGenres": {
     "description": "Seerr row: movie genres"
   },
+  "upcomingMovies": "Próximos filmes",
   "@upcomingMovies": {
     "description": "Seerr row: upcoming movies"
   },
+  "studios": "Estúdios",
   "@studios": {
     "description": "Seerr row: studios"
   },
+  "popularSeries": "Séries populares",
   "@popularSeries": {
     "description": "Seerr row: popular series"
   },
+  "seriesGenres": "Géneros de séries",
   "@seriesGenres": {
     "description": "Seerr row: series genres"
   },
+  "upcomingSeries": "Próximas séries",
   "@upcomingSeries": {
     "description": "Seerr row: upcoming series"
   },
+  "networks": "Redes",
   "@networks": {
     "description": "Seerr row: networks"
   },
+  "seerrDiscoveryRows": "Linhas de descoberta Seerr",
+  "@seerrDiscoveryRows": {
+    "description": "Subtitle shown under Seerr discovery home rows"
+  },
+  "resetRowsToDefaults": "Redefinir linhas para os padrões",
   "@resetRowsToDefaults": {
     "description": "Tooltip for reset rows to defaults"
   },
+  "enableSeerr": "Ativar Seerr",
   "@enableSeerr": {
     "description": "Setting for enabling Seerr"
   },
+  "showSeerrInNavigation": "Mostrar Seerr na navegação (requer plugin de servidor)",
   "@showSeerrInNavigation": {
     "description": "Description for enable Seerr"
   },
+  "seerrUnavailable": "Indisponível porque o suporte do plugin do servidor Seerr está desativado.",
   "@seerrUnavailable": {
     "description": "Description when Seerr is unavailable"
   },
+  "nsfwFilter": "Filtro NSFW",
   "@nsfwFilter": {
     "description": "Setting for NSFW filter"
   },
+  "hideAdultContent": "Ocultar conteúdo adulto nos resultados",
   "@hideAdultContent": {
     "description": "Description for NSFW filter"
   },
+  "loggedInAs": "Sessão iniciada como: {username}",
   "@loggedInAs": {
     "description": "Label showing logged in username",
     "placeholders": {
@@ -3215,24 +4419,31 @@
       }
     }
   },
+  "discoverRows": "Descubra linhas",
   "@discoverRows": {
     "description": "Section title for discover rows"
   },
+  "discoverRowsDescriptionPlugin": "Arrasta para reordenar. Ativa ou desativa linhas. A ordem das linhas ativadas é sincronizada com o plugin Moonfin.",
   "@discoverRowsDescriptionPlugin": {
     "description": "Description for discover rows with plugin"
   },
+  "discoverRowsDescription": "Arrasta para reordenar. Ativa ou desativa linhas.",
   "@discoverRowsDescription": {
     "description": "Description for discover rows without plugin"
   },
+  "enabled": "Ativado",
   "@enabled": {
     "description": "Status: enabled"
   },
+  "hidden": "Escondido",
   "@hidden": {
     "description": "Status: hidden"
   },
+  "aboutTitle": "Sobre",
   "@aboutTitle": {
     "description": "About screen title"
   },
+  "versionValue": "Versão {version}",
   "@versionValue": {
     "description": "Version display",
     "placeholders": {
@@ -3241,45 +4452,59 @@
       }
     }
   },
+  "openSourceLicenses": "Licenças de código aberto",
   "@openSourceLicenses": {
     "description": "Link to open source licenses"
   },
+  "sourceCode": "Código fonte",
   "@sourceCode": {
     "description": "Link to source code"
   },
+  "sourceCodeUrl": "https://github.com/Moonfin-Client/Mobile-Desktop",
   "@sourceCodeUrl": {
     "description": "Displayed source code repository URL"
   },
+  "checkForUpdatesNow": "Verificar atualizações agora",
   "@checkForUpdatesNow": {
     "description": "Button to check for updates"
   },
+  "checksLatestDesktopRelease": "Verifica a versão de desktop mais recente para esta plataforma",
   "@checksLatestDesktopRelease": {
     "description": "Description for check for updates"
   },
+  "youAreUpToDate": "Estás atualizado.",
   "@youAreUpToDate": {
     "description": "Message when app is up to date"
   },
+  "couldNotCheckForUpdates": "Não foi possível verificar atualizações no momento.",
   "@couldNotCheckForUpdates": {
     "description": "Error when update check fails"
   },
+  "noCompatibleUpdate": "Nenhum pacote de atualização compatível encontrado para esta plataforma.",
   "@noCompatibleUpdate": {
     "description": "Message when no compatible update is found"
   },
+  "updateChecksNotSupported": "As verificações de atualização não são suportadas nesta plataforma.",
   "@updateChecksNotSupported": {
     "description": "Message when update checks not supported"
   },
+  "updateNotificationsDisabled": "As notificações de atualização estão desativadas.",
   "@updateNotificationsDisabled": {
     "description": "Message when notifications are disabled"
   },
+  "pleaseWaitBeforeChecking": "Aguarda antes de verificar novamente.",
   "@pleaseWaitBeforeChecking": {
     "description": "Message when checking too soon"
   },
+  "latestUpdateAlreadyShown": "A última atualização já foi mostrada.",
   "@latestUpdateAlreadyShown": {
     "description": "Message when update was already shown"
   },
+  "updateAvailable": "Atualização disponível.",
   "@updateAvailable": {
     "description": "Message when an update is available"
   },
+  "updateAvailableVersion": "Atualização disponível: v{version}",
   "@updateAvailableVersion": {
     "description": "Message with specific update version",
     "placeholders": {
@@ -3288,12 +4513,15 @@
       }
     }
   },
+  "updateNotifications": "Notificações de atualização",
   "@updateNotifications": {
     "description": "Setting for update notifications"
   },
+  "showWhenUpdatesAvailable": "Mostrar quando atualizações estão disponíveis",
   "@showWhenUpdatesAvailable": {
     "description": "Description for update notifications"
   },
+  "updateAvailableTitle": "v{version} Disponível",
   "@updateAvailableTitle": {
     "description": "Title of the update dialog showing the new version",
     "placeholders": {
@@ -3302,42 +4530,55 @@
       }
     }
   },
+  "readReleaseNotes": "Lê as notas de versão",
   "@readReleaseNotes": {
     "description": "Option to read the release notes in a browser"
   },
+  "downloadingUpdate": "A transferir atualização...",
   "@downloadingUpdate": {
     "description": "Label shown while an update is being downloaded"
   },
+  "updateDownloadFailed": "Falha na transferência da atualização. Por favor, tenta novamente.",
   "@updateDownloadFailed": {
     "description": "Error shown when the update download fails"
   },
+  "openReleasesPage": "Abrir página de lançamentos",
   "@openReleasesPage": {
     "description": "Option to open the GitHub releases page in a browser (Linux)"
   },
+  "navigation": "Navegação",
   "@navigation": {
     "description": "Navigation settings title"
   },
+  "watchedIndicatorsBackdrops": "Indicadores vistos, cenários",
   "@watchedIndicatorsBackdrops": {
     "description": "Appearance settings subtitle on mobile"
   },
+  "focusColorWatchedIndicatorsBackdrops": "Cor do foco, indicadores vistos, cenários",
   "@focusColorWatchedIndicatorsBackdrops": {
     "description": "Appearance settings subtitle on desktop"
   },
+  "navbarStyleToolbarAppearance": "Estilo da barra de navegação, botões da barra de ferramentas, aparência",
   "@navbarStyleToolbarAppearance": {
     "description": "Navigation settings subtitle"
   },
+  "reorderToggleHomeRows": "Reordenar e alternar linhas iniciais",
   "@reorderToggleHomeRows": {
     "description": "Home sections settings subtitle"
   },
+  "featuredContentAppearance": "Conteúdo em destaque, aparência",
   "@featuredContentAppearance": {
     "description": "Media bar settings subtitle"
   },
+  "posterSizeImageTypeFolderView": "Tamanho do póster, tipo de imagem, visualização de pasta",
   "@posterSizeImageTypeFolderView": {
     "description": "Library display settings subtitle"
   },
+  "mdbListTmdbRatingSources": "MDBList, TMDB e fontes de classificação",
   "@mdbListTmdbRatingSources": {
     "description": "Ratings settings subtitle"
   },
+  "gbValue": "{value} GB",
   "@gbValue": {
     "description": "Gigabyte value display",
     "placeholders": {
@@ -3346,21 +4587,27 @@
       }
     }
   },
+  "clear": "Claro",
   "@clear": {
     "description": "Button to clear"
   },
+  "browse": "Navegar",
   "@browse": {
     "description": "Button to browse files"
   },
+  "noResults": "Nenhum resultado",
   "@noResults": {
     "description": "Shown when a search or browse returns no items"
   },
+  "seerrAvailableStatus": "Disponível",
   "@seerrAvailableStatus": {
     "description": "Seerr media status when item is available"
   },
+  "seerrRequestedStatus": "Pedida",
   "@seerrRequestedStatus": {
     "description": "Seerr media status when item has been requested"
   },
+  "itemsCount": "{count} Itens",
   "@itemsCount": {
     "description": "Status bar item count",
     "placeholders": {
@@ -3369,21 +4616,27 @@
       }
     }
   },
+  "seerrSettings": "Definições do Seerr",
   "@seerrSettings": {
     "description": "Dialog title for Seerr browse settings"
   },
+  "requestMore": "Pedir mais",
   "@requestMore": {
     "description": "Button to request more seasons"
   },
+  "request": "Pedir",
   "@request": {
     "description": "Button to submit a media request"
   },
+  "cancelRequest": "Cancelar pedido",
   "@cancelRequest": {
     "description": "Button/dialog title to cancel a media request"
   },
+  "playInMoonfin": "Reproduzir no Moonfin",
   "@playInMoonfin": {
     "description": "Button to play available media in Moonfin"
   },
+  "requestedByName": "Pedido por {name}",
   "@requestedByName": {
     "description": "Label showing who requested media",
     "placeholders": {
@@ -3392,18 +4645,23 @@
       }
     }
   },
+  "approve": "Aprovar",
   "@approve": {
     "description": "Tooltip/button to approve a request"
   },
+  "declineAction": "Declínio",
   "@declineAction": {
     "description": "Tooltip/button to decline a request"
   },
+  "similar": "Semelhante",
   "@similar": {
     "description": "Section title for similar media"
   },
+  "recommendations": "Recomendações",
   "@recommendations": {
     "description": "Section title for recommended media"
   },
+  "cancelRequestForTitle": "Cancelar pedido de \"{title}\"?",
   "@cancelRequestForTitle": {
     "description": "Confirmation message for single request cancellation",
     "placeholders": {
@@ -3412,6 +4670,7 @@
       }
     }
   },
+  "cancelCountRequestsForTitle": "Cancelar {count} pedidos para \"{title}\"?",
   "@cancelCountRequestsForTitle": {
     "description": "Confirmation message for multiple request cancellation",
     "placeholders": {
@@ -3423,15 +4682,19 @@
       }
     }
   },
+  "keep": "Manter",
   "@keep": {
     "description": "Button to keep/dismiss a cancel dialog"
   },
+  "itemNotFoundInLibrary": "Item não encontrado na tua biblioteca Moonfin",
   "@itemNotFoundInLibrary": {
     "description": "Snackbar when Seerr item cannot be found in Jellyfin"
   },
+  "errorSearchingLibrary": "Erro ao pesquisar na biblioteca",
   "@errorSearchingLibrary": {
     "description": "Snackbar when library search fails"
   },
+  "budgetAmount": "Orçamento: ${amount}",
   "@budgetAmount": {
     "description": "Movie budget display",
     "placeholders": {
@@ -3440,6 +4703,7 @@
       }
     }
   },
+  "revenueAmount": "Receita: ${amount}",
   "@revenueAmount": {
     "description": "Movie revenue display",
     "placeholders": {
@@ -3448,6 +4712,7 @@
       }
     }
   },
+  "seasonsCount": "{count} {label}",
   "@seasonsCount": {
     "description": "Number of seasons label",
     "placeholders": {
@@ -3459,6 +4724,7 @@
       }
     }
   },
+  "requestSeriesOrMovie": "Pedir {type}",
   "@requestSeriesOrMovie": {
     "description": "Bottom sheet title for requesting media",
     "placeholders": {
@@ -3467,36 +4733,47 @@
       }
     }
   },
+  "submitRequest": "Enviar pedido",
   "@submitRequest": {
     "description": "Button to finalize a media request"
   },
+  "allSeasons": "Todas as temporadas",
   "@allSeasons": {
     "description": "Checkbox label for selecting all seasons"
   },
+  "advancedOptions": "Opções Avançadas",
   "@advancedOptions": {
     "description": "Expansion tile for advanced request options"
   },
+  "noServiceServersConfigured": "Nenhum servidor de serviço configurado",
   "@noServiceServersConfigured": {
     "description": "Shown when no Radarr/Sonarr servers are set up"
   },
+  "server": "Servidor",
   "@server": {
     "description": "Dropdown label for server selection"
   },
+  "qualityProfile": "Perfil de qualidade",
   "@qualityProfile": {
     "description": "Dropdown label for quality profile selection"
   },
+  "rootFolder": "Pasta raiz",
   "@rootFolder": {
     "description": "Dropdown label for root folder selection"
   },
+  "showMore": "Mostrar mais",
   "@showMore": {
     "description": "Button to expand truncated content"
   },
+  "appearances": "Aparências",
   "@appearances": {
     "description": "Section title for cast appearances"
   },
+  "crewSection": "Equipa",
   "@crewSection": {
     "description": "Section title for crew credits"
   },
+  "ageValue": "idade {age}",
   "@ageValue": {
     "description": "Person age display",
     "placeholders": {
@@ -3505,2150 +4782,84 @@
       }
     }
   },
+  "noRequests": "Nenhum pedido",
   "@noRequests": {
     "description": "Shown when request list is empty"
   },
+  "pendingStatus": "Pendente",
   "@pendingStatus": {
     "description": "Request status label"
   },
+  "declinedStatus": "Recusado",
   "@declinedStatus": {
     "description": "Request status label"
   },
+  "partiallyAvailable": "Parcialmente disponível",
   "@partiallyAvailable": {
     "description": "Request status label"
   },
+  "downloadingStatus": "A transferir",
   "@downloadingStatus": {
     "description": "Request status label"
   },
+  "approvedStatus": "Aprovado",
   "@approvedStatus": {
     "description": "Request status label"
   },
+  "notRequestedStatus": "Não pedido",
   "@notRequestedStatus": {
     "description": "Request status label when no request exists"
   },
+  "blocklistedStatus": "Na lista de bloqueio",
   "@blocklistedStatus": {
     "description": "Request status label for blocklisted media"
   },
+  "deletedStatus": "Eliminado",
   "@deletedStatus": {
     "description": "Request status label for deleted media"
   },
+  "tmdbScore": "Pontuação TMDB",
   "@tmdbScore": {
     "description": "Stat label for TMDB user score"
   },
+  "releaseDateLabel": "Data de lançamento",
   "@releaseDateLabel": {
     "description": "Stat label for release date"
   },
+  "firstAirDateLabel": "Primeira data de transmissão",
   "@firstAirDateLabel": {
     "description": "Stat label for first air date"
   },
+  "revenueLabel": "Receita",
   "@revenueLabel": {
     "description": "Stat label for revenue"
   },
+  "runtimeLabel": "Duração",
   "@runtimeLabel": {
     "description": "Stat label for runtime"
   },
+  "budgetLabel": "Orçamento",
   "@budgetLabel": {
     "description": "Stat label for budget"
   },
+  "originalLanguageLabel": "Idioma original",
   "@originalLanguageLabel": {
     "description": "Stat label for original language"
   },
+  "seasonsLabel": "Temporadas",
   "@seasonsLabel": {
     "description": "Stat label for number of seasons"
   },
+  "episodesLabel": "Episódios",
   "@episodesLabel": {
     "description": "Stat label for number of episodes"
   },
-  "@adminPluginUpdatesAvailable": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminPluginsRequiringRestart": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminFailedScheduledTasks": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminRecentAlertEntries": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@errorGeneric": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminCommandFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminActivityLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminDeviceUpdateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminDeviceDeleteFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminScanFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLibraryRenamed": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRenameFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLibraryDeleted": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLibraryDeleteFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminAddPathFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRemovePathConfirm": {
-    "placeholders": {
-      "path": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRemovePathFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLibraryOptionsSaveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLibraryCreateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminDisableUserConfirm": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminEnableUserConfirm": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUserDisabled": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUserEnabled": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUserPolicyUpdateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUserCreateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminSaveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminServerReturnedHttp": {
-    "placeholders": {
-      "status": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminDeleteUserConfirm": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUserDeleted": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUserDeleteFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminApiKeyCreateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRevokeKeyConfirm": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminApiKeyRevokeFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminApiKeyTokenCreated": {
-    "placeholders": {
-      "token": {
-        "type": "String"
-      },
-      "created": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminBackupCreateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminBackupManifest": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminManifestLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRestoreFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminSavedTo": {
-    "placeholders": {
-      "path": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminFileSaveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLogFileLoadFailed": {
-    "placeholders": {
-      "fileName": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTasksLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTaskStartFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTaskStopFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTaskLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTriggerRemoveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTriggerAddFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminHours": {
-    "placeholders": {
-      "hours": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginToggleFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUninstallPluginConfirm": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginUninstallFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPackageInstallFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginUpdateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginsLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminInstallUpdate": {
-    "placeholders": {
-      "version": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminCatalogLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginRemoveAfterRestart": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminUninstallFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginUpdating": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      },
-      "version": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginVersion": {
-    "placeholders": {
-      "version": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRemoveRepositoryConfirm": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRepositoriesSaveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRepositoriesLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginSettingsLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminCouldNotOpenUrl": {
-    "placeholders": {
-      "uri": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataSaveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataRefreshFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRemoteSearchFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminContentTypeUpdateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminImageUpdated": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminImageDownloadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminImageUploaded": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminImageUploadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminDeleteImage": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminImageDeleted": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminImageDeleteFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTunerDiscoveryFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTunerAddFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminProviderAddFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTunerRemoveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTunerResetFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminProviderRemoveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminSettingsSaveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMappingsUpdateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminRecordingPathDisplay": {
-    "placeholders": {
-      "path": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminSeriesPathDisplay": {
-    "placeholders": {
-      "path": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPrePaddingDisplay": {
-    "placeholders": {
-      "minutes": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminPostPaddingDisplay": {
-    "placeholders": {
-      "minutes": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminRestoreConfirmMessage": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLogsMinutesAgo": {
-    "placeholders": {
-      "minutes": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminLogsHoursAgo": {
-    "placeholders": {
-      "hours": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminLogsDaysAgo": {
-    "placeholders": {
-      "days": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminLogViewerLoadFailed": {
-    "placeholders": {
-      "fileName": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminLogViewerMatches": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminMetadataImageUpdated": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataImageUploaded": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataImageDeleted": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataImageDownloadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataImageUploadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataDeleteImageTitle": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataImageDeleteFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminMetadataChooseImage": {
-    "placeholders": {
-      "imageType": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginsUpdateAvailable": {
-    "placeholders": {
-      "version": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginsInstallUpdateVersioned": {
-    "placeholders": {
-      "version": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginsInstalling": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminPluginDetailSettingsTitle": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminReposLoadFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminReposRemoveConfirm": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminReposSaveFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTaskTriggerDaily": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTaskTriggerWeekly": {
-    "placeholders": {
-      "day": {
-        "type": "String"
-      },
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTaskTriggerInterval": {
-    "placeholders": {
-      "duration": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTaskTriggerHours": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminActivityDaysAgo": {
-    "placeholders": {
-      "days": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminActivityHoursAgo": {
-    "placeholders": {
-      "hours": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminActivityMinutesAgo": {
-    "placeholders": {
-      "minutes": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminActivityMinutesShort": {
-    "placeholders": {
-      "minutes": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminActivityHoursShort": {
-    "placeholders": {
-      "hours": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminActivityDaysShort": {
-    "placeholders": {
-      "days": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminActivityDateShort": {
-    "placeholders": {
-      "month": {
-        "type": "int"
-      },
-      "day": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminMetadataContentTypeFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminChannelMappingsUpdateFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@adminTimeLimitDuration": {
-    "placeholders": {
-      "duration": {
-        "type": "String"
-      }
-    }
-  },
-  "@syncPlayParticipantCount": {
-    "description": "Participant count label shown in SyncPlay UI",
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@syncPlayQueueItemFallback": {
-    "description": "Fallback title for SyncPlay queue item when media title is unavailable",
-    "placeholders": {
-      "index": {
-        "type": "int"
-      }
-    }
-  },
-  "@syncPlayUserJoinedGroup": {
-    "description": "Snackbar message when a user joins a SyncPlay group",
-    "placeholders": {
-      "userName": {
-        "type": "String"
-      }
-    }
-  },
-  "@syncPlayUserLeftGroup": {
-    "description": "Snackbar message when a user leaves a SyncPlay group",
-    "placeholders": {
-      "userName": {
-        "type": "String"
-      }
-    }
-  },
-  "@syncPlaySyncingPlaybackToGroup": {
-    "description": "Snackbar message shown when starting playback in a SyncPlay group",
-    "placeholders": {
-      "groupName": {
-        "type": "String"
-      }
-    }
-  },
-  "@integrationSectionsCount": {
-    "description": "Plural label for number of sections discovered in integration status",
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@integrationRowsDiscoveredCount": {
-    "description": "Plural label for number of rows discovered in integration status",
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@castControlFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@castKindControls": {
-    "placeholders": {
-      "kind": {
-        "type": "String"
-      }
-    }
-  },
-  "@castStopKind": {
-    "placeholders": {
-      "kind": {
-        "type": "String"
-      }
-    }
-  },
-  "@pinEnterNDigit": {
-    "placeholders": {
-      "length": {
-        "type": "int"
-      }
-    }
-  },
-  "@pinEnterYourNDigit": {
-    "placeholders": {
-      "length": {
-        "type": "int"
-      }
-    }
-  },
-  "@quickConnectFailedWithMessage": {
-    "placeholders": {
-      "message": {
-        "type": "String"
-      }
-    }
-  },
-  "@remoteCommandFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@castingFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "@trackActionDownloading": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
-  "@skipSegment": {
-    "placeholders": {
-      "segment": {
-        "type": "String"
-      }
-    }
-  },
-  "@downloadingBatchProgress": {
-    "placeholders": {
-      "current": {
-        "type": "int"
-      },
-      "total": {
-        "type": "int"
-      },
-      "fileName": {
-        "type": "String"
-      }
-    }
-  },
-  "@downloadingFile": {
-    "placeholders": {
-      "fileName": {
-        "type": "String"
-      }
-    }
-  },
-  "@playerTooltipPlaybackSpeed": {
-    "description": "Tooltip label for playback speed control in player"
-  },
-  "@playerTooltipCastControls": {
-    "description": "Tooltip label for active cast controls button in player"
-  },
-  "@playerTooltipPlaybackQuality": {
-    "description": "Tooltip label for playback quality/bitrate control in player"
-  },
-  "@playerTooltipEnterFullscreen": {
-    "description": "Tooltip label for entering fullscreen in player"
-  },
-  "@playerTooltipExitFullscreen": {
-    "description": "Tooltip label for exiting fullscreen in player"
-  },
-  "@playerTooltipLockLandscape": {
-    "description": "Tooltip label for locking landscape orientation in player"
-  },
-  "@playerTooltipUnlockOrientation": {
-    "description": "Tooltip label for unlocking orientation lock in player"
-  },
-  "@playerTooltipPrevious": {
-    "description": "Tooltip label for previous item control in player"
-  },
-  "@playerTooltipSeekBack": {
-    "description": "Tooltip label for seek back control in player"
-  },
-  "@playerTooltipSeekForward": {
-    "description": "Tooltip label for seek forward control in player"
-  },
-  "@contextMenuMarkWatched": {
-    "description": "Context menu action to mark an item as watched"
-  },
-  "@contextMenuMarkUnwatched": {
-    "description": "Context menu action to mark an item as unwatched"
-  },
-  "@contextMenuAddToFavorites": {
-    "description": "Context menu action to add an item to favorites"
-  },
-  "@contextMenuRemoveFromFavorites": {
-    "description": "Context menu action to remove an item from favorites"
-  },
-  "@contextMenuGoToSeries": {
-    "description": "Context menu action to navigate to the parent series of an episode"
-  },
-  "@settingsLicenseNoticesCount": {
-    "description": "Plural label for number of license notices",
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@settingsMillisecondsValue": {
-    "description": "Milliseconds duration label",
-    "placeholders": {
-      "value": {
-        "type": "int"
-      }
-    }
-  },
-  "@libraryNameWithServer": {
-    "description": "Library name display with server suffix for multi-server views",
-    "placeholders": {
-      "libraryName": {
-        "type": "String"
-      },
-      "serverName": {
-        "type": "String"
-      }
-    }
-  },
-  "@latestLibraryName": {
-    "description": "Row title for latest media in a specific library",
-    "placeholders": {
-      "libraryName": {
-        "type": "String"
-      }
-    }
-  },
-  "appTitle": "Barbatana Lunar",
-  "signIn": "Entrar",
-  "connectingToServer": "Conectando-se a {serverName}",
-  "quickConnect": "Conexão rápida",
-  "password": "Senha",
-  "username": "Nome de usuário",
-  "quickConnectInstruction": "Insira este código no painel web do seu servidor:",
-  "waitingForAuthorization": "Aguardando autorização...",
-  "back": "Voltar",
-  "serverUnavailable": "O servidor não está disponível",
-  "loginFailed": "falha no login",
-  "quickConnectUnavailable": "QuickConnect indisponível: {detail}",
-  "quickConnectUnavailableWithStatus": "QuickConnect indisponível ({status}): {detail}",
-  "whosWatching": "Quem está assistindo?",
-  "addUser": "Adicionar usuário",
-  "selectServer": "Selecione Servidor",
-  "appVersionFooter": "Moonfin versão {version}",
-  "savedServers": "Servidores salvos",
-  "discoveredServers": "Servidores descobertos",
-  "noneFound": "Nenhum encontrado",
-  "unableToConnectToServer": "Não foi possível conectar ao servidor",
-  "addServer": "Adicionar servidor",
-  "embyConnect": "Emby Conectar",
-  "removeServer": "Remover servidor",
-  "removeServerConfirmation": "Remover \"{serverName}\" dos seus servidores?",
-  "cancel": "Cancelar",
-  "remove": "Remover",
-  "connectToServer": "Conecte-se ao servidor",
-  "serverAddress": "Endereço do servidor",
-  "serverAddressHint": "https://seu-servidor.exemplo.com",
-  "connect": "Conectar",
-  "secureStorageUnavailable": "Armazenamento seguro indisponível",
-  "secureStorageUnavailableMessage": "Moonfin não conseguiu acessar o chaveiro do seu sistema. O login pode continuar, mas o armazenamento seguro de tokens pode ficar indisponível até que o chaveiro seja desbloqueado.",
-  "ok": "OK",
-  "settingsAppearanceTheme": "Tema do aplicativo",
-  "settingsAppearanceThemeSubtitle": "Alterne entre Moonfin e Neon Pulse sem reiniciar o aplicativo",
-  "themeMoonfin": "Barbatana Lunar",
-  "themeMoonfinSubtitle": "Look atual do Moonfin que todos vocês adoraram",
-  "themeNeonPulse": "Pulso de néon",
-  "themeNeonPulseSubtitle": "Estilo Synthwave com brilho magenta, texto ciano e contraste cromado mais forte",
-  "embyConnectSignInSubtitle": "Faça login com sua conta Emby Connect",
-  "emailOrUsername": "E-mail ou nome de usuário",
-  "selectAServer": "Selecione um servidor",
-  "tryAgain": "Tente novamente",
-  "noLinkedServers": "Nenhum servidor vinculado a esta conta Emby Connect",
-  "invalidEmbyConnectCredentials": "Credenciais Emby Connect inválidas",
-  "invalidEmbyConnectLogin": "Nome de usuário ou senha do Emby Connect inválidos",
-  "embyConnectExchangeNotSupported": "O servidor não suporta troca Emby Connect",
-  "embyConnectNetworkError": "Erro de rede ao entrar em contato com o Emby Connect ou o servidor selecionado",
-  "loadingLinkedServers": "Carregando servidores vinculados...",
-  "connectingToServerEllipsis": "Conectando ao servidor...",
-  "noReachableAddress": "Nenhum endereço acessível fornecido",
-  "invalidServerExchangeResponse": "Resposta inválida do endpoint de troca do servidor",
-  "unableToConnectTo": "Não foi possível conectar-se a {target}",
-  "exitApp": "Sair do Moonfin?",
-  "exitAppConfirmation": "Tem certeza de que deseja sair?",
-  "exit": "Saída",
-  "noHomeRowsLoaded": "Nenhuma linha inicial pôde ser carregada",
-  "noHomeRowsHint": "Tente atualizar ou reduzir as seções iniciais ativas.",
-  "retryHomeRows": "Tentar novamente as linhas iniciais",
-  "guide": "Guia",
-  "recordings": "Gravações",
-  "schedule": "Agendar",
-  "series": "Série",
-  "noItemsFound": "Nenhum item encontrado",
-  "home": "Lar",
-  "browseAll": "Navegar por tudo",
-  "genres": "Gêneros",
-  "collectionPlaceholder": "Os itens da coleção aparecerão aqui",
-  "browseByLetter": "Navegar por letra",
-  "alphabeticalBrowsePlaceholder": "A navegação alfabética aparecerá aqui",
-  "suggestions": "Sugestões",
-  "suggestionsPlaceholder": "Itens sugeridos aparecerão aqui",
-  "failedToLoadLibraries": "Falha ao carregar bibliotecas",
-  "noLibrariesFound": "Nenhuma biblioteca encontrada",
-  "library": "Biblioteca",
-  "displaySettings": "Configurações de exibição",
-  "allGenres": "Todos os gêneros",
-  "noGenresFound": "Nenhum gênero encontrado",
-  "failedToLoadFolderError": "Falha ao carregar pasta: {error}",
-  "thisFolderIsEmpty": "Esta pasta está vazia",
-  "itemCountLabel": "{count} itens",
-  "failedToLoadFavorites": "Falha ao carregar favoritos",
-  "retry": "Tentar novamente",
-  "noFavoritesYet": "Ainda não há favoritos",
-  "favorites": "Favoritos",
-  "totalCountItems": "{count} Itens",
-  "continuing": "Continuando",
-  "ended": "Terminou",
-  "sortAndFilter": "Classificar e filtrar",
-  "type": "Tipo",
-  "sortBy": "Ordenar por",
-  "display": "Mostrar",
-  "imageType": "Tipo de imagem",
-  "posterSize": "Tamanho do pôster",
-  "small": "Pequeno",
-  "medium": "Médio",
-  "large": "Grande",
-  "extraLarge": "Extra Grande",
-  "libraryGenresTitle": "{name} — Gêneros",
-  "views": "Visualizações",
-  "albums": "Álbuns",
-  "albumArtists": "Artistas do álbum",
-  "artists": "Artistas",
-  "bookmarks": "Favoritos",
-  "noSavedBookmarks": "Ainda não há marcadores salvos para este título.",
-  "openBook": "Livro aberto",
-  "chapter": "Capítulo",
-  "page": "Página",
-  "bookmark": "Marcador",
-  "justNow": "Agora mesmo",
-  "minutesAgo": "{count}m atrás",
-  "hoursAgo": "{count}h atrás",
-  "daysAgo": "{count}d atrás",
-  "discoverySubjects": "Assuntos de descoberta",
-  "pickDiscoverySubjects": "Escolha quais feeds de assuntos serão exibidos no Discover.",
-  "apply": "Aplicar",
-  "openLink": "Abrir link",
-  "scanWithYourPhone": "Digitalize com seu telefone",
-  "audiobookGenres": "Gêneros de audiolivros",
-  "pickAudiobookGenres": "Escolha quais gêneros mostrar no Audiobook Discover.",
-  "discoverAudiobooks": "Descubra audiolivros",
-  "librivoxDescription": "Títulos populares de domínio público do LibriVox.",
-  "titlesCount": "{count} títulos",
-  "scrollLeft": "Role para a esquerda",
-  "scrollRight": "Role para a direita",
-  "couldNotLoadGenre": "Não foi possível carregar este gênero no momento.",
-  "continueReading": "Continuar lendo",
-  "savedHighlights": "Destaques salvos",
-  "continueListening": "Continuar ouvindo",
-  "listen": "Ouvir",
-  "resume": "Retomar",
-  "failedToLoadLibrary": "Falha ao carregar a biblioteca",
-  "popularNow": "Popular agora",
-  "savedForLater": "Salvo para mais tarde",
-  "topListens": "Principais escutas",
-  "unreadDiscoveries": "Descobertas não lidas",
-  "pickUpAgain": "Pegue novamente",
-  "bookHighlightsDescription": "Seus livros com destaques, favoritos ou progresso de leitura.",
-  "handPickedFromLibrary": "Escolhido a dedo em sua biblioteca.",
-  "handPickedFromListeningQueue": "Escolhido a dedo na sua fila de escuta.",
-  "booksWithHighlights": "Livros com destaques, favoritos ou progresso de leitura.",
-  "jumpBackNarration": "Volte para a narração sem procurar seu lugar.",
-  "unreadBooksReady": "Livros não lidos prontos para a próxima hora tranquila.",
-  "quickAccessFavorites": "Acesso rápido aos livros que você sempre consulta.",
-  "searchAudiobooks": "Pesquisar audiolivros",
-  "searchYourLibrary": "Pesquise na sua biblioteca",
-  "pickUpStory": "Continue a história de onde você parou",
-  "savedPlacesChapters": "Seus lugares salvos e capítulos inacabados",
-  "authorsCount": "{count} autores",
-  "genresCount": "{count} gêneros",
-  "percentCompleted": "{percent}% concluído",
-  "readyWhenYouAre": "Pronto quando você estiver",
-  "details": "Detalhes",
-  "listeningRoom": "Sala de escuta",
-  "bookmarksAndProgress": "Marcadores e progresso",
-  "titlesArrangedForBrowsing": "{count} títulos organizados para navegação com leitura inicial.",
-  "titles": "Títulos",
-  "allTitles": "Todos os títulos",
-  "authors": "Autores",
-  "browseByAuthor": "Navegar por autor",
-  "browseByGenre": "Navegar por gênero",
-  "discover": "Descobrir",
-  "trendingTitlesOpenLibrary": "Títulos populares por assunto da Open Library.",
-  "noBookmarkedItems": "Ainda não há itens marcados como favoritos",
-  "nothingMatchesSection": "Nada corresponde a esta seção ainda. Tente outra guia ou volte após o término da sincronização da biblioteca.",
-  "audiobooks": "Audiolivros",
-  "noLabelFound": "Nenhum {label} encontrado",
-  "folder": "Pasta",
-  "filters": "Filtros",
-  "readingStatus": "Status de leitura",
-  "playedStatus": "Status jogado",
-  "readStatus": "Ler",
-  "watched": "Assistido",
-  "unread": "Não lido",
-  "unwatched": "Não assistido",
-  "seriesStatus": "Status da série",
-  "allLibraries": "Todas as bibliotecas",
-  "books": "Livros",
-  "author": "Autor",
-  "unknownAuthor": "Autor desconhecido",
-  "uncategorized": "Sem categoria",
-  "overview": "Visão geral",
-  "noLibrivoxDescription": "Nenhuma descrição fornecida pelo LibriVox para este título ainda.",
-  "readers": "Leitores",
-  "openLinks": "Links abertos",
-  "librivoxPage": "Página LibriVox",
-  "internetArchive": "Arquivo da Internet",
-  "rssFeed": "Feed RSS",
-  "downloadZip": "Baixar Zip",
-  "sectionCountLabel": "Seções {count}",
-  "firstPublished": "Publicado pela primeira vez {year}",
-  "noOpenLibraryOverview": "Nenhuma visão geral disponível na Open Library para este título ainda.",
-  "subjects": "Assuntos",
-  "all": "Todos",
-  "booksCount": "{count} livros",
-  "couldNotLoadSubject": "Não foi possível carregar este assunto agora.",
-  "audiobookDetails": "Detalhes do audiolivro",
-  "authorsCountTitle": "{count} Autores",
-  "audiobookCountLabel": "{count, plural, =1{1 audiobook} other{{count} audiobooks}}",
-  "trackList": "Lista de faixas",
-  "itemListPlaceholder": "A lista de itens aparecerá aqui",
-  "favoriteTracksPlaceholder": "As faixas favoritas aparecerão aqui",
-  "failedToLoad": "Falha ao carregar",
-  "delete": "Excluir",
-  "save": "Salvar",
-  "moreLikeThis": "Mais como este",
-  "castAndCrew": "Elenco e equipe",
-  "collection": "Coleção",
-  "episodes": "Episódios",
-  "nextUp": "Próximo",
-  "seasons": "Temporadas",
-  "chapters": "Capítulos",
-  "features": "Características",
-  "movies": "Filmes",
-  "other": "Outro",
-  "discography": "Discografia",
-  "similarArtists": "Artistas semelhantes",
-  "tableOfContents": "Índice",
-  "tracklist": "Lista de faixas",
-  "biography": "Biografia",
-  "authorDetails": "Detalhes do autor",
-  "noOverviewAvailable": "Nenhuma visão geral disponível para este título ainda.",
-  "noBiographyAvailable": "Nenhuma biografia disponível para este autor.",
-  "noBooksFound": "Nenhum livro encontrado deste autor.",
-  "unableToLoadAuthorDetails": "Não é possível carregar os detalhes do autor no momento.",
-  "published": "Publicado {year}",
-  "publicationDateUnknown": "Data de publicação desconhecida",
-  "seasonCount": "{count, plural, =1{1 Season} other{{count} Seasons}}",
-  "endsAt": "Termina em {time}",
-  "view": "Visualizar",
-  "resumeReading": "Retomar leitura",
-  "read": "Ler",
-  "resumeFrom": "Currículo de {position}",
-  "play": "Jogar",
-  "startOver": "Recomeçar",
-  "restart": "Reiniciar",
-  "readOffline": "Ler off-line",
-  "playOffline": "Jogue off-line",
-  "audio": "Áudio",
-  "subtitles": "Legendas",
-  "version": "Versão",
-  "cast": "Elenco",
-  "trailer": "Reboque",
-  "finished": "Finalizado",
-  "favorited": "Favorito",
-  "favorite": "Favorito",
-  "playlist": "Lista de reprodução",
-  "downloaded": "Baixado",
-  "downloadAll": "Baixar tudo",
-  "download": "Download",
-  "deleteDownloaded": "Excluir baixado",
-  "goToSeries": "Ir para a série",
-  "editMetadata": "Editar metadados",
-  "less": "Menos",
-  "more": "Mais",
-  "deleteItem": "Excluir item",
-  "deletePlaylist": "Excluir lista de reprodução",
-  "deletePlaylistMessage": "Excluir esta playlist do servidor?",
-  "deleteItemMessage": "Excluir este item do servidor?",
-  "failedToDeletePlaylist": "Falha ao excluir a playlist",
-  "failedToDeleteItem": "Falha ao excluir item",
-  "renamePlaylist": "Renomear lista de reprodução",
-  "playlistName": "Nome da lista de reprodução",
-  "deleteDownloadedAlbum": "Excluir álbum baixado",
-  "deleteDownloadedTracksMessage": "Excluir faixas baixadas de \"{title}\"?",
-  "downloadedTracksDeleted": "Faixas baixadas excluídas",
-  "downloadedTracksDeleteFailed": "Algumas faixas baixadas não puderam ser excluídas",
-  "noTracksLoaded": "Nenhuma faixa carregada",
-  "noItemsLoaded": "Nenhum {itemLabel} carregado",
-  "downloadingTitle": "Baixando {title} ({count} itens)...",
-  "deleteConfirmMessage": "Tem certeza de que deseja excluir \"{name}\" do servidor? Esta ação não pode ser desfeita.",
-  "itemDeleted": "Item excluído",
-  "noPlayableTrailerFound": "Nenhum trailer jogável encontrado.",
-  "unsupportedBookFormat": "Formato de livro não suportado: .{extension}",
-  "audioTrack": "Faixa de áudio",
-  "subtitleTrack": "Faixa de legenda",
-  "none": "Nenhum",
-  "downloadSubtitlesLabel": "Baixar legendas...",
-  "searchOpenSubtitlesPlugin": "Pesquise usando o plugin OpenSubtitles",
-  "downloadSubtitles": "Baixar legendas",
-  "selectedSubtitleInvalid": "A legenda selecionada é inválida.",
-  "subtitleDownloadedSelected": "Legenda baixada e selecionada: {name}",
-  "subtitleDownloadedPending": "Legenda baixada. Pode demorar um pouco para aparecer enquanto o Jellyfin atualiza o item.",
-  "noRemoteSubtitlesFound": "Nenhuma legenda remota encontrada para {language}.",
-  "selectVersion": "Selecione a versão",
-  "versionNumber": "Versão {number}",
-  "downloadAllQuality": "Baixe tudo - qualidade",
-  "downloadQuality": "Qualidade de download",
-  "originalFileNoReencoding": "Arquivo original, sem recodificação",
-  "originalFilesNoReencoding": "Arquivos originais, sem recodificação",
-  "noEpisodesLoaded": "Nenhum episódio carregado",
-  "downloadingItem": "Baixando {name} ({quality})...",
-  "deleteDownloadedFiles": "Excluir arquivos baixados",
-  "deleteLocalFilesMessage": "Excluir arquivos locais para {typeLabel}?\n\nIsso irá liberar espaço de armazenamento. Você pode baixar novamente mais tarde.",
-  "downloadedFilesDeleted": "Arquivos baixados excluídos",
-  "failedToDeleteFiles": "Falha ao excluir arquivos",
-  "deleteFiles": "Excluir arquivos",
-  "director": "DIRETOR",
-  "writers": "ESCRITORES",
-  "studio": "ESTÚDIO",
-  "studioMoreCount": "+{count} mais",
-  "totalEpisodes": "{count} Episódios",
-  "episodeProgress": "{watched} / {total}",
-  "episodeLabel": "Episódio {number}",
-  "chapterNumber": "Capítulo {number}",
-  "trackCount": "{count, plural, =1{1 track} other{{count} tracks}}",
-  "chapterCount": "{count, plural, =1{1 chapter} other{{count} chapters}}",
-  "born": "Nasceu {date}",
-  "died": "Morreu {date}",
-  "age": "Idade {age}",
-  "showLess": "Mostrar menos",
-  "readMore": "Leia mais",
-  "shuffle": "Embaralhar",
-  "downloadsCount": "{count} downloads",
-  "perfectMatch": "Combinação perfeita",
-  "channelsCount": "{count}ch",
-  "mono": "Mono",
-  "stereo": "Estéreo",
-  "remoteSubtitlePermissionError": "A legenda remota {action} requer a permissão de gerenciamento de legendas Jellyfin para este usuário.",
-  "remoteSubtitleNotFoundError": "Este item não foi encontrado no servidor para legenda remota {action}.",
-  "remoteSubtitleDetailError": "Legenda remota {action} falhou: {detail}",
-  "remoteSubtitleHttpError": "A legenda remota {action} falhou (HTTP {status}).",
-  "remoteSubtitleGenericError": "Falha ao {action} legendas remotas.",
-  "deleteSeriesFiles": "todos os episódios baixados de \"{name}\"",
-  "deleteSeasonFiles": "todos os episódios baixados nesta temporada",
-  "stillWatching": "Ainda está assistindo?",
-  "unableToLoadTrailerStream": "Não foi possível carregar o fluxo do trailer.",
-  "trailerTimedOut": "O tempo limite do trailer expirou durante o carregamento.",
-  "playbackFailedForTrailer": "Falha na reprodução deste trailer.",
-  "photoCountOf": "{current} / {total}",
-  "castingUnavailableOffline": "A transmissão não está disponível durante a reprodução offline.",
-  "castActionFailed": "{label} ação falhou: {error}",
-  "failedToSetCastVolume": "Falha ao definir o volume de transmissão: {error}",
-  "castControlsTitle": "{label} Controles",
-  "deviceVolume": "Volume do dispositivo",
-  "unavailable": "Indisponível",
-  "pause": "Pausa",
-  "syncPosition": "Posição de sincronização",
-  "stopCast": "Pare {label}",
-  "queueIsEmpty": "A fila está vazia",
-  "trackNumber": "Rastrear {number}",
-  "remotePlayback": "Reprodução Remota",
-  "castingToGoogleCast": "Transmitindo para o Google Cast",
-  "castingViaAirPlay": "Transmissão via AirPlay",
-  "castingViaDlna": "Transmissão via DLNA",
-  "secondsCount": "{seconds} segundos",
-  "longPressToUnlock": "Pressione e segure para desbloquear",
-  "off": "Desligado",
-  "streamTypeFallback": "{streamType} {number}",
-  "auto": "Auto",
-  "bitrateValueMbps": "{mbps}Mbps",
-  "bitrateOverride": "Substituição de taxa de bits",
-  "audioDelay": "Atraso de áudio",
-  "delayMinusMs": "-{value}ms",
-  "delayPlusMs": "+{value}ms",
-  "subtitleDelay": "Atraso de legenda",
-  "reset": "Reiniciar",
-  "unknown": "Desconhecido",
-  "playbackInformation": "Informações de reprodução",
-  "playback": "Reprodução",
-  "playMethod": "Método de jogo",
-  "directPlay": "Jogo direto",
-  "directStream": "Transmissão direta",
-  "transcoding": "Transcodificação",
-  "transcodeReasons": "Razões de transcodificação",
-  "player": "Jogador",
-  "container": "Recipiente",
-  "bitrate": "Taxa de bits",
-  "video": "Vídeo",
-  "resolution": "Resolução",
-  "hdr": "HDR",
-  "codec": "Codec",
-  "videoBitrate": "Taxa de bits de vídeo",
-  "track": "Acompanhar",
-  "channels": "Canais",
-  "audioBitrate": "Taxa de bits de áudio",
-  "sampleRate": "Taxa de amostragem",
-  "format": "Formatar",
-  "external": "Externo",
-  "embedded": "Integrado",
-  "castSessionError": "{protocol} erro de sessão",
-  "failedToLoadBookDetails": "Falha ao carregar detalhes do livro: {error}",
-  "epubUnavailableOnPlatform": "A renderização de EPUB no aplicativo ainda não está disponível nesta plataforma.",
-  "formatCannotRenderInApp": "Este formato (.{extension}) ainda não pode ser renderizado no aplicativo.",
-  "embeddedRenderingUnavailable": "A renderização de documentos incorporados não está disponível nesta plataforma.",
-  "couldNotOpenExternalViewer": "Não foi possível abrir o visualizador externo.",
-  "failedToOpenInAppReader": "Falha ao abrir o leitor no aplicativo: {error}",
-  "bookmarkAlreadySaved": "Marcador já salvo em {label}.",
-  "bookmarkAdded": "Marcador adicionado: {label}",
-  "noBookmarksYet": "Ainda não há favoritos.\nToque no ícone de marcador durante a leitura para salvar sua posição.",
-  "noTableOfContentsAvailable": "Nenhum índice disponível",
-  "pageLabel": "Página {number}",
-  "position": "Posição",
-  "bookReader": "Leitor de livros",
-  "formatExtension": "Formato: .{extension}",
-  "percentRead": "{percent}% lido",
-  "updating": "Atualizando...",
-  "markUnread": "Marcar como não lido",
-  "markAsRead": "Marcar como lido",
-  "reloadReader": "Recarregar leitor",
-  "noPagesFound": "Nenhuma página encontrada.",
-  "failedToDecodePageImage": "Falha ao decodificar a imagem da página.",
-  "resetZoom": "Redefinir zoom ({zoom}x)",
-  "singlePage": "Página única",
-  "twoPageSpread": "Spread de duas páginas",
-  "addBookmark": "Adicionar marcador",
-  "bookmarksEllipsis": "Marcadores...",
-  "markedAsRead": "Marcado como lido",
-  "markedAsUnread": "Marcado como não lido",
-  "failedToUpdateReadState": "Falha ao atualizar o estado de leitura: {error}",
-  "themeSystem": "Tema: Sistema",
-  "themeLight": "Tema: Luz",
-  "themeDark": "Tema: Escuro",
-  "themeSepia": "Tema: Sépia",
-  "invertColorsFixedLayout": "Inverter cores (layout fixo)",
-  "invertColorsPdf": "Inverter cores (PDF)",
-  "preparingInAppReader": "Preparando leitor no aplicativo...",
-  "pdfDataNotAvailable": "Dados PDF não disponíveis.",
-  "readerFallbackModeActive": "Modo substituto do leitor ativo",
-  "platformCannotHostDocumentEngine": "Esta plataforma não pode hospedar o mecanismo de documento incorporado para arquivos {extension}.",
-  "reloadReaderPlatformHint": "Use o Reload Reader depois de mudar para uma plataforma compatível (Android, iOS, macOS).",
-  "openExternally": "Abrir externamente",
-  "noEpubChaptersFound": "Nenhum capítulo do EPUB encontrado.",
-  "readerNotReady": "Leitor não está pronto.",
-  "seriesRecordings": "Gravações de séries",
-  "now": "Agora",
-  "sports": "Esportes",
-  "news": "Notícias",
-  "kids": "Crianças",
-  "premiere": "Estreia",
-  "guideTimeline": "Linha do tempo do guia",
-  "failedToLoadGuide": "Falha ao carregar o guia: {error}",
-  "noChannelsFound": "Nenhum canal encontrado",
-  "liveBadge": "AO VIVO",
-  "movie": "Filme",
-  "removedFromFavoriteChannels": "Removido dos canais favoritos",
-  "addedToFavoriteChannels": "Adicionado aos canais favoritos",
-  "failedToUpdateFavoriteChannel": "Falha ao atualizar canal favorito",
-  "unfavoriteChannel": "Canal não favorito",
-  "favoriteChannel": "Canal favorito",
-  "watch": "Assistir",
-  "close": "Fechar",
-  "failedToPlayChannel": "Falha ao reproduzir {name}",
-  "failedToLoadRecordings": "Falha ao carregar gravações",
-  "scheduledInNext24Hours": "Agendado para as próximas 24 horas",
-  "recentRecordings": "Gravações recentes",
-  "tvSeries": "Série de TV",
-  "failedToLoadSchedule": "Falha ao carregar agendamento",
-  "noScheduledRecordings": "Nenhuma gravação agendada",
-  "cancelRecording": "Cancelar gravação?",
-  "cancelScheduledRecordingOf": "Cancelar a gravação agendada de \"{name}\"?",
-  "no": "Não",
-  "yesCancel": "Sim, cancelar",
-  "failedToCancelRecording": "Falha ao cancelar a gravação",
-  "failedToLoadSeriesRecordings": "Falha ao carregar gravações da série",
-  "noSeriesRecordings": "Sem gravações de série",
-  "cancelSeriesRecording": "Cancelar gravação de série",
-  "cancelSeriesRecordingQuestion": "Cancelar a gravação da série?",
-  "stopRecordingName": "Parar de gravar \"{name}\"?",
-  "failedToCancelSeriesRecording": "Falha ao cancelar a gravação da série",
-  "searchThisLibrary": "Pesquisar nesta biblioteca...",
-  "searchEllipsis": "Procurar...",
-  "noResultsForQuery": "Nenhum resultado para \"{query}\"",
-  "searchFailedError": "Falha na pesquisa: {error}",
-  "seerr": "Vidente",
-  "savedMedia": "Mídia salva",
-  "tvShows": "Programas de TV",
-  "music": "Música",
-  "musicAlbums": "Álbuns de música",
-  "noMediaInFilter": "Nenhuma mídia neste filtro",
-  "noDownloadedMediaYet": "Nenhuma mídia baixada ainda",
-  "browseLibrary": "Navegar na biblioteca",
-  "deleteDownload": "Excluir download",
-  "removeItemAndFiles": "Remover \"{name}\" e seus arquivos?",
-  "tracksCount": "{count} faixas",
-  "album": "Álbum",
-  "playAlbum": "Reproduzir álbum",
-  "failedToLoadAlbum": "Falha ao carregar o álbum: {error}",
-  "noDownloadedTracksForAlbum": "Nenhuma faixa baixada encontrada para {name}.",
-  "season": "Temporada",
-  "errorLoadingEpisodes": "Erro ao carregar episódios",
-  "noDownloadedEpisodes": "Nenhum episódio baixado",
-  "deleteEpisode": "Excluir episódio",
-  "removeName": "Remover \"{name}\"?",
-  "durationMinutes": "{minutes} min",
-  "seasonEpisodeLabel": "S{season} E{episode}",
-  "episodeNumber": "Episódio {number}",
-  "seriesNotFound": "Série não encontrada",
-  "errorLoadingSeries": "Erro ao carregar a série",
-  "downloadedEpisodes": "Episódios baixados",
-  "seasonNumber": "Temporada {number}",
-  "seasonChip": "S{number}",
-  "specials": "Especiais",
-  "deleteSeason": "Excluir temporada",
-  "deleteAllEpisodesInSeason": "Excluir todos os episódios baixados em {season}?",
-  "episodeCount": "{count, plural, =1{1 episode} other{{count} episodes}}",
-  "storageManagement": "Gerenciamento de armazenamento",
-  "storageBreakdown": "Divisão de armazenamento",
-  "downloadedItems": "Itens baixados",
-  "storageLimit": "Limite de armazenamento",
-  "noLimit": "Sem limite",
-  "deleteAllDownloads": "Excluir todos os downloads",
-  "deleteAllDownloadsWarning": "Isso removerá todos os arquivos de mídia baixados e não poderá ser desfeito.",
-  "deleteAll": "Excluir tudo",
-  "deleteSelected": "Excluir selecionado",
-  "deleteSelectedCount": "Excluir {count} itens baixados?",
-  "musicAndAudiobooks": "Música e audiolivros",
-  "images": "Imagens",
-  "database": "Banco de dados",
-  "ofStorageLimit": "do limite {limit}",
-  "settings": "Configurações",
-  "authentication": "Autenticação",
-  "autoLoginServerManagement": "Login automático, gerenciamento de servidor",
-  "pinCode": "Código PIN",
-  "setUpPinCodeProtection": "Configurar proteção por código PIN",
-  "parentalControls": "Controles dos pais",
-  "contentRatingRestrictions": "Restrições de classificação de conteúdo",
-  "bitRateResolutionBehavior": "Taxa de bits, resolução, comportamento",
-  "languageSizeAppearance": "Idioma, tamanho, aparência",
-  "qualityStorage": "Qualidade, armazenamento",
-  "serverSyncAndPluginStatus": "Sincronização do servidor e status do plugin",
-  "mediaRequestIntegration": "Integração de solicitação de mídia",
-  "switchServer": "Trocar servidor",
-  "signOut": "Sair",
-  "versionLicenses": "Versão, licenças",
-  "account": "Conta",
-  "signInAndSecurity": "Login e segurança",
-  "administration": "Administração",
-  "serverSettingsUsersLibraries": "Configurações do servidor, usuários, bibliotecas",
-  "customization": "Personalização",
-  "themeAndLayout": "Tema e layout",
-  "videoAndSubtitles": "Vídeo e legendas",
-  "integrations": "Integrações",
-  "pluginAndRequests": "Plug-in e solicitações",
-  "customizeAccountPlaybackInterface": "Personalize a conta, a reprodução e o comportamento da interface",
-  "optionsCount": "{count} opções",
-  "themeAndAppearance": "Tema e aparência",
-  "focusBorderColor": "Cor da borda do foco",
-  "watchedIndicators": "Indicadores observados",
-  "always": "Sempre",
-  "hideUnwatched": "Ocultar não assistido",
-  "episodesOnly": "Apenas episódios",
-  "never": "Nunca",
-  "focusExpansionAnimation": "Animação de expansão de foco",
-  "scaleFocusedCards": "Dimensione cartões e blocos focados ou pairados",
-  "backgroundBackdrops": "Cenários de fundo",
-  "showBackdropImages": "Mostrar imagens de fundo por trás do conteúdo",
-  "seriesThumbnails": "Miniaturas de séries",
-  "seriesThumbnailsDescription": "Somente episódios: use arte da série que corresponda a cada tipo de imagem de linha",
-  "homeRowInfoOverlay": "Sobreposição de informações da linha inicial",
-  "showTitleMetadataOnHomeRows": "Mostrar título e metadados ao navegar nas linhas iniciais",
-  "clockDisplay": "Exibição do relógio",
-  "inMenus": "Nos menus",
-  "inVideo": "Em vídeo",
-  "seasonalEffects": "Efeitos sazonais",
-  "snow": "Neve",
-  "fireworks": "Fogos de artifício",
-  "confetti": "Confete",
-  "fallingLeaves": "Folhas caindo",
-  "themeMusic": "Música Temática",
-  "playThemeMusicOnDetailPages": "Reproduzir música tema nas páginas de detalhes",
-  "themeMusicVolume": "Volume da música temática",
-  "percentValue": "{value}%",
-  "themeMusicOnHomeRows": "Música tema nas linhas iniciais",
-  "playWhenBrowsingHomeScreen": "Jogue enquanto navega na tela inicial",
-  "detailsBackgroundBlur": "Detalhes do desfoque de fundo",
-  "pixelValue": "{value}px",
-  "browsingBackgroundBlur": "Navegando em desfoque de fundo",
-  "maxStreamingBitrate": "Taxa máxima de bits de streaming",
-  "maxResolution": "Resolução máxima",
-  "playerZoomMode": "Modo de zoom do jogador",
-  "fit": "Ajustar",
-  "autoCrop": "Corte automático",
-  "stretch": "Esticar",
-  "refreshRateSwitching": "Mudança de taxa de atualização",
-  "disabled": "Desabilitado",
-  "scaleOnTv": "Escala na TV",
-  "scaleOnDevice": "Dimensionar no dispositivo",
-  "trickPlay": "Truque",
-  "showPreviewThumbnailsWhenSeeking": "Mostrar miniaturas de visualização ao pesquisar",
-  "showDescriptionOnPause": "Mostrar descrição em pausa",
-  "dimVideoShowOverview": "Escureça o vídeo e mostre o texto de visão geral durante a pausa",
-  "osdLockButton": "Botão de bloqueio OSD",
-  "osdLockButtonDescription": "Mostrar um botão de bloqueio que bloqueia a entrada por toque até ser pressionado por muito tempo",
-  "audioBehavior": "Comportamento de áudio",
-  "downmixToStereo": "Downmix para estéreo",
-  "defaultAudioLanguage": "Idioma de áudio padrão",
-  "autoServerDefault": "Automático (padrão do servidor)",
-  "english": "Inglês",
-  "spanish": "Espanhol",
-  "french": "Francês",
-  "german": "Alemão",
-  "italian": "italiano",
-  "portuguese": "Português",
-  "japanese": "japonês",
-  "korean": "coreano",
-  "chinese": "chinês",
-  "russian": "russo",
-  "arabic": "árabe",
-  "hindi": "hindi",
-  "dutch": "Holandês",
-  "swedish": "sueco",
-  "norwegian": "norueguês",
-  "danish": "dinamarquês",
-  "finnish": "finlandês",
-  "polish": "polonês",
-  "ac3Passthrough": "Passagem AC3",
-  "dtsPassthrough": "Passagem DTS",
-  "trueHdSupport": "Suporte TrueHD",
-  "enableDtsPassthrough": "Áudio Bitstream DTS apenas para AVR; requer suporte de receptor e trilha de origem DTS",
-  "enableTrueHdAudio": "Ative o áudio TrueHD (pode não funcionar em todas as plataformas)",
-  "nightMode": "Modo noturno",
-  "compressDynamicRange": "Comprimir faixa dinâmica",
-  "advancedMpv": "Avançado mpv",
-  "enableCustomMpvConf": "Habilitar mpv.conf personalizado",
-  "applyMpvConfBeforePlayback": "Aplique um mpv.conf especificado pelo usuário antes do início da reprodução",
-  "unsafeAdvancedMpvOptions": "Opções avançadas de mpv inseguras",
-  "unsafeMpvOptionsDescription": "Permita um conjunto mais amplo de opções de mpv. Pode interromper o comportamento de reprodução.",
-  "hardwareDecoding": "Decodificação de hardware",
-  "hardwareDecodingSubtitle": "Pode melhorar o desempenho, mas pode causar problemas de reprodução em alguns dispositivos.",
-  "nextUpAndQueuing": "Próximo e na fila",
-  "extended": "Estendido",
-  "minimal": "Mínimo",
-  "nextUpTimeout": "Próximo tempo limite",
-  "secondsValue": "{value}s",
-  "mediaQueuing": "Enfileiramento de mídia",
-  "autoQueueNextEpisodes": "Colocar automaticamente os próximos episódios na fila",
-  "stillWatchingPrompt": "Ainda assistindo ao prompt",
-  "afterEpisodesAndHours": "Depois de episódios de {episodes} / {hours}h",
-  "resumeAndSkip": "Retomar e pular",
-  "resumeRewind": "Retomar retrocesso",
-  "unpauseRewind": "Retomar retrocesso",
-  "fiveSeconds": "5 segundos",
-  "tenSeconds": "10 segundos",
-  "fifteenSeconds": "15 segundos",
-  "thirtySeconds": "30 segundos",
-  "skipBackLength": "Comprimento do salto para trás",
-  "skipForwardLength": "Pular comprimento para frente",
-  "customMpvConfPath": "Caminho mpv.conf personalizado",
-  "notSetMpvConf": "Não definido. Moonfin tentará um mpv.conf padrão nas pastas app/data.",
-  "selectMpvConf": "Selecione mpv.conf",
-  "pathToMpvConf": "/caminho/para/mpv.conf",
-  "subtitleStyleDescription": "As configurações de estilo (tamanho, cor, deslocamento) aplicam-se a legendas baseadas em texto (SRT, VTT, TTML). As legendas ASS/SSA usam seu próprio estilo incorporado, a menos que \"ASS/SSA Direct Play\" esteja desativado. Legendas de bitmap (PGS, DVB, VobSub) não podem ser reestilizadas.",
-  "defaultSubtitleLanguage": "Idioma de legenda padrão",
-  "defaultToNoSubtitles": "Padrão sem legendas",
-  "turnOffSubtitlesByDefault": "Desative as legendas por padrão",
-  "subtitleSize": "Tamanho da legenda",
-  "textFillColor": "Cor de preenchimento de texto",
-  "backgroundColor": "Cor de fundo",
-  "textStrokeColor": "Cor do traço do texto",
-  "subtitleCustomization": "Personalização de legendas",
-  "subtitleCustomizationDescription": "Personalize a aparência das legendas",
-  "subtitlePreviewText": "A rápida raposa marrom salta sobre o cachorro preguiçoso",
-  "verticalOffset": "Deslocamento vertical",
-  "pgsDirectPlay": "Jogo direto PGS",
-  "directPlayPgsSubtitles": "Legendas PGS com reprodução direta",
-  "assSsaDirectPlay": "Jogo direto ASS/SSA",
-  "directPlayAssSsaSubtitles": "Legendas ASS/SSA com reprodução direta",
-  "white": "Branco",
-  "black": "Preto",
-  "yellow": "Amarelo",
-  "green": "Verde",
-  "cyan": "Ciano",
-  "red": "Vermelho",
-  "transparent": "Transparente",
-  "semiTransparentBlack": "Preto Semitransparente",
-  "global": "Global",
-  "desktop": "Área de trabalho",
-  "mobile": "Móvel",
-  "tv": "TV",
-  "loadedProfileSettings": "Configurações de perfil {profile} carregadas.",
-  "failedToLoadProfileSettings": "Falha ao carregar as configurações do perfil {profile}.",
-  "syncedSettingsToProfile": "Configurações locais sincronizadas com o perfil {profile}.",
-  "customizationProfile": "Perfil de personalização",
-  "customizationProfileDescription": "Escolha o perfil para carregar, editar e sincronizar. Global se aplica a todos os lugares, a menos que um perfil de dispositivo o substitua. O ponto verde marca o perfil do seu dispositivo atual.",
-  "loadProfile": "Carregar perfil",
-  "syncing": "Sincronizando...",
-  "syncToProfile": "Sincronizar com perfil",
-  "profileSyncHidden": "Sincronização de perfil oculta",
-  "enablePluginSyncDescription": "Ative a sincronização do plug-in do servidor nas configurações do plug-in para mostrar os controles do perfil aqui.",
-  "quality": "Qualidade",
-  "defaultDownloadQuality": "Qualidade de download padrão",
-  "network": "Rede",
-  "wifiOnlyDownloads": "Downloads somente WiFi",
-  "onlyDownloadOnWifi": "Baixe apenas quando conectado ao WiFi",
-  "storage": "Armazenar",
-  "storageUsed": "Armazenamento usado",
-  "manage": "Gerenciar",
-  "calculating": "Calculando...",
-  "downloadLocation": "Local de download",
-  "defaultLabel": "Padrão",
-  "saveToDownloadsFolder": "Salvar na pasta Downloads",
-  "downloadsVisibleToOtherApps": "Downloads/Moonfin – visível para outros aplicativos",
-  "dangerZone": "Zona de perigo",
-  "clearAllDownloads": "Limpar todos os downloads",
-  "original": "Original",
-  "changeDownloadLocation": "Alterar local de download",
-  "changeDownloadLocationDescription": "Novos downloads serão salvos na pasta selecionada. Os downloads existentes permanecerão em seu local atual e poderão ser gerenciados nas configurações de armazenamento.",
-  "confirm": "Confirmar",
-  "cannotWriteToFolder": "Não é possível gravar na pasta selecionada. Escolha um local diferente ou conceda permissões de armazenamento.",
-  "saveToDownloadsFolderQuestion": "Salvar na pasta Downloads?",
-  "saveToDownloadsFolderDescription": "A mídia baixada será salva em Downloads/Moonfin no seu dispositivo. Esses arquivos ficarão visíveis para outros aplicativos, como sua galeria ou reprodutor de música.\n\nOs downloads existentes permanecerão no local atual.",
-  "enable": "Habilitar",
-  "clearAllDownloadsWarning": "Isso excluirá todas as mídias baixadas e não poderá ser desfeito.",
-  "clearAll": "Limpar tudo",
-  "navigationStyle": "Estilo de navegação",
-  "topBar": "Barra superior",
-  "leftSidebar": "Barra lateral esquerda",
-  "showShuffleButton": "Mostrar botão aleatório",
-  "showGenresButton": "Botão Mostrar gêneros",
-  "showFavoritesButton": "Mostrar botão Favoritos",
-  "showLibrariesInToolbar": "Mostrar bibliotecas na barra de ferramentas",
-  "navbarOpacity": "Opacidade da barra de navegação",
-  "navbarColor": "Cor da barra de navegação",
-  "gray": "Cinza",
-  "darkBlue": "Azul escuro",
-  "purple": "Roxo",
-  "teal": "Cerceta",
-  "navy": "Marinha",
-  "charcoal": "Carvão",
-  "brown": "Marrom",
-  "darkRed": "Vermelho Escuro",
-  "darkGreen": "Verde Escuro",
-  "slate": "Ardósia",
-  "indigo": "Índigo",
-  "libraryDisplay": "Exibição da Biblioteca",
-  "posterLabel": "Poster",
-  "thumbnailLabel": "Miniatura",
-  "bannerLabel": "Bandeira",
-  "overridePerLibrarySettings": "Substituir configurações por biblioteca",
-  "applyImageTypeToAllLibraries": "Aplicar tipo de imagem a todas as bibliotecas",
-  "multiServerLibraries": "Bibliotecas multiservidor",
-  "showLibrariesFromAllServers": "Mostrar bibliotecas de todos os servidores conectados",
-  "enableFolderView": "Ativar visualização de pasta",
-  "showFolderBrowsingOption": "Mostrar opção de navegação em pastas",
-  "libraryVisibility": "Visibilidade da Biblioteca",
-  "libraryVisibilityDescription": "Alternar a visibilidade da página inicial por biblioteca. Reinicie o Moonfin para que as alterações tenham efeito.",
-  "showInNavigation": "Mostrar na navegação",
-  "showInLatestMedia": "Mostrar na mídia mais recente",
-  "sourceLibraries": "Bibliotecas de origem",
-  "sourceCollections": "Coleções de origem",
-  "excludedGenres": "Gêneros excluídos",
-  "selectAll": "Selecionar tudo",
-  "itemsSelected": "{count} selecionado",
-  "mediaBar": "Barra de mídia",
-  "mediaBarMode": "Estilo da barra de mídia",
-  "mediaBarModeDescription": "Escolha entre vários estilos de barra de mídia ou desative a barra de mídia",
-  "mediaBarModeMoonfin": "Barbatana Lunar",
-  "mediaBarModeMakd": "MakD",
-  "mediaBarModeOff": "Desligado",
-  "enableMediaBar": "Ativar barra de mídia",
-  "showFeaturedContentSlideshow": "Mostrar apresentação de slides de conteúdo em destaque na página inicial",
-  "contentType": "Tipo de conteúdo",
-  "moviesAndTvShows": "Filmes e programas de TV",
-  "moviesOnly": "Apenas filmes",
-  "tvShowsOnly": "Somente programas de TV",
-  "itemCount": "Contagem de itens",
-  "noneSelected": "Nenhum selecionado",
-  "noneExcluded": "Nenhum excluído",
-  "autoAdvance": "Avanço automático",
-  "autoAdvanceSlides": "Avançar automaticamente para o próximo slide",
-  "autoAdvanceInterval": "Intervalo de avanço automático",
-  "trailerPreview": "Pré-visualização do trailer",
-  "autoPlayTrailers": "Reproduza trailers automaticamente na barra de mídia após 3 segundos",
-  "episodePreview": "Prévia do episódio",
-  "episodePreviewDescription": "Reproduza uma visualização in-line de 30 segundos em cartões focados, pairados ou pressionados por muito tempo",
-  "previewAudio": "Visualizar áudio",
-  "enablePreviewAudio": "Ativar áudio para prévias de trailers e episódios",
-  "latestMedia": "Últimas mídias",
-  "recentlyReleased": "Lançado recentemente",
-  "myMedia": "Minha mídia",
-  "myMediaSmall": "Minha mídia (pequena)",
-  "continueWatching": "Continuar assistindo",
-  "resumeAudio": "Retomar áudio",
-  "resumeBooks": "Retomar livros",
-  "activeRecordings": "Gravações Ativas",
-  "playlists": "Listas de reprodução",
-  "liveTV": "TV ao vivo",
-  "homeSections": "Seções iniciais",
-  "resetToDefaults": "Redefinir para os padrões",
-  "homeRowPosterSize": "Tamanho do pôster da linha inicial",
-  "perRowImageTypeSelection": "Seleção de tipo de imagem por linha",
-  "configureImageTypeForEachRow": "Configure o tipo de imagem para cada linha inicial habilitada",
-  "mergeContinueWatchingAndNextUp": "Mesclar Continuar Assistindo e Próximo",
-  "combineBothRows": "Combine as duas linhas em uma única seção inicial",
-  "perRowImageType": "Tipo de imagem por linha",
-  "perRowSettings": "Configurações por linha",
-  "autoLogin": "Login automático",
-  "lastUser": "Último usuário",
-  "specificUser": "Usuário específico",
-  "alwaysAuthenticate": "Sempre autenticar",
-  "requirePasswordWithToken": "Exigir senha mesmo com token armazenado",
-  "confirmExit": "Confirmar saída",
-  "showConfirmationBeforeExiting": "Mostrar confirmação antes de sair",
-  "blockContentWithRatings": "Bloqueie conteúdo com as seguintes classificações:",
-  "noContentRatingsFound": "Nenhuma classificação de conteúdo foi encontrada neste servidor ainda.",
-  "couldNotLoadServerRatings": "Não foi possível carregar as classificações do servidor. Mostrando apenas avaliações salvas.",
-  "couldNotRefreshRatings": "Não foi possível atualizar as classificações do servidor. Mostrando avaliações salvas.",
-  "enablePinCode": "Ativar código PIN",
-  "requirePinToAccess": "Exigir um PIN para acessar sua conta",
-  "changePin": "Alterar PIN",
-  "setNewPinCode": "Defina um novo código PIN",
-  "removePin": "Remover PIN",
-  "removePinProtection": "Remover proteção do código PIN",
-  "screensaver": "Protetor de tela",
-  "inAppScreensaver": "Protetor de tela no aplicativo",
-  "enableBuiltInScreensaver": "Habilite o protetor de tela integrado",
-  "mode": "Modo",
-  "libraryArt": "Arte da Biblioteca",
-  "logo": "Logotipo",
-  "clock": "Relógio",
-  "timeout": "Tempo esgotado",
-  "minutesShort": "{minutes} min",
-  "dimmingLevel": "Nível de escurecimento",
-  "maxAgeRating": "Classificação etária máxima",
-  "any": "Qualquer",
-  "agePlusValue": "{age}+",
-  "requireAgeRating": "Exigir classificação etária",
-  "onlyShowRatedContent": "Mostrar apenas conteúdo avaliado",
-  "showClock": "Mostrar relógio",
-  "displayClockDuringScreensaver": "Exibir relógio durante o protetor de tela",
-  "rottenTomatoesCritics": "Tomates podres (críticos)",
-  "rottenTomatoesAudience": "Tomates podres (público)",
-  "imdb": "IMDB",
-  "tmdb": "TMDB",
-  "metacritic": "Metacrítico",
-  "metacriticUser": "Metacrítico (usuário)",
-  "trakt": "Trakt",
-  "letterboxd": "Caixa de correio",
-  "myAnimeList": "Minha lista de animes",
-  "aniList": "ListaAni",
-  "communityRating": "Classificação da comunidade",
-  "ratings": "Avaliações",
-  "additionalRatings": "Avaliações Adicionais",
-  "showMdbListAndTmdbRatings": "Mostrar classificações MDBList e TMDB",
-  "ratingLabels": "Etiquetas de classificação",
-  "showLabelsNextToIcons": "Mostrar rótulos ao lado dos ícones de classificação",
-  "ratingBadges": "Selos de classificação",
-  "showDecorativeBadges": "Mostrar emblemas decorativos atrás das avaliações",
-  "episodeRatings": "Avaliações de episódios",
-  "showRatingsOnEpisodes": "Mostrar classificações em episódios individuais",
-  "ratingSources": "Fontes de classificação",
-  "ratingSourcesDescription": "Ative e reordene as fontes de classificação mostradas em todo o aplicativo",
-  "pluginLabel": "Plug-in",
-  "pluginDetected": "Plug-in detectado",
-  "pluginNotDetected": "Plug-in não detectado",
-  "pluginDetectedDescription": "Plug-in de servidor detectado. A sincronização é ativada automaticamente na primeira vez que o plugin é encontrado.",
-  "pluginNotDetectedDescription": "O plugin do servidor não foi detectado no momento. As configurações locais ainda usam seus valores salvos ou padrões integrados.",
-  "pluginStatusVersion": "{status}\nVersão: {version}",
-  "availableServices": "Serviços disponíveis",
-  "serverPluginSync": "Sincronização de plug-in de servidor",
-  "syncSettingsWithPlugin": "Sincronizar configurações com o plugin do servidor",
-  "whatSyncControls": "Quais controles de sincronização",
-  "syncControlsDescription": "A sincronização controla apenas se as configurações apoiadas pelo plug-in são enviadas e extraídas do servidor. A seleção de perfil e as ações de sincronização de perfil estão nas configurações de personalização quando a sincronização do plug-in está habilitada.",
-  "recentRequests": "Solicitações recentes",
-  "recentlyAdded": "Adicionado recentemente",
-  "trending": "Tendências",
-  "popularMovies": "Filmes populares",
-  "movieGenres": "Gêneros de filmes",
-  "upcomingMovies": "Próximos filmes",
-  "studios": "Estúdios",
-  "popularSeries": "Séries populares",
-  "seriesGenres": "Gêneros de séries",
-  "upcomingSeries": "Próximas séries",
-  "networks": "Redes",
-  "resetRowsToDefaults": "Redefinir linhas para os padrões",
-  "enableSeerr": "Habilitar Seer",
-  "showSeerrInNavigation": "Mostrar Seerr na navegação (requer plugin de servidor)",
-  "seerrUnavailable": "Indisponível porque o suporte do plugin do servidor Seerr está desativado.",
-  "nsfwFilter": "Filtro NSFW",
-  "hideAdultContent": "Ocultar conteúdo adulto nos resultados",
-  "loggedInAs": "Conectado como: {username}",
-  "discoverRows": "Descubra linhas",
-  "discoverRowsDescriptionPlugin": "Arraste para reordenar. Habilite ou desabilite linhas. A ordem das linhas habilitada é sincronizada com o plugin Moonfin.",
-  "discoverRowsDescription": "Arraste para reordenar. Habilite ou desabilite linhas.",
-  "enabled": "Habilitado",
-  "hidden": "Escondido",
-  "aboutTitle": "Sobre",
-  "versionValue": "Versão {version}",
-  "openSourceLicenses": "Licenças de código aberto",
-  "sourceCode": "Código Fonte",
-  "sourceCodeUrl": "https://github.com/Moonfin-Client/Mobile-Desktop",
-  "checkForUpdatesNow": "Verifique se há atualizações agora",
-  "checksLatestDesktopRelease": "Verifica a versão de desktop mais recente para esta plataforma",
-  "youAreUpToDate": "Você está atualizado.",
-  "couldNotCheckForUpdates": "Não foi possível verificar atualizações no momento.",
-  "noCompatibleUpdate": "Nenhum pacote de atualização compatível encontrado para esta plataforma.",
-  "updateChecksNotSupported": "As verificações de atualização não são suportadas nesta plataforma.",
-  "updateNotificationsDisabled": "As notificações de atualização estão desativadas.",
-  "pleaseWaitBeforeChecking": "Aguarde antes de verificar novamente.",
-  "latestUpdateAlreadyShown": "A última atualização já foi mostrada.",
-  "updateAvailable": "Atualização disponível.",
-  "updateAvailableVersion": "Atualização disponível: v{version}",
-  "updateNotifications": "Notificações de atualização",
-  "showWhenUpdatesAvailable": "Mostrar quando atualizações estão disponíveis",
-  "updateAvailableTitle": "v{version} Disponível",
-  "readReleaseNotes": "Leia as notas de versão",
-  "downloadingUpdate": "Baixando atualização...",
-  "updateDownloadFailed": "Falha no download da atualização. Por favor, tente novamente.",
-  "openReleasesPage": "Abrir página de lançamentos",
-  "navigation": "Navegação",
-  "watchedIndicatorsBackdrops": "Indicadores observados, cenários",
-  "focusColorWatchedIndicatorsBackdrops": "Cor do foco, indicadores observados, cenários",
-  "navbarStyleToolbarAppearance": "Estilo da barra de navegação, botões da barra de ferramentas, aparência",
-  "reorderToggleHomeRows": "Reordenar e alternar linhas iniciais",
-  "featuredContentAppearance": "Conteúdo em destaque, aparência",
-  "posterSizeImageTypeFolderView": "Tamanho do pôster, tipo de imagem, visualização de pasta",
-  "mdbListTmdbRatingSources": "MDBList, TMDB e fontes de classificação",
-  "gbValue": "{value} GB",
-  "clear": "Claro",
-  "browse": "Navegar",
-  "noResults": "Nenhum resultado",
-  "seerrAvailableStatus": "Disponível",
-  "seerrRequestedStatus": "Solicitado",
-  "itemsCount": "{count} Itens",
-  "seerrSettings": "Configurações do visualizador",
-  "requestMore": "Solicite mais",
-  "request": "Solicitar",
-  "cancelRequest": "Cancelar solicitação",
-  "playInMoonfin": "Jogue em Moonfin",
-  "requestedByName": "Solicitado por {name}",
-  "approve": "Aprovar",
-  "declineAction": "Declínio",
-  "similar": "Semelhante",
-  "recommendations": "Recomendações",
-  "cancelRequestForTitle": "Cancelar solicitação de \"{title}\"?",
-  "cancelCountRequestsForTitle": "Cancelar solicitações {count} para \"{title}\"?",
-  "keep": "Manter",
-  "itemNotFoundInLibrary": "Item não encontrado em sua biblioteca Moonfin",
-  "errorSearchingLibrary": "Erro ao pesquisar biblioteca",
-  "budgetAmount": "Orçamento: ${amount}",
-  "revenueAmount": "Receita: ${amount}",
-  "seasonsCount": "{count} {label}",
-  "requestSeriesOrMovie": "Solicitar {type}",
-  "submitRequest": "Enviar solicitação",
-  "allSeasons": "Todas as temporadas",
-  "advancedOptions": "Opções Avançadas",
-  "noServiceServersConfigured": "Nenhum servidor de serviço configurado",
-  "server": "Servidor",
-  "qualityProfile": "Perfil de qualidade",
-  "rootFolder": "Pasta raiz",
-  "showMore": "Mostrar mais",
-  "appearances": "Aparências",
-  "crewSection": "Equipe",
-  "ageValue": "idade {age}",
-  "noRequests": "Nenhuma solicitação",
-  "pendingStatus": "Pendente",
-  "declinedStatus": "Recusado",
-  "partiallyAvailable": "Parcialmente disponível",
-  "downloadingStatus": "Baixando",
-  "approvedStatus": "Aprovado",
-  "notRequestedStatus": "Não solicitado",
-  "blocklistedStatus": "Na lista de bloqueio",
-  "deletedStatus": "Excluído",
-  "tmdbScore": "Pontuação TMDB",
-  "releaseDateLabel": "Data de lançamento",
-  "firstAirDateLabel": "Primeira data de transmissão",
-  "revenueLabel": "Receita",
-  "runtimeLabel": "Tempo de execução",
-  "budgetLabel": "Orçamento",
-  "originalLanguageLabel": "Idioma Original",
-  "seasonsLabel": "Temporadas",
-  "episodesLabel": "Episódios",
   "access": "Acesso",
   "add": "Adicionar",
   "address": "Endereço",
   "analytics": "Análise",
   "catalog": "Catálogo",
-  "content": "Contente",
+  "content": "Conteúdo",
   "copy": "Cópia",
   "create": "Criar",
   "disable": "Desativar",
@@ -5657,14 +4868,14 @@
   "encoding": "Codificação",
   "error": "Erro",
   "forward": "Avançar",
-  "general": "Em geral",
+  "general": "Geral",
   "go": "Ir",
   "install": "Instalar",
   "installed": "Instalado",
   "interval": "Intervalo",
   "name": "Nome",
   "networking": "Rede",
-  "next": "Próximo",
+  "next": "Seguinte",
   "path": "Caminho",
   "paused": "Pausado",
   "permissions": "Permissões",
@@ -5677,80 +4888,122 @@
   "revoke": "Revogar",
   "role": "Papel",
   "root": "Raiz",
-  "run": "Correr",
+  "run": "Executar",
   "search": "Procurar",
-  "select": "Selecione",
+  "select": "Selecionar",
   "send": "Enviar",
   "sessions": "Sessões",
   "set": "Definir",
-  "status": "Status",
+  "status": "Estado",
   "stop": "Parar",
   "streaming": "Transmissão",
   "time": "Tempo",
-  "trickplay": "Truques",
+  "trickplay": "Trickplay",
   "uninstall": "Desinstalar",
   "up": "Acima",
   "update": "Atualizar",
-  "upload": "Carregar",
+  "upload": "Enviar",
   "unmute": "Ativar som",
   "mute": "Mudo",
   "branding": "Marca",
   "adminDrawerDashboard": "Painel",
   "adminDrawerAnalytics": "Análise",
-  "adminDrawerSettings": "Configurações",
+  "adminDrawerSettings": "Definições",
   "adminDrawerBranding": "Marca",
-  "adminDrawerUsers": "Usuários",
+  "adminDrawerUsers": "Utilizadores",
   "adminDrawerLibraries": "Bibliotecas",
   "adminDrawerTranscoding": "Transcodificação",
   "adminDrawerResume": "Retomar",
   "adminDrawerStreaming": "Transmissão",
-  "adminDrawerTrickplay": "Truques",
+  "adminDrawerTrickplay": "Trickplay",
   "adminDrawerDevices": "Dispositivos",
   "adminDrawerActivity": "Atividade",
   "adminDrawerNetworking": "Rede",
   "adminDrawerApiKeys": "Chaves de API",
   "adminDrawerBackups": "Cópias de segurança",
-  "adminDrawerLogs": "Registros",
+  "adminDrawerLogs": "Registos",
   "adminDrawerScheduledTasks": "Tarefas agendadas",
-  "adminDrawerPlugins": "Plug-ins",
+  "adminDrawerPlugins": "Plugins",
   "adminDrawerRepositories": "Repositórios",
   "adminDrawerLiveTv": "TV ao vivo",
   "adminExitTooltip": "Sair do administrador",
   "adminDashboardLoadFailed": "Falha ao carregar o painel",
-  "adminMediaOverview": "Visão geral da mídia",
-  "adminMediaTotalsError": "Não foi possível carregar os totais de mídia do servidor.",
-  "adminMediaOverviewSubtitle": "Uma leitura rápida sobre a quantidade de conteúdo neste servidor.",
-  "adminPluginUpdatesAvailable": "Atualizações de plug-in disponíveis: {count}",
-  "adminPluginsRequiringRestart": "Plugins que requerem reinicialização: {count}",
+  "adminMediaOverview": "Vista geral do conteúdo",
+  "adminMediaTotalsError": "Não foi possível carregar os totais de conteúdo do servidor.",
+  "adminMediaOverviewSubtitle": "Uma visão rápida sobre a quantidade de conteúdo neste servidor.",
+  "adminPluginUpdatesAvailable": "Atualizações de plugin disponíveis: {count}",
+  "@adminPluginUpdatesAvailable": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "adminPluginsRequiringRestart": "Plugins que requerem reinício: {count}",
+  "@adminPluginsRequiringRestart": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "adminFailedScheduledTasks": "Tarefas agendadas com falha: {count}",
-  "adminRecentAlertEntries": "Entradas recentes de aviso/erro: {count}",
-  "analyticsMediaDistribution": "Distribuição de mídia",
+  "@adminFailedScheduledTasks": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "adminRecentAlertEntries": "Registos recentes de aviso/erro: {count}",
+  "@adminRecentAlertEntries": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "analyticsMediaDistribution": "Distribuição de conteúdo",
   "analyticsVideoCodecs": "Codecs de vídeo",
   "analyticsAudioCodecs": "Codecs de áudio",
   "analyticsContainers": "Recipientes",
-  "analyticsTopGenres": "Principais gêneros",
+  "analyticsTopGenres": "Principais géneros",
   "analyticsReleaseYears": "Anos de lançamento",
   "analyticsContentRatings": "Avaliações de conteúdo",
-  "analyticsRuntimeBuckets": "Baldes de tempo de execução",
-  "analyticsFileFormats": "Formatos de arquivo",
+  "analyticsRuntimeBuckets": "Intervalos de duração",
+  "analyticsFileFormats": "Formatos de ficheiro",
   "analyticsNoData": "Nenhum dado disponível.",
-  "adminServerInfo": "Informações do servidor",
-  "adminRestartPending": "Reinicialização pendente",
+  "adminServerInfo": "Informação do servidor",
+  "adminRestartPending": "Reinício pendente",
   "adminServerPaths": "Caminhos de servidor",
   "adminServerActions": "Ações do servidor",
-  "adminRestartServer": "Reinicie o servidor",
+  "adminRestartServer": "Reinicia o servidor",
   "adminShutdownServer": "Desligar servidor",
   "adminScanLibraries": "Digitalizar bibliotecas",
   "adminLibraryScanStarted": "Verificação da biblioteca iniciada",
   "errorGeneric": "Erro: {error}",
-  "adminServerRebootInProgress": "Reinicialização do servidor em andamento",
-  "adminServerRebootMessage": "Reinicialização do servidor em andamento, reinicie o Moonfin",
+  "@errorGeneric": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminServerRebootInProgress": "Reinício do servidor em curso",
+  "adminServerRebootMessage": "Reinício do servidor em curso, reinicia o Moonfin",
   "adminActiveSessions": "Sessões ativas",
   "adminSessionsLoadFailed": "Falha ao carregar sessões",
   "adminNoActiveSessions": "Nenhuma sessão ativa",
   "adminRecentActivity": "Atividade recente",
   "adminNoRecentActivity": "Nenhuma atividade recente",
   "adminCommandFailed": "Falha no comando: {error}",
+  "@adminCommandFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminSendMessage": "Enviar mensagem",
   "adminMessageTextHint": "Texto da mensagem",
   "adminSetVolume": "Definir volume",
@@ -5761,7 +5014,7 @@
   "sessionVolumeDown": "Volume –",
   "sessionVolumeUp": "Vol +",
   "uhd4k": "4K",
-  "nowPlaying": "Agora jogando",
+  "nowPlaying": "A reproduzir",
   "volume": "Volume",
   "actions": "Ações",
   "videoCodec": "Codec de vídeo",
@@ -5772,169 +5025,466 @@
   "adminDisconnect": "Desconectar",
   "adminClearDates": "Limpar datas",
   "adminActivityLoadFailed": "Falha ao carregar o log de atividades: {error}",
+  "@adminActivityLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminNoActivityEntries": "Nenhuma entrada de atividade",
   "adminEditDeviceName": "Editar nome do dispositivo",
   "adminCustomName": "Nome personalizado",
   "adminDeviceNameUpdated": "Nome do dispositivo atualizado",
   "adminDeviceUpdateFailed": "Falha ao atualizar o dispositivo: {error}",
-  "adminDeleteDevice": "Excluir dispositivo",
-  "adminDeviceDeleted": "Dispositivo excluído",
-  "adminDeviceDeleteFailed": "Falha ao excluir dispositivo: {error}",
+  "@adminDeviceUpdateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminDeleteDevice": "Eliminar dispositivo",
+  "adminDeviceDeleted": "Dispositivo eliminado",
+  "adminDeviceDeleteFailed": "Falha ao eliminar dispositivo: {error}",
+  "@adminDeviceDeleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminDevicesLoadFailed": "Falha ao carregar dispositivos",
   "adminSearchDevices": "Pesquisar dispositivos",
   "adminThisDevice": "Este dispositivo",
   "adminEditName": "Editar nome",
   "adminLibrariesLoadFailed": "Falha ao carregar bibliotecas",
   "adminNoLibraries": "Nenhuma biblioteca configurada",
-  "adminScanAllLibraries": "Digitalize todas as bibliotecas",
+  "adminScanAllLibraries": "Digitalizar todas as bibliotecas",
   "adminAddLibrary": "Adicionar biblioteca",
   "adminScanFailed": "Falha ao iniciar a verificação: {error}",
+  "@adminScanFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminRenameLibrary": "Renomear biblioteca",
   "adminNewName": "Novo nome",
   "adminLibraryRenamed": "Biblioteca renomeada para \"{name}\"",
+  "@adminLibraryRenamed": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminRenameFailed": "Falha ao renomear: {error}",
-  "adminDeleteLibrary": "Excluir biblioteca",
-  "adminLibraryDeleted": "Biblioteca \"{name}\" excluída",
-  "adminLibraryDeleteFailed": "Falha ao excluir biblioteca: {error}",
+  "@adminRenameFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminDeleteLibrary": "Eliminar biblioteca",
+  "adminLibraryDeleted": "Biblioteca \"{name}\" eliminada",
+  "@adminLibraryDeleted": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminLibraryDeleteFailed": "Falha ao eliminar biblioteca: {error}",
+  "@adminLibraryDeleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminAddPathFailed": "Falha ao adicionar caminho: {error}",
+  "@adminAddPathFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminRemovePath": "Remover caminho",
   "adminRemovePathConfirm": "Remover \"{path}\" desta biblioteca?",
+  "@adminRemovePathConfirm": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
   "adminRemovePathFailed": "Falha ao remover caminho: {error}",
-  "adminLibraryOptionsSaved": "Opções de biblioteca salvas",
-  "adminLibraryOptionsSaveFailed": "Falha ao salvar opções: {error}",
+  "@adminRemovePathFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminLibraryOptionsSaved": "Opções de biblioteca guardadas",
+  "adminLibraryOptionsSaveFailed": "Falha ao guardar opções: {error}",
+  "@adminLibraryOptionsSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminLibraryLoadFailed": "Falha ao carregar a biblioteca",
-  "adminNoMediaPaths": "Nenhum caminho de mídia configurado",
+  "adminNoMediaPaths": "Nenhum caminho de conteúdo configurado",
   "adminAddPath": "Adicionar caminho",
-  "adminBrowseFilesystem": "Navegue pelo sistema de arquivos do servidor:",
-  "adminSaveOptions": "Salvar opções",
+  "adminBrowseFilesystem": "Navega pelo sistema de ficheiros do servidor:",
+  "adminSaveOptions": "Guardar opções",
   "adminPreferredMetadataLanguage": "Idioma de metadados preferido",
   "adminMetadataLanguageHint": "por exemplo en, de, fr",
   "adminMetadataCountryCode": "Código do país dos metadados",
   "adminMetadataCountryHint": "por exemplo EUA, DE, FR",
   "adminLibraryNameRequired": "O nome da biblioteca é obrigatório",
   "adminLibraryCreateFailed": "Falha ao criar biblioteca: {error}",
+  "@adminLibraryCreateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminLibraryName": "Nome da Biblioteca",
   "adminSelectedPaths": "Caminhos selecionados:",
   "adminNoPathsAdded": "Nenhum caminho adicionado (pode ser adicionado posteriormente)",
   "adminCreateLibrary": "Criar biblioteca",
   "paths": "Caminhos:",
-  "adminDisableUser": "Desabilitar usuário",
-  "adminEnableUser": "Habilitar usuário",
-  "adminDisableUserConfirm": "Desativar {name}? Eles não poderão fazer login.",
-  "adminEnableUserConfirm": "Habilitar {name}? Eles poderão fazer login novamente.",
-  "adminUserDisabled": "Usuário \"{name}\" desativado",
-  "adminUserEnabled": "Usuário \"{name}\" ativado",
-  "adminUserPolicyUpdateFailed": "Falha ao atualizar a política do usuário: {error}",
-  "adminUsersLoadFailed": "Falha ao carregar usuários",
-  "adminSearchUsers": "Pesquisar usuários",
-  "adminEditUser": "Editar usuário",
-  "adminAddUser": "Adicionar usuário",
-  "adminUserCreateFailed": "Falha ao criar usuário: {error}",
-  "adminCreateUser": "Criar usuário",
-  "adminPasswordOptional": "Senha (opcional)",
-  "adminUsernameRequired": "O nome de usuário não pode ficar vazio",
-  "adminNoProfileChanges": "Nenhuma alteração de perfil para salvar",
-  "adminProfileSaved": "Perfil salvo",
-  "adminSaveFailed": "Falha ao salvar: {error}",
-  "adminPermissionsSaved": "Permissões salvas",
-  "adminPasswordsMismatch": "As senhas não coincidem",
+  "adminDisableUser": "Desativar utilizador",
+  "adminEnableUser": "Ativar utilizador",
+  "adminDisableUserConfirm": "Desativar {name}? Não poderá iniciar sessão.",
+  "@adminDisableUserConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminEnableUserConfirm": "Ativar {name}? Poderá iniciar sessão novamente.",
+  "@adminEnableUserConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUserDisabled": "Utilizador \"{name}\" desativado",
+  "@adminUserDisabled": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUserEnabled": "Utilizador \"{name}\" ativado",
+  "@adminUserEnabled": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUserPolicyUpdateFailed": "Falha ao atualizar a política do utilizador: {error}",
+  "@adminUserPolicyUpdateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUsersLoadFailed": "Falha ao carregar utilizadores",
+  "adminSearchUsers": "Pesquisar utilizadores",
+  "adminEditUser": "Editar utilizador",
+  "adminAddUser": "Adicionar utilizador",
+  "adminUserCreateFailed": "Falha ao criar utilizador: {error}",
+  "@adminUserCreateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminCreateUser": "Criar utilizador",
+  "adminPasswordOptional": "Palavra-passe (opcional)",
+  "adminUsernameRequired": "O nome de utilizador não pode ficar vazio",
+  "adminNoProfileChanges": "Nenhuma alteração de perfil para guardar",
+  "adminProfileSaved": "Perfil guardado",
+  "adminSaveFailed": "Falha ao guardar: {error}",
+  "@adminSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminPermissionsSaved": "Permissões guardadas",
+  "adminPasswordsMismatch": "As palavras-passe não coincidem",
   "adminFailed": "Falha: {error}",
-  "adminUserLoadFailed": "Falha ao carregar usuário",
-  "adminBackToUsers": "Voltar para Usuários",
-  "adminSaveProfile": "Salvar perfil",
-  "adminDeleteUser": "Excluir usuário",
+  "@adminFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUserLoadFailed": "Falha ao carregar utilizador",
+  "adminBackToUsers": "Voltar a Utilizadores",
+  "adminSaveProfile": "Guardar perfil",
+  "adminDeleteUser": "Eliminar utilizador",
   "admin": "Administrador",
   "adminFullAccessWarning": "Os administradores têm acesso completo ao servidor. Conceda com cautela.",
   "administrator": "Administrador",
-  "adminHiddenUser": "Usuário oculto",
-  "adminAllowMediaPlayback": "Permitir reprodução de mídia",
+  "adminHiddenUser": "Utilizador oculto",
+  "adminAllowMediaPlayback": "Permitir reprodução de conteúdo",
   "adminAllowAudioTranscoding": "Permitir transcodificação de áudio",
   "adminAllowVideoTranscoding": "Permitir transcodificação de vídeo",
   "adminAllowRemuxing": "Permitir remixagem",
   "adminForceRemoteTranscoding": "Forçar transcodificação de fonte remota",
-  "adminAllowContentDeletion": "Permitir exclusão de conteúdo",
-  "adminAllowContentDownloading": "Permitir download de conteúdo",
-  "adminAllowPublicSharing": "Permitir compartilhamento público",
-  "adminAllowRemoteControl": "Permitir controle remoto de outros usuários",
-  "adminAllowSharedDeviceControl": "Permitir controle de dispositivo compartilhado",
+  "adminAllowContentDeletion": "Permitir eliminação de conteúdo",
+  "adminAllowContentDownloading": "Permitir transferência de conteúdo",
+  "adminAllowPublicSharing": "Permitir partilha pública",
+  "adminAllowRemoteControl": "Permitir controlo remoto de outros utilizadores",
+  "adminAllowSharedDeviceControl": "Permitir controlo de dispositivo partilhado",
   "adminAllowRemoteAccess": "Permitir acesso remoto",
   "adminRemoteBitrateLimit": "Limite de taxa de bits do cliente remoto (bps)",
   "adminLeaveEmptyNoLimit": "Deixe em branco sem limite",
   "adminMaxActiveSessions": "Máximo de sessões ativas",
   "adminAllowLiveTvAccess": "Permitir acesso à TV ao vivo",
-  "adminAllowLiveTvManagement": "Permitir gerenciamento de TV ao vivo",
-  "adminAllowCollectionManagement": "Permitir gerenciamento de coleção",
-  "adminAllowSubtitleManagement": "Permitir gerenciamento de legendas",
-  "adminAllowLyricManagement": "Permitir gerenciamento de letras",
-  "adminSavePermissions": "Salvar permissões",
-  "adminEnableAllLibraryAccess": "Habilite o acesso a todas as bibliotecas",
-  "adminSaveAccess": "Salvar acesso",
-  "adminChangePassword": "Alterar a senha",
-  "adminNewPassword": "Nova Senha",
-  "adminConfirmPassword": "Confirme sua senha",
-  "adminSetPassword": "Definir senha",
-  "adminResetPassword": "Redefinir senha",
-  "adminPasswordReset": "Redefinição de senha",
-  "adminPasswordUpdated": "Senha atualizada",
-  "adminUserSettings": "Configurações do usuário",
+  "adminAllowLiveTvManagement": "Permitir gestão de TV ao vivo",
+  "adminAllowCollectionManagement": "Permitir gestão de coleção",
+  "adminAllowSubtitleManagement": "Permitir gestão de legendas",
+  "adminAllowLyricManagement": "Permitir gestão de letras",
+  "adminSavePermissions": "Guardar permissões",
+  "adminEnableAllLibraryAccess": "Ativa o acesso a todas as bibliotecas",
+  "adminSaveAccess": "Guardar acesso",
+  "adminChangePassword": "Alterar a palavra-passe",
+  "adminNewPassword": "Nova palavra-passe",
+  "adminConfirmPassword": "Confirma a tua palavra-passe",
+  "adminSetPassword": "Definir palavra-passe",
+  "adminResetPassword": "Repor palavra-passe",
+  "adminPasswordReset": "Repor palavra-passe",
+  "adminPasswordUpdated": "Palavra-passe atualizada",
+  "adminUserSettings": "Definições do utilizador",
   "adminLibraryAccess": "Acesso à biblioteca",
   "adminDeviceAndChannelAccess": "Acesso a dispositivos e canais",
-  "adminEnableAllDevices": "Habilite o acesso a todos os dispositivos",
-  "adminEnableAllChannels": "Habilite o acesso a todos os canais",
-  "adminResetPasswordWarning": "Isso removerá a senha. O usuário poderá fazer login sem senha.",
+  "adminEnableAllDevices": "Ativa o acesso a todos os dispositivos",
+  "adminEnableAllChannels": "Ativa o acesso a todos os canais",
+  "adminResetPasswordWarning": "Isto removerá a palavra-passe. O utilizador poderá iniciar sessão sem palavra-passe.",
   "adminServerReturnedHttp": "Servidor retornou HTTP {status}",
-  "adminDeleteUserConfirm": "Tem certeza de que deseja excluir {name}?",
-  "adminUserDeleted": "Usuário \"{name}\" excluído",
-  "adminUserDeleteFailed": "Falha ao excluir usuário: {error}",
+  "@adminServerReturnedHttp": {
+    "placeholders": {
+      "status": {
+        "type": "int"
+      }
+    }
+  },
+  "adminDeleteUserConfirm": "Tens a certeza de que queres eliminar {name}?",
+  "@adminDeleteUserConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUserDeleted": "Utilizador \"{name}\" eliminado",
+  "@adminUserDeleted": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUserDeleteFailed": "Falha ao eliminar utilizador: {error}",
+  "@adminUserDeleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminCreateApiKey": "Criar chave de API",
-  "adminAppName": "Nome do aplicativo",
+  "adminAppName": "Nome da aplicação",
   "adminApiKeyCreated": "Chave de API criada",
   "adminApiKeyCreatedNoToken": "Chave criada com sucesso. O servidor não retornou o token. Verifique as chaves de API do servidor.",
   "adminKeyCopied": "Chave copiada para a área de transferência",
   "adminApiKeyCreateFailed": "Falha ao criar chave: {error}",
+  "@adminApiKeyCreateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminKeyTokenMissing": "Token de chave ausente na resposta do servidor",
   "adminRevokeApiKey": "Revogar chave de API",
   "adminRevokeKeyConfirm": "Revogar chave para {name}?",
+  "@adminRevokeKeyConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminApiKeyRevoked": "Chave de API revogada",
   "adminApiKeyRevokeFailed": "Falha ao revogar chave: {error}",
+  "@adminApiKeyRevokeFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminApiKeysLoadFailed": "Falha ao carregar chaves de API",
   "adminApiKeysTitle": "Chaves de API",
   "adminCreateKey": "Criar chave",
   "adminNoApiKeys": "Nenhuma chave de API encontrada",
-  "adminUnknownApp": "Aplicativo desconhecido",
+  "adminUnknownApp": "Aplicação desconhecida",
   "adminApiKeyTokenCreated": "Token: {token}\\nCriado: {created}",
-  "adminCreatingBackup": "Criando backup...",
-  "adminBackupCreated": "Backup criado com sucesso",
-  "adminBackupCreateFailed": "Falha ao criar backup: {error}",
-  "adminBackupPathMissing": "Caminho de backup ausente na resposta do servidor",
+  "@adminApiKeyTokenCreated": {
+    "placeholders": {
+      "token": {
+        "type": "String"
+      },
+      "created": {
+        "type": "String"
+      }
+    }
+  },
+  "adminCreatingBackup": "A criar cópia de segurança...",
+  "adminBackupCreated": "Cópia de segurança criada com sucesso",
+  "adminBackupCreateFailed": "Falha ao criar cópia de segurança: {error}",
+  "@adminBackupCreateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminBackupPathMissing": "Caminho da cópia de segurança ausente na resposta do servidor",
   "adminBackupManifest": "Manifesto: {name}",
+  "@adminBackupManifest": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminManifestLoadFailed": "Falha ao carregar o manifesto: {error}",
+  "@adminManifestLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminConfirmRestore": "Confirmar restauração",
-  "adminRestoringBackup": "Restaurando backup...",
-  "adminRestoreFailed": "Falha ao restaurar o backup: {error}",
-  "adminBackupsLoadFailed": "Falha ao carregar backups",
-  "adminCreateBackup": "Criar backup",
-  "adminNoBackups": "Nenhum backup encontrado",
+  "adminRestoringBackup": "A restaurar cópia de segurança...",
+  "adminRestoreFailed": "Falha ao restaurar a cópia de segurança: {error}",
+  "@adminRestoreFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminBackupsLoadFailed": "Falha ao carregar cópias de segurança",
+  "adminCreateBackup": "Criar cópia de segurança",
+  "adminNoBackups": "Nenhuma cópia de segurança encontrada",
   "adminViewDetails": "Ver detalhes",
   "restore": "Restaurar",
-  "adminLogsLoadFailed": "Falha ao carregar logs do servidor",
-  "adminNoLogFiles": "Nenhum arquivo de log encontrado",
+  "adminLogsLoadFailed": "Falha ao carregar registos do servidor",
+  "adminNoLogFiles": "Nenhum ficheiro de registo encontrado",
   "adminLogCopied": "Log copiado para a área de transferência",
-  "adminSaveLogFile": "Salvar arquivo de registro",
-  "adminSavedTo": "Salvo em {path}",
-  "adminFileSaveFailed": "Falha ao salvar arquivo: {error}",
+  "adminSaveLogFile": "Guardar ficheiro de registo",
+  "adminSavedTo": "Guardado em {path}",
+  "@adminSavedTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "adminFileSaveFailed": "Falha ao guardar ficheiro: {error}",
+  "@adminFileSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminLogFileLoadFailed": "Falha ao carregar {fileName}",
-  "adminSearchInLog": "Pesquisar no registro",
+  "@adminLogFileLoadFailed": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "adminSearchInLog": "Pesquisar no registo",
   "adminNoMatchingLines": "Nenhuma linha correspondente",
   "adminTasksLoadFailed": "Falha ao carregar tarefas: {error}",
+  "@adminTasksLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminNoScheduledTasks": "Nenhuma tarefa agendada encontrada",
   "adminNoTasksMatchFilter": "Nenhuma tarefa corresponde ao filtro atual",
   "adminTaskStartFailed": "Falha ao iniciar a tarefa: {error}",
+  "@adminTaskStartFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminTaskStopFailed": "Falha ao interromper a tarefa: {error}",
+  "@adminTaskStopFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminTaskLoadFailed": "Falha ao carregar tarefa: {error}",
-  "adminRunNow": "Corra agora",
+  "@adminTaskLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminRunNow": "Executar agora",
   "adminTriggerRemoveFailed": "Falha ao remover o gatilho: {error}",
+  "@adminTriggerRemoveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminTriggerAddFailed": "Falha ao adicionar gatilho: {error}",
+  "@adminTriggerAddFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminLastExecution": "Última Execução",
   "adminTriggers": "Gatilhos",
   "adminAddTrigger": "Adicionar gatilho",
@@ -5943,120 +5493,256 @@
   "adminTimeLimit": "Limite de tempo (opcional)",
   "adminNoLimit": "Sem limite",
   "adminHours": "{hours} hora(s)",
+  "@adminHours": {
+    "placeholders": {
+      "hours": {
+        "type": "String"
+      }
+    }
+  },
   "adminDayOfWeek": "Dia da semana",
-  "adminSearchPlugins": "Pesquisar plug-ins...",
+  "adminSearchPlugins": "Pesquisar plugins...",
   "adminPluginToggleFailed": "Falha ao alternar o plugin: {error}",
-  "adminUninstallPlugin": "Desinstalar plug-in",
-  "adminUninstallPluginConfirm": "Tem certeza de que deseja desinstalar \"{name}\"?",
+  "@adminPluginToggleFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminUninstallPlugin": "Desinstalar plugin",
+  "adminUninstallPluginConfirm": "Tens a certeza de que queres desinstalar \"{name}\"?",
+  "@adminUninstallPluginConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminPluginUninstallFailed": "Falha ao desinstalar o plugin: {error}",
+  "@adminPluginUninstallFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminPackageInstallFailed": "Falha ao instalar o pacote: {error}",
+  "@adminPackageInstallFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminPluginUpdateFailed": "Falha ao instalar a atualização: {error}",
-  "adminPluginsLoadFailed": "Falha ao carregar plug-ins: {error}",
-  "adminNoPluginsMatchSearch": "Nenhum plug-in corresponde à sua pesquisa",
-  "adminNoPluginsInstalled": "Nenhum plug-in instalado",
+  "@adminPluginUpdateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminPluginsLoadFailed": "Falha ao carregar plugins: {error}",
+  "@adminPluginsLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminNoPluginsMatchSearch": "Nenhum plugin corresponde à tua pesquisa",
+  "adminNoPluginsInstalled": "Nenhum plugin instalado",
   "adminInstallUpdate": "Instalar atualização (v{version})",
+  "@adminInstallUpdate": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "adminCatalogLoadFailed": "Falha ao carregar o catálogo: {error}",
-  "adminNoPackagesMatchSearch": "Nenhum pacote corresponde à sua pesquisa",
+  "@adminCatalogLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminNoPackagesMatchSearch": "Nenhum pacote corresponde à tua pesquisa",
   "adminNoPackagesAvailable": "Nenhum pacote disponível",
   "adminExperimentalIntegration": "Integração Experimental",
-  "adminExperimentalWarning": "A integração das configurações do plugin ainda é experimental. Algumas páginas de configurações podem não ser renderizadas corretamente.",
+  "adminExperimentalWarning": "A integração das definições do plugin ainda é experimental. Algumas páginas de definições podem não ser renderizadas corretamente.",
   "continueAction": "Continuar",
   "adminPluginRemoveAfterRestart": "\"{name}\" será removido após a reinicialização do servidor",
+  "@adminPluginRemoveAfterRestart": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminUninstallFailed": "Falha ao desinstalar: {error}",
-  "adminPluginUpdating": "Atualizando \"{name}\" para v{version}...",
-  "adminMissingAuthToken": "Não é possível abrir as configurações: token de autenticação ausente.",
-  "adminPluginLoadFailed": "Falha ao carregar o plug-in: {error}",
-  "adminPluginNotFound": "Plug-in não encontrado",
+  "@adminUninstallFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminPluginUpdating": "A atualizar \"{name}\" para v{version}...",
+  "@adminPluginUpdating": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMissingAuthToken": "Não é possível abrir as definições: token de autenticação ausente.",
+  "adminPluginLoadFailed": "Falha ao carregar o plugin: {error}",
+  "@adminPluginLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminPluginNotFound": "Plugin não encontrado",
   "adminPluginVersion": "Versão {version}",
-  "adminEnablePlugin": "Habilitar plug-in",
-  "adminPluginSettingsPage": "Página de configurações do plug-in",
+  "@adminPluginVersion": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "adminEnablePlugin": "Ativar plugin",
+  "adminPluginSettingsPage": "Página de definições do plugin",
   "adminRevisionHistory": "Histórico de revisões",
   "adminNoChangelog": "Nenhum registro de alterações disponível.",
   "adminRemoveRepository": "Remover repositório",
-  "adminRemoveRepositoryConfirm": "Tem certeza de que deseja remover \"{name}\"?",
-  "adminRepositoriesSaveFailed": "Falha ao salvar repositórios: {error}",
+  "adminRemoveRepositoryConfirm": "Tens a certeza de que queres remover \"{name}\"?",
+  "@adminRemoveRepositoryConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "adminRepositoriesSaveFailed": "Falha ao guardar repositórios: {error}",
+  "@adminRepositoriesSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminRepositoriesLoadFailed": "Falha ao carregar repositórios: {error}",
+  "@adminRepositoriesLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminRepositoryNameHint": "por exemplo Estável Jellyfin",
   "adminRepositoryUrl": "URL do repositório",
   "adminAddEntry": "Adicionar entrada",
   "adminInvalidUrl": "URL inválido",
-  "adminPluginSettingsLoadFailed": "Não foi possível carregar as configurações do plugin: {error}",
+  "adminPluginSettingsLoadFailed": "Não foi possível carregar as definições do plugin: {error}",
+  "@adminPluginSettingsLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminCouldNotOpenUrl": "Não foi possível abrir {uri}",
+  "@adminCouldNotOpenUrl": {
+    "placeholders": {
+      "uri": {
+        "type": "String"
+      }
+    }
+  },
   "adminOpenInBrowser": "Abrir no navegador",
   "adminOpenExternally": "Abrir externamente",
-  "adminGeneralSettings": "Configurações Gerais",
+  "adminGeneralSettings": "Definições Gerais",
   "adminServerName": "Nome do servidor",
   "adminPreferredMetadataCountry": "País de metadados preferido",
-  "adminCachePath": "Caminho do cache",
+  "adminCachePath": "Caminho da cache",
   "adminMetadataPath": "Caminho de metadados",
   "adminLibraryScanConcurrency": "Simultaneidade de verificação de biblioteca",
   "adminParallelImageEncodingLimit": "Limite de codificação de imagem paralela",
   "adminSlowResponseThreshold": "Limite de resposta lenta (ms)",
-  "adminBrandingSaved": "Configurações de marca salvas",
-  "adminBrandingLoadFailed": "Falha ao carregar as configurações de marca",
-  "adminLoginDisclaimer": "Isenção de responsabilidade de login",
-  "adminLoginDisclaimerHint": "HTML exibido abaixo do formulário de login",
+  "adminBrandingSaved": "Definições de marca guardadas",
+  "adminBrandingLoadFailed": "Falha ao carregar as definições de marca",
+  "adminLoginDisclaimer": "Aviso legal de início de sessão",
+  "adminLoginDisclaimerHint": "HTML apresentado abaixo do formulário de início de sessão",
   "adminCustomCss": "CSS personalizado",
   "adminCustomCssHint": "CSS personalizado aplicado à interface web",
-  "adminEnableSplashScreen": "Ativar tela inicial",
-  "adminStreamingSaved": "Configurações de streaming salvas",
-  "adminStreamingLoadFailed": "Falha ao carregar as configurações de streaming",
-  "adminStreamingDescription": "Defina limites globais de taxa de bits de streaming para conexões remotas.",
+  "adminEnableSplashScreen": "Ativar ecrã inicial",
+  "adminStreamingSaved": "Definições de streaming guardadas",
+  "adminStreamingLoadFailed": "Falha ao carregar as definições de streaming",
+  "adminStreamingDescription": "Definir limites globais de taxa de bits de streaming para ligações remotas.",
   "adminRemoteBitrateLimitMbps": "Limite de taxa de bits do cliente remoto (Mbps)",
   "adminLeaveEmptyForUnlimited": "Deixe em branco ou 0 para ilimitado",
-  "adminPlaybackSaved": "Configurações de reprodução salvas",
-  "adminPlaybackLoadFailed": "Falha ao carregar as configurações de reprodução",
+  "adminPlaybackSaved": "Definições de reprodução guardadas",
+  "adminPlaybackLoadFailed": "Falha ao carregar as definições de reprodução",
   "adminPlaybackTranscoding": "Reprodução/Transcodificação",
   "adminHardwareAcceleration": "Aceleração de hardware",
   "adminVaapiDevice": "Dispositivo VA-API",
-  "adminEnableHardwareEncoding": "Habilitar codificação de hardware",
-  "adminEnableHardwareDecoding": "Habilite a decodificação de hardware para:",
+  "adminEnableHardwareEncoding": "Ativar codificação de hardware",
+  "adminEnableHardwareDecoding": "Ativa a descodificação de hardware para:",
   "adminEncodingThreads": "Codificação de threads",
   "adminAutomatic": "0 = automático",
   "adminTranscodingTempPath": "Caminho temporário de transcodificação",
   "adminEnableFallbackFont": "Ativar fonte substituta",
   "adminFallbackFontPath": "Caminho da fonte substituta",
-  "adminAllowSegmentDeletion": "Permitir exclusão de segmento",
+  "adminAllowSegmentDeletion": "Permitir eliminação de segmento",
   "adminSegmentKeepSeconds": "Manter segmento (segundos)",
   "adminThrottleBuffering": "Buffer de aceleração",
-  "adminTrickplaySaved": "Configurações do Trickplay salvas",
-  "adminTrickplayLoadFailed": "Falha ao carregar as configurações do trickplay",
-  "adminEnableHardwareAcceleration": "Habilitar aceleração de hardware",
-  "adminEnableKeyFrameExtraction": "Ativar extração somente de quadro-chave",
+  "adminTrickplaySaved": "Definições do Trickplay guardadas",
+  "adminTrickplayLoadFailed": "Falha ao carregar as definições do trickplay",
+  "adminEnableHardwareAcceleration": "Ativar aceleração de hardware",
+  "adminEnableKeyFrameExtraction": "Ativar extração apenas de quadro-chave",
   "adminKeyFrameSubtitle": "Mais rápido, mas com menor precisão",
   "adminScanBehavior": "Comportamento de verificação",
   "adminProcessPriority": "Prioridade do processo",
-  "adminImageSettings": "Configurações de imagem",
+  "adminImageSettings": "Definições de imagem",
   "adminIntervalMs": "Intervalo (ms)",
   "adminCaptureFrameSubtitle": "Com que frequência capturar quadros",
   "adminWidthResolutions": "Resoluções de largura",
-  "adminTileWidth": "Largura do ladrilho",
-  "adminTileHeight": "Altura do ladrilho",
-  "adminQualitySubtitle": "Valores mais baixos = melhor qualidade, arquivos maiores",
+  "adminTileWidth": "Largura do mosaico",
+  "adminTileHeight": "Altura do mosaico",
+  "adminQualitySubtitle": "Valores mais baixos = melhor qualidade, ficheiros maiores",
   "adminProcessThreads": "Threads de processo",
-  "adminResumeSaved": "Retomar configurações salvas",
-  "adminResumeLoadFailed": "Falha ao carregar as configurações de currículo",
-  "adminResumeDescription": "Configure quando o conteúdo deve ser marcado como reproduzido parcialmente ou totalmente.",
-  "adminMinResumePercentage": "Porcentagem mínima de currículo",
-  "adminMinResumeSubtitle": "O conteúdo deve ser reproduzido além dessa porcentagem para salvar o progresso",
-  "adminMaxResumePercentage": "Porcentagem máxima de currículo",
-  "adminMaxResumeSubtitle": "O conteúdo é considerado totalmente reproduzido após esta porcentagem",
-  "adminMinResumeDuration": "Duração mínima do currículo (segundos)",
+  "adminResumeSaved": "Definições de retoma guardadas",
+  "adminResumeLoadFailed": "Falha ao carregar as definições de retoma",
+  "adminResumeDescription": "Configura quando o conteúdo deve ser marcado como reproduzido parcialmente ou totalmente.",
+  "adminMinResumePercentage": "Percentagem mínima de retomar",
+  "adminMinResumeSubtitle": "O conteúdo deve ser reproduzido além dessa percentagem para guardar o progresso",
+  "adminMaxResumePercentage": "Percentagem máxima de retomar",
+  "adminMaxResumeSubtitle": "O conteúdo é considerado totalmente reproduzido após esta percentagem",
+  "adminMinResumeDuration": "Duração mínima do retomar (segundos)",
   "adminMinResumeDurationSubtitle": "Itens menores que isso não são recuperáveis",
-  "adminMinAudiobookResume": "Porcentagem mínima de currículo de audiolivro",
-  "adminMaxAudiobookResume": "Porcentagem máxima de currículo de audiolivro",
-  "adminNetworkingSaved": "Configurações de rede salvas. Pode ser necessário reiniciar o servidor.",
-  "adminNetworkingLoadFailed": "Falha ao carregar as configurações de rede",
-  "adminNetworkingWarning": "As alterações nas configurações de rede podem exigir a reinicialização do servidor.",
-  "adminEnableRemoteAccess": "Habilitar acesso remoto",
+  "adminMinAudiobookResume": "Percentagem mínima de retomar de audiolivro",
+  "adminMaxAudiobookResume": "Percentagem máxima de retomar de audiolivro",
+  "adminNetworkingSaved": "Definições de rede guardadas. Pode ser necessário reiniciar o servidor.",
+  "adminNetworkingLoadFailed": "Falha ao carregar as definições de rede",
+  "adminNetworkingWarning": "As alterações nas definições de rede podem exigir o reinício do servidor.",
+  "adminEnableRemoteAccess": "Ativar acesso remoto",
   "ports": "Portas",
   "adminHttpPort": "Porta HTTP",
   "adminHttpsPort": "Porta HTTPS",
   "adminPublicHttpsPort": "Porta HTTPS pública",
   "adminBaseUrl": "URL base",
-  "adminBaseUrlHint": "por exemplo /geleia",
+  "adminBaseUrlHint": "por exemplo /jellyfin",
   "https": "HTTPS",
-  "adminEnableHttps": "Habilitar HTTPS",
+  "adminEnableHttps": "Ativar HTTPS",
   "adminLocalNetwork": "Rede local",
   "adminLocalNetworkAddresses": "Endereços de rede local",
   "adminKnownProxies": "Proxies conhecidos",
@@ -6066,39 +5752,130 @@
   "whitelist": "Lista de permissões",
   "blacklist": "Lista negra",
   "notSet": "Não definido",
-  "adminMetadataSaved": "Metadados salvos",
+  "adminMetadataSaved": "Metadados guardados",
   "adminMetadataLoadFailed": "Falha ao carregar metadados: {error}",
-  "adminMetadataSaveFailed": "Falha ao salvar metadados: {error}",
+  "@adminMetadataLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMetadataSaveFailed": "Falha ao guardar metadados: {error}",
+  "@adminMetadataSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminRefreshMetadata": "Atualizar metadados",
   "recursive": "Recursivo",
-  "adminReplaceAllMetadata": "Substitua todos os metadados",
-  "adminReplaceAllImages": "Substitua todas as imagens",
+  "adminReplaceAllMetadata": "Substitui todos os metadados",
+  "adminReplaceAllImages": "Substitui todas as imagens",
   "adminMetadataRefreshRequested": "Atualização de metadados solicitada",
   "adminMetadataRefreshFailed": "Falha ao atualizar metadados: {error}",
+  "@adminMetadataRefreshFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminSearchRemotePerson": "Pesquisar Pessoa Remota",
   "adminNoRemoteMatches": "Nenhuma correspondência remota encontrada",
   "adminRemoteResults": "Resultados remotos",
   "adminRemoteMetadataApplied": "Metadados remotos aplicados",
   "adminRemoteSearchFailed": "Falha na pesquisa remota: {error}",
+  "@adminRemoteSearchFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminUpdateContentType": "Atualizar tipo de conteúdo",
   "adminContentType": "Tipo de conteúdo",
   "adminContentTypeUpdated": "Tipo de conteúdo atualizado",
   "adminContentTypeUpdateFailed": "Falha ao atualizar o tipo de conteúdo: {error}",
+  "@adminContentTypeUpdateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminMetadataEditorLoadFailed": "Falha ao carregar o editor de metadados",
   "adminNoPeopleEntries": "Nenhuma entrada de pessoas",
   "adminNoExternalIds": "Nenhum ID externo disponível",
   "adminImageUpdated": "{imageType} imagem atualizada",
-  "adminImageDownloadFailed": "Falha ao baixar imagem: {error}",
+  "@adminImageUpdated": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminImageDownloadFailed": "Falha ao transferir imagem: {error}",
+  "@adminImageDownloadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminUnsupportedImageFormat": "Formato de imagem não suportado",
   "adminImageReadFailed": "Falha ao ler a imagem selecionada",
   "adminImageUploaded": "{imageType} imagem enviada",
-  "adminImageUploadFailed": "Falha ao fazer upload da imagem: {error}",
-  "adminDeleteImage": "Excluir imagem {imageType}",
-  "adminImageDeleted": "{imageType} imagem excluída",
-  "adminImageDeleteFailed": "Falha ao excluir imagem: {error}",
-  "adminAllProviders": "Todos os provedores",
+  "@adminImageUploaded": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminImageUploadFailed": "Falha ao enviar a imagem: {error}",
+  "@adminImageUploadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminDeleteImage": "Eliminar imagem {imageType}",
+  "@adminDeleteImage": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminImageDeleted": "{imageType} imagem eliminada",
+  "@adminImageDeleted": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminImageDeleteFailed": "Falha ao eliminar imagem: {error}",
+  "@adminImageDeleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminAllProviders": "Todos os fornecedores",
   "adminNoRemoteImages": "Nenhuma imagem remota encontrada",
   "adminTunerDiscoveryFailed": "Falha na descoberta do sintonizador: {error}",
+  "@adminTunerDiscoveryFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminAddTuner": "Adicionar sintonizador",
   "adminTunerType": "Tipo de sintonizador",
   "adminTunerTypeHint": "HDHomeRun, M3U, Outro",
@@ -6106,29 +5883,78 @@
   "adminNameOptional": "Nome (opcional)",
   "adminTunerAdded": "Sintonizador adicionado",
   "adminTunerAddFailed": "Falha ao adicionar sintonizador: {error}",
-  "adminAddGuideProvider": "Adicionar provedor de guia",
-  "adminProviderType": "Tipo de provedor",
-  "adminProviderTypeHint": "HoráriosDirect ou XMLTV",
-  "adminUsernameOptional": "Nome de usuário (opcional)",
+  "@adminTunerAddFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminAddGuideProvider": "Adicionar fornecedor de guia",
+  "adminProviderType": "Tipo de fornecedor",
+  "adminProviderTypeHint": "Horários Direct ou XMLTV",
+  "adminUsernameOptional": "Nome de utilizador (opcional)",
   "adminRefreshInterval": "Intervalo de atualização (horas)",
-  "adminProviderAdded": "Provedor adicionado",
-  "adminProviderAddFailed": "Falha ao adicionar provedor: {error}",
+  "adminProviderAdded": "Fornecedor adicionado",
+  "adminProviderAddFailed": "Falha ao adicionar fornecedor: {error}",
+  "@adminProviderAddFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminTunerRemoveFailed": "Falha ao remover o sintonizador: {error}",
+  "@adminTunerRemoveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminTunerResetRequested": "Solicitação de redefinição do sintonizador",
   "adminTunerResetFailed": "Falha ao redefinir o sintonizador: {error}",
+  "@adminTunerResetFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminProviderRemoveFailed": "Falha ao remover provedor: {error}",
-  "adminRecordingSettings": "Configurações de gravação",
+  "@adminProviderRemoveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminRecordingSettings": "Definições de gravação",
   "adminPrePadding": "Pré-preenchimento (minutos)",
   "adminPostPadding": "Pós-preenchimento (minutos)",
   "adminRecordingPath": "Caminho de gravação",
   "adminSeriesRecordingPath": "Caminho de gravação da série",
-  "adminRecordingSettingsSaved": "Configurações de gravação salvas",
-  "adminSettingsSaveFailed": "Falha ao salvar configurações: {error}",
+  "adminRecordingSettingsSaved": "Definições de gravação guardadas",
+  "adminSettingsSaveFailed": "Falha ao guardar definições: {error}",
+  "@adminSettingsSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminSetChannelMappings": "Definir mapeamentos de canais",
-  "adminMappingJson": "Mapeando JSON",
+  "adminMappingJson": "Mapeamento JSON",
   "adminMappingJsonHint": "Exemplo: mapeamentos de carga JSON",
   "adminChannelMappingsUpdated": "Mapeamentos de canais atualizados",
   "adminMappingsUpdateFailed": "Falha ao atualizar mapeamentos: {error}",
+  "@adminMappingsUpdateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminLiveTvLoadFailed": "Falha ao carregar a administração de TV ao vivo",
   "adminTunerDevices": "Dispositivos sintonizadores",
   "adminNoTunerHosts": "Nenhum host do sintonizador configurado",
@@ -6136,36 +5962,106 @@
   "adminAddProvider": "Adicionar provedor",
   "adminNoListingProviders": "Nenhum provedor de listagem configurado",
   "adminRecordingPathDisplay": "Caminho de gravação: {path}",
+  "@adminRecordingPathDisplay": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
   "adminSeriesPathDisplay": "Caminho da série: {path}",
+  "@adminSeriesPathDisplay": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
   "adminPrePaddingDisplay": "Pré-preenchimento: {minutes} min",
+  "@adminPrePaddingDisplay": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "adminPostPaddingDisplay": "Pós-preenchimento: {minutes} min",
+  "@adminPostPaddingDisplay": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "adminTunerDiscovery": "Descoberta do sintonizador",
   "adminChannelMappings": "Mapeamentos de canais",
   "adminNoDiscoveredTuners": "Nenhum sintonizador descoberto ainda",
-  "adminSettingsSaved": "Configurações salvas",
-  "adminBackupsNotAvailable": "Os backups não estão disponíveis nesta compilação de servidor.",
-  "adminRestoreWarning1": "A restauração substituirá TODOS os dados atuais do servidor pelos dados de backup.",
-  "adminRestoreWarning2": "As configurações atuais do servidor, usuários e dados da biblioteca serão substituídos.",
+  "adminSettingsSaved": "Definições guardadas",
+  "adminBackupsNotAvailable": "As cópias de segurança não estão disponíveis nesta versão do servidor.",
+  "adminRestoreWarning1": "A restauração substituirá TODOS os dados atuais do servidor pelos dados da cópia de segurança.",
+  "adminRestoreWarning2": "As definições atuais do servidor, utilizadores e dados da biblioteca serão substituídos.",
   "adminRestoreWarning3": "O servidor será reiniciado após a restauração.",
-  "adminRestoreConfirmMessage": "Restaurar backup {name} agora?",
+  "adminRestoreConfirmMessage": "Restaurar cópia de segurança {name} agora?",
+  "@adminRestoreConfirmMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminRestoreRequested": "Restauração solicitada. A reinicialização do servidor pode desconectar esta sessão.",
   "adminBackupsTitle": "Cópias de segurança",
   "adminUnknownDate": "Data desconhecida",
-  "adminUnnamedBackup": "Backup sem nome",
+  "adminUnnamedBackup": "Cópia de segurança sem nome",
   "adminLiveTvNotAvailable": "A administração de TV ao vivo não está disponível nesta versão de servidor.",
   "adminLiveTvTitle": "Administração de TV ao vivo",
   "adminApply": "Aplicar",
   "adminNotSet": "Não definido",
   "adminReset": "Reiniciar",
-  "adminLogsTitle": "Registros do servidor",
+  "adminLogsTitle": "Registos do servidor",
   "adminLogsNewestFirst": "Mais novo primeiro",
   "adminLogsOldestFirst": "Mais antigo primeiro",
   "adminLogsJustNow": "Agora mesmo",
   "adminLogsMinutesAgo": "{minutes}m atrás",
+  "@adminLogsMinutesAgo": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "adminLogsHoursAgo": "{hours}h atrás",
+  "@adminLogsHoursAgo": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
   "adminLogsDaysAgo": "{days}d atrás",
+  "@adminLogsDaysAgo": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  },
   "adminLogViewerLoadFailed": "Falha ao carregar {fileName}",
+  "@adminLogViewerLoadFailed": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
   "adminLogViewerMatches": "{count} corresponde",
+  "@adminLogViewerMatches": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "adminLogViewerNoMatches": "Nenhuma linha correspondente",
   "adminMetadataEditorTitle": "Editor de metadados",
   "adminMetadataRemote": "Remoto",
@@ -6184,11 +6080,11 @@
   "adminMetadataFieldCriticRating": "Avaliação crítica",
   "adminMetadataFieldTagline": "Slogan",
   "adminMetadataFieldOverview": "Visão geral",
-  "adminMetadataGenres": "Gêneros",
+  "adminMetadataGenres": "Géneros",
   "adminMetadataTags": "Etiquetas",
   "adminMetadataStudios": "Estúdios",
   "adminMetadataPeople": "Pessoas",
-  "adminMetadataAddGenre": "Adicionar gênero",
+  "adminMetadataAddGenre": "Adicionar género",
   "adminMetadataAddTag": "Adicionar etiqueta",
   "adminMetadataAddStudio": "Adicionar estúdio",
   "adminMetadataAddPerson": "Adicionar pessoa",
@@ -6197,69 +6093,174 @@
   "adminMetadataImagePrimary": "Primário",
   "adminMetadataImageBackdrop": "Pano de fundo",
   "adminMetadataImageLogo": "Logotipo",
-  "adminMetadataImageBanner": "Bandeira",
-  "adminMetadataImageThumb": "Dedão",
+  "adminMetadataImageBanner": "Banner",
+  "adminMetadataImageThumb": "Miniatura",
   "adminMetadataRecursive": "Recursivo",
-  "adminMetadataProvider": "Provedor",
+  "adminMetadataProvider": "Fornecedor",
   "adminMetadataImageUpdated": "{imageType} imagem atualizada",
+  "@adminMetadataImageUpdated": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
   "adminMetadataImageUploaded": "{imageType} imagem enviada",
-  "adminMetadataImageDeleted": "{imageType} imagem excluída",
-  "adminMetadataImageDownloadFailed": "Falha ao baixar imagem: {error}",
+  "@adminMetadataImageUploaded": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMetadataImageDeleted": "{imageType} imagem eliminada",
+  "@adminMetadataImageDeleted": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMetadataImageDownloadFailed": "Falha ao transferir imagem: {error}",
+  "@adminMetadataImageDownloadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminMetadataImageReadFailed": "Falha ao ler a imagem selecionada",
-  "adminMetadataImageUploadFailed": "Falha ao fazer upload da imagem: {error}",
-  "adminMetadataDeleteImageTitle": "Excluir imagem {imageType}",
-  "adminMetadataDeleteImageContent": "Isso remove a imagem atual do item.",
-  "adminMetadataImageDeleteFailed": "Falha ao excluir imagem: {error}",
-  "adminMetadataChooseImage": "Escolha a imagem {imageType}",
-  "adminMetadataUpload": "Carregar",
+  "adminMetadataImageUploadFailed": "Falha ao enviar a imagem: {error}",
+  "@adminMetadataImageUploadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMetadataDeleteImageTitle": "Eliminar imagem {imageType}",
+  "@adminMetadataDeleteImageTitle": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMetadataDeleteImageContent": "Isto remove a imagem atual do item.",
+  "adminMetadataImageDeleteFailed": "Falha ao eliminar imagem: {error}",
+  "@adminMetadataImageDeleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMetadataChooseImage": "Escolher a imagem {imageType}",
+  "@adminMetadataChooseImage": {
+    "placeholders": {
+      "imageType": {
+        "type": "String"
+      }
+    }
+  },
+  "adminMetadataUpload": "Enviar",
   "adminMetadataUpdate": "Atualizar",
   "adminMetadataRemoteImage": "Imagem remota",
   "adminPluginsInstalled": "Instalado",
   "adminPluginsCatalog": "Catálogo",
   "adminPluginsActive": "Ativo",
   "adminPluginsRestart": "Reiniciar",
-  "adminPluginsNoSearchResults": "Nenhum plug-in corresponde à sua pesquisa",
-  "adminPluginsNoneInstalled": "Nenhum plug-in instalado",
+  "adminPluginsNoSearchResults": "Nenhum plugin corresponde à tua pesquisa",
+  "adminPluginsNoneInstalled": "Nenhum plugin instalado",
   "adminPluginsUpdateAvailable": "Atualização disponível: v{version}",
+  "@adminPluginsUpdateAvailable": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "adminPluginsUpdateAvailableGeneric": "Atualização disponível",
   "adminPluginsPendingRemoval": "Remoção pendente após reinicialização",
   "adminPluginsChangesPending": "Alterações pendentes de reinicialização",
-  "adminPluginsEnable": "Habilitar",
+  "adminPluginsEnable": "Ativar",
   "adminPluginsDisable": "Desativar",
   "adminPluginsInstallUpdate": "Instalar atualização",
   "adminPluginsInstallUpdateVersioned": "Instalar atualização (v{version})",
-  "adminPluginsCatalogNoSearchResults": "Nenhum pacote corresponde à sua pesquisa",
+  "@adminPluginsInstallUpdateVersioned": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "adminPluginsCatalogNoSearchResults": "Nenhum pacote corresponde à tua pesquisa",
   "adminPluginsCatalogEmpty": "Nenhum pacote disponível",
-  "adminPluginsInstalling": "\"{name}\" está sendo instalado...",
+  "adminPluginsInstalling": "\"{name}\" está a ser instalado...",
+  "@adminPluginsInstalling": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminPluginDetailExperimental": "Integração Experimental",
-  "adminPluginDetailExperimentalContent": "A integração das configurações do plugin ainda é experimental. Alguns campos ou layouts podem ainda não ser renderizados corretamente.",
-  "adminPluginDetailToggle404": "Falha ao alternar o plugin. O servidor não conseguiu encontrar esta versão do plugin. Tente atualizar os plug-ins e tente novamente.",
-  "adminPluginDetailToggleDioError": "Falha ao alternar o plugin. Verifique os logs do servidor para obter detalhes.",
-  "adminPluginDetailSettingsTitle": "{name} Configurações",
+  "adminPluginDetailExperimentalContent": "A integração das definições do plugin ainda é experimental. Alguns campos ou esquemas podem ainda não ser renderizados corretamente.",
+  "adminPluginDetailToggle404": "Falha ao alternar o plugin. O servidor não conseguiu encontrar esta versão do plugin. Tenta atualizar os plugins e tenta novamente.",
+  "adminPluginDetailToggleDioError": "Falha ao alternar o plugin. Verifica os registos do servidor para obter detalhes.",
+  "adminPluginDetailSettingsTitle": "{name} Definições",
+  "@adminPluginDetailSettingsTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminPluginDetailDetails": "Detalhes",
   "adminPluginDetailDeveloper": "Desenvolvedor",
   "adminPluginDetailRepository": "Repositório",
   "adminPluginDetailBundled": "Empacotado",
-  "adminPluginDetailEnablePlugin": "Habilitar plug-in",
+  "adminPluginDetailEnablePlugin": "Ativar plugin",
   "adminPluginDetailRestartRequired": "É necessário reiniciar o servidor para que as alterações tenham efeito.",
   "adminPluginDetailRemovalPending": "Este plugin será removido após a reinicialização do servidor.",
   "adminPluginDetailMalfunctioned": "Este plugin não funcionou corretamente e pode não funcionar corretamente.",
   "adminPluginDetailNotSupported": "Este plugin não é compatível com a versão atual do servidor.",
   "adminPluginDetailSuperseded": "Este plugin foi substituído por uma versão mais recente.",
   "adminReposLoadFailed": "Falha ao carregar repositórios: {error}",
+  "@adminReposLoadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminReposRemoveTitle": "Remover repositório",
-  "adminReposRemoveConfirm": "Tem certeza de que deseja remover \"{name}\"?",
+  "adminReposRemoveConfirm": "Tens a certeza de que queres remover \"{name}\"?",
+  "@adminReposRemoveConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "adminReposRemove": "Remover",
-  "adminReposSaveFailed": "Falha ao salvar repositórios: {error}",
+  "adminReposSaveFailed": "Falha ao guardar repositórios: {error}",
+  "@adminReposSaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminReposEmpty": "Nenhum repositório configurado",
-  "adminReposEmptySubtitle": "Adicione um repositório para navegar pelos plug-ins disponíveis",
+  "adminReposEmptySubtitle": "Adiciona um repositório para navegar pelos plugins disponíveis",
   "adminReposUnnamed": "(sem nome)",
   "adminReposEditTitle": "Editar repositório",
   "adminReposAddTitle": "Adicionar repositório",
   "adminReposUrl": "URL do repositório",
   "adminReposNameHint": "por exemplo Estável Jellyfin",
   "adminPluginSettingsInvalidUrl": "URL inválido",
-  "adminGeneralSettingsTitle": "Configurações Gerais",
+  "adminGeneralSettingsTitle": "Definições Gerais",
   "adminGeneralMetadataLanguage": "Idioma de metadados preferido",
   "adminGeneralMetadataLanguageHint": "por exemplo en, de, fr",
   "adminGeneralMetadataCountry": "País de metadados preferido",
@@ -6270,12 +6271,12 @@
   "adminBrowse": "Navegar",
   "adminCloseBrowser": "Fechar navegador",
   "adminNetworkingTitle": "Rede",
-  "adminNetworkingRestartWarning": "As alterações nas configurações de rede podem exigir a reinicialização do servidor.",
-  "adminNetworkingRemoteAccess": "Habilitar acesso remoto",
+  "adminNetworkingRestartWarning": "As alterações nas definições de rede podem exigir o reinício do servidor.",
+  "adminNetworkingRemoteAccess": "Ativar acesso remoto",
   "adminNetworkingPorts": "Portas",
   "adminNetworkingHttpPort": "Porta HTTP",
   "adminNetworkingHttpsPort": "Porta HTTPS",
-  "adminNetworkingEnableHttps": "Habilitar HTTPS",
+  "adminNetworkingEnableHttps": "Ativar HTTPS",
   "adminNetworkingLocalNetwork": "Rede local",
   "adminNetworkingLocalAddresses": "Endereços de rede local",
   "adminNetworkingAddressHint": "por exemplo 192.168.1.0/24",
@@ -6285,15 +6286,15 @@
   "adminNetworkingBlacklist": "Lista negra",
   "adminNetworkingAddEntry": "Adicionar entrada",
   "adminBrandingTitle": "Marca",
-  "adminBrandingLoginDisclaimer": "Isenção de responsabilidade de login",
-  "adminBrandingLoginDisclaimerHint": "HTML exibido abaixo do formulário de login",
+  "adminBrandingLoginDisclaimer": "Aviso legal de início de sessão",
+  "adminBrandingLoginDisclaimerHint": "HTML apresentado abaixo do formulário de início de sessão",
   "adminBrandingCustomCss": "CSS personalizado",
   "adminBrandingCustomCssHint": "CSS personalizado aplicado à interface web",
-  "adminBrandingEnableSplash": "Ativar tela inicial",
+  "adminBrandingEnableSplash": "Ativar ecrã inicial",
   "adminPlaybackHwAccel": "Aceleração de Hardware",
   "adminPlaybackHwAccelLabel": "Aceleração de hardware",
-  "adminPlaybackEnableHwEncoding": "Habilitar codificação de hardware",
-  "adminPlaybackEnableHwDecoding": "Habilite a decodificação de hardware para:",
+  "adminPlaybackEnableHwEncoding": "Ativar codificação de hardware",
+  "adminPlaybackEnableHwDecoding": "Ativa a descodificação de hardware para:",
   "adminPlaybackEncoding": "Codificação",
   "adminPlaybackEncodingThreads": "Codificação de threads",
   "adminPlaybackFallbackFont": "Ativar fonte substituta",
@@ -6301,13 +6302,13 @@
   "adminPlaybackStreaming": "Transmissão",
   "adminResumeVideo": "Vídeo",
   "adminResumeAudiobooks": "Audiolivros",
-  "adminResumeMinAudiobookPct": "Porcentagem mínima de currículo de audiolivro",
-  "adminResumeMaxAudiobookPct": "Porcentagem máxima de currículo de audiolivro",
+  "adminResumeMinAudiobookPct": "Percentagem mínima de retomar de audiolivro",
+  "adminResumeMaxAudiobookPct": "Percentagem máxima de retomar de audiolivro",
   "adminStreamingBitrateLimit": "Limite de taxa de bits do cliente remoto (Mbps)",
   "adminStreamingBitrateLimitHint": "Deixe em branco ou 0 para ilimitado",
-  "adminTrickplayHwAccel": "Habilitar aceleração de hardware",
-  "adminTrickplayHwEncoding": "Habilitar codificação de hardware",
-  "adminTrickplayKeyFrameOnly": "Ativar extração somente de quadro-chave",
+  "adminTrickplayHwAccel": "Ativar aceleração de hardware",
+  "adminTrickplayHwEncoding": "Ativar codificação de hardware",
+  "adminTrickplayKeyFrameOnly": "Ativar extração apenas de quadro-chave",
   "adminTrickplayKeyFrameOnlySubtitle": "Mais rápido, mas com menor precisão",
   "adminTrickplayNonBlocking": "Sem bloqueio",
   "adminTrickplayBlocking": "Bloqueio",
@@ -6315,61 +6316,144 @@
   "adminTrickplayPriorityAboveNormal": "Acima do normal",
   "adminTrickplayPriorityNormal": "Normal",
   "adminTrickplayPriorityBelowNormal": "Abaixo do normal",
-  "adminTrickplayPriorityIdle": "Parado",
-  "adminTrickplayImageSettings": "Configurações de imagem",
+  "adminTrickplayPriorityIdle": "Inativo",
+  "adminTrickplayImageSettings": "Definições de imagem",
   "adminTrickplayInterval": "Intervalo (ms)",
   "adminTrickplayIntervalSubtitle": "Com que frequência capturar quadros",
   "adminTrickplayWidthResolutionsHint": "Larguras de pixels separadas por vírgula (por exemplo, 320)",
   "adminTrickplayQuality": "Qualidade",
   "adminTrickplayQScale": "Escala de qualidade",
-  "adminTrickplayQScaleSubtitle": "Valores mais baixos = melhor qualidade, arquivos maiores",
+  "adminTrickplayQScaleSubtitle": "Valores mais baixos = melhor qualidade, ficheiros maiores",
   "adminTrickplayJpegQuality": "Qualidade JPEG",
   "adminTrickplayProcessing": "Processamento",
   "adminTasksEmpty": "Nenhuma tarefa agendada encontrada",
   "adminTasksNoFilterMatch": "Nenhuma tarefa corresponde ao filtro atual",
-  "adminTaskCancelling": "Cancelando...",
-  "adminTaskRunning": "Correndo...",
-  "adminTaskNeverRun": "Nunca corra",
+  "adminTaskCancelling": "A cancelar...",
+  "adminTaskRunning": "A executar...",
+  "adminTaskNeverRun": "Nunca executada",
   "adminTaskStop": "Parar",
-  "adminTaskRun": "Correr",
+  "adminTaskRun": "Executar",
   "adminTaskDetailLastExecution": "Última Execução",
   "adminTaskDetailStarted": "Iniciado",
   "adminTaskDetailEnded": "Terminou",
   "adminTaskDetailDuration": "Duração",
   "adminTaskDetailErrorLabel": "Erro:",
   "adminTaskTriggerDaily": "Diariamente em {time}",
+  "@adminTaskTriggerDaily": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "adminTaskTriggerWeekly": "Cada {day} em {time}",
+  "@adminTaskTriggerWeekly": {
+    "placeholders": {
+      "day": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "adminTaskTriggerInterval": "Cada {duration}",
-  "adminTaskTriggerStartup": "Na inicialização do aplicativo",
+  "@adminTaskTriggerInterval": {
+    "placeholders": {
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
+  "adminTaskTriggerStartup": "Na inicialização da aplicação",
   "adminTaskTriggerTypeDaily": "Diário",
   "adminTaskTriggerTypeWeekly": "Semanalmente",
-  "adminTaskTriggerTypeInterval": "Em um intervalo",
+  "adminTaskTriggerTypeInterval": "Em intervalos",
   "adminTaskTriggerIntervalLabel": "Intervalo",
   "adminTaskTriggerEveryHour": "A cada hora",
   "adminTaskTriggerEvery6Hours": "A cada 6 horas",
   "adminTaskTriggerEvery12Hours": "A cada 12 horas",
   "adminTaskTriggerEvery24Hours": "A cada 24 horas",
   "adminTaskTriggerEvery2Days": "A cada 2 dias",
-  "adminTaskTriggerHours": "{count, plural, one{1 hour} other{{count} hours}}",
+  "adminTaskTriggerHours": "{count, plural, one{1 hora} other{{count} horas}}",
+  "@adminTaskTriggerHours": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "adminTaskTriggerTime": "Tempo",
   "adminTaskTriggerNoLimit": "Sem limite",
   "adminActivityJustNow": "Agora mesmo",
   "adminActivityLastHour": "Última hora",
   "adminActivityToday": "Hoje",
   "adminActivityYesterday": "Ontem",
-  "adminActivityOlder": "Mais velho",
+  "adminActivityOlder": "Mais antigo",
   "adminActivityDaysAgo": "{days}d atrás",
+  "@adminActivityDaysAgo": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  },
   "adminActivityHoursAgo": "{hours}h atrás",
+  "@adminActivityHoursAgo": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
   "adminActivityMinutesAgo": "{minutes}m atrás",
+  "@adminActivityMinutesAgo": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "adminActivityNow": "agora",
   "adminActivityMinutesShort": "{minutes}m",
+  "@adminActivityMinutesShort": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "adminActivityHoursShort": "{hours}h",
+  "@adminActivityHoursShort": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  },
   "adminActivityDaysShort": "{days}d",
+  "@adminActivityDaysShort": {
+    "placeholders": {
+      "days": {
+        "type": "int"
+      }
+    }
+  },
   "adminActivityDateShort": "{month}/{day}",
-  "adminTrickplayDescription": "Configure a geração de imagens trickplay para miniaturas de visualização de busca.",
+  "@adminActivityDateShort": {
+    "placeholders": {
+      "month": {
+        "type": "int"
+      },
+      "day": {
+        "type": "int"
+      }
+    }
+  },
+  "adminTrickplayDescription": "Configura a geração de imagens trickplay para miniaturas de visualização de procura.",
   "adminNetworkingPublicHttpsPort": "Porta HTTPS pública",
   "adminNetworkingBaseUrl": "URL base",
-  "adminNetworkingBaseUrlHint": "por exemplo /geleia",
+  "adminNetworkingBaseUrlHint": "por exemplo /jellyfin",
   "adminNetworkingHttps": "HTTPS",
   "adminNetworkingCertPath": "Caminho do certificado",
   "adminNetworkingRemoteIpFilter": "Filtro IP remoto",
@@ -6377,174 +6461,314 @@
   "adminPlaybackVaapiDevice": "Dispositivo VA-API",
   "adminPlaybackAutomatic": "0 = automático",
   "adminPlaybackTranscodeTempPath": "Caminho temporário de transcodificação",
-  "adminPlaybackSegmentDeletion": "Permitir exclusão de segmento",
+  "adminPlaybackSegmentDeletion": "Permitir eliminação de segmento",
   "adminPlaybackSegmentKeep": "Manter segmento (segundos)",
   "adminPlaybackThrottleBuffering": "Buffer de aceleração",
-  "adminResumeMinPct": "Porcentagem mínima de currículo",
-  "adminResumeMinPctSubtitle": "O conteúdo deve ser reproduzido além dessa porcentagem para salvar o progresso",
-  "adminResumeMaxPct": "Porcentagem máxima de currículo",
-  "adminResumeMaxPctSubtitle": "O conteúdo é considerado totalmente reproduzido após esta porcentagem",
-  "adminResumeMinDuration": "Duração mínima do currículo (segundos)",
-  "adminResumeMinDurationSubtitle": "Itens menores que isso não são recuperáveis",
+  "adminResumeMinPct": "Percentagem mínima para resumo",
+  "adminResumeMinPctSubtitle": "É necessário reproduzir o conteúdo para além desta percentagem para guardar o progresso",
+  "adminResumeMaxPct": "Percentagem máxima do resumo",
+  "adminResumeMaxPctSubtitle": "O conteúdo é considerado totalmente reproduzido após esta percentagem",
+  "adminResumeMinDuration": "Duração mínima da reativação (segundos)",
+  "adminResumeMinDurationSubtitle": "Os itens mais curtos do que este não podem ser retomados",
   "adminTrickplayScanBehavior": "Comportamento de verificação",
   "adminTrickplayProcessPriority": "Prioridade do processo",
-  "adminTrickplayTileWidth": "Largura do ladrilho",
-  "adminTrickplayTileHeight": "Altura do ladrilho",
+  "adminTrickplayTileWidth": "Largura do mosaico",
+  "adminTrickplayTileHeight": "Altura do mosaico",
   "adminTrickplayProcessThreads": "Threads de processo",
   "adminTrickplayWidthResolutions": "Resoluções de largura",
   "adminMetadataDefault": "Padrão",
   "adminMetadataContentTypeUpdated": "Tipo de conteúdo atualizado",
   "adminMetadataContentTypeFailed": "Falha ao atualizar o tipo de conteúdo: {error}",
+  "@adminMetadataContentTypeFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminGeneralSlowResponseThreshold": "Limite de resposta lenta (ms)",
   "adminGeneralCachePath": "Caminho do cache",
   "adminGeneralMetadataPath": "Caminho de metadados",
   "adminGeneralServerName": "Nome do servidor",
-  "adminSettingsLoadFailed": "Falha ao carregar as configurações",
+  "adminSettingsLoadFailed": "Falha ao carregar as definições",
   "adminDiscover": "Descobrir",
   "adminChannelMappingsUpdateFailed": "Falha ao atualizar mapeamentos: {error}",
+  "@adminChannelMappingsUpdateFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "adminTimeLimitDuration": "Limite de tempo: {duration}",
+  "@adminTimeLimitDuration": {
+    "placeholders": {
+      "duration": {
+        "type": "String"
+      }
+    }
+  },
   "folders": "Pastas",
   "libraries": "Bibliotecas",
   "syncPlay": "SyncPlay",
   "syncPlayDisabledTitle": "SyncPlay desativado",
-  "syncPlayDisabledMessage": "Ative o SyncPlay em Configurações para usar a reprodução sincronizada.",
+  "syncPlayDisabledMessage": "Ativa o SyncPlay em Definições para usar a reprodução sincronizada.",
   "syncPlayServerUnsupportedTitle": "Servidor não suportado",
   "syncPlayServerUnsupportedMessage": "SyncPlay requer um servidor Jellyfin. O servidor atual não oferece suporte.",
   "syncPlayGroupFallbackName": "Grupo SyncPlay",
   "syncPlayGroupTooltip": "Grupo SyncPlay",
-  "syncPlayParticipantCount": "{count, plural, one {# participant} other {# participants}}",
+  "syncPlayParticipantCount": "{count, plural, one {# participante} other {# participantes}}",
+  "@syncPlayParticipantCount": {
+    "description": "Participant count label shown in SyncPlay UI",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "syncPlayIgnoreWait": "Ignorar espera",
-  "syncPlayIgnoreWaitSubtitle": "Não segure o grupo enquanto este dispositivo armazena em buffer",
-  "syncPlayContinueLocallyNoWait": "Continue localmente sem esperar por membros lentos",
-  "syncPlayRepeat": "Repita",
-  "syncPlayRepeatOne": "Um",
-  "syncPlayShuffleModeShuffled": "Embaralhado",
+  "syncPlayIgnoreWaitSubtitle": "Não reter o grupo enquanto este dispositivo armazena em buffer",
+  "syncPlayContinueLocallyNoWait": "Continua localmente sem esperar por membros lentos",
+  "syncPlayRepeat": "Repetir",
+  "syncPlayRepeatOne": "Uma vez",
+  "syncPlayShuffleModeShuffled": "Baralhado",
   "syncPlayShuffleModeSorted": "Classificado",
   "syncPlaySyncCurrentQueue": "Sincronizar a fila de reprodução atual",
-  "syncPlaySyncCurrentQueueSubtitle": "Substitua a fila do grupo pelo que está sendo reproduzido localmente",
+  "syncPlaySyncCurrentQueueSubtitle": "Substitui a fila do grupo pelo que está a ser reproduzido localmente",
   "syncPlayLeaveGroup": "Sair do grupo",
-  "syncPlayGroupQueue": "Fila de grupo",
+  "syncPlayGroupQueue": "Fila do grupo",
   "syncPlayQueueItemFallback": "Item {index}",
-  "syncPlayPlayNow": "Jogue agora",
-  "syncPlayCreateNewGroup": "Crie um novo grupo",
+  "@syncPlayQueueItemFallback": {
+    "description": "Fallback title for SyncPlay queue item when media title is unavailable",
+    "placeholders": {
+      "index": {
+        "type": "int"
+      }
+    }
+  },
+  "syncPlayPlayNow": "Reproduzir agora",
+  "syncPlayCreateNewGroup": "Cria um novo grupo",
   "syncPlayGroupName": "Nome do grupo",
-  "syncPlayDefaultGroupName": "Meu grupo SyncPlay",
+  "syncPlayDefaultGroupName": "O meu grupo SyncPlay",
   "syncPlayCreateGroup": "Criar grupo",
   "syncPlayAvailableGroups": "Grupos disponíveis",
   "syncPlayNoGroupsAvailable": "Nenhum grupo disponível",
-  "syncPlayJoinGroupQuestion": "Participar do grupo SyncPlay?",
-  "syncPlayJoinGroupWarning": "Participar de um grupo SyncPlay pode substituir sua fila de reprodução atual. Continuar?",
-  "syncPlayJoin": "Juntar",
-  "syncPlayStateIdle": "Parado",
-  "syncPlayStateWaiting": "Esperando",
+  "syncPlayJoinGroupQuestion": "Participar no grupo SyncPlay?",
+  "syncPlayJoinGroupWarning": "Participar num grupo SyncPlay pode substituir a tua fila de reprodução atual. Continuar?",
+  "syncPlayJoin": "Participar",
+  "syncPlayStateIdle": "Inativo",
+  "syncPlayStateWaiting": "A aguardar",
   "syncPlayStatePaused": "Pausado",
-  "syncPlayStatePlaying": "Jogando",
+  "syncPlayStatePlaying": "A reproduzir",
   "syncPlayUserJoinedGroup": "{userName} juntou-se ao grupo SyncPlay",
+  "@syncPlayUserJoinedGroup": {
+    "description": "Snackbar message when a user joins a SyncPlay group",
+    "placeholders": {
+      "userName": {
+        "type": "String"
+      }
+    }
+  },
   "syncPlayUserLeftGroup": "{userName} saiu do grupo SyncPlay",
+  "@syncPlayUserLeftGroup": {
+    "description": "Snackbar message when a user leaves a SyncPlay group",
+    "placeholders": {
+      "userName": {
+        "type": "String"
+      }
+    }
+  },
   "syncPlayAccessDeniedTitle": "Acesso ao SyncPlay negado",
-  "syncPlayAccessDeniedMessage": "Você não tem acesso a um ou mais itens neste grupo SyncPlay. Peça ao proprietário do grupo para verificar as permissões da biblioteca ou escolha uma fila diferente.",
-  "syncPlaySyncingPlaybackToGroup": "Sincronizando a reprodução com {groupName}",
+  "syncPlayAccessDeniedMessage": "Não tens acesso a um ou mais itens neste grupo SyncPlay. Pede ao proprietário do grupo para verificar as permissões da biblioteca ou escolhe uma fila diferente.",
+  "syncPlaySyncingPlaybackToGroup": "A sincronizar a reprodução com {groupName}",
+  "@syncPlaySyncingPlaybackToGroup": {
+    "description": "Snackbar message shown when starting playback in a SyncPlay group",
+    "placeholders": {
+      "groupName": {
+        "type": "String"
+      }
+    }
+  },
   "voiceSearchUnavailable": "A pesquisa por voz não está disponível.",
   "dolbyVisionDirectPlayFailedTitle": "Falha na reprodução direta do Dolby Vision",
   "dolbyVisionDirectPlayFailedMessage": "A reprodução direta não foi iniciada para esta transmissão Dolby Vision. Tentar novamente usando a transcodificação do servidor?",
   "retryWithTranscode": "Tentar novamente com transcodificação",
   "dolbyVisionNotSupportedTitle": "Dolby Vision não compatível",
-  "dolbyVisionNotSupportedMessage": "Este dispositivo não pode decodificar conteúdo Dolby Vision diretamente. Use o substituto HDR10 ou solicite a transcodificação do servidor.",
-  "rememberMyChoice": "Lembre-se da minha escolha",
+  "dolbyVisionNotSupportedMessage": "Este dispositivo não pode decodificar conteúdo Dolby Vision diretamente. Usa o substituto HDR10 ou solicita a transcodificação do servidor.",
+  "rememberMyChoice": "Lembrar a minha escolha",
   "playHdr10Fallback": "Reproduzir substituto HDR10",
-  "requestTranscode": "Solicitar transcodificação",
-  "homeScreenSectionsIntegrationDescription": "Detecte linhas expostas pelo plugin \"Home Screen Sections\" do IAmParadox27. As linhas podem ser habilitadas e reordenadas abaixo.",
-  "homeScreenSectionsIntegrationNoServers": "Nenhum servidor Jellyfin reportando o plugin ainda.",
-  "kefinTweaksIntegrationDescription": "Detecte linhas configuradas por meio do plugin \"KefinTweaks\" do ranaldsgift. Seções personalizadas, lançadas recentemente, assistidas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.",
-  "kefinTweaksIntegrationNoServers": "Nenhum servidor Jellyfin reportando KefinTweaks ainda.",
-  "integrationOpenHomeSections": "Abrir seções iniciais",
+  "requestTranscode": "Pedir transcodificação",
+  "homeScreenSectionsIntegrationDescription": "Deteta linhas expostas pelo plugin \"Home Screen Sections\" do IAmParadox27. As linhas podem ser ativadas e reordenadas abaixo.",
+  "homeScreenSectionsIntegrationNoServers": "Nenhum servidor Jellyfin a reportar o plugin ainda.",
+  "kefinTweaksIntegrationDescription": "Deteta linhas configuradas através do plugin \"KefinTweaks\" do ranaldsgift. Secções personalizadas, lançadas recentemente, vistas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.",
+  "kefinTweaksIntegrationNoServers": "Nenhum servidor Jellyfin a reportar KefinTweaks ainda.",
+  "integrationOpenHomeSections": "Abrir secções iniciais",
   "integrationOpenHomeSectionsSubtitle": "Ativar, desativar e reordenar linhas",
   "integrationInstalledButDisabled": "Instalado, mas desativado",
   "integrationNotInstalled": "Não instalado",
-  "integrationSectionsCount": "{count, plural, one {# section} other {# sections}}",
-  "integrationRowsDiscoveredCount": "{count, plural, one {# row discovered} other {# rows discovered}}",
+  "integrationSectionsCount": "{count, plural, one {# secção} other {# secções}}",
+  "@integrationSectionsCount": {
+    "description": "Plural label for number of sections discovered in integration status",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "integrationRowsDiscoveredCount": "{count, plural, one {# linha descoberta} other {# linhas descobertas}}",
+  "@integrationRowsDiscoveredCount": {
+    "description": "Plural label for number of rows discovered in integration status",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "jellyseerr": "Jellyseerr",
   "seeAll": "Ver tudo",
   "noItems": "Nenhum item",
-  "switchUser": "Trocar usuário",
-  "remoteControl": "Controle remoto",
-  "mediaBarLoading": "Carregando barra de mídia...",
-  "mediaBarError": "A barra de mídia não foi carregada",
-  "offlineServerUnavailable": "Conectado à Internet, mas o servidor atual não está disponível.",
-  "offlineNoInternet": "Você está off-line. Apenas o conteúdo baixado está disponível.",
-  "offlineFileNotAvailable": "Arquivo não disponível",
+  "switchUser": "Trocar utilizador",
+  "remoteControl": "Controlo remoto",
+  "mediaBarLoading": "A carregar barra multimédia...",
+  "mediaBarError": "A barra de conteúdo não foi carregada",
+  "offlineServerUnavailable": "Ligado à Internet, mas o servidor atual não está disponível.",
+  "offlineNoInternet": "Está offline. Apenas o conteúdo transferido está disponível.",
+  "offlineFileNotAvailable": "Ficheiro não disponível",
   "offlineSwitchServer": "Trocar servidor",
-  "offlineSavedMedia": "Mídia salva",
+  "offlineSavedMedia": "Conteúdo guardado",
   "castGoogleCast": "Google Cast",
   "castAirPlay": "AirPlay",
   "castDlna": "DLNA",
   "castRemotePlayback": "Reprodução Remota",
-  "castControlFailed": "Falha no controle de transmissão: {error}",
-  "castKindControls": "{kind} Controles",
+  "castControlFailed": "Falha no controlo de transmissão: {error}",
+  "@castControlFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "castKindControls": "{kind} Controlos",
+  "@castKindControls": {
+    "placeholders": {
+      "kind": {
+        "type": "String"
+      }
+    }
+  },
   "castDeviceVolume": "Volume do dispositivo",
   "castVolumeUnavailable": "Indisponível",
-  "castStopKind": "Pare {kind}",
+  "castStopKind": "Parar {kind}",
+  "@castStopKind": {
+    "placeholders": {
+      "kind": {
+        "type": "String"
+      }
+    }
+  },
   "audioLabel": "Áudio",
   "subtitlesLabel": "Legendas",
   "pinConfirmTitle": "Confirmar PIN",
   "pinSetTitle": "Definir PIN",
   "pinEnterTitle": "Insira o PIN",
-  "pinReenterToConfirm": "Digite novamente seu PIN para confirmar",
+  "pinReenterToConfirm": "Introduz novamente o teu PIN para confirmar",
   "pinEnterNDigit": "Insira um PIN de {length} dígitos",
-  "pinEnterYourNDigit": "Digite seu PIN de {length} dígitos",
+  "@pinEnterNDigit": {
+    "placeholders": {
+      "length": {
+        "type": "int"
+      }
+    }
+  },
+  "pinEnterYourNDigit": "Introduz o teu PIN de {length} dígitos",
+  "@pinEnterYourNDigit": {
+    "placeholders": {
+      "length": {
+        "type": "int"
+      }
+    }
+  },
   "pinIncorrect": "PIN incorreto",
   "pinMismatch": "Os PINs não correspondem",
   "pinForgot": "Esqueceu o PIN?",
-  "pinClear": "Claro",
-  "pinBackspace": "Retrocesso",
-  "quickConnectAuthorized": "Solicitação de conexão rápida autorizada.",
+  "pinClear": "Limpar",
+  "pinBackspace": "Apagar",
+  "quickConnectAuthorized": "Solicitação de ligação rápida autorizada.",
   "quickConnectInvalidOrExpired": "O código do Quick Connect é inválido ou expirou.",
   "quickConnectNotSupported": "O Quick Connect não é compatível com este servidor.",
   "quickConnectAuthorizeFailed": "Falha ao autorizar o código do Quick Connect.",
-  "quickConnectDisabled": "O Quick Connect está desabilitado neste servidor.",
-  "quickConnectForbidden": "Sua conta não pode autorizar esta solicitação do Quick Connect.",
+  "quickConnectDisabled": "O Quick Connect está desativado neste servidor.",
+  "quickConnectForbidden": "A tua conta não pode autorizar este pedido do Quick Connect.",
   "quickConnectNotFound": "O código do Quick Connect não foi encontrado. Experimente um novo código.",
-  "quickConnectFailedWithMessage": "Falha na conexão rápida: {message}",
+  "quickConnectFailedWithMessage": "Falha na ligação rápida: {message}",
+  "@quickConnectFailedWithMessage": {
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
   "quickConnectEnterCode": "Insira o código",
   "quickConnectAuthorize": "Autorizar",
   "remoteCommandFailed": "Falha no comando: {error}",
-  "remoteControlTitle": "Controle remoto",
+  "@remoteCommandFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "remoteControlTitle": "Controlo remoto",
   "remoteFailedToLoadSessions": "Falha ao carregar sessões",
   "remoteNoSessions": "Sem sessões controláveis",
   "remoteStartPlayback": "Iniciar a reprodução em outro dispositivo",
   "unknownUser": "Desconhecido",
   "unknownItem": "Desconhecido",
-  "remoteNothingPlaying": "Nada tocando nesta sessão",
+  "remoteNothingPlaying": "Nada em reprodução nesta sessão",
   "castingStarted": "A transmissão começou no dispositivo selecionado",
   "castingFailed": "Falha ao iniciar a transmissão: {error}",
-  "noRemoteDevices": "Nenhum dispositivo de reprodução remota disponível.",
-  "noRemoteDevicesIos": "Nenhum dispositivo de reprodução remota disponível.\n\nNo iOS, os alvos AirPlay podem estar indisponíveis no simulador.",
-  "trackActionPlayNext": "Jogue a seguir",
+  "@castingFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "noRemoteDevices": "Não existem dispositivos de reprodução remota disponíveis.",
+  "noRemoteDevicesIos": "Não existem dispositivos de reprodução remota disponíveis.\n\niOS, os destinos AirPlay podem não estar disponíveis no simulador.",
+  "trackActionPlayNext": "Reproduzir Próximo",
   "trackActionAddToQueue": "Adicionar à fila",
   "trackActionAddToPlaylist": "Adicionar à lista de reprodução",
-  "trackActionCancelDownload": "Cancelar download",
-  "trackActionDeleteFromPlaylist": "Excluir da lista de reprodução",
+  "trackActionCancelDownload": "Cancelar transferência",
+  "trackActionDeleteFromPlaylist": "Eliminar da lista de reprodução",
   "trackActionMoveUp": "Subir",
   "trackActionMoveDown": "Mover para baixo",
   "trackActionRemoveFromFavorites": "Remover dos Favoritos",
   "trackActionAddToFavorites": "Adicionar aos Favoritos",
   "trackActionGoToAlbum": "Ir para o álbum",
   "trackActionGoToArtist": "Ir para o Artista",
-  "trackActionDownloading": "Baixando {name}...",
-  "trackActionDeletedFile": "Arquivo baixado excluído",
-  "trackActionDeleteFileFailed": "Não foi possível excluir o arquivo baixado",
+  "trackActionDownloading": "A transferir {name}...",
+  "@trackActionDownloading": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "trackActionDeletedFile": "Ficheiro transferido eliminado",
+  "trackActionDeleteFileFailed": "Não foi possível eliminar o ficheiro transferido",
   "shuffleBy": "Embaralhar por",
-  "shuffleSelectLibrary": "Selecione Biblioteca",
-  "shuffleSelectGenre": "Selecione o gênero",
+  "shuffleSelectLibrary": "Selecionar Biblioteca",
+  "shuffleSelectGenre": "Selecionar o género",
   "shuffleLibrary": "Biblioteca",
-  "shuffleGenre": "Gênero",
+  "shuffleGenre": "Género",
   "shuffleNoLibraries": "Nenhuma biblioteca compatível disponível.",
-  "shuffleNoGenres": "Nenhum gênero encontrado para este modo aleatório.",
+  "shuffleNoGenres": "Nenhum género encontrado para este modo aleatório.",
   "posterDisplayTitle": "Mostrar",
   "posterImageType": "Tipo de imagem",
   "imageTypePoster": "Poster",
   "imageTypeThumbnail": "Miniatura",
-  "imageTypeBanner": "Bandeira",
+  "imageTypeBanner": "Faixa",
   "playlistAddFailed": "Falha ao adicionar à playlist",
   "playlistCreateFailed": "Falha ao criar lista de reprodução",
   "playlistNew": "Nova lista de reprodução",
@@ -6554,43 +6778,123 @@
   "addToPlaylist": "Adicionar à lista de reprodução",
   "lyricsNotAvailable": "Nenhuma letra disponível",
   "upNext": "A seguir",
-  "playNext": "Jogue a seguir",
-  "stillWatchingContent": "A reprodução foi pausada. Você ainda está assistindo?",
+  "playNext": "Reproduzir a seguir",
+  "stillWatchingContent": "A reprodução foi pausada. Ainda estás a ver?",
   "stillWatchingStop": "Parar",
   "stillWatchingContinue": "Continuar",
-  "skipSegment": "Pular {segment}",
+  "skipSegment": "Saltar {segment}",
+  "@skipSegment": {
+    "placeholders": {
+      "segment": {
+        "type": "String"
+      }
+    }
+  },
   "liveTv": "TV ao vivo",
-  "continueWatchingAndNextUp": "Continue assistindo e próximo",
-  "downloadingBatchProgress": "Baixando {current}/{total} — {fileName}",
-  "downloadingFile": "Baixando {fileName}",
+  "continueWatchingAndNextUp": "Continuar a ver e a seguir",
+  "downloadingBatchProgress": "A transferir {current}/{total} — {fileName}",
+  "@downloadingBatchProgress": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      },
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
+  "downloadingFile": "A transferir {fileName}",
+  "@downloadingFile": {
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
+  },
   "nextEpisode": "Próximo episódio",
   "moreFromThisSeason": "Mais desta temporada",
   "playerTooltipPlaybackSpeed": "Velocidade de reprodução",
-  "playerTooltipCastControls": "Controles de transmissão",
+  "@playerTooltipPlaybackSpeed": {
+    "description": "Tooltip label for playback speed control in player"
+  },
+  "playerTooltipCastControls": "Controlos de transmissão",
+  "@playerTooltipCastControls": {
+    "description": "Tooltip label for active cast controls button in player"
+  },
   "playerTooltipPlaybackQuality": "Taxa de bits",
-  "playerTooltipEnterFullscreen": "Entrar em tela cheia",
-  "playerTooltipExitFullscreen": "Sair da tela cheia",
+  "@playerTooltipPlaybackQuality": {
+    "description": "Tooltip label for playback quality/bitrate control in player"
+  },
+  "playerTooltipEnterFullscreen": "Entrar em ecrã inteiro",
+  "@playerTooltipEnterFullscreen": {
+    "description": "Tooltip label for entering fullscreen in player"
+  },
+  "playerTooltipExitFullscreen": "Sair do ecrã inteiro",
+  "@playerTooltipExitFullscreen": {
+    "description": "Tooltip label for exiting fullscreen in player"
+  },
+  "playerTooltipFloatOnTop": "Flutuar no topo",
+  "@playerTooltipFloatOnTop": {
+    "description": "Tooltip label for enabling always-on-top in desktop player"
+  },
+  "playerTooltipExitFloatOnTop": "Desativar flutuação no topo",
+  "@playerTooltipExitFloatOnTop": {
+    "description": "Tooltip label for disabling always-on-top in desktop player"
+  },
   "playerTooltipLockLandscape": "Bloquear paisagem",
+  "@playerTooltipLockLandscape": {
+    "description": "Tooltip label for locking landscape orientation in player"
+  },
   "playerTooltipUnlockOrientation": "Permitir rotação",
+  "@playerTooltipUnlockOrientation": {
+    "description": "Tooltip label for unlocking orientation lock in player"
+  },
   "playerTooltipPrevious": "Anterior",
-  "playerTooltipSeekBack": "Procure de volta",
-  "playerTooltipSeekForward": "Procure avançar",
-  "contextMenuMarkWatched": "Marcar como assistido",
-  "contextMenuMarkUnwatched": "Marcar como não assistido",
+  "@playerTooltipPrevious": {
+    "description": "Tooltip label for previous item control in player"
+  },
+  "playerTooltipSeekBack": "Procurar para trás",
+  "@playerTooltipSeekBack": {
+    "description": "Tooltip label for seek back control in player"
+  },
+  "playerTooltipSeekForward": "Procurar para a frente",
+  "@playerTooltipSeekForward": {
+    "description": "Tooltip label for seek forward control in player"
+  },
+  "contextMenuMarkWatched": "Marcar como visto",
+  "@contextMenuMarkWatched": {
+    "description": "Context menu action to mark an item as watched"
+  },
+  "contextMenuMarkUnwatched": "Marcar como não visto",
+  "@contextMenuMarkUnwatched": {
+    "description": "Context menu action to mark an item as unwatched"
+  },
   "contextMenuAddToFavorites": "Adicionar aos Favoritos",
+  "@contextMenuAddToFavorites": {
+    "description": "Context menu action to add an item to favorites"
+  },
   "contextMenuRemoveFromFavorites": "Remover dos Favoritos",
+  "@contextMenuRemoveFromFavorites": {
+    "description": "Context menu action to remove an item from favorites"
+  },
   "contextMenuGoToSeries": "Ir para a série",
-  "settingsAdministrationSubtitle": "Acesse o painel de administração do servidor",
+  "@contextMenuGoToSeries": {
+    "description": "Context menu action to navigate to the parent series of an episode"
+  },
+  "settingsAdministrationSubtitle": "Aceder ao painel de administração do servidor",
   "settingsAccountSecurity": "Conta e segurança",
-  "settingsAccountSecuritySubtitle": "Autenticação, código PIN e controle dos pais",
+  "settingsAccountSecuritySubtitle": "Autenticação, código PIN e controlo parental",
   "settingsPersonalization": "Personalização",
   "settingsPersonalizationSubtitle": "Tema, navegação, linhas iniciais e visibilidade da biblioteca",
   "settingsDynamicContent": "Conteúdo Dinâmico",
-  "settingsDynamicContentSubtitle": "Barra de mídia e sobreposições visuais",
+  "settingsDynamicContentSubtitle": "Barra de conteúdo e sobreposições visuais",
   "settingsPlaybackSyncplay": "Reprodução e SyncPlay",
-  "settingsPlaybackSyncplaySubtitle": "Configurações de áudio/vídeo, legendas, downloads e controles do SyncPlay",
-  "settingsIntegrationsSubtitle": "Sincronização de plug-ins, Seerr, classificações e muito mais",
-  "settingsAboutSubtitle": "Versão do aplicativo, informações legais e créditos",
+  "settingsPlaybackSyncplaySubtitle": "Definições de áudio/vídeo, legendas, transferências e controlos do SyncPlay",
+  "settingsIntegrationsSubtitle": "Sincronização de plugins, Seerr, classificações e muito mais",
+  "settingsAboutSubtitle": "Versão da aplicação, informações legais e créditos",
   "settingsAuthenticationSection": "AUTENTICAÇÃO",
   "settingsSortServersBy": "Classificar servidores por",
   "settingsLastUsed": "Último uso",
@@ -6598,78 +6902,109 @@
   "settingsPrivacyAndSafetySection": "PRIVACIDADE E SEGURANÇA",
   "settingsBlockedRatings": "Avaliações bloqueadas",
   "settingsGeneralStyle": "Estilo Geral",
-  "settingsGeneralStyleSubtitle": "Acentos temáticos, cenários, indicadores assistidos e música temática",
+  "settingsGeneralStyleSubtitle": "Acentos temáticos, cenários, indicadores vistos e música temática",
   "settingsHomePage": "Página inicial",
-  "settingsHomePageSubtitle": "Seções, tipos de imagens, sobreposições e visualizações de mídia",
+  "settingsHomePageSubtitle": "Secções, tipos de imagens, sobreposições e visualizações de conteúdo",
   "settingsLibrariesSubtitle": "Visibilidade da biblioteca, visualização de pastas e comportamento multiservidor",
   "settingsTwentyFourHourClock": "Relógio de 24 horas",
-  "settingsTwentyFourHourClockSubtitle": "Use a formatação de 24 horas sempre que o relógio for mostrado",
+  "settingsTwentyFourHourClockSubtitle": "Usa a formatação de 24 horas sempre que o relógio for mostrado",
   "settingsShowShuffleButtonInNavigation": "Mostrar o botão aleatório na barra de navegação",
-  "settingsShowGenresButtonInNavigation": "Mostrar o botão de gêneros na barra de navegação",
+  "settingsShowGenresButtonInNavigation": "Mostrar o botão de géneros na barra de navegação",
   "settingsShowFavoritesButtonInNavigation": "Mostrar o botão de favoritos na barra de navegação",
   "settingsShowLibrariesButtonInNavigation": "Mostrar o botão de bibliotecas na barra de navegação",
-  "settingsLibraryVisibilitySubtitle": "Alternar a visibilidade da página inicial por biblioteca. Reinicie o Moonfin para que as alterações tenham efeito.",
-  "settingsMediaBarAndLocalPreviews": "Barra de mídia e visualizações locais",
+  "settingsShowSeerrButtonInNavigation": "Mostrar o botão Seerr na barra de navegação",
+  "settingsLibraryVisibilitySubtitle": "Alternar a visibilidade da página inicial por biblioteca. Reinicia o Moonfin para que as alterações tenham efeito.",
+  "settingsMediaBarAndLocalPreviews": "Barra de conteúdo e visualizações locais",
   "settingsVisualOverlays": "Sobreposições visuais",
   "settingsSeasonalSurprise": "Surpresa sazonal",
   "settingsMetadataAndRatings": "Metadados e classificações",
   "settingsPluginScreenDescription": "Moonbase possibilita integrações do lado do servidor, incluindo fontes de classificação adicionais, solicitações Seerr e preferências sincronizadas.",
-  "settingsOfflineDownloads": "Downloads off-line",
+  "settingsOfflineDownloads": "Transferencias off-line",
   "settingsHigh": "Alto",
   "settingsLow": "Baixo",
   "settingsCustomPath": "Caminho personalizado",
-  "settingsEnterDownloadFolderPath": "Digite o caminho da pasta de download",
-  "settingsConcurrentDownloads": "Downloads simultâneos",
-  "settingsConcurrentDownloadsDescription": "Número máximo de itens para download de uma vez.",
-  "settingsAppInfo": "INFORMAÇÕES DO APLICATIVO",
+  "settingsEnterDownloadFolderPath": "Introduzir o caminho da pasta de transferência",
+  "settingsConcurrentDownloads": "Transferências simultâneas ",
+  "settingsConcurrentDownloadsDescription": "Número máximo de itens para transferir de uma vez.",
+  "settingsAppInfo": "INFORMAÇÕES DA APLICAÇÃO",
   "settingsReportAnIssue": "Informar um problema",
-  "settingsReportAnIssueSubtitle": "Abra o rastreador de problemas no GitHub",
-  "settingsJoinDiscord": "Junte-se a Discord",
-  "settingsJoinDiscordSubtitle": "Converse com a comunidade",
-  "settingsJoinTheDiscord": "Participe do Discord",
-  "settingsSupportMoonfin": "Apoie Moonfin",
+  "settingsReportAnIssueSubtitle": "Abrir o rastreador de problemas no GitHub",
+  "settingsJoinDiscord": "Juntar-se ao Discord",
+  "settingsJoinDiscordSubtitle": "Conversa com a comunidade",
+  "settingsJoinTheDiscord": "Participa no Discord",
+  "settingsSupportMoonfin": "Apoia o Moonfin",
+  "settingsSupportMoonfinSubtitle": "Doe um café para o programador",
   "settingsLegal": "JURÍDICO",
   "settingsLicenses": "Licenças",
   "settingsOpenSourceLicenseNotices": "Avisos de licença de código aberto",
-  "settingsPrivacyPolicy": "política de Privacidade",
-  "settingsPrivacyPolicySubtitle": "Como Moonfin trata seus dados",
-  "settingsCheckForUpdates": "Verifique se há atualizações",
-  "settingsCheckForUpdatesSubtitle": "Verifique o último lançamento do Moonfin",
+  "settingsPrivacyPolicy": "Política de Privacidade",
+  "settingsPrivacyPolicySubtitle": "Como Moonfin trata os teus dados",
+  "settingsCheckForUpdates": "Verifica se há atualizações",
+  "settingsCheckForUpdatesSubtitle": "Verifica o último lançamento do Moonfin",
   "settingsPoweredByFlutter": "Desenvolvido por Flutter",
-  "settingsLicenseNoticesCount": "{count, plural, one {# license notice} other {# license notices}}",
+  "settingsLicenseNoticesCount": "{count, plural, one {# aviso de licença} other {# avisos de licença}}",
+  "@settingsLicenseNoticesCount": {
+    "description": "Plural label for number of license notices",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "settingsBoth": "Ambos",
   "settingsShuffleContentTypeFilter": "Filtro de tipo de conteúdo aleatório",
   "settingsVideoPlaybackPreferences": "Preferências de reprodução de vídeo",
-  "settingsVideoPlaybackPreferencesSubtitle": "Mecanismo de vídeo principal e configurações de qualidade de streaming",
+  "settingsVideoPlaybackPreferencesSubtitle": "Mecanismo de vídeo principal e definições de qualidade de streaming",
   "settingsAudioPreferences": "Preferências de áudio",
   "settingsAudioPreferencesSubtitle": "Faixas de áudio, processamento e opções de passagem",
   "settingsAutomationAndQueue": "Automação e fila",
   "settingsAutomationAndQueueSubtitle": "Reprodução e sequenciamento automatizados",
   "settingsOfflineDownloadsSubtitle": "Qualidade de download, limites de armazenamento e tamanho da fila",
   "settingsSyncplaySubtitle": "Lógica de sincronização para sessões de grupo",
-  "settingsAdvancedOptionsSubtitle": "Recursos especializados do jogador. Use com cuidado, pois algumas opções podem causar problemas de reprodução",
-  "settingsSkipIntrosAndOutros": "Pular introduções e outros?",
-  "settingsPromptUser": "Solicitar usuário",
-  "settingsSkip": "Pular",
-  "settingsDoNothing": "Não faça nada",
+  "settingsAdvancedOptionsSubtitle": "Recursos especializados do reprodutor. Usa com cuidado, pois algumas opções podem causar problemas de reprodução",
+  "settingsSkipIntrosAndOutros": "Saltar introduções e outros?",
+  "settingsMediaSegmentCountdown": "Contagem regressiva de segmentos de conteúdo",
+  "@settingsMediaSegmentCountdown": {
+    "description": "Setting label for media segment countdown customizations"
+  },
+  "settingsProgressBar": "Barra de progresso",
+  "@settingsProgressBar": {
+    "description": "Option label to show only progress bar on media segment countdown overlay"
+  },
+  "settingsTimer": "Temporizador",
+  "@settingsTimer": {
+    "description": "Option label to show only countdown timer on media segment countdown overlay"
+  },
+  "@settingsBoth": {
+    "description": "Option label to show both progress bar and countdown timer on media segment countdown overlay"
+  },
+  "settingsNone": "Nenhum",
+  "@settingsNone": {
+    "description": "Option label to hide all decorations on media segment countdown overlay"
+  },
+  "settingsPromptUser": "Pedir ao utilizador",
+  "settingsSkip": "Saltar",
+  "settingsDoNothing": "Não fazer nada",
   "settingsMaxBitrateDescription": "Limite a taxa de bits do streaming. O conteúdo acima desse limite será transcodificado para caber.",
-  "settingsMaxResolutionDescription": "Limite a resolução máxima que o player irá solicitar. O conteúdo de resolução mais alta será transcodificado.",
-  "settingsPlayerZoomDescription": "Como o vídeo deve ser dimensionado para caber na tela.",
+  "settingsMaxResolutionDescription": "Limite a resolução máxima que o reprodutor irá solicitar. O conteúdo de resolução mais alta será transcodificado.",
+  "settingsPlayerZoomDescription": "Como o vídeo deve ser dimensionado para caber no ecrã.",
   "settingsPlaybackEngineAndroidTv": "Mecanismo de reprodução (Android TV)",
-  "settingsPlaybackEngineAndroidTvDescription": "Escolha o mecanismo de reprodução padrão em dispositivos Android TV. As alterações se aplicam à próxima sessão de reprodução.",
+  "settingsPlaybackEngineAndroidTvDescription": "Escolher o mecanismo de reprodução padrão em dispositivos Android TV. As alterações são aplicadas à próxima sessão de reprodução.",
   "settingsPlaybackEngineMedia3Recommended": "Media3 (recomendado)",
+  "settingsPlaybackEngineMedia3Legacy": "Media3 (legado)",
   "settingsPlaybackEngineMpvLegacy": "mpv (legado)",
+  "settingsPlaybackEngineMpvRecommended": "mpv (recomendado)",
   "settingsDolbyVisionFallback": "Substituição Dolby Vision",
   "settingsDolbyVisionFallbackDescription": "Comportamento para títulos Dolby Vision em dispositivos sem decodificação Dolby Vision.",
   "settingsAskEachTime": "Pergunte sempre",
-  "settingsPreferHdr10Fallback": "Prefira substituto HDR10",
-  "settingsPreferServerTranscode": "Prefira a transcodificação do servidor",
+  "settingsPreferHdr10Fallback": "Preferir substituto HDR10",
+  "settingsPreferServerTranscode": "Preferir a transcodificação do servidor",
   "settingsDolbyVisionProfile7DirectPlay": "Perfil Dolby Vision 7 Reprodução direta",
   "settingsDolbyVisionProfile7DirectPlayDescription": "Controla se os fluxos de camada de aprimoramento do perfil Dolby Vision 7 devem direcionar a reprodução.",
-  "settingsAutoAftkrtEnabled": "Automático (AFTKRT habilitado)",
+  "settingsAutoAftkrtEnabled": "Automático (AFTKRT ativado)",
   "settingsEnabledOnThisDevice": "Ativado neste dispositivo",
-  "settingsDisabledPreferTranscode": "Desativado (prefira transcodificação)",
-  "settingsResumeRewindDescription": "Ao retomar a reprodução (a partir de Continuar assistindo ou de uma página de item de mídia), quantos segundos devem ser retrocedidos?",
+  "settingsDisabledPreferTranscode": "Desativado (preferir transcodificação)",
+  "settingsResumeRewindDescription": "Ao retomar a reprodução (a partir de Continuar a ver ou de uma página de item de conteúdo), quantos segundos devem ser retrocedidos?",
   "settingsUnpauseRewindDescription": "Ao retomar a reprodução após pressionar o botão de pausa, quantos segundos devem ser retrocedidos?",
   "settingsSkipBackLengthDescription": "Quantos segundos para voltar depois de pressionar o botão de retrocesso.",
   "settingsOneSecond": "1 segundo",
@@ -6680,27 +7015,36 @@
   "settingsBitstreamAc3ToExternalDecoder": "Bitstream AC3 para decodificador externo",
   "settingsCinemaMode": "Modo Cinema",
   "settingsCinemaModeSubtitle": "Reproduzir trailers/prerolls antes de um filme principal",
+  "settingsNextUpDisplayDescription": "Extended mostra um cartão completo com a arte e a descrição do episódio. Mínimo mostra uma sobreposição compacta de contagem regressiva. Desativado oculta totalmente o prompt.",
   "settingsShort": "Curto",
   "settingsLong": "Longo",
   "settingsVeryLong": "Muito Longo",
   "settingsVideoStartDelay": "Atraso no início do vídeo",
   "settingsMillisecondsValue": "{value} ms",
+  "@settingsMillisecondsValue": {
+    "description": "Milliseconds duration label",
+    "placeholders": {
+      "value": {
+        "type": "int"
+      }
+    }
+  },
   "settingsLiveTvDirect": "TV ao vivo direto",
-  "settingsLiveTvDirectSubtitle": "Ative a reprodução direta para TV ao vivo",
+  "settingsLiveTvDirectSubtitle": "Ativa a reprodução direta para TV ao vivo",
   "settingsOpenGroups": "Grupos abertos",
-  "settingsOpenGroupsSubtitle": "Crie, participe ou gerencie grupos SyncPlay",
+  "settingsOpenGroupsSubtitle": "Cria, participa ou gere grupos SyncPlay",
   "settingsSyncplayEnabled": "SyncPlay ativado",
-  "settingsSyncplayEnabledSubtitle": "Habilite recursos de observação em grupo",
+  "settingsSyncplayEnabledSubtitle": "Ativa recursos de observação em grupo",
   "settingsSyncplayButton": "Botão SyncPlay",
   "settingsSyncplayButtonSubtitle": "Mostrar o botão SyncPlay na barra de navegação",
   "settingsSyncplayAdvancedCorrection": "Correção Avançada",
-  "settingsSyncplayAdvancedCorrectionSubtitle": "Habilitar lógica de sincronização refinada",
+  "settingsSyncplayAdvancedCorrectionSubtitle": "Ativar lógica de sincronização refinada",
   "settingsSyncplaySyncCorrection": "Correção de sincronização",
-  "settingsSyncplaySyncCorrectionSubtitle": "Ajuste automaticamente a reprodução para permanecer sincronizado",
+  "settingsSyncplaySyncCorrectionSubtitle": "Ajusta automaticamente a reprodução para permanecer sincronizado",
   "settingsSyncplaySpeedToSync": "Velocidade para sincronizar",
-  "settingsSyncplaySpeedToSyncSubtitle": "Use o ajuste da velocidade de reprodução para sincronizar",
-  "settingsSyncplaySkipToSync": "Pular para sincronizar",
-  "settingsSyncplaySkipToSyncSubtitle": "Use a busca para sincronizar",
+  "settingsSyncplaySpeedToSyncSubtitle": "Usa o ajuste da velocidade de reprodução para sincronizar",
+  "settingsSyncplaySkipToSync": "Saltar para sincronizar",
+  "settingsSyncplaySkipToSyncSubtitle": "Usa a procura para sincronizar",
   "settingsSyncplayMinimumSpeedDelay": "Atraso mínimo de velocidade",
   "settingsSyncplayMaximumSpeedDelay": "Atraso de velocidade máxima",
   "settingsSyncplaySpeedDuration": "Duração da velocidade",
@@ -6710,165 +7054,182 @@
   "collections": "Coleções",
   "lastPlayed": "Jogado pela última vez",
   "libraryNameWithServer": "{libraryName} ({serverName})",
-  "latestLibraryName": "Último {libraryName}",
-  "discNumber": "Disco {number}",
-  "desktopUiScale": "Escala de UI de desktop",
-  "nextUpDisplay": "Próximo display",
-  "settingsNextUpDisplayDescription": "Extended mostra um cartão completo com a arte e a descrição do episódio. Mínimo mostra uma sobreposição compacta de contagem regressiva. Desativado oculta totalmente o prompt.",
-  "@discNumber": {
-    "description": "Label for an album disc section in a multi-disc track list",
+  "@libraryNameWithServer": {
+    "description": "Library name display with server suffix for multi-server views",
     "placeholders": {
-      "number": {
-        "type": "int"
+      "libraryName": {
+        "type": "String"
+      },
+      "serverName": {
+        "type": "String"
       }
     }
   },
-  "@desktopUiScale": {
-    "description": "Setting for desktop UI scale"
+  "latestLibraryName": "Último {libraryName}",
+  "@latestLibraryName": {
+    "description": "Row title for latest media in a specific library",
+    "placeholders": {
+      "libraryName": {
+        "type": "String"
+      }
+    }
   },
-  "@nextUpDisplay": {
-    "description": "Setting for next up behavior"
-  },
-  "playerTooltipFloatOnTop": "Flutuar no topo",
-  "playerTooltipExitFloatOnTop": "Desativar flutuação no topo",
-  "@playerTooltipFloatOnTop": {
-    "description": "Tooltip label for enabling always-on-top in desktop player"
-  },
-  "@playerTooltipExitFloatOnTop": {
-    "description": "Tooltip label for disabling always-on-top in desktop player"
-  },
-  "email": "E-mail",
-  "seerrAccountType": "Tipo de conta Seerr",
-  "jellyfinAccount": "Jellyfin",
-  "localAccount": "Local",
-  "@email": {
-    "description": "Email field label"
-  },
-  "@seerrAccountType": {
-    "description": "Header for selecting Seerr authentication account type"
-  },
-  "@jellyfinAccount": {
-    "description": "Auth option label for Seerr sign in using Jellyfin credentials"
-  },
-  "@localAccount": {
-    "description": "Auth option label for Seerr sign in using local Seerr credentials"
-  },
-  "seasonalEffectsDescription": "Efeitos visuais e decorações sazonais",
-  "mediaSources": "Fontes de mídia",
-  "behavior": "Comportamento",
-  "seconds": "segundos",
-  "localPreviews": "Visualizações locais",
-  "localPreviewsDescription": "Configure visualizações de trailer, mídia e áudio.",
-  "mediaPreview": "Visualização de mídia",
-  "mediaPreviewDescription": "Reproduza uma visualização in-line de 30 segundos em cartões focados, pairados ou pressionados por muito tempo",
-  "keyboardPreferSystemIme": "Prefira o teclado do sistema",
-  "keyboardPreferSystemImeDescription": "Use o método de entrada do seu dispositivo por padrão para entrada de texto",
-  "musicVideos": "Vídeos musicais",
-  "record": "Registro",
-  "cancelRecordingAction": "Cancelar gravação",
-  "programSetToRecord": "Programa pronto para gravar",
-  "recordingCancelled": "Gravação cancelada",
-  "unableToCreateRecording": "Não foi possível criar a gravação",
-  "settingsAudioOutputMode": "Modo de saída de áudio",
-  "settingsAudioOutputModeAvrPassthrough": "Passagem AVR",
-  "settingsAudioFallbackCodec": "Codec substituto de áudio",
-  "settingsAudioFallbackAacStereo": "Estéreo AAC",
-  "settingsAudioFallbackAc35_1": "AC3 5.1",
-  "settingsAudioFallbackEac35_1": "EAC3 5.1",
-  "settingsAudioPassthroughAdvanced": "Passagem (avançado)",
-  "settingsAudioCodecPassthrough": "Passagem de codec",
-  "settingsAudioCodecPassthroughDescription": "Ative apenas os formatos suportados pelo coletor AVR ou HDMI.",
-  "settingsAudioEac3Passthrough": "Passagem EAC3",
-  "settingsAudioEac3JocPassthrough": "Passagem EAC3 JOC (Atmos)",
-  "settingsAudioDtsCorePassthrough": "Passagem principal DTS",
-  "settingsAudioDtsHdPassthrough": "Passagem DTS-HD MA",
-  "settingsAudioTrueHdPassthrough": "Passagem TrueHD",
-  "settingsAudioTrueHdAtmosPassthrough": "Passagem TrueHD Atmos",
-  "settingsAudioBitstreamEac3ToExternalDecoder": "Bitstream Dolby Digital Plus (EAC3) para decodificador externo.",
-  "settingsAudioBitstreamEac3JocToExternalDecoder": "Bitstream Dolby Atmos sobre EAC3 (JOC) para decodificador externo.",
-  "settingsAudioBitstreamDtsHdToExternalDecoder": "Bitstream DTS-HD MA (inclui núcleo DTS) para decodificador externo.",
-  "settingsAudioBitstreamTrueHdAtmosToExternalDecoder": "Bitstream Dolby TrueHD com metadados Atmos para decodificador externo.",
-  "settingsDetectedAudioCapabilities": "Capacidades de áudio detectadas",
-  "settingsDetectedAudioCapabilitiesUnavailable": "Nenhum instantâneo de capacidade de tempo de execução disponível ainda.",
-  "settingsAudioRouteLabel": "Rota",
-  "settingsAudioDecodeLabel": "Decodificar",
-  "settingsAudioPassthroughLabel": "Passagem",
-  "settingsAudioHdRoute": "Rota de áudio HD",
-  "settingsAudioRouteHdmi": "HDMI",
-  "settingsAudioRouteArc": "ARC",
-  "settingsAudioRouteEarc": "eARC",
-  "settingsAudioRouteBluetooth": "Bluetooth",
-  "settingsAudioRouteSpeaker": "Palestrante",
-  "settingsAudioPcmChannels": "{count}ch PCM",
-  "settingsAudioDiagnostics": "Diagnóstico",
-  "settingsAudioDiagnosticsVideoLevel": "Nível de vídeo",
-  "settingsAudioDiagnosticsVideoRange": "Faixa de vídeo",
-  "settingsAudioDiagnosticsSubtitleCodec": "Codec de legenda",
-  "settingsAudioDiagnosticsAllowedAudioCodecs": "Codecs de áudio permitidos",
-  "settingsAudioDiagnosticsHlsMpegTsAudioCodecs": "Codecs de áudio HLS MPEG-TS",
-  "settingsAudioDiagnosticsHlsFmp4AudioCodecs": "Codecs de áudio HLS fMP4",
-  "settingsAudioDiagnosticsAudioSpdifPassthrough": "passagem de áudio-spdif",
-  "settingsAudioDiagnosticsActiveAudioRoute": "Rota de áudio ativa",
-  "settingsAudioDiagnosticsRouteHdAudioSupport": "Suporte de áudio HD de rota",
-  "settingsPlaybackEngineMedia3Legacy": "Media3 (legado)",
-  "settingsPlaybackEngineMpvRecommended": "mpv (recomendado)",
   "autoplayNextEpisode": "Reproduzir automaticamente o próximo episódio",
-  "autoplayNextEpisodeSubtitle": "Reproduza automaticamente o próximo episódio quando disponível.",
-  "skipSilenceTitle": "Pular silêncio",
+  "@autoplayNextEpisode": {
+    "description": "Setting title: automatically start the next episode"
+  },
+  "autoplayNextEpisodeSubtitle": "Reproduzir automaticamente o próximo episódio quando disponível.",
+  "@autoplayNextEpisodeSubtitle": {
+    "description": "Setting subtitle for autoplay next episode"
+  },
+  "skipSilenceTitle": "Saltar silêncio",
+  "@skipSilenceTitle": {
+    "description": "Setting title: skip silent audio segments during playback"
+  },
   "skipSilenceSubtitle": "Ignora automaticamente segmentos de áudio silenciosos quando suportado pelo stream.",
+  "@skipSilenceSubtitle": {
+    "description": "Setting subtitle for skip silence"
+  },
   "allowExternalAudioEffectsTitle": "Permitir efeitos de áudio externos",
-  "allowExternalAudioEffectsSubtitle": "Permitir que aplicativos de equalizador e efeitos (por exemplo, Wavelet) sejam anexados às sessões de reprodução Media3.",
-  "disableTunnelingTitle": "Desabilitar tunelamento",
+  "@allowExternalAudioEffectsTitle": {
+    "description": "Setting title: allow equalizer apps to attach to Media3"
+  },
+  "allowExternalAudioEffectsSubtitle": "Permitir que aplicações de equalizador e efeitos (por exemplo, Wavelet) sejam anexadas às sessões de reprodução Media3.",
+  "@allowExternalAudioEffectsSubtitle": {
+    "description": "Setting subtitle for external audio effects"
+  },
+  "disableTunnelingTitle": "Desativar tunelamento",
+  "@disableTunnelingTitle": {
+    "description": "Setting title: force non-tunneled video playback"
+  },
   "disableTunnelingSubtitle": "Forçar a reprodução sem tunelamento. Útil em dispositivos com descontinuidades de áudio/vídeo de tunelamento.",
+  "@disableTunnelingSubtitle": {
+    "description": "Setting subtitle for disable tunneling"
+  },
+  "enableTunnelingTitle": "Ativar tunelamento",
+  "@enableTunnelingTitle": {
+    "description": "Setting title: enable tunneled video playback (advanced)"
+  },
+  "enableTunnelingSubtitle": "Avançado. Encaminha áudio e vídeo através de um caminho de hardware acoplado. Desativado por predefinição porque causa quedas de áudio/vídeo em alguns dispositivos.",
+  "@enableTunnelingSubtitle": {
+    "description": "Setting subtitle for enable tunneling"
+  },
   "mapDolbyVisionP7Title": "Mapear Dolby Vision perfil 7 para HEVC",
-  "mapDolbyVisionP7Subtitle": "Reproduza fluxos de perfil Dolby Vision 7 como HEVC compatível com HDR10 em dispositivos não DV.",
-  "subtitlesUseEmbeddedStyles": "Use estilos de legenda incorporados",
-  "subtitlesUseEmbeddedStylesSubtitle": "Aplique cores, fontes e posicionamento incorporados na faixa de legenda. Desative para usar suas preferências de estilo de legenda.",
-  "subtitlesUseEmbeddedFontSizes": "Use tamanhos de fonte de legenda incorporados",
-  "subtitlesUseEmbeddedFontSizesSubtitle": "Aplique dicas de tamanho de fonte incorporadas na faixa de legenda. Desative o uso do tamanho da legenda em suas preferências de estilo.",
-  "useDetailedSubHeadings": "Use subtítulos detalhados",
-  "useDetailedSubHeadingsDescription": "Mostrar sub-rows detalhado ou mínimo nas páginas da Biblioteca.",
-  "savedThemesDeleteDialogTitle": "Excluir tema salvo?",
+  "@mapDolbyVisionP7Title": {
+    "description": "Setting title: play DV P7 as HDR10 HEVC on non-DV devices"
+  },
+  "mapDolbyVisionP7Subtitle": "Reproduzir fluxos de perfil Dolby Vision 7 como HEVC compatível com HDR10 em dispositivos não DV.",
+  "@mapDolbyVisionP7Subtitle": {
+    "description": "Setting subtitle for DV P7 to HEVC mapping"
+  },
+  "subtitlesUseEmbeddedStyles": "Usa estilos de legenda incorporados",
+  "@subtitlesUseEmbeddedStyles": {
+    "description": "Setting title: apply colours/positioning from the subtitle track"
+  },
+  "subtitlesUseEmbeddedStylesSubtitle": "Aplica cores, fontes e posicionamento incorporados na faixa de legenda. Desativa para usar as tuas preferências de estilo de legenda.",
+  "@subtitlesUseEmbeddedStylesSubtitle": {
+    "description": "Setting subtitle for embedded styles toggle"
+  },
+  "subtitlesUseEmbeddedFontSizes": "Usa tamanhos de fonte de legenda incorporados",
+  "@subtitlesUseEmbeddedFontSizes": {
+    "description": "Setting title: apply font sizes from the subtitle track"
+  },
+  "subtitlesUseEmbeddedFontSizesSubtitle": "Aplica dicas de tamanho de fonte incorporadas na faixa de legenda. Desativa o uso do tamanho da legenda nas tuas preferências de estilo.",
+  "@subtitlesUseEmbeddedFontSizesSubtitle": {
+    "description": "Setting subtitle for embedded font sizes toggle"
+  },
+  "useDetailedSubHeadings": "Usa subtítulos detalhados",
+  "@useDetailedSubHeadings": {
+    "description": "Label for setting to toggle detailed or minimal subrow on library pages"
+  },
+  "useDetailedSubHeadingsDescription": "Mostrar sublinha detalhada ou minimalista nas páginas da Biblioteca.",
+  "@useDetailedSubHeadingsDescription": {
+    "description": "Subtitle for the use detailed sub headings setting"
+  },
+  "savedThemesDeleteDialogTitle": "Eliminar tema guardado?",
   "savedThemesDeleteDialogMessage": "Remover \"{themeName}\" do cache deste dispositivo?",
-  "savedThemesDeletedMessage": "Excluído \"{themeName}\" deste dispositivo.",
-  "savedThemesDeleteFailedMessage": "Não foi possível excluir \"{themeName}\".",
-  "savedThemesTitle": "Temas salvos",
-  "savedThemesDescription": "Estes são temas baixados do plugin Moonfin para o servidor atual. A exclusão remove apenas esta cópia local.",
-  "savedThemesEmpty": "Nenhum tema salvo foi encontrado para este servidor.",
+  "@savedThemesDeleteDialogMessage": {
+    "description": "Confirmation message for deleting a saved custom theme",
+    "placeholders": {
+      "themeName": {
+        "type": "String"
+      }
+    }
+  },
+  "savedThemesDeletedMessage": "Eliminado \"{themeName}\" deste dispositivo.",
+  "@savedThemesDeletedMessage": {
+    "description": "Status message shown after deleting a saved custom theme",
+    "placeholders": {
+      "themeName": {
+        "type": "String"
+      }
+    }
+  },
+  "savedThemesDeleteFailedMessage": "Não foi possível eliminar \"{themeName}\".",
+  "@savedThemesDeleteFailedMessage": {
+    "description": "Status message shown when deleting a saved custom theme fails",
+    "placeholders": {
+      "themeName": {
+        "type": "String"
+      }
+    }
+  },
+  "savedThemesTitle": "Temas guardados",
+  "savedThemesDescription": "Estes são temas transferidos do plugin Moonfin para o servidor atual. A exclusão remove apenas esta cópia local.",
+  "savedThemesEmpty": "Nenhum tema guardado foi encontrado para este servidor.",
   "savedThemesCurrentThemeId": "{themeId} • Atualmente ativo",
-  "savedThemesDeleteTooltip": "Excluir tema salvo",
-  "savedThemesManageSubtitle": "Gerenciar temas de plug-ins baixados neste dispositivo",
+  "@savedThemesCurrentThemeId": {
+    "description": "Subtitle showing the saved theme id when it is currently selected",
+    "placeholders": {
+      "themeId": {
+        "type": "String"
+      }
+    }
+  },
+  "savedThemesDeleteTooltip": "Eliminar tema guardado",
+  "savedThemesManageSubtitle": "Gerir temas de plugins baixados neste dispositivo",
   "kefinTweaksTitle": "KefinTweaks",
-  "homeScreenSectionsTitle": "Seções da tela inicial",
+  "homeScreenSectionsTitle": "Secções do ecrã inicial",
   "themeEditor": "Editor de Tema",
-  "themeEditorSubtitle": "Abra o Editor de Tema Moonfin em seu navegador",
-  "homeScreen": "Tela inicial",
+  "themeEditorSubtitle": "Abre o Editor de Tema Moonfin no teu navegador",
+  "homeScreen": "Ecrã inicial",
   "bottomBar": "Barra inferior",
   "homeRowsStyleClassic": "Clássico",
   "homeRowsStyleModern": "Moderno",
   "homeRowsSection": "Linhas iniciais",
+  "homeRowDisplay": "Visualização da linha inicial",
+  "homeRowSections": "Secções da linha inicial",
+  "homeRowToggles": "Alternâncias da linha inicial",
+  "homeRowTogglesSubtitle": "Ativar ou desativar categorias diferentes de linhas iniciais",
+  "homeRowTogglesDescription": "Ativa as seguintes alternâncias para mostrar as linhas nas Secções Iniciais.",
   "rowsType": "Tipo de linhas",
   "rowsTypeDescription": "Classic mantém o tipo de imagem por linha e a sobreposição de informações. Moderno usa linhas do retrato ao pano de fundo.",
-  "displayFavoritesRows": "Exibir linhas de favoritos",
-  "displayFavoritesRowsSubtitle": "Mostre filmes, séries favoritos e outras linhas favoritas nas seções iniciais.",
+  "displayFavoritesRows": "Mostrar linhas de favoritos",
+  "displayFavoritesRowsSubtitle": "Mostrar filmes, séries favoritos e outras linhas favoritas nas secções iniciais.",
   "favoritesRowSorting": "Classificação de linhas de favoritos",
-  "favoritesRowSortingDescription": "Classifique as linhas de Favoritos por data de adição, data de lançamento, em ordem alfabética e muito mais.",
-  "displayCollectionsRows": "Exibir linhas de coleções",
-  "displayCollectionsRowsSubtitle": "Mostrar linhas de coleções nas seções iniciais.",
+  "favoritesRowSortingDescription": "Classificar as linhas de Favoritos por data de adição, data de lançamento, em ordem alfabética e muito mais.",
+  "displayCollectionsRows": "Mostrar linhas de coleções",
+  "displayCollectionsRowsSubtitle": "Mostrar linhas de coleções nas secções iniciais.",
   "collectionsRowSorting": "Classificação de linhas de coleções",
-  "collectionsRowSortingDescription": "Classifique as linhas das coleções por data de adição, data de lançamento, em ordem alfabética e muito mais.",
-  "displayGenresRows": "Exibir linhas de gêneros",
-  "displayGenresRowsSubtitle": "Mostrar linhas de gêneros nas seções iniciais.",
-  "genresRowSorting": "Classificação de linha de gêneros",
-  "genresRowSortingDescription": "Classifique as linhas de gêneros por data de adição, data de lançamento, em ordem alfabética e muito mais.",
-  "genresRowItems": "Itens de linha de gêneros",
-  "genresRowItemsDescription": "Mostre filmes, séries ou ambos nas linhas de gêneros.",
+  "collectionsRowSortingDescription": "Classificar as linhas das coleções por data de adição, data de lançamento, em ordem alfabética e muito mais.",
+  "displayGenresRows": "Mostrar linhas de géneros",
+  "displayGenresRowsSubtitle": "Mostrar linhas de géneros nas secções iniciais.",
+  "genresRowSorting": "Classificação de linha de géneros",
+  "genresRowSortingDescription": "Classificar as linhas de géneros por data de adição, data de lançamento, em ordem alfabética e muito mais.",
+  "genresRowItems": "Itens de linha de géneros",
+  "genresRowItemsDescription": "Mostrar filmes, séries ou ambos nas linhas de géneros.",
+  "displayPlaylistsRows": "Mostrar linhas de listas de reprodução",
+  "displayPlaylistsRowsSubtitle": "Mostrar linhas de listas de reprodução nas Secções Iniciais.",
+  "playlistsRowSorting": "Classificação de linhas de listas de reprodução",
+  "playlistsRowSortingDescription": "Classificar linhas de listas de reprodução por data de adição, data de lançamento, ordem alfabética e muito mais.",
+  "displaySeerrRows": "Mostrar linhas de descoberta Seerr",
+  "displaySeerrRowsSubtitle": "Mostrar linhas de descoberta Seerr nas Secções Iniciais.",
   "appearance": "Aparência",
   "cardSize": "Tamanho do cartão",
-  "externalPlayerApp": "Aplicativo de player externo",
-  "externalPlayerAskEachTimeSubtitle": "Mostrar seletor de aplicativos quando a reprodução começar.",
-  "loadingInstalledPlayers": "Carregando players instalados...",
-  "connection": "Conexão",
+  "externalPlayerApp": "Reprodutor externo",
+  "externalPlayerAskEachTimeSubtitle": "Mostrar seletor de aplicações quando a reprodução começar.",
+  "loadingInstalledPlayers": "A carregar reprodutores instalados...",
+  "connection": "Ligação",
   "audioTranscodeTarget": "Alvo de transcodificação de áudio",
   "passthrough": "Passagem",
   "supportedOnThisDevice": "Compatível com este dispositivo",
@@ -6876,28 +7237,44 @@
   "settingsAudioDtsXPassthrough": "Passagem DTS:X (DTS UHD)",
   "settingsAudioBitstreamDtsXToExternalDecoder": "Bitstream DTS:X (DTS UHD) para decodificador externo.",
   "settingsAudioTrueHdJocPassthrough": "Passagem TrueHD com Atmos (JOC)",
-  "mediaPlayerBehavior": "Comportamento do reprodutor de mídia",
+  "mediaPlayerBehavior": "Comportamento do reprodutor de conteúdo",
   "playbackEnhancements": "Melhorias de reprodução",
   "alwaysOn": "Sempre ligado.",
-  "replaceSkipOutroWithNextUpDisplay": "Substitua Pular outro pela exibição seguinte",
-  "replaceSkipOutroWithNextUpDisplaySubtitle": "Mostre a sobreposição Next Up em vez do botão Pular Outro.",
-  "playerRouting": "Roteamento de Jogador",
-  "preferSoftwareDecoders": "Prefira decodificadores de software",
-  "preferSoftwareDecodersSubtitle": "Use FFmpeg (áudio) e libgav1 (AV1) antes dos decodificadores de hardware. Desative se a passagem de áudio HDMI for interrompida.",
+  "replaceSkipOutroWithNextUpDisplay": "Substitui Saltar outro pela apresentação seguinte",
+  "replaceSkipOutroWithNextUpDisplaySubtitle": "Mostrar a sobreposição Next Up em vez do botão Saltar Outro.",
+  "playerRouting": "Encaminhamento de Reprodutor",
+  "preferSoftwareDecoders": "Preferir decodificadores de software",
+  "preferSoftwareDecodersSubtitle": "Usa FFmpeg (áudio) e libgav1 (AV1) antes dos decodificadores de hardware. Desativa se a passagem de áudio HDMI for interrompida.",
   "useExternalPlayer": "Usar reprodutor externo",
-  "useExternalPlayerSubtitle": "Abra a reprodução de vídeo no aplicativo externo selecionado na Android TV.",
+  "useExternalPlayerSubtitle": "Abre a reprodução de vídeo na aplicação externa selecionada na Android TV.",
   "automaticQueuing": "Enfileiramento Automático",
-  "preferSdhSubtitles": "Prefira legendas SDH",
-  "preferSdhSubtitlesSubtitle": "Priorize faixas de legenda SDH/CC ao selecionar automaticamente.",
+  "preferSdhSubtitles": "Preferir legendas SDH",
+  "preferSdhSubtitlesSubtitle": "Prioriza faixas de legenda SDH/CC ao selecionar automaticamente.",
   "webDiagnostics": "Diagnóstico da Web",
   "webDiagnosticsTitle": "Moonfin Diagnóstico da Web",
-  "webDiagnosticsIntro": "Use esta página para diagnosticar problemas de conectividade do navegador (CORS, conteúdo misto e configurações de descoberta).",
+  "webDiagnosticsIntro": "Usa esta página para diagnosticar problemas de conectividade do navegador (CORS, conteúdo misto e definições de descoberta).",
   "webDiagnosticsDetectedMixedContentFailure": "Falha de conteúdo misto detectada",
   "webDiagnosticsDetectedCorsPreflightFailure": "Falha de CORS/Preflight detectada",
-  "webDiagnosticsMixedContentFailureBody": "Moonfin detectou uma página HTTPS tentando chamar um URL de servidor HTTP. Os navegadores bloqueiam essa solicitação antes que ela chegue ao seu servidor.",
-  "webDiagnosticsCorsFailureBody": "Moonfin detectou uma falha de solicitação no nível do navegador que geralmente é causada pela falta de CORS ou cabeçalhos de simulação no servidor de mídia.",
+  "webDiagnosticsMixedContentFailureBody": "Moonfin detetou uma página HTTPS a tentar chamar um URL de servidor HTTP. Os navegadores bloqueiam esse pedido antes que ele chegue ao teu servidor.",
+  "webDiagnosticsCorsFailureBody": "Moonfin detetou uma falha de pedido ao nível do navegador que geralmente é causada pela falta de CORS ou cabeçalhos de simulação no servidor de conteúdo.",
   "webDiagnosticsTargetUrl": "URL de destino: {url}",
+  "@webDiagnosticsTargetUrl": {
+    "description": "Target URL shown in diagnostics summary",
+    "placeholders": {
+      "url": {
+        "type": "String"
+      }
+    }
+  },
   "webDiagnosticsDetail": "Detalhe: {detail}",
+  "@webDiagnosticsDetail": {
+    "description": "Error detail shown in diagnostics summary",
+    "placeholders": {
+      "detail": {
+        "type": "String"
+      }
+    }
+  },
   "webDiagnosticsCurrentRuntimeContext": "Contexto de tempo de execução atual",
   "webDiagnosticsOrigin": "Origem",
   "webDiagnosticsScheme": "Esquema",
@@ -6909,19 +7286,19 @@
   "notConfigured": "não configurado",
   "webDiagnosticsMixedContent": "Conteúdo Misto",
   "webDiagnosticsMixedContentDetected": "Esta página é carregada por HTTPS, mas um ou mais URLs configurados são HTTP. Os navegadores impedem que páginas HTTPS chamem APIs HTTP.",
-  "webDiagnosticsMixedContentFix": "Correção: sirva seu servidor de mídia ou endpoint de proxy via HTTPS ou carregue Moonfin por HTTP apenas em redes locais confiáveis.",
-  "webDiagnosticsNoMixedContentDetected": "Nenhuma configuração óbvia de conteúdo misto detectada nas configurações de tempo de execução atuais.",
+  "webDiagnosticsMixedContentFix": "Correção: serve o teu servidor de conteúdo ou endpoint de proxy via HTTPS ou carrega Moonfin por HTTP apenas em redes locais fiáveis.",
+  "webDiagnosticsNoMixedContentDetected": "Nenhuma configuração óbvia de conteúdo misto detectada nas definições de tempo de execução atuais.",
   "webDiagnosticsCorsChecklist": "Lista de verificação do CORS",
   "webDiagnosticsCorsChecklistItem1": "• Permitir a origem do navegador em Access-Control-Allow-Origin.",
   "webDiagnosticsCorsChecklistItem2": "• Incluir autorização, X-Emby-Authorization e X-Emby-Token em Access-Control-Allow-Headers.",
-  "webDiagnosticsCorsChecklistItem3": "• Expor Content-Range e Accept-Ranges para streaming e comportamento de busca.",
+  "webDiagnosticsCorsChecklistItem3": "• Expor Content-Range e Accept-Ranges para streaming e comportamento de procura.",
   "webDiagnosticsCorsChecklistItem4": "• Retornar 204 para solicitações de comprovação de OPTIONS.",
   "webDiagnosticsHeaderSnippetTitle": "Exemplo de snippet de cabeçalho (estilo nginx)",
   "note": "Observação",
-  "webDiagnosticsNonWebNote": "Esta rota de diagnóstico destina-se a compilações web. Se você estiver vendo isso em outra plataforma, essas verificações podem não se aplicar.",
+  "webDiagnosticsNonWebNote": "Esta rota de diagnóstico destina-se a compilações web. Se estiveres a ver isto noutra plataforma, estas verificações podem não se aplicar.",
   "backToServerSelect": "Voltar para seleção de servidor",
-  "signOutAllUsers": "Desconectar todos os usuários",
-  "voiceSearchPermissionPermanentlyDenied": "A permissão do microfone foi negada permanentemente. Habilite-o nas configurações do sistema.",
+  "signOutAllUsers": "Terminar sessão de todos os utilizadores",
+  "voiceSearchPermissionPermanentlyDenied": "A permissão do microfone foi negada permanentemente. Ativa-o nas definições do sistema.",
   "voiceSearchPermissionRequired": "A permissão do microfone é necessária para pesquisa por voz.",
   "voiceSearchNoMatch": "Não entendi isso. Tente novamente.",
   "voiceSearchNoSpeechDetected": "Nenhuma fala detectada.",
@@ -6931,59 +7308,73 @@
   "microphonePermissionPermanentlyDenied": "A permissão do microfone foi negada permanentemente.",
   "microphonePermissionDenied": "A permissão do microfone foi negada.",
   "speechRecognitionUnavailable": "O reconhecimento de fala não está disponível neste dispositivo.",
-  "openIosRoutePicker": "Abra o seletor de rota do iOS",
-  "airPlayRoutePickerUnavailable": "AirPlay o seletor de rota não está disponível neste dispositivo.",
+  "openIosRoutePicker": "Abrir o seletor de rota do iOS",
+  "airPlayRoutePickerUnavailable": "O seletor de rotas AirPlay não está disponível neste dispositivo.",
   "videos": "Vídeos",
-  "trailers": "Reboques",
+  "trailers": "Trailers",
   "programs": "Programas",
   "songs": "Músicas",
   "photoAlbums": "Álbuns de fotos",
   "photos": "Fotos",
   "people": "Pessoas",
   "recentlyReleasedEpisodes": "Episódios lançados recentemente",
-  "watchAgain": "Assistir novamente",
+  "watchAgain": "Ver novamente",
   "guestAppearances": "Participações de convidados",
   "appearancesSeerr": "Aparições (Seerr)",
-  "watchWithGroup": "Assista com grupo",
+  "watchWithGroup": "Ver com o grupo",
   "errors": "Erros",
   "warnings": "Avisos",
   "disk": "Disco",
   "openInBrowser": "Abrir no navegador",
   "embeddedBrowserNotAvailable": "O navegador incorporado não está disponível nesta plataforma.",
-  "adminRestartServerConfirmation": "Tem certeza de que deseja reiniciar o servidor?",
-  "adminShutdownServerConfirmation": "Tem certeza de que deseja encerrar o servidor? Você precisará reiniciá-lo manualmente.",
+  "adminRestartServerConfirmation": "Tens a certeza de que queres reiniciar o servidor?",
+  "adminShutdownServerConfirmation": "Tens a certeza de que queres encerrar o servidor? Vais precisar de o reiniciar manualmente.",
   "internal": "Interno",
   "idle": "Parado",
   "os": "OS",
-  "adminNoUsersFound": "Nenhum usuário encontrado",
-  "adminNoUsersMatchSearch": "Nenhum usuário corresponde à sua pesquisa",
+  "adminNoUsersFound": "Nenhum utilizador encontrado",
+  "adminNoUsersMatchSearch": "Nenhum utilizador corresponde à tua pesquisa",
   "adminNoDevicesFound": "Nenhum dispositivo encontrado",
   "adminNoDevicesMatchCurrentFilters": "Nenhum dispositivo corresponde aos filtros atuais",
-  "passwordSet": "Conjunto de senha",
-  "noPasswordConfigured": "Nenhuma senha configurada",
+  "passwordSet": "Palavra-passe definida",
+  "noPasswordConfigured": "Nenhuma palavra-passe configurada",
   "remoteAccess": "Acesso remoto",
   "localOnly": "Somente locais",
-  "adminMediaAnalyticsLoadFailed": "Falha ao carregar análise de mídia",
-  "analyticsCombinedAcrossLibraries": "Análises combinadas em todas as bibliotecas de mídia.",
+  "adminMediaAnalyticsLoadFailed": "Falha ao carregar análise de conteúdo",
+  "analyticsCombinedAcrossLibraries": "Análises combinadas em todas as bibliotecas de conteúdo.",
   "analyticsTopArtists": "Principais artistas",
   "analyticsTopAuthors": "Principais autores",
   "analyticsTopContributors": "Principais colaboradores",
-  "analyticsLibrariesCount": "{count, plural, =1{1 Library} other{{count} Libraries}}",
-  "analyticsNoIndexedMediaTotals": "Nenhum total de mídia indexada está disponível para esta seleção ainda.",
+  "analyticsLibrariesCount": "{count, plural, =1{1 Biblioteca} other{{count} Bibliotecas}}",
+  "@analyticsLibrariesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "analyticsNoIndexedMediaTotals": "Ainda não estão disponíveis totais de conteúdo indexado para esta selecção.",
   "analyticsLibraryDetails": "Detalhes da biblioteca",
-  "analyticsLibraryBreakdown": "Divisão da Biblioteca",
-  "analyticsNoLibrariesAvailable": "Nenhuma biblioteca está disponível.",
-  "adminServerAdministrationTitle": "Administração de Servidor",
+  "analyticsLibraryBreakdown": "Análise da biblioteca",
+  "analyticsNoLibrariesAvailable": "Não há bibliotecas disponíveis.",
+  "adminServerAdministrationTitle": "Administração do Servidor",
   "adminServerPathData": "Dados",
   "adminServerPathImageCache": "Cache de imagens",
   "adminServerPathCache": "Cache",
-  "adminServerPathLogs": "Registros",
+  "adminServerPathLogs": "Registos",
   "adminServerPathMetadata": "Metadados",
   "adminServerPathTranscode": "Transcodificar",
   "adminServerPathWeb": "Rede",
   "adminNoServerPathsReturned": "Nenhum caminho de servidor retornado por este servidor.",
   "adminPercentUsed": "{percent}% usado",
-  "userActivity": "Atividade do usuário",
+  "@adminPercentUsed": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "userActivity": "Atividade do utilizador",
   "systemEvents": "Eventos do sistema",
   "needsAttention": "Precisa de atenção",
   "adminDrawerSectionServer": "Servidor",
@@ -6993,319 +7384,14 @@
   "adminDrawerSectionPlugins": "Plug-ins",
   "adminDrawerSectionLiveTv": "TV ao vivo",
   "homeVideos": "Vídeos caseiros",
-  "mixedContent": "Conteúdo Misto",
-  "homeVideosAndPhotos": "Vídeos e fotos caseiras",
-  "mixedMoviesAndShows": "Filmes e programas mistos",
-  "intelQuickSync": "Sincronização rápida Intel",
-  "rockchipMpp": "MPP Rockchip",
+  "mixedContent": "Conteúdo Variado",
+  "homeVideosAndPhotos": "Vídeos e fotos caseiros",
+  "mixedMoviesAndShows": "Filmes e séries variados",
+  "intelQuickSync": "Intel QuickSync",
+  "rockchipMpp": "Rockchip MPP",
   "dolbyVision": "Dolby Vision",
   "noRecordingsFound": "Nenhuma gravação encontrada",
   "noImagePagesFoundInArchive": "Nenhuma página de imagem encontrada no arquivo .{extension}.",
-  "embeddedRendererFailed": "Falha no renderizador incorporado ({code}): {description}",
-  "epubRendererFailed": "Falha no renderizador EPUB ({code}): {description}",
-  "missingLocalFileForReader": "Arquivo local ausente para leitor: {uri}",
-  "httpStatusWhileOpeningBookData": "HTTP {status} ao abrir dados do livro de {uri}",
-  "noReadableBookEndpointAvailable": "Nenhum endpoint de livro legível disponível",
-  "unsupportedComicArchiveFormat": "Formato de arquivo de quadrinhos não suportado: .{extension}",
-  "cbrExtractionPluginUnavailable": "O plugin de extração CBR não está disponível nesta plataforma.",
-  "failedToExtractCbrArchive": "Falha ao extrair o arquivo .cbr.",
-  "cb7ExtractionUnavailable": "A extração CB7 não está disponível nesta plataforma.",
-  "cb7ExtractionPluginUnavailable": "O plugin de extração CB7 não está disponível nesta plataforma.",
-  "closeGenrePanel": "Fechar painel de gênero",
-  "loadingShuffle": "Carregando ordem aleatória...",
-  "libraryShuffleLabel": "LIBRARY SHUFFLE",
-  "randomShuffleLabel": "RANDOM SHUFFLE",
-  "genresShuffleLabel": "GENRES SHUFFLE",
-  "autoHdrSwitching": "Troca automática de HDR",
-  "autoHdrSwitchingDescription": "Ative automaticamente o HDR para reprodução de vídeo HDR e restaure o modo de exibição ao sair.",
-  "whenFullscreen": "Quando em tela cheia",
-  "transcodingLimits": "Limites de transcodificação",
-  "@keyboardPreferSystemIme": {
-    "description": "Settings label for preferring the native system keyboard instead of the custom TV keyboard"
-  },
-  "@keyboardPreferSystemImeDescription": {
-    "description": "Settings subtitle for the system keyboard preference"
-  },
-  "@musicVideos": {
-    "description": "Section header for music videos filmography row"
-  },
-  "@record": {
-    "description": "Button label to schedule a live TV recording"
-  },
-  "@cancelRecordingAction": {
-    "description": "Button label to cancel a scheduled live TV recording"
-  },
-  "@programSetToRecord": {
-    "description": "Snackbar confirmation after scheduling a live TV program recording"
-  },
-  "@recordingCancelled": {
-    "description": "Snackbar confirmation after cancelling a live TV recording"
-  },
-  "@unableToCreateRecording": {
-    "description": "Error when creating a live TV recording fails"
-  },
-  "@seasonalEffectsDescription": {
-    "description": "Description for seasonal effects settings"
-  },
-  "@settingsAudioOutputMode": {
-    "description": "Setting for audio output mode"
-  },
-  "@settingsAudioOutputModeAvrPassthrough": {
-    "description": "Audio output mode option for AVR passthrough"
-  },
-  "@settingsAudioFallbackCodec": {
-    "description": "Setting for fallback audio codec"
-  },
-  "@settingsAudioFallbackAacStereo": {
-    "description": "Fallback codec option for AAC stereo"
-  },
-  "@settingsAudioFallbackAc35_1": {
-    "description": "Fallback codec option for AC3 5.1"
-  },
-  "@settingsAudioFallbackEac35_1": {
-    "description": "Fallback codec option for EAC3 5.1"
-  },
-  "@settingsAudioPassthroughAdvanced": {
-    "description": "Section title for advanced passthrough controls"
-  },
-  "@settingsAudioCodecPassthrough": {
-    "description": "Title for codec passthrough settings group"
-  },
-  "@settingsAudioCodecPassthroughDescription": {
-    "description": "Description for codec passthrough settings group"
-  },
-  "@settingsAudioEac3Passthrough": {
-    "description": "Setting for EAC3 passthrough"
-  },
-  "@settingsAudioEac3JocPassthrough": {
-    "description": "Setting for EAC3 JOC Atmos passthrough"
-  },
-  "@settingsAudioDtsCorePassthrough": {
-    "description": "Setting for DTS core passthrough"
-  },
-  "@settingsAudioDtsHdPassthrough": {
-    "description": "Setting for DTS-HD MA passthrough"
-  },
-  "@settingsAudioTrueHdPassthrough": {
-    "description": "Setting for TrueHD passthrough"
-  },
-  "@settingsAudioTrueHdAtmosPassthrough": {
-    "description": "Setting for TrueHD Atmos passthrough"
-  },
-  "@settingsAudioBitstreamEac3ToExternalDecoder": {
-    "description": "Description for EAC3 passthrough"
-  },
-  "@settingsAudioBitstreamEac3JocToExternalDecoder": {
-    "description": "Description for EAC3 JOC passthrough"
-  },
-  "@settingsAudioBitstreamDtsHdToExternalDecoder": {
-    "description": "Description for DTS-HD MA passthrough"
-  },
-  "@settingsAudioBitstreamTrueHdAtmosToExternalDecoder": {
-    "description": "Description for TrueHD Atmos passthrough"
-  },
-  "@settingsDetectedAudioCapabilities": {
-    "description": "Section title for detected runtime audio capabilities"
-  },
-  "@settingsDetectedAudioCapabilitiesUnavailable": {
-    "description": "Message shown when runtime audio capability snapshot is missing"
-  },
-  "@settingsAudioRouteLabel": {
-    "description": "Label for active audio route row"
-  },
-  "@settingsAudioDecodeLabel": {
-    "description": "Label for audio decode capability row"
-  },
-  "@settingsAudioPassthroughLabel": {
-    "description": "Label for audio passthrough capability row"
-  },
-  "@settingsAudioHdRoute": {
-    "description": "Label indicating the active route supports HD audio"
-  },
-  "@settingsAudioRouteHdmi": {
-    "description": "Audio route type HDMI"
-  },
-  "@settingsAudioRouteArc": {
-    "description": "Audio route type ARC"
-  },
-  "@settingsAudioRouteEarc": {
-    "description": "Audio route type eARC"
-  },
-  "@settingsAudioRouteBluetooth": {
-    "description": "Audio route type Bluetooth"
-  },
-  "@settingsAudioRouteSpeaker": {
-    "description": "Audio route type speaker"
-  },
-  "@settingsAudioPcmChannels": {
-    "description": "Audio route subtitle showing max PCM channels",
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@settingsAudioDiagnostics": {
-    "description": "Section title for playback diagnostics"
-  },
-  "@settingsAudioDiagnosticsVideoLevel": {
-    "description": "Diagnostics label for video level"
-  },
-  "@settingsAudioDiagnosticsVideoRange": {
-    "description": "Diagnostics label for video range"
-  },
-  "@settingsAudioDiagnosticsSubtitleCodec": {
-    "description": "Diagnostics label for subtitle codec"
-  },
-  "@settingsAudioDiagnosticsAllowedAudioCodecs": {
-    "description": "Diagnostics label for allowed audio codecs"
-  },
-  "@settingsAudioDiagnosticsHlsMpegTsAudioCodecs": {
-    "description": "Diagnostics label for HLS MPEG-TS audio codecs"
-  },
-  "@settingsAudioDiagnosticsHlsFmp4AudioCodecs": {
-    "description": "Diagnostics label for HLS fMP4 audio codecs"
-  },
-  "@settingsAudioDiagnosticsAudioSpdifPassthrough": {
-    "description": "Diagnostics label for audio-spdif passthrough codecs"
-  },
-  "@settingsAudioDiagnosticsActiveAudioRoute": {
-    "description": "Diagnostics label for active audio route"
-  },
-  "@settingsAudioDiagnosticsRouteHdAudioSupport": {
-    "description": "Diagnostics label for route HD audio support"
-  },
-  "@mediaSources": {
-    "description": "Section heading for media source options"
-  },
-  "@behavior": {
-    "description": "Section heading for behavior options"
-  },
-  "@seconds": {
-    "description": "Time unit label in seconds"
-  },
-  "@localPreviews": {
-    "description": "Local previews settings screen title"
-  },
-  "@localPreviewsDescription": {
-    "description": "Description for local previews settings"
-  },
-  "@mediaPreview": {
-    "description": "Setting for media preview"
-  },
-  "@mediaPreviewDescription": {
-    "description": "Description for media preview"
-  },
-  "@autoplayNextEpisode": {
-    "description": "Setting title: automatically start the next episode"
-  },
-  "@autoplayNextEpisodeSubtitle": {
-    "description": "Setting subtitle for autoplay next episode"
-  },
-  "@skipSilenceTitle": {
-    "description": "Setting title: skip silent audio segments during playback"
-  },
-  "@skipSilenceSubtitle": {
-    "description": "Setting subtitle for skip silence"
-  },
-  "@allowExternalAudioEffectsTitle": {
-    "description": "Setting title: allow equalizer apps to attach to Media3"
-  },
-  "@allowExternalAudioEffectsSubtitle": {
-    "description": "Setting subtitle for external audio effects"
-  },
-  "@disableTunnelingTitle": {
-    "description": "Setting title: force non-tunneled video playback"
-  },
-  "@disableTunnelingSubtitle": {
-    "description": "Setting subtitle for disable tunneling"
-  },
-  "@mapDolbyVisionP7Title": {
-    "description": "Setting title: play DV P7 as HDR10 HEVC on non-DV devices"
-  },
-  "@mapDolbyVisionP7Subtitle": {
-    "description": "Setting subtitle for DV P7 to HEVC mapping"
-  },
-  "@subtitlesUseEmbeddedStyles": {
-    "description": "Setting title: apply colours/positioning from the subtitle track"
-  },
-  "@subtitlesUseEmbeddedStylesSubtitle": {
-    "description": "Setting subtitle for embedded styles toggle"
-  },
-  "@subtitlesUseEmbeddedFontSizes": {
-    "description": "Setting title: apply font sizes from the subtitle track"
-  },
-  "@subtitlesUseEmbeddedFontSizesSubtitle": {
-    "description": "Setting subtitle for embedded font sizes toggle"
-  },
-  "@useDetailedSubHeadings": {
-    "description": "Label for setting to toggle detailed or minimal subrow on library pages"
-  },
-  "@useDetailedSubHeadingsDescription": {
-    "description": "Subtitle for the use detailed sub headings setting"
-  },
-  "@savedThemesDeleteDialogMessage": {
-    "description": "Confirmation message for deleting a saved custom theme",
-    "placeholders": {
-      "themeName": {
-        "type": "String"
-      }
-    }
-  },
-  "@savedThemesDeletedMessage": {
-    "description": "Status message shown after deleting a saved custom theme",
-    "placeholders": {
-      "themeName": {
-        "type": "String"
-      }
-    }
-  },
-  "@savedThemesDeleteFailedMessage": {
-    "description": "Status message shown when deleting a saved custom theme fails",
-    "placeholders": {
-      "themeName": {
-        "type": "String"
-      }
-    }
-  },
-  "@savedThemesCurrentThemeId": {
-    "description": "Subtitle showing the saved theme id when it is currently selected",
-    "placeholders": {
-      "themeId": {
-        "type": "String"
-      }
-    }
-  },
-  "@webDiagnosticsTargetUrl": {
-    "description": "Target URL shown in diagnostics summary",
-    "placeholders": {
-      "url": {
-        "type": "String"
-      }
-    }
-  },
-  "@webDiagnosticsDetail": {
-    "description": "Error detail shown in diagnostics summary",
-    "placeholders": {
-      "detail": {
-        "type": "String"
-      }
-    }
-  },
-  "@analyticsLibrariesCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "@adminPercentUsed": {
-    "placeholders": {
-      "percent": {
-        "type": "int"
-      }
-    }
-  },
   "@noImagePagesFoundInArchive": {
     "placeholders": {
       "extension": {
@@ -7313,6 +7399,7 @@
       }
     }
   },
+  "embeddedRendererFailed": "Falha no renderizador incorporado ({code}): {description}",
   "@embeddedRendererFailed": {
     "placeholders": {
       "code": {
@@ -7323,6 +7410,7 @@
       }
     }
   },
+  "epubRendererFailed": "Falha no renderizador EPUB ({code}): {description}",
   "@epubRendererFailed": {
     "placeholders": {
       "code": {
@@ -7333,6 +7421,7 @@
       }
     }
   },
+  "missingLocalFileForReader": "Arquivo local ausente para leitor: {uri}",
   "@missingLocalFileForReader": {
     "placeholders": {
       "uri": {
@@ -7340,6 +7429,7 @@
       }
     }
   },
+  "httpStatusWhileOpeningBookData": "HTTP {status} ao abrir dados do livro de {uri}",
   "@httpStatusWhileOpeningBookData": {
     "placeholders": {
       "status": {
@@ -7350,6 +7440,8 @@
       }
     }
   },
+  "noReadableBookEndpointAvailable": "Nenhum endpoint de livro legível disponível",
+  "unsupportedComicArchiveFormat": "Formato de arquivo de quadrinhos não suportado: .{extension}",
   "@unsupportedComicArchiveFormat": {
     "placeholders": {
       "extension": {
@@ -7357,5 +7449,17 @@
       }
     }
   },
-  "settingsSupportMoonfinSubtitle": "Doe um café para o desenvolvedor"
+  "cbrExtractionPluginUnavailable": "O plugin de extração CBR não está disponível nesta plataforma.",
+  "failedToExtractCbrArchive": "Falha ao extrair o arquivo .cbr.",
+  "cb7ExtractionUnavailable": "A extração CB7 não está disponível nesta plataforma.",
+  "cb7ExtractionPluginUnavailable": "O plugin de extração CB7 não está disponível nesta plataforma.",
+  "closeGenrePanel": "Fechar painel de género",
+  "loadingShuffle": "A carregar ordem aleatória...",
+  "libraryShuffleLabel": "Mistura da Biblioteca",
+  "randomShuffleLabel": "Mistura Aleatória",
+  "genresShuffleLabel": "Mistura de Géneros",
+  "autoHdrSwitching": "Troca automática de HDR",
+  "autoHdrSwitchingDescription": "Ativa automaticamente o HDR para reprodução de vídeo HDR e restaura o modo de apresentação ao sair.",
+  "whenFullscreen": "Quando em ecrã inteiro",
+  "transcodingLimits": "Limites de transcodificação"
 }

--- a/lib/l10n/app_pt-PT.arb
+++ b/lib/l10n/app_pt-PT.arb
@@ -3872,7 +3872,7 @@
   "@mediaBarMode": {
     "description": "Setting for choosing media bar style"
   },
-  "mediaBarModeDescription": "Escolhe entre Moonfin, MakD ou desliga a barra de conteúdo",
+  "mediaBarModeDescription": "Escolhe entre vários estilos de barra de conteúdo ou desativa a barra de conteúdo",
   "@mediaBarModeDescription": {
     "description": "Description for media bar style setting"
   },


### PR DESCRIPTION
# Pull Request

## Summary
Complete European Portuguese (pt-PT) localization corrections. Replaced Brazilian Portuguese (pt-BR) translations


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Corrected all pt-BR translations to pt-PT (e.g. `Senha`→`Palavra-passe`, `usuário`→`utilizador`, `salvos`→`guardados`, `assistindo`→`a ver`)
- Fixed formal imperatives to informal register (`Introduza`→`Introduzir`, `Abra`→`Abrir`, `Junte-se`→`Juntar-se`, `Reinicie`→`Reinicia`)
- Replaced incorrect terminology (`jogador`→`reprodutor`, `cast`(Chromecast)→`Transmitir`, `Correr`→`Executar`)
- Fixed color name gender (`Castanha`→`Castanho` for brown)
- Fixed gender agreement (`anexados`→`anexadas` for feminine noun)
- Fixed Brazilian reflexive (`se aplicam`→`são aplicadas`)
- Translated 32 new keys added by upstream (home row toggles, scroll wheel, Seerr, playlists, etc.)

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

## Observations

Translations from upstream where made with auto translator, resulting on many incorrect translated strings, many with incorrect names, making the app very confusing.
Some strings should been translated at all like Moonfin, Seer, Letterbox...

Please provide  a translation platform like https://translate.codeberg.org so user can translate and fix the current translation easily 