### PR TITLE
fix: hide Seerr button in navigation when Seerr is unavailable

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -48,6 +48,7 @@ class PluginSyncService extends ChangeNotifier {
   String? get seerrUrl => _seerrUrl;
   bool _seerrEnabled = false;
   bool get seerrEnabled => _seerrEnabled;
+  bool get seerrAvailable => _pluginAvailable && _seerrEnabled;
   bool _seerrInfoAvailable = false;
   bool get seerrInfoAvailable => _seerrInfoAvailable;
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -24,6 +24,7 @@ import '../../../data/services/media_server_client_factory.dart';
 import '../../../data/services/book_reader_service.dart';
 import '../../../data/services/theme_music_service.dart';
 import '../../../data/viewmodels/item_detail_view_model.dart';
+import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../l10n/app_localizations.dart';
@@ -167,6 +168,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     );
     _viewModel.addListener(_onChanged);
     _prefs.addListener(_onPrefsChanged);
+    GetIt.instance<PluginSyncService>().addListener(_onPrefsChanged);
     _viewModel.load();
 
     _backdropUrl = _backgroundService.currentUrl;
@@ -197,6 +199,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     _backgroundService.clearBackgrounds();
     _viewModel.removeListener(_onChanged);
     _prefs.removeListener(_onPrefsChanged);
+    try {
+      GetIt.instance<PluginSyncService>().removeListener(_onPrefsChanged);
+    } catch (_) {}
     _viewModel.dispose();
     _initialContentFocusNode?.dispose();
     super.dispose();
@@ -412,7 +417,9 @@ class _DetailContentState extends State<_DetailContent> {
     if (item == null || item.type != 'Person') return;
     final tmdbId = item.tmdbId;
     if (tmdbId == null || tmdbId.isEmpty) return;
-    if (!prefs.get(UserPreferences.seerrEnabled)) return;
+    if (!GetIt.instance<PluginSyncService>().seerrAvailable) {
+      return;
+    }
 
     if (mounted) {
       setState(() {
@@ -2004,7 +2011,7 @@ class _DetailContentState extends State<_DetailContent> {
     final hasSeerrButton =
         item.tmdbId != null &&
         item.tmdbId!.isNotEmpty &&
-        prefs.get(UserPreferences.seerrEnabled);
+        GetIt.instance<PluginSyncService>().seerrAvailable;
     final seerrFocusNode = hasSeerrButton
         ? _sectionFocusNode('detailPersonSeerrButton')
         : null;

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -17,6 +17,7 @@ import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../data/repositories/seerr_repository.dart';
+import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../data/utils/bounded_concurrency.dart';
 import '../../../preference/seerr_preferences.dart';
@@ -155,7 +156,8 @@ class HomeViewModel extends ChangeNotifier {
       final showPlaylistsRows =
           _prefs.get(UserPreferences.displayPlaylistsRows);
       final showSeerrRows =
-          _prefs.get(UserPreferences.displaySeerrRows);
+          _prefs.get(UserPreferences.displaySeerrRows) &&
+          GetIt.instance<PluginSyncService>().seerrAvailable;
 
       // Plugin-dynamic sections only make sense on the active server.
       final visibleConfigsRaw = configs

--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -24,6 +24,24 @@ class HomeRowTogglesScreen extends StatefulWidget {
 
 class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
   final _prefs = GetIt.instance<UserPreferences>();
+  late final PluginSyncService _syncService;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncService = GetIt.instance<PluginSyncService>();
+    _syncService.addListener(_onSyncChanged);
+  }
+
+  @override
+  void dispose() {
+    _syncService.removeListener(_onSyncChanged);
+    super.dispose();
+  }
+
+  void _onSyncChanged() {
+    if (mounted) setState(() {});
+  }
 
   void _pushPersonalizationSync() {
     final syncService = GetIt.instance<PluginSyncService>();
@@ -235,22 +253,25 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                 onChanged: _onPlaylistsSortChanged,
               ),
 
-            _SectionHeader(l10n.seerr),
-            SwitchPreferenceTile(
-              preference: UserPreferences.displaySeerrRows,
-              title: l10n.displaySeerrRows,
-              subtitle: seerrEnabledOnAccount
-                  ? l10n.displaySeerrRowsSubtitle
-                  : '${l10n.displaySeerrRowsSubtitle} (Requires Seerr login in Plugins)',
-              enabled: seerrEnabledOnAccount,
-              iconBuilder: (size, color) => Image.asset(
-                'assets/icons/seerr.png',
-                width: size,
-                height: size,
+            if (_syncService.seerrAvailable) ...[
+              _SectionHeader(l10n.seerr),
+              SwitchPreferenceTile(
+                preference: UserPreferences.displaySeerrRows,
+                title: l10n.displaySeerrRows,
+                subtitle: seerrEnabledOnAccount
+                    ? l10n.displaySeerrRowsSubtitle
+                    : '${l10n.displaySeerrRowsSubtitle} (Requires Seerr login in Plugins)',
+                enabled: seerrEnabledOnAccount,
+                iconBuilder: (size, color) => Image.asset(
+                  'assets/icons/seerr.png',
+                  width: size,
+                  height: size,
+                ),
+                onChanged: _onSeerrRowsToggleChanged,
               ),
-              onChanged: _onSeerrRowsToggleChanged,
-            ),
+            ],
             const SizedBox(height: 32),
+
           ],
         ),
       ),

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -408,7 +408,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         _prefs.get(UserPreferences.displayCollectionsRows);
     final showGenresRows = _prefs.get(UserPreferences.displayGenresRows);
     final showPlaylistsRows = _prefs.get(UserPreferences.displayPlaylistsRows);
-    final showSeerrRows = _prefs.get(UserPreferences.displaySeerrRows);
+    final showSeerrRows = _prefs.get(UserPreferences.displaySeerrRows) &&
+        GetIt.instance<PluginSyncService>().seerrAvailable;
 
     final hiddenByFavorites =
       !showFavoritesRows && _isFavoriteSectionType(section.type);

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -771,11 +771,14 @@ class _NavigationCategoryScreen extends StatefulWidget {
 
 class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
   late final PreferenceBinding<bool> _showShuffleButtonBinding;
+  late final PluginSyncService _syncService;
   bool _navbarNormalizeQueued = false;
 
   @override
   void initState() {
     super.initState();
+    _syncService = GetIt.instance<PluginSyncService>();
+    _syncService.addListener(_onSyncChanged);
     _showShuffleButtonBinding = PreferenceBinding(
       GetIt.instance<PreferenceStore>(),
       UserPreferences.showShuffleButton,
@@ -784,8 +787,13 @@ class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
 
   @override
   void dispose() {
+    _syncService.removeListener(_onSyncChanged);
     _showShuffleButtonBinding.dispose();
     super.dispose();
+  }
+
+  void _onSyncChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
@@ -873,7 +881,7 @@ class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
               icon: Icons.video_library,
               onChanged: _pushPersonalizationSync,
             ),
-            if (seerrEnabledOnAccount)
+            if (seerrEnabledOnAccount && _syncService.seerrAvailable)
               SwitchPreferenceTile(
                 preference: UserPreferences.showSeerrButton,
                 title: l10n.showSeerrButton,
@@ -885,6 +893,7 @@ class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
                 ),
                 onChanged: _pushPersonalizationSync,
               ),
+
           ],
         ),
       ),

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -822,7 +822,8 @@ class _LeftSidebarState extends State<LeftSidebar> {
                       );
                     },
                   ),
-                if (_prefs.get(UserPreferences.showSeerrButton))
+                if (_prefs.get(UserPreferences.showSeerrButton) &&
+                    GetIt.instance<PluginSyncService>().seerrAvailable)
                   _SidebarItem(
                     baseColor: nextSidebarColor(),
                     iconBuilder: (size, color) => seerrPrefs.isSeerrVariant

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -281,7 +281,8 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
 
   bool _seerrEnabled() {
     try {
-      return _prefs.get(UserPreferences.showSeerrButton);
+      return _prefs.get(UserPreferences.showSeerrButton) &&
+          GetIt.instance<PluginSyncService>().seerrAvailable;
     } catch (_) {
       return false;
     }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -614,7 +614,8 @@ class _TopToolbarState extends State<TopToolbar> {
         _prefs.get(UserPreferences.syncPlayEnabled) &&
         _prefs.get(UserPreferences.showSyncPlayButton);
     final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final showSeerr = _prefs.get(UserPreferences.showSeerrButton);
+    final showSeerr = _prefs.get(UserPreferences.showSeerrButton) &&
+        GetIt.instance<PluginSyncService>().seerrAvailable;
     final l10n = AppLocalizations.of(context);
     final seerrDisplayName = seerrPrefs.moonfinDisplayName.trim();
     final seerrNavLabel = seerrDisplayName.isNotEmpty


### PR DESCRIPTION
# Pull Request

## Summary
Hides the Seerr button from navigation menus (left sidebar, top toolbar, and mobile bottom navigation bar) when the Seerr integration is not configured or enabled on the media server or account. Previously, the button would render regardless of whether the service was actually configured on the server.

## Related Issues
Related to Seerr navigation visibility issues mentioned on Discord

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Updated left_sidebar.dart to check both `UserPreferences.showSeerrButton` and `UserPreferences.seerrEnabled` before rendering the sidebar button.
- Modified `_seerrEnabled()` in mobile_bottom_nav_bar.dart to check both preferences.
- Updated the `showSeerr` visibility check in top_toolbar.dart to ensure the Seerr button is hidden when Seerr is unavailable.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X ] Not tested (explain why): Seerr is available on my server but this is a simple enough logic change and the bug was simply due to an oversight.

### Test Steps
1. Log into a media server that does not have Seerr configured or enabled.
2. Confirm the Seerr button is hidden from all navigation areas (left sidebar, top toolbar, and mobile bottom navigation) even if the user preference "Show Seerr Button" was enabled.
3. Log into a media server with Seerr configured and enabled, and confirm the button is visible or hidden correctly according to user preferences.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
