### PR TITLE
Fix grey screen navigation crash in Web client

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -108,6 +108,7 @@ class _HomeShellState extends State<_HomeShell>
   @override
   void initState() {
     super.initState();
+    _viewModel = GetIt.instance<HomeViewModel>();
     WidgetsBinding.instance.addObserver(this);
     appRouter.routerDelegate.addListener(_onRouteChanged);
     _lastObservedPath = appRouter.routerDelegate.currentConfiguration.uri.path;
@@ -120,7 +121,6 @@ class _HomeShellState extends State<_HomeShell>
     });
     _backdropUrl = _backgroundService.currentUrl;
 
-    _viewModel = GetIt.instance<HomeViewModel>();
     _viewModel.addListener(_onViewModelChanged);
     _viewModel.mediaBarViewModel.addListener(_onMediaBarStateChanged);
     _lastMediaBarStateRuntime = _viewModel.mediaBarViewModel.state.runtimeType;


### PR DESCRIPTION
# The one about going home (from Seerr)

## Summary
Fix a navigation crash (resulting in a blank/grey screen) on the Web client when navigating to the Seerr discover screen and then clicking "Home".
## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #458 
- Related to #

## Type of Change
- [X ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Moved the initialization of `_viewModel = GetIt.instance<HomeViewModel>();` to the very top of `_HomeShellState.initState()` in `home_screen.dart`, before checking `consumePendingHomeRefresh()`. This prevents a `LateInitializationError` from being thrown when returning to Home from a top-level route on platforms like Web where routes are replaced via `router.go`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Very straight forward fix

### Test Steps
1. Navigate to the Seerr Discover screen.
2. Click "Home" in the navigation sidebar or top toolbar.
3. Confirm that the home screen loads successfully without producing a blank grey screen.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X ] Code builds successfully
- [X ] Code follows project style and conventions
- [X ] No unnecessary commented-out code
- [X ] No new warnings introduced
