### PR TITLE
fix(home): preserve custom library image tags in aggregated views

### DIFF
--- a/lib/data/models/aggregated_library.dart
+++ b/lib/data/models/aggregated_library.dart
@@ -3,11 +3,15 @@ class AggregatedLibrary {
   final String name;
   final String collectionType;
   final String serverId;
+  final Map<String, dynamic>? imageTags;
+  final List<String>? backdropImageTags;
 
   const AggregatedLibrary({
     required this.id,
     required this.name,
     required this.collectionType,
     required this.serverId,
+    this.imageTags,
+    this.backdropImageTags,
   });
 }

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -166,6 +166,8 @@ class MultiServerRepository {
                   : name,
               collectionType: data['CollectionType'] as String? ?? '',
               serverId: session.server.id,
+              imageTags: data['ImageTags'] != null ? Map<String, dynamic>.from(data['ImageTags'] as Map) : null,
+              backdropImageTags: (data['BackdropImageTags'] as List?)?.map((e) => e.toString()).toList(),
             );
           }).toList();
         }, label: 'libraries from ${session.server.name}'),
@@ -692,6 +694,8 @@ class MultiServerRepository {
                   'Name': lib.name,
                   'CollectionType': lib.collectionType,
                   'Type': 'CollectionFolder',
+                  if (lib.imageTags != null) 'ImageTags': lib.imageTags,
+                  if (lib.backdropImageTags != null) 'BackdropImageTags': lib.backdropImageTags,
                 },
               ),
             )

--- a/lib/data/repositories/user_views_repository.dart
+++ b/lib/data/repositories/user_views_repository.dart
@@ -20,6 +20,8 @@ class UserViewsRepository extends ChangeNotifier {
         name: data['Name'] as String,
         collectionType: data['CollectionType'] as String? ?? '',
         serverId: data['ServerId'] as String? ?? '',
+        imageTags: data['ImageTags'] != null ? Map<String, dynamic>.from(data['ImageTags'] as Map) : null,
+        backdropImageTags: (data['BackdropImageTags'] as List?)?.map((e) => e.toString()).toList(),
       );
     }).toList();
   }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes missing custom primary/backdrop images for library folder cards on the Home screen when the "Multi-Server Libraries" preference is enabled. Hopefully this will fix/close #431 but, even if it doesn't, it is a gap in Moonfin's coverage that should be addressed.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #431 
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `imageTags` and `backdropImageTags` fields to the `AggregatedLibrary` model.
- Populated these fields during views aggregation in `UserViewsRepository` and `MultiServerRepository`.
- Passed the image tag fields into the `AggregatedItem`'s `rawData` map in `getAggregatedLibraryTiles()` so the Home screen image resolver can fetch them.
- 
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Flutter verified but will get user to test, since I don't have a multi-server library.

### Test Steps
1. Enable the "Multi-Server Libraries" preference under Settings -> Libraries.
2. Upload custom library folder artwork (Primary / Backdrop) in Jellyfin.
3. Verify that these custom images load correctly on the Home screen library tiles.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
