### PR TITLE
fix: resolve current episode highlight color and focus clash

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -9044,18 +9044,18 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
             width: widget.isMobile ? 180.0 : 220.0 * desktopScale,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(8),
-              border: widget.isCurrent
-                  ? Border.fromBorderSide(
-                      ThemeRegistry.active.borders.focusBorder.copyWith(
-                        color: AppColorScheme.accent,
-                        width: 2,
-                      ),
-                    )
-                  : showFocusBorder
+              border: showFocusBorder
                   ? Border.fromBorderSide(
                       ThemeRegistry.active.borders.focusBorder.copyWith(
                         color: isNeon ? AppColorScheme.accent : focusColor,
                         width: 1.5,
+                      ),
+                    )
+                  : widget.isCurrent
+                  ? Border.fromBorderSide(
+                      ThemeRegistry.active.borders.focusBorder.copyWith(
+                        color: AppColorScheme.onSurface,
+                        width: 2.5,
                       ),
                     )
                   : null,


### PR DESCRIPTION
# Pull Request

## Summary
Implements a visual theme-appropriate distinction for the "next up" episode card highlights.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `_EpisodeListCardState.build` in `lib/ui/screens/detail/item_detail_screen.dart` to check `showFocusBorder` first. Active focus highlights now cleanly override next-up borders.
- Styled the next-up episode (`widget.isCurrent` when not focused) using `AppColorScheme.onSurface` (cyan in Neon Pulse, white in the default Moonfin theme) 
- Fixed outdated preference migration key assertions (`pref_audio_preference_split_v1` -> `v2`) in `audio_migration_test.dart` to keep the test suite passing.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a TV Series detail page in the Neon Pulse theme.
2. Verify that the next-up episode card has a thicker, cyan outline when not focused.
3. Move focus to the card and verify it scales and displays the primary pink focus border.

## Screenshots (if applicable)

Original:
<img width="400" alt="2026-06-11_08-19-36_moonfin" src="https://github.com/user-attachments/assets/8ef65289-f277-40b7-9305-2f68af7049e5" />

New (with both themes):
<img width="400" alt="2026-06-11_08-34-32_moonfin" src="https://github.com/user-attachments/assets/1e195b95-f97c-4dc5-9daf-3a3da42b1e0e" /> 

<img width="400" alt="2026-06-11_08-34-15_moonfin" src="https://github.com/user-attachments/assets/2bbc14b1-0e56-4a13-8b02-23636f5c2c0b" />




## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
