### PR TITLE
fix: resolve subtitle defaultToNone logic reversal

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5171,9 +5171,6 @@ class _ActionButtonsState extends State<_ActionButtons> {
     final prefs = GetIt.instance<UserPreferences>();
     final defaultToNone = prefs.get(UserPreferences.subtitlesDefaultToNone);
     if (defaultToNone) {
-      if (subtitleStreams.isNotEmpty) {
-        return subtitleStreams.first['Index'] as int?;
-      }
       return -1;
     }
 


### PR DESCRIPTION
# The one about telling subs that no means no

## Summary
Fix the Subtitles Always On bug where enabling the client setting "Default to no subtitles" (`subtitlesDefaultToNone`) was mistakenly returning the first subtitle track index instead of `-1` (disabled).

## Related Issues
Link related issues or tickets separated by commas.
Resolves @Booker's issue on Discord

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.
- In `_effectiveSubtitleStreamIndex()` in [item_detail_screen.dart](file:///C:/Moonfin-Core/lib/ui/screens/detail/item_detail_screen.dart#L5161), corrected the `defaultToNone` check logic. It now immediately returns `-1` (subtitles disabled) when the preference is true, instead of checking if the list of streams is not empty and returning the first track index.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X ] Tested on physical device
- [X ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. In subtitle settings, enable Default to no subtitles
2. Play a video that contains embedded subtitles.
3. Verify that playback starts with subtitles off
4. REJOICE and then turn subs back on because you are old and prefer them

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Picture Moonfin playing a show and people talking... without subtitles.

## Checklist
- [X ] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
