### PR TITLE
fix(home): resolve missing thumbnails for music videos and videos

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3618,14 +3618,16 @@ class _ContentRowsState extends State<_ContentRows>
         tag: item.backdropImageTags.first,
       );
     }
-    final parentId = item.parentBackdropItemId;
-    final parentTags = item.parentBackdropImageTags;
-    if (parentId != null && parentTags.isNotEmpty) {
-      return imageApi.getBackdropImageUrl(
-        parentId,
-        maxWidth: maxW,
-        tag: parentTags.first,
-      );
+    if (item.type != 'Video' && item.type != 'MusicVideo') {
+      final parentId = item.parentBackdropItemId;
+      final parentTags = item.parentBackdropImageTags;
+      if (parentId != null && parentTags.isNotEmpty) {
+        return imageApi.getBackdropImageUrl(
+          parentId,
+          maxWidth: maxW,
+          tag: parentTags.first,
+        );
+      }
     }
     return _resolvePrimaryImageUrl(item, imageApi, maxWidth: maxW);
   }
@@ -3845,16 +3847,16 @@ class _ContentRowsState extends State<_ContentRows>
     if (imageType == ImageType.thumb) {
       final maxW = (height * 16 / 9 * requestScale).toInt();
       final maxH = (height * requestScale).toInt();
-      if (!useSeriesThumbs) {
-        if (item.type == 'Episode') {
-          final episodePrimary = _resolvePrimaryImageUrl(
+      if (!useSeriesThumbs || item.type == 'Video' || item.type == 'MusicVideo') {
+        if (item.type == 'Episode' || item.type == 'Video' || item.type == 'MusicVideo') {
+          final videoPrimary = _resolvePrimaryImageUrl(
             item,
             imageApi,
             maxHeight: maxH,
             maxWidth: maxW,
           );
-          if (episodePrimary != null) {
-            return episodePrimary;
+          if (videoPrimary != null) {
+            return videoPrimary;
           }
         } else if (item.type == 'Series') {
           final latestEpId = item.rawData['LatestEpisodeId'] as String?;


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where recently downloaded music videos (which lack extracted Thumb artwork on the Jellyfin server) fail to render thumbnails on the home screen rows (Classic or Modern layouts), displaying blank cards.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #271 
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

Modified lib/ui/screens/home/home_screen.dart:
* Updated _resolveRowImageUrl under the ImageType.thumb block to check for MusicVideo and generic Video items, allowing them to fall back to their own Primary image tag instead of incorrectly falling back to the parent artist/folder backdrop or thumbnail.
* Updated _resolveLandscapeImageUrl to bypass the parent backdrop lookup for MusicVideo and generic Video items, preventing them from falling back to the artist's backdrop image when their own primary image is available.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Don't have music video library but prepared a beta APK to share with user for verification.

### Test Steps
Run beta build of Moonfin.
Verify that recently downloaded music videos (without thumb/backdrop tags) load their primary artwork on the home screen rows.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
