### PR TITLE
fix(playback): resolve race condition to prevent OSD takeover

### DIFF
--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -1125,16 +1125,16 @@ class MediaKitPlayerBackend implements PlayerBackend {
   });
 
   @override
-  Stream<bool> get playingStream => _player.stream.playing.map((playing) {
-    _updateStaleState();
-    return _isStale ? false : playing;
-  });
+  Stream<bool> get playingStream => _mergeWithStale<bool>(
+        _player.stream.playing,
+        () => _isStale ? false : _player.state.playing,
+      );
 
   @override
-  Stream<bool> get bufferingStream => _player.stream.buffering.map((buffering) {
-    _updateStaleState();
-    return _isStale ? false : buffering;
-  });
+  Stream<bool> get bufferingStream => _mergeWithStale<bool>(
+        _player.stream.buffering,
+        () => _isStale ? false : _player.state.buffering,
+      );
 
   @override
   Stream<bool> get completedStream => _player.stream.completed.map((completed) {
@@ -1406,6 +1406,32 @@ class MediaKitPlayerBackend implements PlayerBackend {
         '${r.toRadixString(16).padLeft(2, '0')}'
         '${g.toRadixString(16).padLeft(2, '0')}'
         '${b.toRadixString(16).padLeft(2, '0')}';
+  }
+
+  Stream<T> _mergeWithStale<T>(Stream<T> source, T Function() getValue) {
+    late StreamController<T> controller;
+    StreamSubscription<T>? sourceSub;
+    StreamSubscription<Playlist>? playlistSub;
+
+    controller = StreamController<T>.broadcast(
+      onListen: () {
+        void checkAndPush() {
+          _updateStaleState();
+          if (!controller.isClosed) {
+            controller.add(getValue());
+          }
+        }
+
+        sourceSub = source.listen((_) => checkAndPush());
+        playlistSub = _player.stream.playlist.listen((_) => checkAndPush());
+        checkAndPush();
+      },
+      onCancel: () {
+        sourceSub?.cancel();
+        playlistSub?.cancel();
+      },
+    );
+    return controller.stream;
   }
 
   @override

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -191,6 +191,16 @@ class MediaKitPlayerBackend implements PlayerBackend {
   bool _isStale = false;
   String? _currentUrl;
 
+  late final Stream<bool> _playingStream = _mergeWithStale<bool>(
+    _player.stream.playing,
+    () => _isStale ? false : _player.state.playing,
+  );
+
+  late final Stream<bool> _bufferingStream = _mergeWithStale<bool>(
+    _player.stream.buffering,
+    () => _isStale ? false : _player.state.buffering,
+  );
+
   void _updateStaleState() {
     if (!_isStale) return;
     try {
@@ -1125,16 +1135,10 @@ class MediaKitPlayerBackend implements PlayerBackend {
   });
 
   @override
-  Stream<bool> get playingStream => _mergeWithStale<bool>(
-        _player.stream.playing,
-        () => _isStale ? false : _player.state.playing,
-      );
+  Stream<bool> get playingStream => _playingStream;
 
   @override
-  Stream<bool> get bufferingStream => _mergeWithStale<bool>(
-        _player.stream.buffering,
-        () => _isStale ? false : _player.state.buffering,
-      );
+  Stream<bool> get bufferingStream => _bufferingStream;
 
   @override
   Stream<bool> get completedStream => _player.stream.completed.map((completed) {


### PR DESCRIPTION
# resolve race condition to prevent OSD takeover

## Summary
Resolves a race condition on desktop platforms using `media_kit` where the play/pause button state gets stuck on the Play icon and the OSD controls fail to auto-hide when video playback begins.

## Related Issues
None - bug found during playback testing

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Implemented the `_mergeWithStale<T>` helper method in `MediaKitPlayerBackend` which merges the underlying streams with `_player.stream.playlist` events.
- Updated `playingStream` and `bufferingStream` getters to utilize this helper to ensure they are re-evaluated and re-emitted once `_isStale` becomes `false` when media loads.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code (but only impact Desktop clients)

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Build and run the Windows application.
2. Play any video.
3. Verify that the play button switches to the **Pause** icon once playback begins.
4. Verify that the OSD correctly auto-hides after the inactivity delay.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
