### PR TITLE
Fix offline playback freezing and file path resolution

### DIFF
--- a/lib/playback/offline_playback_launcher.dart
+++ b/lib/playback/offline_playback_launcher.dart
@@ -61,12 +61,12 @@ Future<void> launchOfflinePlayback(
   if (episodeQueue != null && episodeQueue.length > 1) {
     queueUrls = episodeQueue
         .where((e) => e.localFilePath != null && e.downloadStatus == 2)
-        .map((e) => File(e.localFilePath!).uri.toString())
+        .map((e) => e.localFilePath!)
         .toList();
     startIndex = queueUrls.indexOf(result.url).clamp(0, queueUrls.length - 1);
     for (final ep in episodeQueue) {
       if (ep.localFilePath != null && ep.downloadStatus == 2) {
-        final url = File(ep.localFilePath!).uri.toString();
+        final url = ep.localFilePath!;
         final epMeta = jsonDecode(ep.metadataJson) as Map<String, dynamic>;
         if (isAudio) {
           await _injectLocalPaths(ep, epMeta);
@@ -89,7 +89,7 @@ Future<void> launchOfflinePlayback(
       await tracker.stopTracking();
       if (episodeQueue == null) return;
       final nextEp = episodeQueue.firstWhere(
-        (e) => e.localFilePath != null && File(e.localFilePath!).uri.toString() == url,
+        (e) => e.localFilePath != null && e.localFilePath == url,
         orElse: () => item,
       );
       final nextResult = await resolver.resolve(nextEp.itemId);

--- a/lib/playback/offline_stream_resolver.dart
+++ b/lib/playback/offline_stream_resolver.dart
@@ -90,7 +90,7 @@ class OfflineStreamResolver {
       if (subFile == null) continue;
       final fileExt = subFile.uri.pathSegments.last.split('.').last;
       externalSubs.add(OfflineSubtitle(
-        path: subFile.uri.toString(),
+        path: subFile.path,
         title: stream['DisplayTitle'] as String? ?? stream['Title'] as String?,
         language: stream['Language'] as String?,
         index: index,
@@ -99,7 +99,7 @@ class OfflineStreamResolver {
     }
 
     return OfflineStreamResult(
-      url: file.uri.toString(),
+      url: file.path,
       mediaStreams: mediaStreams,
       itemId: itemId,
       serverId: item.serverId,

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1801,13 +1801,16 @@ class PlaybackManager implements AudioOwnable {
         (_offlineMetadataByUrl[url]?['MediaStreams'] as List?)
             ?.cast<Map<String, dynamic>>() ??
         const <Map<String, dynamic>>[];
-    await _backend!.play(
-      _buildBackendMediaPayload(url: url, mediaStreams: offlineStreams),
-      startPosition: startPosition,
-    );
-    await _syncBackendRepeatModeIfSupported();
-    await _waitForMediaReady();
-    _waitingForMedia = false;
+    try {
+      await _backend!.play(
+        _buildBackendMediaPayload(url: url, mediaStreams: offlineStreams),
+        startPosition: startPosition,
+      );
+      await _syncBackendRepeatModeIfSupported();
+      await _waitForMediaReady(timeout: const Duration(seconds: 5));
+    } finally {
+      _waitingForMedia = false;
+    }
 
     if (startPosition > Duration.zero) {
       await _seekWhilePausedAndResume(startPosition);


### PR DESCRIPTION
# Pull Request

## Summary
Fixes offline playback failure and GUI freezing in Moonfin-Core on Android (Issue #456).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #456 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Changed `OfflineStreamResolver` to return raw local filesystem paths (`file.path` / `subFile.path`) instead of `file.uri.toString()`, allowing `media_kit` (libmpv) on Android to successfully resolve the media and subtitle files.
- Updated `OfflinePlaybackLauncher` to use raw local file paths for episode queue mapping, metadata setups, and auto-advance comparisons.
- Wrapped player and media readiness logic in `PlaybackManager.playOffline` in a `try-finally` block to guarantee `_waitingForMedia = false` is always executed, preventing UI lockups on failure.
- Set a shorter 5-second timeout in `_waitForMediaReady` inside `playOffline` since local file media is expected to load almost instantly.

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Need to cook dinner. Posting the PR for GH to make a build for testers to test :)

### Test Steps
1. Navigate to the Saved Media/Downloads screen.
2. Select a downloaded item to trigger offline playback.
3. Verify that the media resolves immediately and plays back successfully without freezing the UI or hanging.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
