### PR TITLE
fix(browse): support sorting by date in mixed/home videos libraries

### DIFF
--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -217,6 +217,18 @@ class LibraryBrowseViewModel extends ChangeNotifier {
             ?.toLowerCase();
       }
 
+      if (isHomeVideosLibrary || isMixedContentLibrary) {
+        if (_sortBy != LibrarySortBy.name &&
+            _sortBy != LibrarySortBy.dateAdded &&
+            _sortBy != LibrarySortBy.random) {
+          _sortBy = LibrarySortBy.name;
+          await _prefs.set(
+            UserPreferences.librarySortBy(_prefKey),
+            LibrarySortBy.name,
+          );
+        }
+      }
+
       _refreshPosterSizeFromScope();
 
       if (!_imageTypeSynced) {
@@ -306,7 +318,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       sortBy = 'SortName';
     } else if (isHomeVideosLibrary || isMixedContentLibrary) {
       recursive = false;
-      sortBy = 'IsFolder,SortName';
+      sortBy = 'IsFolder,$sortBy';
     }
 
     if (genreId != null &&

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -28,7 +28,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String connectingToServer(String serverName) {
-    return 'Conectándose a $serverName';
+    return 'Conectando a $serverName';
   }
 
   @override
@@ -70,7 +70,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get whosWatching => '¿Quién está viendo?';
+  String get whosWatching => '¿Quién es?';
 
   @override
   String get addUser => 'Añadir usuario';
@@ -80,14 +80,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Versión Moonfin $version';
+    return 'Versión de Moonfin: $version';
   }
 
   @override
   String get savedServers => 'Servidores guardados';
 
   @override
-  String get discoveredServers => 'Servidores descubiertos';
+  String get discoveredServers => 'Servidores encontrados';
 
   @override
   String get noneFound => 'Ninguno encontrado';
@@ -99,7 +99,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get addServer => 'Añadir servidor';
 
   @override
-  String get embyConnect => 'Emby Conectar';
+  String get embyConnect => 'Conectar Emby';
 
   @override
   String get removeServer => 'Eliminar servidor';
@@ -156,7 +156,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get themeMoonfinSubtitle =>
-      'Aspecto actual de Moonfin que a todos les encanta';
+      'El aspecto actual de Moonfin que gusta a todos';
 
   @override
   String get themeNeonPulse => 'Pulso de neón';
@@ -245,7 +245,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get schedule => 'Programación';
 
   @override
-  String get series => 'Serie';
+  String get series => 'Series';
 
   @override
   String get noItemsFound => 'No se encontraron elementos';
@@ -494,7 +494,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get bookHighlightsDescription =>
-      'Tus libros con destacados, favoritos o progreso de lectura.';
+      'Tus libros destacados, favoritos o con progreso de lectura.';
 
   @override
   String get handPickedFromLibrary => 'Seleccionados de tu biblioteca.';
@@ -505,7 +505,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get booksWithHighlights =>
-      'Libros con destacados, favoritos o progreso de lectura.';
+      'Libros destacados, favoritos o con progreso de lectura.';
 
   @override
   String get jumpBackNarration =>
@@ -3577,7 +3577,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get originalLanguageLabel => 'Idioma original';
 
   @override
-  String get seasonsLabel => 'Temporadas';
+  String get seasonsLabel => 'Estaciones';
 
   @override
   String get episodesLabel => 'Episodios';
@@ -8431,7 +8431,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   }
 
   @override
-  String get continuing => 'En emisión';
+  String get continuing => 'Continuo';
 
   @override
   String get ended => 'Terminado';
@@ -8858,7 +8858,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get nextUp => 'Siguiente';
 
   @override
-  String get seasons => 'Temporadas';
+  String get seasons => 'Estaciones';
 
   @override
   String get chapters => 'Capítulos';
@@ -8952,7 +8952,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   }
 
   @override
-  String get play => 'Reproducir';
+  String get play => 'Jugar';
 
   @override
   String get startOver => 'Empezar de nuevo';
@@ -8964,7 +8964,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get readOffline => 'Leer sin conexión';
 
   @override
-  String get playOffline => 'Reproducir sin conexión';
+  String get playOffline => 'Jugar sin conexión';
 
   @override
   String get audio => 'Audio';
@@ -8976,7 +8976,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get version => 'Versión';
 
   @override
-  String get cast => 'Transmitir';
+  String get cast => 'Elenco';
 
   @override
   String get trailer => 'Tráiler';
@@ -9249,7 +9249,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get readMore => 'Leer más';
 
   @override
-  String get shuffle => 'Aleatorio';
+  String get shuffle => 'Barajar';
 
   @override
   String downloadsCount(int count) {
@@ -11511,7 +11511,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get cancelRequest => 'Cancelar solicitud';
 
   @override
-  String get playInMoonfin => 'Reproducir en Moonfin';
+  String get playInMoonfin => 'Jugar en Moonfin';
 
   @override
   String requestedByName(String name) {
@@ -11545,7 +11545,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
 
   @override
   String get itemNotFoundInLibrary =>
-      'Artículo no encontrado en tu biblioteca de Moonfin';
+      'Artículo no encontrado en tu biblioteca Moonfin';
 
   @override
   String get errorSearchingLibrary => 'Error al buscar biblioteca';
@@ -11574,7 +11574,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get submitRequest => 'Enviar solicitud';
 
   @override
-  String get allSeasons => 'Todas las temporadas';
+  String get allSeasons => 'Todas las estaciones';
 
   @override
   String get advancedOptions => 'Opciones avanzadas';
@@ -11655,7 +11655,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get originalLanguageLabel => 'Idioma original';
 
   @override
-  String get seasonsLabel => 'Temporadas';
+  String get seasonsLabel => 'Estaciones';
 
   @override
   String get episodesLabel => 'Episodios';
@@ -16222,7 +16222,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get savedServers => 'Servidores guardados';
 
   @override
-  String get discoveredServers => 'Servidores encontrados';
+  String get discoveredServers => 'Servidores descubiertos';
 
   @override
   String get noneFound => 'No se encontró ninguno';
@@ -16462,7 +16462,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   }
 
   @override
-  String get continuing => 'En emisión';
+  String get continuing => 'Continuo';
 
   @override
   String get ended => 'Terminado';
@@ -16889,7 +16889,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get nextUp => 'Siguiente';
 
   @override
-  String get seasons => 'Temporadas';
+  String get seasons => 'Estaciones';
 
   @override
   String get chapters => 'Capítulos';
@@ -16983,7 +16983,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   }
 
   @override
-  String get play => 'Reproducir';
+  String get play => 'Jugar';
 
   @override
   String get startOver => 'Empezar de nuevo';
@@ -16995,7 +16995,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get readOffline => 'Leer sin conexión';
 
   @override
-  String get playOffline => 'Reproducir sin conexión';
+  String get playOffline => 'Jugar sin conexión';
 
   @override
   String get audio => 'Audio';
@@ -17007,7 +17007,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get version => 'Versión';
 
   @override
-  String get cast => 'Transmitir';
+  String get cast => 'Elenco';
 
   @override
   String get trailer => 'Tráiler';
@@ -17280,7 +17280,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get readMore => 'Leer más';
 
   @override
-  String get shuffle => 'Aleatorio';
+  String get shuffle => 'Barajar';
 
   @override
   String downloadsCount(int count) {
@@ -19542,7 +19542,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get cancelRequest => 'Cancelar solicitud';
 
   @override
-  String get playInMoonfin => 'Reproducir en Moonfin';
+  String get playInMoonfin => 'Jugar en Moonfin';
 
   @override
   String requestedByName(String name) {
@@ -19576,7 +19576,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get itemNotFoundInLibrary =>
-      'Artículo no encontrado en tu biblioteca de Moonfin';
+      'Artículo no encontrado en tu biblioteca Moonfin';
 
   @override
   String get errorSearchingLibrary => 'Error al buscar biblioteca';
@@ -19605,7 +19605,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get submitRequest => 'Enviar solicitud';
 
   @override
-  String get allSeasons => 'Todas las temporadas';
+  String get allSeasons => 'Todas las estaciones';
 
   @override
   String get advancedOptions => 'Opciones avanzadas';
@@ -19686,7 +19686,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get originalLanguageLabel => 'Idioma original';
 
   @override
-  String get seasonsLabel => 'Temporadas';
+  String get seasonsLabel => 'Estaciones';
 
   @override
   String get episodesLabel => 'Episodios';
@@ -24253,7 +24253,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get savedServers => 'Servidores guardados';
 
   @override
-  String get discoveredServers => 'Servidores encontrados';
+  String get discoveredServers => 'Servidores descubiertos';
 
   @override
   String get noneFound => 'No se encontró ninguno';
@@ -24493,7 +24493,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
-  String get continuing => 'En emisión';
+  String get continuing => 'Continuo';
 
   @override
   String get ended => 'Terminado';
@@ -24920,7 +24920,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get nextUp => 'Siguiente';
 
   @override
-  String get seasons => 'Temporadas';
+  String get seasons => 'Estaciones';
 
   @override
   String get chapters => 'Capítulos';
@@ -25014,7 +25014,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
-  String get play => 'Reproducir';
+  String get play => 'Jugar';
 
   @override
   String get startOver => 'Empezar de nuevo';
@@ -25026,7 +25026,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get readOffline => 'Leer sin conexión';
 
   @override
-  String get playOffline => 'Reproducir sin conexión';
+  String get playOffline => 'Jugar sin conexión';
 
   @override
   String get audio => 'Audio';
@@ -25038,7 +25038,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get version => 'Versión';
 
   @override
-  String get cast => 'Transmitir';
+  String get cast => 'Elenco';
 
   @override
   String get trailer => 'Tráiler';
@@ -25311,7 +25311,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get readMore => 'Leer más';
 
   @override
-  String get shuffle => 'Aleatorio';
+  String get shuffle => 'Barajar';
 
   @override
   String downloadsCount(int count) {
@@ -27573,7 +27573,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get cancelRequest => 'Cancelar solicitud';
 
   @override
-  String get playInMoonfin => 'Reproducir en Moonfin';
+  String get playInMoonfin => 'Jugar en Moonfin';
 
   @override
   String requestedByName(String name) {
@@ -27607,7 +27607,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get itemNotFoundInLibrary =>
-      'Artículo no encontrado en tu biblioteca de Moonfin';
+      'Artículo no encontrado en tu biblioteca Moonfin';
 
   @override
   String get errorSearchingLibrary => 'Error al buscar biblioteca';
@@ -27636,7 +27636,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get submitRequest => 'Enviar solicitud';
 
   @override
-  String get allSeasons => 'Todas las temporadas';
+  String get allSeasons => 'Todas las estaciones';
 
   @override
   String get advancedOptions => 'Opciones avanzadas';
@@ -27717,7 +27717,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get originalLanguageLabel => 'Idioma original';
 
   @override
-  String get seasonsLabel => 'Temporadas';
+  String get seasonsLabel => 'Estaciones';
 
   @override
   String get episodesLabel => 'Episodios';
@@ -32284,7 +32284,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get savedServers => 'Servidores guardados';
 
   @override
-  String get discoveredServers => 'Servidores encontrados';
+  String get discoveredServers => 'Servidores descubiertos';
 
   @override
   String get noneFound => 'No se encontró ninguno';
@@ -32524,7 +32524,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
-  String get continuing => 'En emisión';
+  String get continuing => 'Continuo';
 
   @override
   String get ended => 'Terminado';
@@ -32951,7 +32951,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get nextUp => 'Siguiente';
 
   @override
-  String get seasons => 'Temporadas';
+  String get seasons => 'Estaciones';
 
   @override
   String get chapters => 'Capítulos';
@@ -33045,7 +33045,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
-  String get play => 'Reproducir';
+  String get play => 'Jugar';
 
   @override
   String get startOver => 'Empezar de nuevo';
@@ -33057,7 +33057,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get readOffline => 'Leer sin conexión';
 
   @override
-  String get playOffline => 'Reproducir sin conexión';
+  String get playOffline => 'Jugar sin conexión';
 
   @override
   String get audio => 'Audio';
@@ -33069,7 +33069,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get version => 'Versión';
 
   @override
-  String get cast => 'Transmitir';
+  String get cast => 'Elenco';
 
   @override
   String get trailer => 'Tráiler';
@@ -33342,7 +33342,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get readMore => 'Leer más';
 
   @override
-  String get shuffle => 'Aleatorio';
+  String get shuffle => 'Barajar';
 
   @override
   String downloadsCount(int count) {
@@ -35604,7 +35604,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get cancelRequest => 'Cancelar solicitud';
 
   @override
-  String get playInMoonfin => 'Reproducir en Moonfin';
+  String get playInMoonfin => 'Jugar en Moonfin';
 
   @override
   String requestedByName(String name) {
@@ -35638,7 +35638,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get itemNotFoundInLibrary =>
-      'Artículo no encontrado en tu biblioteca de Moonfin';
+      'Artículo no encontrado en tu biblioteca Moonfin';
 
   @override
   String get errorSearchingLibrary => 'Error al buscar biblioteca';
@@ -35667,7 +35667,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get submitRequest => 'Enviar solicitud';
 
   @override
-  String get allSeasons => 'Todas las temporadas';
+  String get allSeasons => 'Todas las estaciones';
 
   @override
   String get advancedOptions => 'Opciones avanzadas';
@@ -35748,7 +35748,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get originalLanguageLabel => 'Idioma original';
 
   @override
-  String get seasonsLabel => 'Temporadas';
+  String get seasonsLabel => 'Estaciones';
 
   @override
   String get episodesLabel => 'Episodios';

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -4850,7 +4850,9 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
             ),
             Divider(color: dividerColor),
             _sectionHeader(l10n.sortBy, sectionColor),
-            for (final option in LibrarySortBy.values)
+            for (final option in (vm.isHomeVideosLibrary || vm.isMixedContentLibrary)
+                ? const [LibrarySortBy.name, LibrarySortBy.dateAdded, LibrarySortBy.random]
+                : LibrarySortBy.values)
               _radioTile(
                 label: option.displayName,
                 selected: vm.sortBy == option,


### PR DESCRIPTION
# Pull Request - Sort Home Media Libraries

## Summary
Allows sorting by relevant parameters (such as 'Date Added' / `DateCreated`) in Home Video and Mixed Content libraries, while filtering out unsupported sort options that cause API errors and UI freezes. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #452 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* Modified the sort options dialog inside `_FilterSortDialogState` in `library_browse_screen.dart` to only render Name, Date Added, and Random options for home video and mixed libraries. This prevents users from selecting unsupported metadata-based sorts (like ratings/runtime).
* Enabled the `sortBy` parameter inside `_fetchPage` for home video and mixed libraries in `library_browse_view_model.dart` instead of hardcoding it to `SortName`.
*  Implemented validation check on library loading inside `load()` in `library_browse_view_model.dart`. If an invalid sort key is stored in preferences for a home video or mixed library, the model automatically falls back to `LibrarySortBy.name` and updates the saved preference to restore the view and prevent infinite loading spinners on the Homepage/Library.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a Mixed or Home Movies library.
2. Open the Sort & Filter dialog and verify that only Name, Date Added, and Random are shown as options.
3. Select "Date Added" (ascending or descending) and verify that items sort correctly without error.
4. Verify that returning to the Homepage loads the library list normally and doesn't get stuck on a loading indicator.
5. Manually configure a library with an unsupported sort parameter in preferences and load the library; verify that the app resets the preference to Name and loads successfully.

## Screenshots (if applicable)
OLD UI:
<img width="300" alt="2026-06-10_21-38-31_moonfin" src="https://github.com/user-attachments/assets/5048e9f6-3d58-4b6b-bfa8-ec9326349cf1" />

NEW UI:
<img width="300" alt="2026-06-10_21-52-53_moonfin" src="https://github.com/user-attachments/assets/4173af92-f034-4b62-bf29-7b3e4b87d4b2" />

Sort by random:
<img width="350" alt="2026-06-10_21-52-12_moonfin" src="https://github.com/user-attachments/assets/c54b3d9b-1f28-4c72-a8ed-a84430c964ed" />

Sort by Name:
<img width="300" height="118" alt="2026-06-10_21-53-24_moonfin" src="https://github.com/user-attachments/assets/31d07d94-f980-4eaf-82d1-98b602e91cf2" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
