### PR TITLE
Fix USB keyboard, remote, and Flirc input issues

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -451,10 +451,10 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
         return false;
       }
       if (appRouter.canPop()) {
-        // On Android the system also delivers popRoute via MethodChannel,
-        // which would cause a double pop if we also popped here. Let the
-        // platform handle the pop; just consume the KeyEvent.
-        if (PlatformDetection.isAndroid) {
+        // On Android the system also delivers popRoute via MethodChannel for the
+        // system back button (goBack). For other back-like keys (escape, browserBack),
+        // we must manually pop in Flutter even on Android.
+        if (PlatformDetection.isAndroid && key == LogicalKeyboardKey.goBack) {
           return true;
         }
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -462,7 +462,7 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
           appRouter.pop();
         });
       } else if (!_exitDialogShowing) {
-        if (PlatformDetection.isAndroid) {
+        if (PlatformDetection.isAndroid && key == LogicalKeyboardKey.goBack) {
           return true;
         }
         _exitDialogShowing = true;

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2655,8 +2655,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   bool _isTvTemporarySpeedKey(LogicalKeyboardKey key) {
-    return key == LogicalKeyboardKey.mediaPause ||
-        key == LogicalKeyboardKey.mediaPlayPause;
+    return key == LogicalKeyboardKey.mediaPause;
   }
 
   bool _canUseTvTemporarySpeedHold() {
@@ -3151,9 +3150,19 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           _focusTvPrimaryButton();
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaPlayPause:
+        case LogicalKeyboardKey.space:
           _togglePlayPause();
           _showControls();
           _focusTvPrimaryButton();
+          return KeyEventResult.handled;
+        case LogicalKeyboardKey.mediaStop:
+          _exitPlayback();
+          return KeyEventResult.handled;
+        case LogicalKeyboardKey.mediaTrackNext:
+          unawaited(_manager.next());
+          return KeyEventResult.handled;
+        case LogicalKeyboardKey.mediaTrackPrevious:
+          unawaited(_manager.previous());
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaFastForward:
           _seekRelative(_prefs.get(UserPreferences.skipForwardLength));
@@ -3170,6 +3179,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
     switch (event.logicalKey) {
       case LogicalKeyboardKey.space:
+      case LogicalKeyboardKey.mediaPlayPause:
         _togglePlayPause();
         _showControls();
         return KeyEventResult.handled;
@@ -3183,10 +3193,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _showControls();
         _focusTvPrimaryButton();
         return KeyEventResult.handled;
-      case LogicalKeyboardKey.mediaPlayPause:
-        _togglePlayPause();
-        _showControls();
-        _focusTvPrimaryButton();
+      case LogicalKeyboardKey.mediaStop:
+        _exitPlayback();
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.mediaTrackNext:
+        unawaited(_manager.next());
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.mediaTrackPrevious:
+        unawaited(_manager.previous());
         return KeyEventResult.handled;
       case LogicalKeyboardKey.mediaFastForward:
         _seekRelative(_prefs.get(UserPreferences.skipForwardLength));


### PR DESCRIPTION
# Pull Request

## Summary
Fix USB keyboard, remote, and Flirc input issues on Android TV.
* USB Back Button (#249): Fix escape / back keys (Escape, browserBack, backspace) from USB/Flirc input devices being swallowed and not navigating back on Android.
* USB Media Buttons (#250): Map missing media keys (Stop, Next Track, and Previous Track) and Space play/pause key in the video player, and remove mediaPlayPause from TV temporary speed hold to allow immediate play/pause toggling.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #249 #250  
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

In the UI:
* lib/app.dart: Differentiate system-level back (goBack) from simulated keyboard keys (escape, browserBack, backspace). Do not bypass manual pop navigation on Android unless the event is exactly LogicalKeyboardKey.goBack (which the OS pops automatically), allowing USB keyboards and Flirc IR remotes to navigate back correctly.

During Video Playback:
* lib/ui/screens/playback/video_player_screen.dart: Excluded LogicalKeyboardKey.mediaPlayPause from _isTvTemporarySpeedKey to prevent the keydown event from being swallowed/delayed by temporary speed hold.
* Added mappings for LogicalKeyboardKey.mediaStop to exit playback. 
* Added mappings for LogicalKeyboardKey.mediaTrackNext and LogicalKeyboardKey.mediaTrackPrevious to skip tracks/episodes.
* Mapped LogicalKeyboardKey.space to toggle play/pause and focus primary buttons on Android TV.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
* Navigate around the app using a USB keyboard / Flirc remote and press Escape or Menu Escape: verify it goes back to the previous screen.
* Open the video player and play a show/movie:
    * Press Stop (■): verify playback exits immediately to the detail screen.
    * Press Play/Pause (▶/▮▮): verify playback pauses/resumes immediately and OSD shows up.
    * Press Space: verify playback pauses/resumes immediately and OSD shows up.
    * Press Next Track (▸▸▮): verify it skips to the next episode.
    * Press Previous Track (▮◂◂): verify it skips to the previous episode.

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
