### PR TITLE
fix: resolve folder navigation and image display bugs in nested mixed libraries

### DIFF
--- a/lib/data/viewmodels/folder_browse_view_model.dart
+++ b/lib/data/viewmodels/folder_browse_view_model.dart
@@ -208,16 +208,23 @@ class FolderBrowseViewModel extends ChangeNotifier {
 
   bool isNavigableFolder(AggregatedItem item) {
     final type = item.type;
+    if (type == 'Series' ||
+        type == 'Season' ||
+        type == 'BoxSet' ||
+        type == 'Playlist') {
+      return false;
+    }
+
+    final isFolder = item.rawData['IsFolder'] as bool? ?? false;
+    if (isFolder) return true;
+
     return type == 'Folder' ||
         type == 'CollectionFolder' ||
         type == 'UserView' ||
-        type == 'BoxSet' ||
         type == 'MusicAlbum' ||
-        type == 'Season' ||
-        type == 'Series' ||
-        type == 'PhotoAlbum' ||
-        type == 'Playlist';
+        type == 'PhotoAlbum';
   }
+
 
   @override
   void dispose() {

--- a/lib/ui/screens/browse/folder_browse_screen.dart
+++ b/lib/ui/screens/browse/folder_browse_screen.dart
@@ -71,30 +71,56 @@ class _FolderBrowseScreenState extends State<FolderBrowseScreen> {
 
   String? _imageUrl(AggregatedItem item, {int? maxWidth}) {
     final api = _vm.imageApi;
+    final isFolder = _vm.isNavigableFolder(item);
 
     final imageTags = item.rawData['ImageTags'];
     if (imageTags is Map) {
-      final thumbTag = imageTags['Thumb'] as String?;
-      if (thumbTag != null) {
-        return api.getThumbImageUrl(item.id, maxWidth: maxWidth, tag: thumbTag);
-      }
+      if (isFolder) {
+        final thumbTag = imageTags['Thumb'] as String?;
+        if (thumbTag != null) {
+          return api.getThumbImageUrl(item.id, maxWidth: maxWidth, tag: thumbTag);
+        }
 
-      final primaryTag = imageTags['Primary'] as String?;
-      if (primaryTag != null) {
-        return api.getPrimaryImageUrl(
-          item.id,
-          maxWidth: maxWidth,
-          tag: primaryTag,
-        );
-      }
+        final primaryTag = imageTags['Primary'] as String?;
+        if (primaryTag != null) {
+          return api.getPrimaryImageUrl(
+            item.id,
+            maxWidth: maxWidth,
+            tag: primaryTag,
+          );
+        }
 
-      final backdropTag = imageTags['Backdrop'] as String?;
-      if (backdropTag != null) {
-        return api.getBackdropImageUrl(
-          item.id,
-          maxWidth: maxWidth,
-          tag: backdropTag,
-        );
+        final backdropTag = imageTags['Backdrop'] as String?;
+        if (backdropTag != null) {
+          return api.getBackdropImageUrl(
+            item.id,
+            maxWidth: maxWidth,
+            tag: backdropTag,
+          );
+        }
+      } else {
+        final primaryTag = imageTags['Primary'] as String?;
+        if (primaryTag != null) {
+          return api.getPrimaryImageUrl(
+            item.id,
+            maxWidth: maxWidth,
+            tag: primaryTag,
+          );
+        }
+
+        final thumbTag = imageTags['Thumb'] as String?;
+        if (thumbTag != null) {
+          return api.getThumbImageUrl(item.id, maxWidth: maxWidth, tag: thumbTag);
+        }
+
+        final backdropTag = imageTags['Backdrop'] as String?;
+        if (backdropTag != null) {
+          return api.getBackdropImageUrl(
+            item.id,
+            maxWidth: maxWidth,
+            tag: backdropTag,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
# The one about Mixed Media

## Summary
Resolves mixed content library nested folder browsing issues where Series/Seasons/Collections/Playlists are incorrectly navigated as folders and media items use landscape thumbs instead of portrait posters.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #262 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `FolderBrowseViewModel.isNavigableFolder` to return `false` for `Series`, `Season`, `BoxSet`, and `Playlist`.
- Modified `FolderBrowseScreen._imageUrl` to check folder navigation status. Prioritizes `Primary` poster images over `Thumb` landscape images for media items, and keeps `Thumb` prioritization for actual folders.
- Fixed outdated assertions checking `pref_audio_preference_split_v1` in `audio_migration_test.dart` (updated to `v2`) so that all tests pass.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate into a nested folder containing movies and TV shows.
2. Verify that movies and TV shows display using their portrait primary posters.
3. Verify that clicking on a TV series navigates to the series detail screen rather than folder view.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
