### PR TITLE
ui: remove focus overlay and use theme highlight color on genres

### DIFF
--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -4002,9 +4002,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                 delegate: SliverChildBuilderDelegate((context, index) {
                   final item = _vm.items[index];
                   final itemAspectRatio = _itemAspectRatio(item);
-                  final focusColor = Color(
-                    _prefs.get(UserPreferences.focusColor).colorValue,
-                  );
+                  final focusColor = _vm.isGenreBrowse
+                      ? ThemeRegistry.active.borders.focusBorder.color
+                      : Color(
+                          _prefs.get(UserPreferences.focusColor).colorValue,
+                        );
                   final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
                   Widget card = MediaCard(
                     title: item.name,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3194,7 +3194,9 @@ class _ContentRowsState extends State<_ContentRows>
             itemType: item.type,
             seerrMediaType: item.seerrMediaType,
             seerrStatus: item.seerrStatus,
-            focusColor: focusColor,
+            focusColor: (row.rowType == HomeRowType.genres && row.id == 'genres')
+                ? ThemeRegistry.active.borders.focusBorder.color
+                : focusColor,
             cardFocusExpansion: isRowsV2 ? false : cardExpansion && !showPreviewVideo,
             externalIsFocused: effectiveV2Focused,
             suppressImageFocusBorder: showPreviewVideo,

--- a/lib/ui/widgets/genre_grid_card.dart
+++ b/lib/ui/widgets/genre_grid_card.dart
@@ -95,101 +95,127 @@ class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
           child: AnimatedScale(
             scale: widget.cardFocusExpansion && showFocusBorder ? 1.05 : 1.0,
             duration: const Duration(milliseconds: 150),
-            child: DecoratedBox(
-              position: DecorationPosition.foreground,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(10),
-                border: showFocusBorder
-                    ? Border.fromBorderSide(
-                        ThemeRegistry.active.borders.focusBorder.copyWith(
-                          color: borderColor,
-                          width: 2.4,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                if (showFocusBorder && ThemeRegistry.active.borders.focusGlow.isNotEmpty)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          boxShadow: ThemeRegistry.active.borders.focusGlow,
                         ),
-                      )
-                    : null,
-                boxShadow: showFocusBorder
-                    ? [
-                        BoxShadow(
-                          color: AppColorScheme.accent.withAlpha(145),
-                          blurRadius: 14,
-                          spreadRadius: 1.2,
+                      ),
+                    ),
+                  )
+                else if (showFocusBorder)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          boxShadow: [
+                            BoxShadow(
+                              color: AppColorScheme.accent.withAlpha(145),
+                              blurRadius: 14,
+                              spreadRadius: 1.2,
+                            ),
+                          ],
                         ),
-                      ]
-                    : null,
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    if (imageUrl != null)
-                      BoundedNetworkImage(
-                        imageUrl: imageUrl,
-                        fadeInDuration: const Duration(milliseconds: 200),
-                        errorBuilder: (_, _, _) => Container(
+                      ),
+                    ),
+                  ),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      if (imageUrl != null)
+                        BoundedNetworkImage(
+                          imageUrl: imageUrl,
+                          fadeInDuration: const Duration(milliseconds: 200),
+                          errorBuilder: (_, _, _) => Container(
+                            color: AppColorScheme.surface.withValues(alpha: 0.35),
+                          ),
+                        )
+                      else
+                        Container(
                           color: AppColorScheme.surface.withValues(alpha: 0.35),
                         ),
-                      )
-                    else
                       Container(
-                        color: AppColorScheme.surface.withValues(alpha: 0.35),
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              Colors.transparent,
+                              AppColorScheme.scrim.withAlpha(165),
+                            ],
+                          ),
+                        ),
                       ),
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [
-                            Colors.transparent,
-                            AppColorScheme.scrim.withAlpha(165),
+                      Positioned(
+                        left: 12 * desktopScale,
+                        right: 12 * desktopScale,
+                        bottom: 8 * desktopScale,
+                        child: Column(
+                          crossAxisAlignment: widget.centerTitle
+                              ? CrossAxisAlignment.center
+                              : CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            showMarquee
+                                ? MarqueeText(
+                                    text: widget.genre.name,
+                                    style: titleStyle,
+                                  )
+                                : Text(
+                                    widget.genre.name,
+                                    maxLines: titleMaxLines,
+                                    overflow: TextOverflow.ellipsis,
+                                    textAlign: widget.centerTitle
+                                        ? TextAlign.center
+                                        : TextAlign.start,
+                                    style: titleStyle,
+                                  ),
+                            if (widget.genre.itemCount > 0) ...[
+                              const SizedBox(height: 2),
+                              showMarquee
+                                  ? MarqueeText(
+                                      text: '${widget.genre.itemCount} items',
+                                      style: subtitleStyle,
+                                    )
+                                  : Text(
+                                      '${widget.genre.itemCount} items',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: subtitleStyle,
+                                    ),
+                            ],
                           ],
                         ),
                       ),
-                    ),
-                    Positioned(
-                      left: 12 * desktopScale,
-                      right: 12 * desktopScale,
-                      bottom: 8 * desktopScale,
-                      child: Column(
-                        crossAxisAlignment: widget.centerTitle
-                            ? CrossAxisAlignment.center
-                            : CrossAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          showMarquee
-                              ? MarqueeText(
-                                  text: widget.genre.name,
-                                  style: titleStyle,
-                                )
-                              : Text(
-                                  widget.genre.name,
-                                  maxLines: titleMaxLines,
-                                  overflow: TextOverflow.ellipsis,
-                                  textAlign: widget.centerTitle
-                                      ? TextAlign.center
-                                      : TextAlign.start,
-                                  style: titleStyle,
-                                ),
-                          if (widget.genre.itemCount > 0) ...[
-                            const SizedBox(height: 2),
-                            showMarquee
-                                ? MarqueeText(
-                                    text: '${widget.genre.itemCount} items',
-                                    style: subtitleStyle,
-                                  )
-                                : Text(
-                                    '${widget.genre.itemCount} items',
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: subtitleStyle,
-                                  ),
-                          ],
-                        ],
+                    ],
+                  ),
+                ),
+                if (showFocusBorder)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.fromBorderSide(
+                            ThemeRegistry.active.borders.focusBorder.copyWith(
+                              color: borderColor,
+                              width: 2.4,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ],
-                ),
-              ),
+                  ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
# Pull Request

## Summary

Remove the focus color overlay from genre cards and ensure that the theme's accent/highlight color is used consistently for the focus border when browsing or viewing genres and their subitems.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Refactored `GenreGridCard` to draw the focus glow (shadow) in the background rather than in the foreground, preventing the shadow from overlaying the poster design.
- Updated `LibraryBrowseScreen` to override the card focus border color with the active theme's highlight color when browsing items in a genre.
- Updated `HomeScreen` to override the card focus border color with the active theme's highlight color for items in the home screen's genres row.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed: Windows
- [ ] Not tested (explain why):

### Test Steps
1. Launch the app and go to the "All Genres" page or any genre sub-list.
2. Focus on a genre grid card (like "Martial Arts"). Verify that the pink highlight border is drawn in the foreground on Neon Pulse, and that the glow shadow is rendered in the background rather than overlaying the card image.
3. Open a genre (e.g. "Martial Arts") to view its subitems (movies or shows). Focus on a media card and verify that the border highlights using the active theme's highlight color (e.g. Pink on Neon Pulse) without any overlay.

## Screenshots (if applicable)
<img width="500" alt="2026-06-11_00-28-37_moonfin" src="https://github.com/user-attachments/assets/36dd90ba-8e67-488d-bb34-f8ac5b146bb6" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
