### PR TITLE
fix(desktop): disable double-click for fullscreen

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -243,7 +243,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   double _verticalDragStartValue = 0.0;
   bool _verticalDragIsVolume = false;
   Offset? _doubleTapDownPosition;
-  DateTime? _lastControlButtonPressAt;
+
   bool _showSkipForward = false;
   bool _showSkipBackward = false;
   Timer? _skipForwardTimer;
@@ -3293,7 +3293,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 : PlatformDetection.useMobileUi && !_isOsdLocked
                 ? _onDoubleTapDown
                 : null,
-            onDoubleTap: _handleDoubleTapGesture,
+            onDoubleTap: PlatformDetection.useDesktopUi
+                ? null
+                : _handleDoubleTapGesture,
             onVerticalDragStart: PlatformDetection.isTV
                 ? null
                 : PlatformDetection.useMobileUi && !_isOsdLocked
@@ -5177,25 +5179,13 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   void _handleControlButtonPress(VoidCallback onPressed) {
-    _lastControlButtonPressAt = DateTime.now();
     onPressed();
     _showControls();
   }
 
-  bool _recentlyPressedControlButton() {
-    final lastPress = _lastControlButtonPressAt;
-    return lastPress != null &&
-        DateTime.now().difference(lastPress) <
-            const Duration(milliseconds: 350);
-  }
 
   void _handleDoubleTapGesture() {
     if (PlatformDetection.useDesktopUi) {
-      if (_recentlyPressedControlButton()) {
-        return;
-      }
-      unawaited(_toggleDesktopFullscreen());
-      _showControls();
       return;
     }
     if (PlatformDetection.useMobileUi && !_isOsdLocked) {


### PR DESCRIPTION
# CLICK BAIT

## Summary
Disable double-click to toggle fullscreen on desktop platforms, leaving single-click controls and the control bar fullscreen toggle intact. This also improves tap responsiveness on desktop by removing the double-tap gesture delay.

## Related Issues
Link related issues or tickets separated by commas.

Related to Discord request.
- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Set `onDoubleTap` to `null` on the player gesture surface when `PlatformDetection.useDesktopUi` is true. This removes the double-click-to-fullscreen feature on desktop, while instantly triggering `onTap` (controls visibility) without the default 300ms double-tap gesture timeout delay.
- Modified `_handleDoubleTapGesture()` to return early on desktop platforms.
- Removed the unused private method `_recentlyPressedControlButton` and the associated field `_lastControlButtonPressAt` to resolve static analysis warnings.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X ] Tested on physical device
- [X ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video on a desktop build (e.g. Windows).
2. Click the video area once and verify controls show/hide instantly (no gesture delay).
3. Double-click the video area and verify that it does not enter/exit fullscreen.
4. Verify the fullscreen button on the control bar still successfully toggles fullscreen.

## Screenshots (if applicable)
Imagine double clicking on rewind and not having the screen throw a fit. That's what we got.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
