### PR TITLE
fix(playback): suppress loading overlay during trickplay seeks

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -243,7 +243,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   double _verticalDragStartValue = 0.0;
   bool _verticalDragIsVolume = false;
   Offset? _doubleTapDownPosition;
-
+  DateTime? _lastSeekTime;
   bool _showSkipForward = false;
   bool _showSkipBackward = false;
   Timer? _skipForwardTimer;
@@ -2587,6 +2587,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       ),
     );
     _manager.seekTo(clamped);
+    _lastSeekTime = DateTime.now();
     if (showControls) {
       _showControls();
     }
@@ -2621,6 +2622,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _pendingScrubSeekTarget = null;
         _scrubSeekDebounceTimer = null;
         unawaited(_manager.seekTo(pendingTarget));
+        _lastSeekTime = DateTime.now();
         if (mounted) {
           setState(() {
             _isSeeking = false;
@@ -2933,6 +2935,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
           case LogicalKeyboardKey.mediaRewind:
             unawaited(_manager.seekTo(Duration.zero));
+            _lastSeekTime = DateTime.now();
             unawaited(_manager.resume());
             return KeyEventResult.handled;
 
@@ -3599,6 +3602,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       initialData: _state.isBuffering,
       builder: (context, snap) {
         if (snap.data != true || _isBringupInProgress(_bringupState.phase)) {
+          return const SizedBox.shrink();
+        }
+        final hasTrickplay = _trickplayInfo != null && _trickplayInfo!.isValid;
+        final recentlySought = _lastSeekTime != null &&
+            DateTime.now().difference(_lastSeekTime!) < const Duration(seconds: 3);
+        if (hasTrickplay && (_isSeeking || recentlySought)) {
           return const SizedBox.shrink();
         }
         return const Center(


### PR DESCRIPTION
# The one about Trickplay

## Summary
Disable the "Loading Stream..." buffering indicator overlay when fast-forwarding, rewinding, or scrubbing on media items that have valid trickplay images, ensuring the visual seek preview remains completely visible.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #432 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Declared and tracked `_lastSeekTime` in `_VideoPlayerScreenState` to record whenever a seek/skip operation is performed (scrubbing, arrow key skipping, skip buttons, and media rewind key).
- Updated `_buildBufferingIndicator()` to check if trickplay is active (`_trickplayInfo != null && _trickplayInfo!.isValid`) and the player is seeking (`_isSeeking`) or was recently sought (last seek < 3 seconds ago). If so, the buffering spinner overlay is suppressed (`SizedBox.shrink()`).
- Kept the buffering indicator intact for regular playback buffer events (e.g. network drops) and on items without trickplay images.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ X] Tested on physical device
- [X ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video that has trickplay images generated on the server.
2. Drag the seekbar or use the arrow keys to scrub forward/backward.
3. Verify that the "Loading Stream..." spinner overlay does not appear during seek or immediately after releasing, keeping the trickplay thumbnails completely visible.
4. Verify that normal network buffering (not initiated by seeking) still shows the loading spinner.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X ] Code builds successfully
- [X ] Code follows project style and conventions
- [X ] No unnecessary commented-out code
- [X ] No new warnings introduced
