### PR TITLE
fix(auth): resolve account-switching issues on Android TV

### DIFF
--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -1,5 +1,9 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
+import '../../ui/navigation/app_router.dart';
+import '../../ui/navigation/destinations.dart';
+
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:playback_core/playback_core.dart';
@@ -217,6 +221,15 @@ class SessionRepository {
       if (serverUser.configuration != null) {
         GetIt.instance<UserPreferences>()
             .initLanguagePrefs(serverUser.configuration!);
+      }
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        _logger.w('Access token expired or unauthorized. Logging out.');
+        await destroyCurrentSession();
+        appRouter.go(
+          '${Destinations.login}?serverId=$serverId&username=${Uri.encodeComponent(user.name)}',
+        );
+        return;
       }
     } catch (_) {
     }

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -237,7 +237,10 @@ final appRouter = GoRouter(
     // General
     GoRoute(
       path: Destinations.home,
-      builder: (context, state) => const HomeScreen(),
+      builder: (context, state) {
+        final session = GetIt.instance<SessionRepository>();
+        return HomeScreen(key: ValueKey(session.activeUserId ?? ''));
+      },
     ),
     GoRoute(
       path: Destinations.search,


### PR DESCRIPTION
# Pull Request

## Summary

This PR addresses two critical bugs related to account-switching and session lifecycle on Android TV devices:

1. HomeScreen State Retention (Stale ViewModel): When switching from the primary account to another profile (e.g. Arlie's), the home page loaded blank/stale data. This happened because GoRouter/Flutter reuses the existing `_HomeShellState` during fast transitions (`/home` -> `/startup?bootstrap=1` -> `/home`). It held a reference to the old user's `HomeViewModel` even though singletons were reset.
2. Silently Caught 401 Expirations: If a profile's token was expired/revoked (e.g. Hux's), the initial `getCurrentUser` check in `_postLoginSync` would catch a `401 Unauthorized` exception silently, failing to load any libraries or plugin stats, leaving the user stuck on a broken home page without feedback.

## Related Issues
Found during testing after release of 2.1.0 on ATV.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
1. Assigned a `ValueKey(session.activeUserId ?? '')` to the `HomeScreen` in `app_router.dart`. This ensures that when the active user ID changes, the home page state is completely destroyed and rebuilt with the correct user's view model.
2. Explicitly catch `DioException` with a `401` status code in `_postLoginSync`. If detected, the current invalid session is destroyed, and the user is redirected to the `LoginScreen` with their username prefilled to prompt for re-authentication.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Fresh Install
3. Switch users
4. Notice it doesn't break

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
