### PR TITLE
Subtitle burn in fix take 2

### DIFF
--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -451,7 +451,7 @@ class Media3PlayerBackend implements PlayerBackend {
       audioFallbackToStereoAac:
           _prefs.resolveAudioFallbackCodec() == AudioFallbackCodec.aacStereo,
       maxResolution: maxResolution,
-      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay),
+      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay) && canRenderBitmapSubtitles,
       assDirectPlay: _prefs.get(UserPreferences.assDirectPlay),
       supportsAvc: PlatformDetection.supportsAvc,
       supportsAvcHigh10: PlatformDetection.supportsAvcHigh10,

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -450,7 +450,7 @@ class MediaKitPlayerBackend implements PlayerBackend {
       audioFallbackToStereoAac:
           _prefs.resolveAudioFallbackCodec() == AudioFallbackCodec.aacStereo,
       maxResolution: maxResolution,
-      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay),
+      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay) && canRenderBitmapSubtitles,
       assDirectPlay: _prefs.get(UserPreferences.assDirectPlay),
       supportsAvc: capabilities.supportsAvc,
       supportsAvcHigh10: capabilities.supportsAvcHigh10,

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1077,8 +1077,9 @@ class PlaybackManager implements AudioOwnable {
     } else if (resolution.playMethod == StreamPlayMethod.transcode) {
       if (_subtitleStreamIndex != null && _subtitleStreamIndex != -1) {
         final isBurnedIn =
-            _isSubtitleBitmap(_subtitleStreamIndex!) &&
-            !(_backend?.canRenderBitmapSubtitles ?? false);
+            (_isSubtitleBitmap(_subtitleStreamIndex!) &&
+             !(_backend?.canRenderBitmapSubtitles ?? false)) ||
+            resolution.streamUrl.toLowerCase().contains('subtitlemethod=encode');
         if (isBurnedIn) {
           _waitAndDisableSubtitles(sessionToken, force: true);
         } else if (_subtitleRendererModeForStream(_subtitleStreamIndex!) ==
@@ -1472,12 +1473,13 @@ class PlaybackManager implements AudioOwnable {
         _waitAndApplyTrackSelections(_playbackSessionToken);
       }
     } else if (_currentResolution?.playMethod == StreamPlayMethod.transcode) {
-      final previousWasBurnedBitmap =
-          previousSubtitleStreamIndex != null &&
-          previousSubtitleStreamIndex >= 0 &&
-          _isSubtitleBitmap(previousSubtitleStreamIndex) &&
-          !(_backend?.canRenderBitmapSubtitles ?? false);
-      if (previousWasBurnedBitmap && !isBitmap) {
+      final previousWasBurned =
+          (previousSubtitleStreamIndex != null &&
+           previousSubtitleStreamIndex >= 0 &&
+           _isSubtitleBitmap(previousSubtitleStreamIndex) &&
+           !(_backend?.canRenderBitmapSubtitles ?? false)) ||
+          (_currentResolution?.streamUrl.toLowerCase().contains('subtitlemethod=encode') ?? false);
+      if (previousWasBurned && !isBitmap) {
         await _backend?.disableSubtitleTrack();
         await _reResolveAtCurrentPosition();
         return;
@@ -1522,10 +1524,12 @@ class PlaybackManager implements AudioOwnable {
   }
 
   Future<void> disableSubtitles() async {
+    final previousWasBurned =
+        _currentResolution?.streamUrl.toLowerCase().contains('subtitlemethod=encode') ?? false;
     _subtitleStreamIndex = -1;
     await _resetSubtitleRendererMode();
-    if (!_isOfflinePlayback &&
-        !(_backend?.supportsRuntimeTrackSelection ?? true)) {
+    if (previousWasBurned || (!_isOfflinePlayback &&
+        !(_backend?.supportsRuntimeTrackSelection ?? true))) {
       await _reResolveAtCurrentPosition();
       return;
     }
@@ -1578,7 +1582,11 @@ class PlaybackManager implements AudioOwnable {
         if (sessionToken != _playbackSessionToken) return;
       }
     }
-    if (_subtitleStreamIndex != null && _subtitleStreamIndex! >= 0) {
+    final isBurnedIn = _currentResolution?.streamUrl.toLowerCase().contains('subtitlemethod=encode') ?? false;
+    if (isBurnedIn) {
+      await _resetSubtitleRendererMode();
+      await _backend?.disableSubtitleTrack();
+    } else if (_subtitleStreamIndex != null && _subtitleStreamIndex! >= 0) {
       final isBitmap = _isSubtitleBitmap(_subtitleStreamIndex!);
       final canRenderBitmap = _backend?.canRenderBitmapSubtitles ?? false;
       if (isBitmap && !canRenderBitmap) {

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -97,14 +97,6 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       url = url
           .replaceFirst(RegExp(r'\?StartTimeTicks=\d+&'), '?')
           .replaceFirst(RegExp(r'[&?]StartTimeTicks=\d+'), '');
-      if (!enableDirectPlay && subtitleStreamIndex != null && subtitleStreamIndex >= 0) {
-        final smRegex = RegExp(r'SubtitleMethod=\w+');
-        if (smRegex.hasMatch(url)) {
-          url = url.replaceFirst(smRegex, 'SubtitleMethod=Encode');
-        } else {
-          url = '$url&SubtitleMethod=Encode';
-        }
-      }
     }
 
     // Append auth token for mpv (which doesn't use our Dio interceptors).

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -97,6 +97,14 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       url = url
           .replaceFirst(RegExp(r'\?StartTimeTicks=\d+&'), '?')
           .replaceFirst(RegExp(r'[&?]StartTimeTicks=\d+'), '');
+      if (!enableDirectPlay && subtitleStreamIndex != null && subtitleStreamIndex >= 0) {
+        final smRegex = RegExp(r'SubtitleMethod=\w+');
+        if (smRegex.hasMatch(url)) {
+          url = url.replaceFirst(smRegex, 'SubtitleMethod=Encode');
+        } else {
+          url = '$url&SubtitleMethod=Encode';
+        }
+      }
     }
 
     // Append auth token for mpv (which doesn't use our Dio interceptors).


### PR DESCRIPTION
# Pull Request

## Summary
PR-423 fixed the double rendering but did so by displaying a "bad" version of the sub track instead of the removed "good version". This PR reverses the removal of subtitle burn-in (`SubtitleMethod=Encode`) during transcoding and resolve the duplicate subtitle overlay problem on the client side instead.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Restored appending `SubtitleMethod=Encode` query parameter to transcoding URLs when `enableDirectPlay` is false and a subtitle is selected in `JellyfinMediaStreamResolver`.
- Checked if the resolved transcoding stream URL contains `SubtitleMethod=Encode` (case-insensitive) to mark subtitles as burned-in.
- If subtitles are burned-in, disabled the client-side local subtitle track overlay via `_backend?.disableSubtitleTrack()` to prevent duplicate rendering.
- Ensured that changing or disabling subtitle tracks when a burned-in stream is active triggers a re-resolution of the stream so that the server updates transcoding options.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ X] Tested on physical device
- [ X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play video files requiring transcoded subtitles (e.g. unsupported formats).
2. Verify subtitles render with correct formatting (via server burn-in).
3. Verify the client player does not render a duplicate subtitle overlay.
4. Disable subtitles or change tracks and verify the stream re-resolves correctly.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
