### PR TITLE
Bugfix/next up loading

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2651,6 +2651,7 @@ class _ContentRowsState extends State<_ContentRows>
               if (row.isLoading) {
                 rowChild = LibraryRow(
                   title: _localizedRowTitle(row, l10n),
+                  isLoading: true,
                   children: const [],
                 );
                 return Padding(

--- a/lib/ui/widgets/library_row.dart
+++ b/lib/ui/widgets/library_row.dart
@@ -13,6 +13,7 @@ class LibraryRow extends StatefulWidget {
   final VoidCallback? onSeeAll;
   final double? rowHeight;
   final ScrollController? scrollController;
+  final bool isLoading;
 
   const LibraryRow({
     super.key,
@@ -21,6 +22,7 @@ class LibraryRow extends StatefulWidget {
     this.onSeeAll,
     this.rowHeight,
     this.scrollController,
+    this.isLoading = false,
   });
 
   @override
@@ -62,32 +64,40 @@ class _LibraryRowState extends State<LibraryRow> {
       showControls: showControls,
       builder: (_, scrollController) => SizedBox(
         height: rowHeight + (10 * desktopScale),
-        child: hasItems
-            ? ListView.separated(
-                controller: scrollController,
-                scrollDirection: Axis.horizontal,
-                padding: EdgeInsets.fromLTRB(
-                  20 * desktopScale,
-                  5 * desktopScale,
-                  20 * desktopScale,
-                  5 * desktopScale,
+        child: widget.isLoading
+            ? Center(
+                child: SizedBox(
+                  width: 24 * desktopScale,
+                  height: 24 * desktopScale,
+                  child: const CircularProgressIndicator(strokeWidth: 2),
                 ),
-                itemCount: widget.children.length,
-                separatorBuilder: (_, _) =>
-                    SizedBox(width: 12 * desktopScale),
-                itemBuilder: (_, i) => widget.children[i],
               )
-            : Center(
-                child: Text(
-                  l10n.noItems,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSurface
-                            .withAlpha(128),
-                      ),
-                ),
-              ),
+            : hasItems
+                ? ListView.separated(
+                    controller: scrollController,
+                    scrollDirection: Axis.horizontal,
+                    padding: EdgeInsets.fromLTRB(
+                      20 * desktopScale,
+                      5 * desktopScale,
+                      20 * desktopScale,
+                      5 * desktopScale,
+                    ),
+                    itemCount: widget.children.length,
+                    separatorBuilder: (_, _) =>
+                        SizedBox(width: 12 * desktopScale),
+                    itemBuilder: (_, i) => widget.children[i],
+                  )
+                : Center(
+                    child: Text(
+                      l10n.noItems,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withAlpha(128),
+                          ),
+                    ),
+                  ),
       ),
     );
   }

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -130,9 +130,11 @@ class EmbyItemsApi implements ItemsApi {
     String? enableImageTypes,
     int? imageTypeLimit,
   }) async {
+    final userId = _getUserId();
     final response = await _dio.get(
       '/Shows/NextUp',
       queryParameters: {
+        'UserId': userId,
         'SeriesId': ?seriesId,
         'ParentId': ?parentId,
         'Limit': ?limit,

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -129,9 +129,11 @@ class JellyfinItemsApi implements ItemsApi {
     String? enableImageTypes,
     int? imageTypeLimit,
   }) async {
+    final userId = _getUserId();
     final response = await _dio.get(
       '/Shows/NextUp',
       queryParameters: {
+        'UserId': userId,
         'SeriesId': ?seriesId,
         'ParentId': ?parentId,
         'Limit': ?limit,


### PR DESCRIPTION
# Pull Request

## Summary
Fix Next Up row loading/display issues on the home screen:
1. Fix placeholder home rows briefly displaying "No items" before their data is loaded.
2. Fix `/Shows/NextUp` API requests failing to return items on Jellyfin/Emby servers due to a missing `UserId` query parameter.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #476 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `isLoading` property to `LibraryRow` widget, rendering a centered progress loader instead of the empty state text "No items" when `isLoading` is true.
- Passed `isLoading: true` to the placeholder `LibraryRow` in `home_screen.dart` when building `row.isLoading` placeholder rows.
- Modified `JellyfinItemsApi.getNextUp` and `EmbyItemsApi.getNextUp` to retrieve the active user ID and supply it as `UserId` in the query parameters of the `/Shows/NextUp` requests.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X ] Tested on physical device
- [X ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the home page with Next Up unmerged.
2. Observe that the Next Up section shows a loader while querying the server instead of displaying "No items".
3. Verify that Next Up successfully loads and displays the user's next episodes from Jellyfin/Emby rather than disappearing, as the server now receives the required `UserId`.

## Checklist
- [X ] Code builds successfully
- [ X] Code follows project style and conventions
- [X ] No unnecessary commented-out code
- [X ] No new warnings introduced
