### PR TITLE
Fixed Emby Latest Items Issue

### DIFF
--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -183,16 +183,23 @@ class EmbyItemsApi implements ItemsApi {
     final response = await _dio.get(
       '/Users/$userId/Items/Latest',
       queryParameters: {
-        'ParentId': ?parentId,
+        if (parentId != null) 'ParentId': parentId,
         if (includeItemTypes != null)
           'IncludeItemTypes': includeItemTypes.join(','),
-        'Limit': ?limit,
-        'Fields': ?fields,
-        'EnableImageTypes': ?enableImageTypes,
-        'ImageTypeLimit': ?imageTypeLimit,
+        if (limit != null) 'Limit': limit,
+        if (fields != null) 'Fields': fields,
+        if (enableImageTypes != null) 'EnableImageTypes': enableImageTypes,
+        if (imageTypeLimit != null) 'ImageTypeLimit': imageTypeLimit,
       },
     );
-    return response.data as Map<String, dynamic>;
+
+    // /Items/Latest returns a bare array, so normalize it into the
+    // same shape as /Items so all callers stay unchanged.
+    final list = response.data as List;
+    return {
+      'Items': list,
+      'TotalRecordCount': list.length,
+    };
   }
 
   @override


### PR DESCRIPTION
## Fix `getLatestItems` response normalization

### Problem
The Emby/ `/Users/{userId}/Items/Latest` endpoint returns a bare JSON array (`[BaseItemDto]`), unlike the standard `/Items` endpoint which returns a paginated envelope (`{ "Items": [...], "TotalRecordCount": N }`).

This caused a type mismatch — callers throughout the app expected the envelope shape and were indexing into the response with keys like `response['Items']` and `response['TotalRecordCount']`, which would fail at runtime against the raw array.
## Issue
https://github.com/Moonfin-Client/Moonfin-Core/issues/455

### Solution
Normalize the response in `emby_items_api.dart` to match the envelope shape expected by the rest of the codebase. The wrapping happens once at the Emby implementation level, so no call sites need to change.

```dart
final list = response.data as List;
return {
  'Items': list,
  'TotalRecordCount': list.length,
};
```

### Changes
- `packages/server_emby/lib/src/api/emby_items_api.dart` — wrap bare array response into `{ Items, TotalRecordCount }` envelope; fix null-conditional query parameter syntax (`?param` → `if (param != null)`)



## Type of Change
- [ x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Did a build for MacOS 
2. Installed app
3. Connected to Emby

## Screenshots (if ap
<img width="1392" height="832" alt="Screenshot 2026-06-09 at 5 27 13 PM" src="https://github.com/user-attachments/assets/931109a1-7c16-4f0d-a4b1-a89f4bdc8aff" />
plicable)


## Checklist
- [ x] Code builds successfully
- [ x] Code follows project style and conventions
- [ x] No unnecessary commented-out code
- [ x] No new warnings introduced
