### PR TITLE
fix(playback): bypass restrictive device profile query for external players

### DIFF
--- a/lib/ui/screens/playback/external_player_host_screen.dart
+++ b/lib/ui/screens/playback/external_player_host_screen.dart
@@ -7,8 +7,11 @@ import 'package:playback_core/playback_core.dart';
 
 import '../../../data/models/aggregated_item.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../playback/audio_capability_profile.dart';
+import '../../../playback/device_profile_builder.dart';
 import '../../../playback/external_player_policy.dart';
 import '../../../playback/external_player_service.dart';
+import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../navigation/destinations.dart';
 
@@ -98,9 +101,47 @@ class _ExternalPlayerHostScreenState extends State<ExternalPlayerHostScreen> {
 
         final resolver = GetIt.instance<MediaStreamResolver>();
         final playService = GetIt.instance<PlayerService>();
-        final backend = _manager.backend ?? GetIt.instance<PlayerBackend>();
 
-        final profile = backend.getDeviceProfile(useProgressiveTranscode: false);
+        final maxBitrateOption = int.tryParse(_prefs.get(UserPreferences.maxBitrate));
+        final maxResolution = _prefs.get(UserPreferences.maxVideoResolution);
+        final profile = DeviceProfileBuilder.build(
+          maxBitrateMbps: maxBitrateOption,
+          audioCapabilityProfile: const AudioCapabilityProfile.optimistic(),
+          audioOutputMode: AudioOutputMode.auto,
+          audioFallbackCodec: AudioFallbackCodec.auto,
+          maxResolution: maxResolution,
+          pgsDirectPlay: true,
+          assDirectPlay: true,
+          supportsAvc: true,
+          supportsAvcHigh10: true,
+          avcMainLevel: 52,
+          avcHigh10Level: 52,
+          supportsHevc: true,
+          supportsHevcMain10: true,
+          hevcMainLevel: 186,
+          supportsHevcDolbyVision: true,
+          supportsHevcDolbyVisionEl: true,
+          supportsHevcHdr10: true,
+          supportsHevcHdr10Plus: true,
+          supportsAv1: true,
+          supportsAv1Main10: true,
+          supportsAv1DolbyVision: true,
+          supportsAv1Hdr10: true,
+          supportsAv1Hdr10Plus: true,
+          supportsVc1: true,
+          maxResolutionAvcWidth: 4096,
+          maxResolutionAvcHeight: 2160,
+          maxResolutionHevcWidth: 4096,
+          maxResolutionHevcHeight: 2160,
+          maxResolutionAv1Width: 4096,
+          maxResolutionAv1Height: 2160,
+          maxResolutionVc1Width: 4096,
+          maxResolutionVc1Height: 2160,
+          supportsDvProfile5: true,
+          supportsDvProfile7: true,
+          supportsDvProfile8: true,
+          allowDolbyVisionProfile7ElDirectPlay: true,
+        );
         final overrideMbps = _manager.maxBitrateOverrideMbps;
         if (overrideMbps != null) {
           profile['MaxStreamingBitrate'] = overrideMbps * 1000000;


### PR DESCRIPTION
# Pull Request

## Summary
Resolves the issue where 4K HEVC / Dolby Vision video streams fail to launch in external players (e.g., Vimu, MX Player, VLC) and lock up the client app by triggering server-side transcoding. The solution is to bypass the restrictive internal player profile query in `ExternalPlayerHostScreen` with a permissive profile that advertises comprehensive 4K capabilities.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #444 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `ExternalPlayerHostScreen` in external_player_host_screen.dart to build a fully permissive profile via `DeviceProfileBuilder.build(...)` when launching an external player.
- Advertised support for all standard 4K formats (HEVC, DV profiles 5/7/8, AV1, DTS, TrueHD) to prevent server transcoding, while still respecting user-defined maximum bitrate and maximum video resolution preferences.
- Corrected audio_migration_test.dart unit tests to assert against the active `pref_audio_preference_split_v2` migration key instead of the stale `v1` key, resolving pre-existing test failures.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): No external players on my devices

### Test Steps
1. Ran `flutter analyze` to verify the modified code introduces no lints or warnings.
2. Ran `flutter test` to ensure all 42 unit tests pass successfully.
3. Ask user to test fix (no external players on my devices)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced