### PR TITLE
fix: resolve disappearing chapter button in playback queues

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -12,7 +12,7 @@ enum ItemDetailState { loading, ready, error }
 
 class ItemDetailViewModel extends ChangeNotifier {
   static const _episodeOverviewFields =
-      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData';
+      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData,Chapters';
 
   final MediaServerClient _client;
   final ItemMutationRepository _mutations;

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -28,7 +28,7 @@ final _getIt = GetIt.instance;
 
 const _nextSeasonEpisodeFields =
     'Type,UserData,SeriesName,ParentIndexNumber,IndexNumber,SeriesId,SeasonId,'
-    'MediaSources,MediaStreams,RunTimeTicks';
+    'MediaSources,MediaStreams,RunTimeTicks,Chapters';
 
 bool _isDolbyVisionResolution(StreamResolutionResult resolution) {
   for (final stream in resolution.mediaStreams) {

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5561,7 +5561,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
 
   Future<List<AggregatedItem>> _shuffleQueueForItem(AggregatedItem item) async {
     const shuffleQueueFields =
-        'MediaStreams,MediaSources,RunTimeTicks,Trickplay';
+        'MediaStreams,MediaSources,RunTimeTicks,Trickplay,Chapters';
     switch (item.type) {
       case 'Series':
         if (viewModel.episodes.length > 1) {
@@ -5787,7 +5787,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
         switch (item.type) {
           case 'Series':
             const episodeQueueFields =
-                'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData';
+                'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData,Chapters';
 
             final client = _clientForItem(item);
             final data = await client.itemsApi.getEpisodes(
@@ -5922,7 +5922,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
               if (seriesId != null && seriesId.isNotEmpty) {
                 try {
                   const episodeQueueFields =
-                      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData';
+                      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData,Chapters';
                   final client = _clientForItem(item);
                   final data = await client.itemsApi.getEpisodes(
                     seriesId,


### PR DESCRIPTION
# Pull Request

## Summary
Resolves the issue where the OSD Chapter button disappears when playing series episodes via season, shuffle, or play queues.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #435 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `Chapters` field to metadata query arguments in `lib/data/viewmodels/item_detail_view_model.dart`, `lib/di/modules/playback_module.dart`, and `lib/ui/screens/detail/item_detail_screen.dart` (specifically for next-season, shuffle, and episode queues).
- Fixed a broken preference key name check in unit tests (`test/preference/audio_migration_test.dart`: v1 -> v2) to allow all unit tests to pass cleanly.


## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play episodes from a series detail screen using a play/shuffle queue.
2. Verify that the Chapter button remains visible in the OSD player bar during playback and correctly populates the chapters list.
3. Advance to the next episode and verify chapters are still successfully queried and visible.

## Screenshots (if applicable)
Episode 1:
<img width="400" alt="2026-06-11_08-00-17_moonfin" src="https://github.com/user-attachments/assets/dc832c1d-4547-40b8-8ee5-ad4f02ffd1e7" />

Episode 2:
<img width="400" alt="2026-06-11_08-00-59_moonfin" src="https://github.com/user-attachments/assets/97fc6274-1740-4569-9911-63186ae3e980" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
