### PR TITLE
feat(ui): add transparent theme gradient placeholder for My Media rows

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3788,6 +3788,13 @@ class _ContentRowsState extends State<_ContentRows>
     double requestScale,
     {bool isMyMediaRow = false}
   ) {
+    if (imageType == ImageType.poster && isMyMediaRow) {
+      final primaryAr = item.rawData['PrimaryImageAspectRatio'] as num?;
+      if (primaryAr == null || primaryAr >= 1.0) {
+        return null;
+      }
+    }
+
     if (item.serverId == 'seerr') {
       final backdrop = _seerrTmdbImageUrl(item.rawData['BackdropPath'] as String?, 1280);
       final poster = _seerrTmdbImageUrl(item.rawData['PosterPath'] as String?, 300);

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -206,6 +206,7 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
           children: [
             _CardImage(
               imageUrl: widget.imageUrl,
+              title: widget.title,
               aspectRatio: widget.aspectRatio,
               isFavorite: widget.isFavorite,
               isPlayed: widget.isPlayed,
@@ -343,6 +344,7 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
 
 class _CardImage extends StatelessWidget {
   final String? imageUrl;
+  final String? title;
   final double aspectRatio;
   final bool isFavorite;
   final bool isPlayed;
@@ -361,6 +363,7 @@ class _CardImage extends StatelessWidget {
 
   const _CardImage({
     this.imageUrl,
+    this.title,
     required this.aspectRatio,
     required this.isFavorite,
     required this.isPlayed,
@@ -408,7 +411,11 @@ class _CardImage extends StatelessWidget {
               fit: StackFit.expand,
               children: [
                 Container(
-                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                  color: (itemType == 'Network' || itemType == 'Studio')
+                      ? Theme.of(context).colorScheme.surfaceContainerHighest
+                      : (imageUrl != null
+                          ? Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.2)
+                          : Colors.transparent),
                   padding: (itemType == 'Network' || itemType == 'Studio')
                       ? const EdgeInsets.all(8.0)
                       : EdgeInsets.zero,
@@ -422,9 +429,9 @@ class _CardImage extends StatelessWidget {
                           scale: isCircular ? 0.8 : 0.9,
                           maxWidth: aspectRatio > 1.2 ? 960 : 640,
                           errorBuilder: (_, _, _) =>
-                              _PlaceholderIcon(itemType: itemType),
+                              _PlaceholderIcon(itemType: itemType, title: title),
                         )
-                      : _PlaceholderIcon(itemType: itemType),
+                      : _PlaceholderIcon(itemType: itemType, title: title),
                 ),
                 if (isFavorite)
                   Positioned(
@@ -639,11 +646,48 @@ class _CardImage extends StatelessWidget {
 
 class _PlaceholderIcon extends StatelessWidget {
   final String? itemType;
+  final String? title;
 
-  const _PlaceholderIcon({this.itemType});
+  const _PlaceholderIcon({this.itemType, this.title});
 
   @override
   Widget build(BuildContext context) {
+    if (itemType != 'Person') {
+      return Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Theme.of(context).colorScheme.primary.withValues(alpha: 0.25),
+              Theme.of(context).colorScheme.secondary.withValues(alpha: 0.05),
+              Colors.transparent,
+            ],
+            stops: const [0.0, 0.5, 1.0],
+          ),
+        ),
+        child: title != null && title!.isNotEmpty
+            ? Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: Text(
+                    title!.toUpperCase(),
+                    textAlign: TextAlign.center,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: 2.5,
+                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              )
+            : null,
+      );
+    }
+
     return Center(
       child: Icon(
         MediaCard.iconForType(itemType),


### PR DESCRIPTION
# Add My Media row placeholders

## Summary
Got a lazy server owner who hasn't uploaded custom images? Instead of using Jellyfin's pixelated mess, how about using a transparent theme-based gradient placeholder with a centered library name text overlay? This prevents landscape thumbnails from being stretched/squished into the 2/3 portrait layout on the home screen while preserving a *premium* visual aesthetic and background transparency on all themes. Plus, it might mean we won't have to link that one GitHub issue so often.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- In media_card.dart refactored `_PlaceholderIcon` to render a transparent gradient background using the active theme's `primary` (25% opacity) and `secondary` (5% opacity) colors, fading into complete transparency (`Colors.transparent`).
- Passed the item title down and rendered it as uppercase, bold, and spaced-out text in the center of the placeholder card.
- Made the wrapper container background in `_CardImage` transparent for placeholders and low opacity (20%) during image loads, allowing transparency to work on all themes (including Moonfin Classic).
- In home_screen.dart modified `_resolveRowImageUrl` to return `null` when a poster is requested for a My Media row item if its primary image aspect ratio is landscape/square (`>= 1.0` or missing).

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin using either the Moonfin Classic or Neon Pulse theme.
2. Go to the home screen containing the **My Media** row in Modern Rows.
3. Verify that unselected library folders show the transparent gradient cards with their uppercase library name clearly rendered in the middle, displaying the background grid behind the cards.
4. Focus/select a library card and verify it transitions smoothly to its 16:9 landscape aspect ratio and correctly loads the library's landscape thumbnail.

## Screenshots (if applicable)

MOONFIN CLASSIC
<img width="2085" height="724" alt="2026-06-09_21-45-27_moonfin" src="https://github.com/user-attachments/assets/99102492-f888-4a7d-a514-1e09927d181b" />

NEON PULSE
<img width="2500" height="1369" alt="2026-06-09_21-44-44_moonfin" src="https://github.com/user-attachments/assets/d091ec3d-e7c0-4ec4-9639-248bf65f68bf" />

## Checklist
- [X ] Code builds successfully
- [X ] Code follows project style and conventions
- [X ] No unnecessary commented-out code
- [X ] No new warnings introduced
