### PR TITLE
fix(auth): Fix Auto-Logon "Current User" behaviour

### DIFF
--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -270,7 +270,9 @@ class SessionRepository {
 
     await _authPrefs.setLastServerId('');
     await _authPrefs.setLastUserId('');
-    await _authPrefs.clearAutoLogin();
+    if (_authPrefs.loginBehavior != UserSelectBehavior.currentUser) {
+      await _authPrefs.clearAutoLogin();
+    }
 
     _activeServerId = null;
     _activeUserId = null;

--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -74,6 +74,34 @@ class SessionRepository {
 
   String? get activeServerId => _activeServerId;
   String? get activeUserId => _activeUserId;
+
+  // save or clear the auto login target based on the chosen behavior.
+  Future<void> applyAutoLoginForBehavior(UserSelectBehavior behavior) async {
+    if (behavior == UserSelectBehavior.currentUser) {
+      final serverId = _activeServerId;
+      final userId = _activeUserId;
+      if (serverId != null && userId != null) {
+        await _authPrefs.setAutoLogin(serverId, userId);
+      }
+    } else {
+      await _authPrefs.clearAutoLogin();
+    }
+  }
+
+  // true when the person using the app right now is the saved auto login user.
+  bool get activeUserIsAutoLoginTarget =>
+      _activeUserId != null &&
+      _activeServerId != null &&
+      _authPrefs.savedAutoLoginUserId == _activeUserId &&
+      _authPrefs.savedAutoLoginServerId == _activeServerId;
+
+  // the name of the saved auto-login user or null if none.
+  String? autoLoginTargetDisplayName() {
+    final serverId = _authPrefs.savedAutoLoginServerId;
+    final userId = _authPrefs.savedAutoLoginUserId;
+    if (serverId.isEmpty || userId.isEmpty) return null;
+    return _authStore.getUser(serverId, userId)?.name;
+  }
   SessionState get state => _state;
   Stream<SessionState> get stateStream => _stateController.stream;
 

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -24,6 +24,8 @@ import '../../../util/app_distribution.dart';
 import '../../widgets/app_update_dialog.dart';
 
 import '../../../auth/store/authentication_preferences.dart';
+import '../../../auth/store/authentication_store.dart';
+import '../../../auth/repositories/session_repository.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../playback/audio_capability_profile.dart';
 import '../../../playback/external_player_service.dart';
@@ -468,10 +470,51 @@ class _AuthenticationCategoryScreen extends StatelessWidget {
             preference: UserPreferences.autoLoginUserBehavior,
             title: l10n.autoLogin,
             icon: Icons.person,
-            labelOf: (v) => switch (v) {
+            labelOf: (v) {
+              if (v == UserSelectBehavior.currentUser) {
+                final authPrefs = GetIt.instance<AuthenticationPreferences>();
+                final autoUserId = authPrefs.savedAutoLoginUserId;
+                final autoServerId = authPrefs.savedAutoLoginServerId;
+                if (autoUserId.isNotEmpty && autoServerId.isNotEmpty) {
+                  final authStore = GetIt.instance<AuthenticationStore>();
+                  final autoUser = authStore.getUser(autoServerId, autoUserId);
+                  if (autoUser != null) {
+                    final session = GetIt.instance<SessionRepository>();
+                    if (session.activeUserId == autoUserId &&
+                        session.activeServerId == autoServerId) {
+                      return l10n.currentUser;
+                    } else {
+                      return autoUser.name;
+                    }
+                  }
+                }
+                return l10n.currentUser;
+              }
+              return switch (v) {
+                UserSelectBehavior.disabled => l10n.disabled,
+                UserSelectBehavior.lastUser => l10n.lastUser,
+                _ => l10n.currentUser,
+              };
+            },
+            dialogLabelOf: (v) => switch (v) {
               UserSelectBehavior.disabled => l10n.disabled,
               UserSelectBehavior.lastUser => l10n.lastUser,
               UserSelectBehavior.currentUser => l10n.currentUser,
+            },
+            onChanged: () {
+              final store = GetIt.instance<PreferenceStore>();
+              final behavior = store.get(UserPreferences.autoLoginUserBehavior);
+              final authPrefs = GetIt.instance<AuthenticationPreferences>();
+              if (behavior == UserSelectBehavior.currentUser) {
+                final session = GetIt.instance<SessionRepository>();
+                final serverId = session.activeServerId;
+                final userId = session.activeUserId;
+                if (serverId != null && userId != null) {
+                  authPrefs.setAutoLogin(serverId, userId);
+                }
+              } else {
+                authPrefs.clearAutoLogin();
+              }
             },
           ),
           SwitchPreferenceTile(

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -24,7 +24,6 @@ import '../../../util/app_distribution.dart';
 import '../../widgets/app_update_dialog.dart';
 
 import '../../../auth/store/authentication_preferences.dart';
-import '../../../auth/store/authentication_store.dart';
 import '../../../auth/repositories/session_repository.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../playback/audio_capability_profile.dart';
@@ -472,23 +471,11 @@ class _AuthenticationCategoryScreen extends StatelessWidget {
             icon: Icons.person,
             labelOf: (v) {
               if (v == UserSelectBehavior.currentUser) {
-                final authPrefs = GetIt.instance<AuthenticationPreferences>();
-                final autoUserId = authPrefs.savedAutoLoginUserId;
-                final autoServerId = authPrefs.savedAutoLoginServerId;
-                if (autoUserId.isNotEmpty && autoServerId.isNotEmpty) {
-                  final authStore = GetIt.instance<AuthenticationStore>();
-                  final autoUser = authStore.getUser(autoServerId, autoUserId);
-                  if (autoUser != null) {
-                    final session = GetIt.instance<SessionRepository>();
-                    if (session.activeUserId == autoUserId &&
-                        session.activeServerId == autoServerId) {
-                      return l10n.currentUser;
-                    } else {
-                      return autoUser.name;
-                    }
-                  }
-                }
-                return l10n.currentUser;
+                final session = GetIt.instance<SessionRepository>();
+                // If I'm the auto-login user, just say "Current User"
+                // If someone else is, show their name so it's clear
+                if (session.activeUserIsAutoLoginTarget) return l10n.currentUser;
+                return session.autoLoginTargetDisplayName() ?? l10n.currentUser;
               }
               return switch (v) {
                 UserSelectBehavior.disabled => l10n.disabled,
@@ -502,19 +489,10 @@ class _AuthenticationCategoryScreen extends StatelessWidget {
               UserSelectBehavior.currentUser => l10n.currentUser,
             },
             onChanged: () {
-              final store = GetIt.instance<PreferenceStore>();
-              final behavior = store.get(UserPreferences.autoLoginUserBehavior);
-              final authPrefs = GetIt.instance<AuthenticationPreferences>();
-              if (behavior == UserSelectBehavior.currentUser) {
-                final session = GetIt.instance<SessionRepository>();
-                final serverId = session.activeServerId;
-                final userId = session.activeUserId;
-                if (serverId != null && userId != null) {
-                  authPrefs.setAutoLogin(serverId, userId);
-                }
-              } else {
-                authPrefs.clearAutoLogin();
-              }
+              final behavior = GetIt.instance<PreferenceStore>()
+                  .get(UserPreferences.autoLoginUserBehavior);
+              GetIt.instance<SessionRepository>()
+                  .applyAutoLoginForBehavior(behavior);
             },
           ),
           SwitchPreferenceTile(

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -310,6 +310,7 @@ class EnumPreferenceTile<T extends Enum> extends StatefulWidget {
   final String? description;
   final IconData? icon;
   final String Function(T value) labelOf;
+  final String Function(T value)? dialogLabelOf;
   final VoidCallback? onChanged;
   final List<T>? values;
 
@@ -318,6 +319,7 @@ class EnumPreferenceTile<T extends Enum> extends StatefulWidget {
     required this.preference,
     required this.title,
     required this.labelOf,
+    this.dialogLabelOf,
     this.description,
     this.icon,
     this.onChanged,
@@ -402,7 +404,10 @@ class _EnumPreferenceTileState<T extends Enum>
             return TvFocusHighlight(
               builder: (_, _) => ListTile(
                 autofocus: i == autofocusIndex,
-                title: Text(widget.labelOf(v), style: _kSettingsTitleTextStyle),
+                title: Text(
+                  (widget.dialogLabelOf ?? widget.labelOf)(v),
+                  style: _kSettingsTitleTextStyle,
+                ),
                 trailing: selected ? const Icon(Icons.check) : null,
                 onTap: () {
                   if (picked) return;


### PR DESCRIPTION
# Fix and refine the "Current User" login behaviour

## Summary
The bug: the "Current User" setting was not functioning as intended (it was always triggering the user selection screen instead of auto logging in).

The fix: Refined the "Auto Login" setting logic for "Current User" so that the auto-login user target is kept persistent on session switch and sign out, only updating when explicitly changed in the Settings menu. This prevents child/other accounts from automatically overwriting the auto-login configuration on a shared device. Also improved the UX by introducing a `dialogLabelOf` callback to `EnumPreferenceTile` to ensure the picker options show the clear, localized option "Current User", while the main settings screen correctly displays the name of the designated auto-login user (e.g., "Matt") when viewed from other accounts. This can be overridden by the other accounts (by switching auto log-in to disable and then turning Current User back on) if desired.

## Related Issues
Bug found during testing.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `dialogLabelOf` property to `EnumPreferenceTile` in `preference_tiles.dart` to allow displaying different labels in the picker dialog versus the summary tile.
- Configured `dialogLabelOf` on the Auto Login preference tile in `settings_side_panel.dart` to return the localized `currentUser` inside the choice picker dialog, while keeping the summary label showing the auto-login user's username on other accounts.
- Removed the automatic call to `_authPrefs.setAutoLogin` in `SessionRepository.switchCurrentSession` to prevent switching accounts from overwriting the configured auto-login target.
- Modified `destroyCurrentSession` in `session_repository.dart` to avoid clearing the saved auto-login credentials when signing out if behavior is set to `currentUser`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Log in to a main account (e.g., Matt) and set "Auto Login" to "Current User" in settings.
2. Close and restart the app to verify it auto-logs into the main account.
3. Log in to a second account (e.g., child account) and check settings.
4. Verify that the "Auto Login" tile summary correctly shows the main account's name (e.g. "Matt") instead of "Current User".
5. Click the tile to open the picker dialog and verify that the option is labeled "Current User" (not the main account name).
6. Restart the app from the second account, verifying it still auto-logs back into the main account.

## Screenshots (if applicable)
The setting in question:
<img width="350" alt="2026-06-08_16-38-11_moonfin" src="https://github.com/user-attachments/assets/b4d5f6ae-2051-4aef-a591-d886c1aab235" />

Fixed version, my account with auto login set to "Current User"
<img width="500" alt="2026-06-08_17-35-42_moonfin" src="https://github.com/user-attachments/assets/53f1f2f4-17b5-453d-ada3-65f6bcbcd1c2" />

Fixed version, other account when auto login is set to "Matt"
<img width="500" alt="2026-06-08_17-35-56_moonfin" src="https://github.com/user-attachments/assets/24b538e8-ffa5-4eec-9907-1e6a2f51e528" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
