### PR TITLE
feat(playback): add Advanced Playback long-press menu on details page

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -48,6 +48,7 @@ import '../../widgets/focus/focusable_button.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/focus/step_scroll.dart';
 import '../../widgets/overlay_sheet.dart';
+import '../../widgets/settings/preference_tiles.dart';
 import '../../widgets/playback/player_loading_overlay.dart';
 import '../../../playback/offline_playback_launcher.dart';
 import '../../../playback/hdr_stream_capability.dart';
@@ -4396,6 +4397,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
       label: button.label,
       icon: button.icon,
       onPressed: button.onPressed,
+      onLongPress: button.onLongPress,
       onFocused: onFocused ?? button.onFocused,
       onArrowUp: onArrowUp ?? button.onArrowUp,
       onArrowDown: onArrowDown ?? button.onArrowDown,
@@ -4710,6 +4712,13 @@ class _ActionButtonsState extends State<_ActionButtons> {
     final isPhoto = item.type == 'Photo';
     final isBook = _isReadableBookItem(item);
     final isSeries = item.type == 'Series';
+    final mediaType = item.rawData['MediaType'] as String?;
+    final isAudio =
+        item.type == 'Audio' ||
+        item.type == 'MusicAlbum' ||
+        item.type == 'AudioBook' ||
+        mediaType == 'Audio';
+    final isVideo = !isPhoto && !isBook && !isAudio;
     final ws = _computeWatchState(item);
     final isFullyWatched = ws.isFullyWatched;
     final isFullyUnwatched = ws.isFullyUnwatched;
@@ -4787,6 +4796,9 @@ class _ActionButtonsState extends State<_ActionButtons> {
         focusNode: PlatformDetection.isTV ? _tvPlayFocusNode : null,
         autofocus: PlatformDetection.isTV,
         onPressed: () => _play(context, item, resume: !isPhoto && hasProgress),
+        onLongPress: isVideo
+            ? () => _showAdvancedPlaybackMenu(context, item)
+            : null,
       ),
       if (_supportsShuffle(item))
         _DetailActionButton(
@@ -4799,6 +4811,9 @@ class _ActionButtonsState extends State<_ActionButtons> {
           label: isBook ? l10n.startOver : l10n.restart,
           icon: Icons.restart_alt,
           onPressed: () => _play(context, item),
+          onLongPress: isVideo
+              ? () => _showAdvancedPlaybackMenu(context, item, forceStartOver: true)
+              : null,
         ),
       if (_offlineRow != null)
         _DetailActionButton(
@@ -4933,6 +4948,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
           label: widget.label,
           icon: widget.icon,
           onPressed: widget.onPressed,
+          onLongPress: widget.onLongPress,
           onFocused: widget.onFocused,
           onArrowUp: widget.onArrowUp,
           onArrowDown: widget.onArrowDown,
@@ -5299,15 +5315,127 @@ class _ActionButtonsState extends State<_ActionButtons> {
     }
   }
 
+  void _showAdvancedPlaybackMenu(
+    BuildContext context,
+    AggregatedItem item, {
+    bool forceStartOver = false,
+  }) async {
+    final resume = !forceStartOver && (item.playbackPosition?.inMilliseconds ?? 0) > 0;
+    final options = [
+      if (PlatformDetection.isAndroid)
+        _AdvancedPlaybackOption(
+          label: 'Open in External Player',
+          icon: Icons.open_in_new,
+          onTap: () {
+            _play(
+              context,
+              item,
+              resume: resume,
+              openInExternalPlayer: true,
+            );
+          },
+        ),
+      _AdvancedPlaybackOption(
+        label: 'Transcode Stream: High Quality (1080p)',
+        icon: Icons.high_quality,
+        onTap: () {
+          _play(
+            context,
+            item,
+            resume: resume,
+            forceMaxBitrateMbps: 4,
+            forceTranscode: true,
+          );
+        },
+      ),
+      _AdvancedPlaybackOption(
+        label: 'Transcode Stream: Medium Quality (720p)',
+        icon: Icons.video_settings,
+        onTap: () {
+          _play(
+            context,
+            item,
+            resume: resume,
+            forceMaxBitrateMbps: 2,
+            forceTranscode: true,
+          );
+        },
+      ),
+      _AdvancedPlaybackOption(
+        label: 'Transcode Stream: Low Quality (480p)',
+        icon: Icons.sd,
+        onTap: () {
+          _play(
+            context,
+            item,
+            resume: resume,
+            forceMaxBitrateMbps: 1,
+            forceTranscode: true,
+          );
+        },
+      ),
+    ];
+
+    var picked = false;
+    await showFocusRestoringDialog<void>(
+      context: context,
+      useRootNavigator: false,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Text('Advanced Playback'),
+        children: options.asMap().entries.map((entry) {
+          final i = entry.key;
+          final option = entry.value;
+          return FocusableButton(
+            autofocus: i == 0,
+            borderRadius: 6,
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+            onPressed: () {
+              if (picked) return;
+              picked = true;
+              Navigator.of(dialogContext).pop();
+              option.onTap();
+            },
+            child: Row(
+              children: [
+                Icon(option.icon, size: 22),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Text(
+                    option.label,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
   void _play(
     BuildContext context,
     AggregatedItem item, {
     bool resume = false,
+    int? forceMaxBitrateMbps,
+    bool forceTranscode = false,
+    bool openInExternalPlayer = false,
   }) async {
     if (_playLaunchInFlight) return;
     _playLaunchInFlight = true;
     try {
-      await _playInternal(context, item, resume: resume);
+      final manager = GetIt.instance<PlaybackManager>();
+      manager.setBitrateOverride(forceMaxBitrateMbps);
+      if (openInExternalPlayer) {
+        manager.forceExternalPlayerOnce();
+        manager.forceExternalChooserOnce();
+      }
+      await _playInternal(
+        context,
+        item,
+        resume: resume,
+        forceTranscode: forceTranscode,
+      );
     } finally {
       _playLaunchInFlight = false;
     }
@@ -5569,6 +5697,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
     BuildContext context,
     AggregatedItem item, {
     bool resume = false,
+    bool forceTranscode = false,
   }) async {
     final manager = GetIt.instance<PlaybackManager>();
     final mediaStreams = _mediaStreamsForCurrentSelection(item);
@@ -5701,18 +5830,19 @@ class _ActionButtonsState extends State<_ActionButtons> {
                 : Duration.zero;
 
             if (!context.mounted) return;
-            final forceTranscode = await _shouldForceTranscodeForDolbyVision(
+            final dvForceTranscode = await _shouldForceTranscodeForDolbyVision(
               context,
               [selectedEpisode],
             );
+            final directAllowed = !dvForceTranscode && !forceTranscode;
             await manager.playItems(
               seriesQueue,
               startIndex: idx,
               startPosition: startPosition,
               audioStreamIndex: audioStreamIndex,
               subtitleStreamIndex: subtitleStreamIndex,
-              enableDirectPlay: !forceTranscode,
-              enableDirectStream: !forceTranscode,
+              enableDirectPlay: directAllowed,
+              enableDirectStream: directAllowed,
             );
 
           case 'Season':
@@ -5732,18 +5862,19 @@ class _ActionButtonsState extends State<_ActionButtons> {
             final startPosition = resume
                 ? (selectedEpisode.playbackPosition ?? Duration.zero)
                 : Duration.zero;
-            final forceTranscode = await _shouldForceTranscodeForDolbyVision(
+            final dvForceTranscode = await _shouldForceTranscodeForDolbyVision(
               context,
               [selectedEpisode],
             );
+            final directAllowed = !dvForceTranscode && !forceTranscode;
             await manager.playItems(
               seasonQueue,
               startIndex: idx,
               startPosition: startPosition,
               audioStreamIndex: audioStreamIndex,
               subtitleStreamIndex: subtitleStreamIndex,
-              enableDirectPlay: !forceTranscode,
-              enableDirectStream: !forceTranscode,
+              enableDirectPlay: directAllowed,
+              enableDirectStream: directAllowed,
             );
 
           case 'Episode':
@@ -5784,11 +5915,12 @@ class _ActionButtonsState extends State<_ActionButtons> {
                   ? ((selectedEpisode.id == item.id ? item.playbackPosition : selectedEpisode.playbackPosition) ?? Duration.zero)
                   : Duration.zero;
                   
-              final forceTranscode = await _shouldForceTranscodeForDolbyVision(
+              final dvForceTranscode = await _shouldForceTranscodeForDolbyVision(
                 context,
                 [selectedEpisode],
                 mediaSourceId: widget.selectedMediaSourceId,
               );
+              final directAllowed = !dvForceTranscode && !forceTranscode;
               await manager.playItems(
                 episodeQueue,
                 startIndex: idx,
@@ -5796,8 +5928,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
                 audioStreamIndex: audioStreamIndex,
                 subtitleStreamIndex: subtitleStreamIndex,
                 mediaSourceId: widget.selectedMediaSourceId,
-                enableDirectPlay: !forceTranscode,
-                enableDirectStream: !forceTranscode,
+                enableDirectPlay: directAllowed,
+                enableDirectStream: directAllowed,
               );
               break;
             }
@@ -5825,11 +5957,12 @@ class _ActionButtonsState extends State<_ActionButtons> {
             final queue = prerolls.isEmpty
                 ? <AggregatedItem>[item]
                 : <AggregatedItem>[...prerolls, item];
-            final forceTranscode =
+            final dvForceTranscode =
                 !isAudio &&
                 await _shouldForceTranscodeForDolbyVision(context, [
                   item,
                 ], mediaSourceId: selectedMediaSourceId);
+            final directAllowed = !dvForceTranscode && !forceTranscode;
             final playItemsFuture = manager.playItems(
               queue,
               startPosition: startPosition,
@@ -5842,8 +5975,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
               mediaSourceId: applyMainItemStreamOverrides
                   ? selectedMediaSourceId
                   : null,
-              enableDirectPlay: !forceTranscode,
-              enableDirectStream: !forceTranscode,
+              enableDirectPlay: directAllowed,
+              enableDirectStream: directAllowed,
             );
             if (!applyMainItemStreamOverrides && hasMainItemStreamOverrides) {
               manager.setPendingItemOverrides(
@@ -7472,6 +7605,7 @@ class _DetailActionButton extends StatefulWidget {
   final String label;
   final IconData icon;
   final VoidCallback onPressed;
+  final VoidCallback? onLongPress;
   final VoidCallback? onFocused;
   final VoidCallback? onArrowUp;
   final VoidCallback? onArrowDown;
@@ -7488,6 +7622,7 @@ class _DetailActionButton extends StatefulWidget {
     required this.label,
     required this.icon,
     required this.onPressed,
+    this.onLongPress,
     this.onFocused,
     this.onArrowUp,
     this.onArrowDown,
@@ -7507,6 +7642,16 @@ class _DetailActionButton extends StatefulWidget {
 
 class _DetailActionButtonState extends State<_DetailActionButton>
     with FocusStateMixin {
+  Timer? _longPressTimer;
+  bool _longPressFired = false;
+  bool _selectDownSeen = false;
+
+  @override
+  void dispose() {
+    _longPressTimer?.cancel();
+    super.dispose();
+  }
+
   bool _tryFocusSidebar() {
     if (GetIt.instance<UserPreferences>().get(UserPreferences.navbarPosition) !=
         NavbarPosition.left) {
@@ -7640,6 +7785,42 @@ class _DetailActionButtonState extends State<_DetailActionButton>
             widget.onArrowDown!();
             return KeyEventResult.handled;
           }
+          if (widget.onLongPress != null) {
+            if (event.logicalKey.isContextMenuKey) {
+              if (event is KeyDownEvent) {
+                widget.onLongPress!();
+              }
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey.isSelectKey) {
+              if (event is KeyDownEvent) {
+                _selectDownSeen = true;
+                _longPressFired = false;
+                _longPressTimer?.cancel();
+                _longPressTimer = Timer(const Duration(milliseconds: 500), () {
+                  _longPressFired = true;
+                  widget.onLongPress?.call();
+                });
+                return KeyEventResult.handled;
+              }
+              if (event is KeyRepeatEvent) {
+                return _selectDownSeen
+                    ? KeyEventResult.handled
+                    : KeyEventResult.ignored;
+              }
+              if (event is KeyUpEvent) {
+                if (!_selectDownSeen) return KeyEventResult.ignored;
+                _selectDownSeen = false;
+                _longPressTimer?.cancel();
+                _longPressTimer = null;
+                if (!_longPressFired) {
+                  widget.onPressed();
+                }
+                _longPressFired = false;
+                return KeyEventResult.handled;
+              }
+            }
+          }
           if (isActivateKey(event)) {
             widget.onPressed();
             return KeyEventResult.handled;
@@ -7648,6 +7829,8 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         },
         child: GestureDetector(
           onTap: widget.onPressed,
+          onLongPress: widget.onLongPress,
+          onSecondaryTap: widget.onLongPress,
           child: SizedBox(
             width: isMobile ? 80 : 108 * desktopScale,
             child: Column(
@@ -10816,4 +10999,16 @@ class _NavbarFocusPoint extends StatelessWidget {
       child: const SizedBox(height: 1, width: double.infinity),
     );
   }
+}
+
+class _AdvancedPlaybackOption {
+  final String label;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  _AdvancedPlaybackOption({
+    required this.label,
+    required this.icon,
+    required this.onTap,
+  });
 }

--- a/lib/ui/screens/playback/external_player_host_screen.dart
+++ b/lib/ui/screens/playback/external_player_host_screen.dart
@@ -46,9 +46,10 @@ class _ExternalPlayerHostScreenState extends State<ExternalPlayerHostScreen> {
     Duration pendingStartPosition = _manager.consumeDeferredStartPosition();
 
     try {
-      var component = _prefs
-          .get(UserPreferences.externalPlayerComponentName)
-          .trim();
+      final forceChooser = _manager.consumeForceExternalChooserOnce();
+      var component = forceChooser
+          ? ''
+          : _prefs.get(UserPreferences.externalPlayerComponentName).trim();
 
       final selectedPlayer = component.isEmpty
           ? null

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -80,6 +80,8 @@ class PlaybackManager implements AudioOwnable {
   Duration _deferredStartPosition = Duration.zero;
   bool _deferPlaybackToExternalPlayer = false;
   bool _skipExternalRoutingOnce = false;
+  bool _forceExternalPlayerOnce = false;
+  bool _forceExternalChooserOnce = false;
   bool _unsupportedAudioRecoveryInFlight = false;
   bool _suppressNextGenericBackendError = false;
   final _backendChangedController = StreamController<PlayerBackend>.broadcast();
@@ -110,6 +112,24 @@ class PlaybackManager implements AudioOwnable {
 
   void skipExternalRoutingOnce() {
     _skipExternalRoutingOnce = true;
+  }
+
+  void forceExternalPlayerOnce() {
+    _forceExternalPlayerOnce = true;
+  }
+
+  void forceExternalChooserOnce() {
+    _forceExternalChooserOnce = true;
+  }
+
+  bool consumeForceExternalChooserOnce() {
+    final shouldForce = _forceExternalChooserOnce;
+    _forceExternalChooserOnce = false;
+    return shouldForce;
+  }
+
+  void setBitrateOverride(int? mbps) {
+    _maxBitrateOverrideMbps = mbps;
   }
 
   int? get maxBitrateOverrideMbps => _maxBitrateOverrideMbps;
@@ -714,8 +734,11 @@ class PlaybackManager implements AudioOwnable {
     }
     queueService.setQueue(items, startIndex: startIndex);
 
+    final forceExternal = _forceExternalPlayerOnce;
+    _forceExternalPlayerOnce = false;
+
     final externalDecider = _externalPlaybackDecider;
-    if (externalDecider != null && externalDecider(items)) {
+    if (forceExternal || (externalDecider != null && externalDecider(items))) {
       _deferredStartPosition = startPosition;
       _deferPlaybackToExternalPlayer = true;
       _setBringupState(const PlaybackBringupState.idle());


### PR DESCRIPTION
# Add Advanced Playback to Long-Press

## Summary
Add an "Advanced Playback" long-press context menu to the "Play" and "Start Over" action buttons on the Media Details screen. This menu enables users to bypass default configurations to launch playback in an external player (on Android) or force transcoding streams at curated bitrates (1080p, 720p, and 480p; matching the Download options available on Mobile).

## Related Issues
Related to feature request on Discord.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added "Advanced Playback" menu triggered by long pressing (or right-clicking) Play and Start Over action buttons on the details page.
- Implemented option to open item in external player (Android native chooser, bypassing default configurations) and options to force transcoding at High Quality (1080p, 4 Mbps), Medium Quality (720p, 2 Mbps), and Low Quality (480p, 1 Mbps).
- Updated PlaybackManager to support temporary bitrate overrides and force-routing flags.
- Re-implemented advanced playback dialog options using FocusableButton to participate in select-key release suppression (_SelectKeyUpSuppressor) and avoid immediate click triggers on Enter key long press.
- Added key repeat and key release event handling to preserve context actions and prevent duplicate tap event dispatching on details page action buttons.
- Restricted the "Open in External Player" option to Android devices via PlatformDetection.isAndroid.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
* Ran flutter analyze: Passed with no new compile errors or warnings.
* Successfully built and packaged the Windows release installer (Moonfin_Windows_v2.0.1.exe) using the build-windows.ps1 script.
* Manual Test Cases Run
    * Normal Playback: Tapping "Play" starts regular playback and clears any previous bitrate override.
    * Context Menu Launch: Long pressing "Play" (or Select key on keyboard/remote) or right-clicking displays the "Advanced Playback" menu.
    * Select Key Long-Press: Holding down Enter/Select triggers the menu after 500ms and waits for a fresh key repress before executing a menu item (no premature triggers).
    * Platform Specifics: Option to launch in external player is shown on Android and hidden on Windows.
    * Quality Override: Selecting a "Transcode Stream" option forces transcode playback restricted to the selected max bitrate (4 Mbps, 2 Mbps, or 1 Mbps).

## Screenshots (if applicable)
<img width="500" alt="2026-06-08_07-11-41_moonfin" src="https://github.com/user-attachments/assets/588bbd4e-e17e-4ed5-9b1f-af77c661e2c7" />
<img width="500" alt="2026-06-08_07-43-15_moonfin" src="https://github.com/user-attachments/assets/1a4d4aaf-70f7-42e7-bcc8-4933ef6fb22a" />
<img width="500" alt="2026-06-08_07-42-42_moonfin" src="https://github.com/user-attachments/assets/d74ba09f-9c77-4439-bb1c-b938d850cb92" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
