### PR TITLE
fix: resolve connection leaks and track selection carryover in autoplay

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -1505,8 +1505,8 @@ class Media3VideoView(
     }
 
     private fun stopPlaybackAndRestoreDisplayMode() {
-        player.pause()
-        player.seekTo(0)
+        player.stop()
+        player.clearMediaItems()
         restorePreferredDisplayMode()
         firstFrameCover.visibility = View.VISIBLE
         emitState()

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -53,6 +53,10 @@ class PlaybackManager implements AudioOwnable {
   int? _pendingItemAudioStreamIndex;
   int? _pendingItemSubtitleStreamIndex;
   String? _pendingItemMediaSourceId;
+  String? _lastItemId;
+  String? _lastExplicitAudioLanguage;
+  String? _lastExplicitSubtitleLanguage;
+  bool? _lastExplicitSubtitleEnabled;
   Duration _lastKnownPosition = Duration.zero;
   Duration _itemKnownDuration = Duration.zero;
   int? _maxBitrateOverrideMbps;
@@ -677,6 +681,10 @@ class PlaybackManager implements AudioOwnable {
     bool enableTranscoding = true,
   }) async {
     _clearPendingItemOverrides();
+    _lastItemId = null;
+    _lastExplicitAudioLanguage = null;
+    _lastExplicitSubtitleLanguage = null;
+    _lastExplicitSubtitleEnabled = null;
     _isAutoNexting = false;
     _isManualNexting = false;
     suppressAutoNext = false;
@@ -788,6 +796,10 @@ class PlaybackManager implements AudioOwnable {
     final sessionToken = ++_playbackSessionToken;
     final itemId = _traceItemId(item);
     _applyPendingItemOverridesIfNeeded(itemId);
+    if (_lastItemId != null && _lastItemId != itemId) {
+      _translateTrackSelectionsForNewItem(item);
+    }
+    _lastItemId = itemId;
     _setBringupState(
       PlaybackBringupState(
         phase: PlaybackBringupPhase.resolving,
@@ -1264,6 +1276,16 @@ class PlaybackManager implements AudioOwnable {
 
   Future<void> changeAudioTrack(int streamIndex) async {
     _audioStreamIndex = streamIndex;
+    final streams = _currentMediaStreams;
+    if (streams.isNotEmpty) {
+      final selectedStream = streams.firstWhere(
+        (s) => s['Type'] == 'Audio' && s['Index'] == streamIndex,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (selectedStream.isNotEmpty) {
+        _lastExplicitAudioLanguage = selectedStream['Language'] as String?;
+      }
+    }
 
     if (!_isOfflinePlayback &&
         !(_backend?.supportsRuntimeTrackSelection ?? true)) {
@@ -1433,6 +1455,21 @@ class PlaybackManager implements AudioOwnable {
     final isBitmap = _isSubtitleBitmap(streamIndex);
     _subtitleStreamIndex = streamIndex;
     _subtitleSelectionExplicit = streamIndex >= 0;
+    _lastExplicitSubtitleEnabled = streamIndex >= 0;
+    if (streamIndex >= 0) {
+      final streams = _currentMediaStreams;
+      if (streams.isNotEmpty) {
+        final selectedStream = streams.firstWhere(
+          (s) => s['Type'] == 'Subtitle' && s['Index'] == streamIndex,
+          orElse: () => const <String, dynamic>{},
+        );
+        if (selectedStream.isNotEmpty) {
+          _lastExplicitSubtitleLanguage = selectedStream['Language'] as String?;
+        }
+      }
+    } else {
+      _lastExplicitSubtitleLanguage = null;
+    }
 
     await _applySubtitleRendererModeForStream(streamIndex);
 
@@ -1523,6 +1560,8 @@ class PlaybackManager implements AudioOwnable {
 
   Future<void> disableSubtitles() async {
     _subtitleStreamIndex = -1;
+    _lastExplicitSubtitleEnabled = false;
+    _lastExplicitSubtitleLanguage = null;
     await _resetSubtitleRendererMode();
     if (!_isOfflinePlayback &&
         !(_backend?.supportsRuntimeTrackSelection ?? true)) {
@@ -1773,6 +1812,10 @@ class PlaybackManager implements AudioOwnable {
   }) async {
     _deferredStartPosition = Duration.zero;
     _deferPlaybackToExternalPlayer = false;
+    _lastItemId = null;
+    _lastExplicitAudioLanguage = null;
+    _lastExplicitSubtitleLanguage = null;
+    _lastExplicitSubtitleEnabled = null;
     _isAutoNexting = false;
     _isManualNexting = false;
     suppressAutoNext = false;
@@ -1908,6 +1951,66 @@ class PlaybackManager implements AudioOwnable {
     _service?.dispose();
     queueService.dispose();
     state.dispose();
+  }
+
+  List<Map<String, dynamic>> _extractMediaStreams(dynamic item) {
+    if (item is Map) {
+      final streams = item['MediaStreams'] ?? item['mediaStreams'];
+      if (streams is List) {
+        return streams.cast<Map<String, dynamic>>();
+      }
+    }
+    try {
+      final dynamic dyn = item;
+      final streams = dyn.mediaStreams;
+      if (streams is List) {
+        return streams.cast<Map<String, dynamic>>();
+      }
+    } catch (_) {}
+    return const [];
+  }
+
+  void _translateTrackSelectionsForNewItem(dynamic item) {
+    final newStreams = _extractMediaStreams(item);
+    if (newStreams.isEmpty) {
+      _audioStreamIndex = null;
+      if (_lastExplicitSubtitleEnabled == false) {
+        _subtitleStreamIndex = -1;
+      } else {
+        _subtitleStreamIndex = null;
+      }
+      return;
+    }
+
+    if (_lastExplicitAudioLanguage != null) {
+      final audioStreams = newStreams.where((s) => s['Type'] == 'Audio').toList();
+      final targetIdx = audioStreams.indexWhere(
+        (s) => s['Language']?.toString().toLowerCase() == _lastExplicitAudioLanguage!.toLowerCase(),
+      );
+      if (targetIdx >= 0) {
+        _audioStreamIndex = audioStreams[targetIdx]['Index'] as int?;
+      } else {
+        _audioStreamIndex = null;
+      }
+    } else {
+      _audioStreamIndex = null;
+    }
+
+    if (_lastExplicitSubtitleEnabled == false) {
+      _subtitleStreamIndex = -1;
+    } else if (_lastExplicitSubtitleLanguage != null) {
+      final subtitleStreams = newStreams.where((s) => s['Type'] == 'Subtitle').toList();
+      final targetIdx = subtitleStreams.indexWhere(
+        (s) => s['Language']?.toString().toLowerCase() == _lastExplicitSubtitleLanguage!.toLowerCase(),
+      );
+      if (targetIdx >= 0) {
+        _subtitleStreamIndex = subtitleStreams[targetIdx]['Index'] as int?;
+      } else {
+        _subtitleStreamIndex = null;
+      }
+    } else {
+      _subtitleStreamIndex = null;
+    }
   }
 }
 


### PR DESCRIPTION
# The one about Auto-Play

## Summary
Resolve auto-play connection leaks and track selection carryover issues when advancing to the next episode in the playback queue.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #464 
- Related to #

## Type of Change
- [X ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.
- Added sticky track preference fields (`_lastItemId`, `_lastExplicitAudioLanguage`, `_lastExplicitSubtitleLanguage`, `_lastExplicitSubtitleEnabled`) to `PlaybackManager` to track explicit user choices across episodes in the current queue.
- Implemented `_translateTrackSelectionsForNewItem` to map track selections dynamically based on language codes when transitioning to a new item in the queue.
- Reset autoplay/sticky preferences in `playItems` and `playOffline` for fresh session defaults.
- Updated `Media3VideoView.kt` native method `stopPlaybackAndRestoreDisplayMode()` to call `player.stop()` and `player.clearMediaItems()`. This cleanly releases codecs and terminates active HTTP connections on playback stop, resolving socket leak between episode transitions.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play various media with different transcoding and audio settings
2. Trigger auto play, verify the next episode is queued and retains customizations

## Screenshots (if applicable)
Have you ever seen the Moon(fin)?

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X ] No unnecessary commented-out code
- [X] No new warnings introduced
