### PR TITLE
Bugfix/fullscreen maximized

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -546,7 +546,7 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
 
   Future<void> _saveWindowGeometry() async {
     try {
-      final isFullScreen = await windowManager.isFullScreen();
+      final isFullScreen = await FullscreenHelper.isFullscreen();
       if (isFullScreen) return;
       final size = await windowManager.getSize();
       final pos = await windowManager.getPosition();

--- a/lib/util/fullscreen_helper_io.dart
+++ b/lib/util/fullscreen_helper_io.dart
@@ -2,18 +2,33 @@ import 'package:window_manager/window_manager.dart';
 
 import 'platform_detection.dart';
 
+bool _isFullscreen = false;
+bool _wasMaximized = false;
+
 Future<bool> isFullscreen() async {
   if (!PlatformDetection.isDesktop) return false;
-  try {
-    return await windowManager.isFullScreen();
-  } catch (_) {
-    return false;
-  }
+  return _isFullscreen;
 }
 
 Future<void> setFullscreen(bool value) async {
   if (!PlatformDetection.isDesktop) return;
+  if (value == _isFullscreen) return;
   try {
-    await windowManager.setFullScreen(value);
+    if (value) {
+      _wasMaximized = await windowManager.isMaximized();
+      if (_wasMaximized) {
+        // If maximized, we must unmaximize/restore first to avoid title bar remaining visible
+        await windowManager.unmaximize();
+      }
+      await windowManager.setFullScreen(true);
+      _isFullscreen = true;
+    } else {
+      await windowManager.setFullScreen(false);
+      _isFullscreen = false;
+      if (_wasMaximized) {
+        await windowManager.maximize();
+        _wasMaximized = false;
+      }
+    }
   } catch (_) {}
 }


### PR DESCRIPTION
# The one about teaching F11 some manners

## Summary
Fix fullscreen behavior on Windows where entering fullscreen from a maximized viewport leaves window chrome (title bar) visible, and toggling fullscreen from windowed view is ignored for some configurations.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #219 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* `lib/util/fullscreen_helper_io.dart`**: Tracked the fullscreen state via an internal `_isFullscreen` boolean rather than calling `windowManager.isFullScreen()`. This avoids coordinate and rounding issues under high DPI scaling and hidden taskbars where the system incorrectly reports the window is fullscreen.
* In `setFullscreen()`, checked if the window is maximized before entering fullscreen. If maximized, we unmaximize the window first via `windowManager.unmaximize()`, clearing the maximized constraint so the OS can transition the window into a clean borderless fullscreen state.
* Stored the maximized state in `_wasMaximized` when entering fullscreen, and restore the maximized state via `windowManager.maximize()` when exiting fullscreen.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code (but should only impact Windows)

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start the application in windowed mode.
2. Press F11 or click the fullscreen icon. Verify it transitions to true borderless fullscreen (no title bar).
3. Press F11 again, verify it transitions back to windowed mode.
4. Maximize the window.
5. Press F11 or click the fullscreen icon. Verify it transitions to true borderless fullscreen (no title bar is visible).
6. Press F11 again, verify the window is restored back to its maximized state.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
