### PR TITLE
feat(playback): Add headphone auto-pause on disconnection and fix iOS core functionality

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -309,7 +309,7 @@ void main() async {
     await notificationService.initialize();
   } catch (_) {}
 
-  if (PlatformDetection.isMobile || PlatformDetection.isIOS) {
+  if (PlatformDetection.isMobile) {
     try {
       await initAudioService(
         manager: GetIt.instance<PlaybackManager>(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -309,7 +309,7 @@ void main() async {
     await notificationService.initialize();
   } catch (_) {}
 
-  if (PlatformDetection.isMobile) {
+  if (PlatformDetection.isMobile || PlatformDetection.isIOS) {
     try {
       await initAudioService(
         manager: GetIt.instance<PlaybackManager>(),
@@ -333,6 +333,9 @@ void main() async {
       ),
     ));
     await session.setActive(true);
+    session.becomingNoisyEventStream.listen((_) {
+      GetIt.instance<PlaybackManager>().pause();
+    });
   } catch (_) {}
 
   if (!GetIt.instance.isRegistered<PlaybackLifecycleHandler>()) {

--- a/lib/playback/audio_handler.dart
+++ b/lib/playback/audio_handler.dart
@@ -50,6 +50,8 @@ class MoonfinAudioHandler extends BaseAudioHandler
       controls: controls,
       systemActions: const {
         MediaAction.seek,
+        MediaAction.play,
+        MediaAction.pause,
         MediaAction.skipToNext,
         MediaAction.skipToPrevious,
       },


### PR DESCRIPTION
# The one about EXPERIMENTAL Headphones Support

## Summary
This PR adds support for headphone auto-pause when disconnected (e.g., AirPods removal or wired headphone unplug) and fixes media key controls (play/pause) on iOS/iPadOS.

## Related Issues
Requested on Discord.

- Closes #
- Fixes #251
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- iOS/iPadOS Headphone Controls Fix (`lib/playback/audio_handler.dart`): Added `MediaAction.play` and `MediaAction.pause` to the `systemActions` configuration in `MoonfinAudioHandler`. This allows iOS's `MPRemoteCommandCenter` to register play/pause handlers so that AirPods, lock screen, and system control center events are handled (bug fix).
- Headphone Disconnection Auto-Pause (`lib/main.dart`): Configured a listener on the `AudioSession`'s `becomingNoisyEventStream` that automatically pauses playback via `PlaybackManager.pause()`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): As headphone hardware disconnection and iOS remote command center actions require physical device interaction and local testing hardware was unavailable, this PR is submitted as a **draft** for verification by remote testers and should be tagged as experimental

### Test Steps
1. Play any audio/video on iOS or Android and unplug/disconnect headphones/AirPods. Verify that playback auto-pauses.
2. Play any media on iOS/iPadOS and verify play/pause buttons work on the Lock Screen, Control Center, and via AirPods force sensors.

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
