### PR TITLE
fix: respect user clock preference throughout the app

### DIFF
--- a/lib/ui/screens/livetv/live_tv_guide_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_guide_screen.dart
@@ -15,6 +15,7 @@ import '../../widgets/overlay_sheet.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/focus/key_event_utils.dart';
+import '../../../preference/user_preferences.dart';
 
 const _kChannelColumnWidth = 160.0;
 const _kRowHeight = 84.0;
@@ -48,6 +49,7 @@ class LiveTvGuideScreen extends StatefulWidget {
 
 class _LiveTvGuideScreenState extends State<LiveTvGuideScreen> {
   late final LiveTvGuideViewModel _vm;
+  final _prefs = GetIt.instance<UserPreferences>();
   final _channelScrollController = ScrollController();
   final _programScrollController = ScrollController();
   final _timeHeaderHorizontalScrollController = ScrollController();
@@ -289,8 +291,12 @@ class _LiveTvGuideScreenState extends State<LiveTvGuideScreen> {
   }
 
   String _formatTime(DateTime dt) {
+    final use24 = _prefs.get(UserPreferences.use24HourClock);
     final h = dt.hour;
     final m = dt.minute.toString().padLeft(2, '0');
+    if (use24) {
+      return '${h.toString().padLeft(2, '0')}:$m';
+    }
     final amPm = h >= 12 ? 'PM' : 'AM';
     final h12 = h > 12 ? h - 12 : (h == 0 ? 12 : h);
     return '$h12:$m $amPm';

--- a/lib/ui/screens/livetv/live_tv_player_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_player_screen.dart
@@ -1313,8 +1313,12 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
   }
 
   String _formatTime(DateTime dt) {
+    final use24 = _prefs.get(UserPreferences.use24HourClock);
     final h = dt.hour;
     final m = dt.minute.toString().padLeft(2, '0');
+    if (use24) {
+      return '${h.toString().padLeft(2, '0')}:$m';
+    }
     final amPm = h >= 12 ? 'PM' : 'AM';
     final h12 = h > 12 ? h - 12 : (h == 0 ? 12 : h);
     return '$h12:$m $amPm';

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3906,12 +3906,17 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final remaining = duration - position;
     if (remaining <= Duration.zero) return '';
     final end = DateTime.now().add(remaining);
-    final localizations = MaterialLocalizations.of(context);
-    final use24Hour = MediaQuery.of(context).alwaysUse24HourFormat;
-    final time = localizations.formatTimeOfDay(
-      TimeOfDay.fromDateTime(end),
-      alwaysUse24HourFormat: use24Hour,
-    );
+    final use24Hour = _prefs.get(UserPreferences.use24HourClock);
+    final hour = end.hour;
+    final minute = end.minute.toString().padLeft(2, '0');
+    final String time;
+    if (use24Hour) {
+      time = '${hour.toString().padLeft(2, '0')}:$minute';
+    } else {
+      final amPm = hour >= 12 ? 'PM' : 'AM';
+      final h12 = hour > 12 ? hour - 12 : (hour == 0 ? 12 : hour);
+      time = '$h12:$minute $amPm';
+    }
     return AppLocalizations.of(context).endsAt(time);
   }
 

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -181,6 +181,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
 
   void _onPrefsChanged() {
     if (!mounted) return;
+    _updateClock();
     _loadLibraries();
     setState(() {});
   }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -174,6 +174,7 @@ class _TopToolbarState extends State<TopToolbar> {
 
   void _onPrefsChanged() {
     if (!mounted) return;
+    _updateClock();
     _loadLibraries();
     setState(() {});
   }


### PR DESCRIPTION
# Prioritizing User Clocks

## Summary
Ensures all clocks, times, and time-formatting helpers respect the user's selected clock display preference (UserPreferences.use24HourClock) throughout the app instantly and correctly. The playback clock was being drawn using OS localization, hence why it wasn't respecting the user setting. PR also includes a bug fix for the clock setting allowing it to instantly switch display modes (instead of having to wait up to 30 seconds).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #441 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

* video_player_screen.dart: Bypassed MaterialLocalizations.formatTimeOfDay inside the video player OSD (_endsAtLabel) by implementing manual time formatting. This prevents the system locale from overriding alwaysUse24HourFormat: false and forcing 24-hour style when the host OS is configured for 24-hour style.
* top_toolbar.dart & left_sidebar.dart: Added _updateClock() call inside _onPrefsChanged() to force the ValueNotifier<String> clock values to recalculate immediately when interface preferences are toggled, resolving the 30-second delay in clock format updating.
* live_tv_player_screen.dart & live_tv_guide_screen.dart: Updated the _formatTime helpers to format times in 24-hour format if UserPreferences.use24HourClock is enabled.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
Navigate to Settings -> Interface.
Toggle the 24-Hour Clock preference.
Verify that the clocks in the top toolbar/left sidebar update their format instantly.
Open the Live TV player and Live TV Guide and verify all timelines and programme start/end times reflect the updated preference format.
Play a video and check that the "Ends at" time in the video player OSD respects the chosen clock display format.

## Screenshots (if applicable)

### 24 Hour

<img width="300" alt="2026-06-08_22-35-06_moonfin" src="https://github.com/user-attachments/assets/319b7e02-4001-4c3c-9602-9b9c16c892b3" />
<img width="400" alt="2026-06-08_22-35-19_moonfin" src="https://github.com/user-attachments/assets/ecc271dd-0609-4721-b064-bfbbb991bd03" />

### 12 Hour

<img width="300" alt="2026-06-08_22-36-05_moonfin" src="https://github.com/user-attachments/assets/c4b13138-b6c9-4211-91a5-1044fa63fa63" />
<img width="400" alt="2026-06-08_22-45-29_moonfin" src="https://github.com/user-attachments/assets/dc40a436-33e9-4435-a813-f01bb7b89604" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
