### PR TITLE
fix: always respect manual subtitle and audio selections

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -26,6 +26,25 @@ class ItemDetailViewModel extends ChangeNotifier {
   AggregatedItem? _item;
   AggregatedItem? get item => _item;
 
+  int? _selectedAudioIndex;
+  int? get selectedAudioIndex => _selectedAudioIndex;
+  set selectedAudioIndex(int? value) {
+    if (_selectedAudioIndex != value) {
+      _selectedAudioIndex = value;
+      notifyListeners();
+    }
+  }
+
+  int? _selectedSubtitleIndex;
+  int? get selectedSubtitleIndex => _selectedSubtitleIndex;
+  set selectedSubtitleIndex(int? value) {
+    if (_selectedSubtitleIndex != value) {
+      _selectedSubtitleIndex = value;
+      notifyListeners();
+    }
+  }
+
+
   List<AggregatedItem> _similar = const [];
   List<AggregatedItem> get similar => _similar;
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4348,8 +4348,12 @@ class _DolbyVisionPlayDecision {
 }
 
 class _ActionButtonsState extends State<_ActionButtons> {
-  int? _selectedAudioIndex;
-  int? _selectedSubtitleIndex;
+  int? get _selectedAudioIndex => viewModel.selectedAudioIndex;
+  set _selectedAudioIndex(int? value) => viewModel.selectedAudioIndex = value;
+
+  int? get _selectedSubtitleIndex => viewModel.selectedSubtitleIndex;
+  set _selectedSubtitleIndex(int? value) => viewModel.selectedSubtitleIndex = value;
+
   bool _expanded = false;
   bool _playLaunchInFlight = false;
   bool _autoPlayTriggered = false;
@@ -5199,7 +5203,11 @@ class _ActionButtonsState extends State<_ActionButtons> {
     final prefs = GetIt.instance<UserPreferences>();
     final preferred = prefs.get(UserPreferences.defaultAudioLanguage).trim();
     if (preferred.isEmpty) {
-      return null;
+      final defaultStream = audioStreams.firstWhere(
+        (s) => s['IsDefault'] == true,
+        orElse: () => <String, dynamic>{},
+      );
+      return defaultStream['Index'] as int?;
     }
 
     final preferredNormalized = normalizeLanguage(preferred);
@@ -5236,7 +5244,11 @@ class _ActionButtonsState extends State<_ActionButtons> {
 
     final preferred = prefs.get(UserPreferences.defaultSubtitleLanguage).trim();
     if (preferred.isEmpty) {
-      return null;
+      final defaultStream = subtitleStreams.firstWhere(
+        (s) => s['IsDefault'] == true,
+        orElse: () => <String, dynamic>{},
+      );
+      return defaultStream['Index'] as int?;
     }
 
     final preferredNormalized = normalizeLanguage(preferred);

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -479,6 +479,13 @@ class Media3VideoView(
     private var selectedSubtitleIsBitmap = false
     private var selectedExternalSubtitleUrl: String? = null
     private var subtitleTrackEnabled = false
+
+    private var pendingSubtitleIndex: Int? = null
+    private var pendingSubtitleCodec: String? = null
+    private var pendingSubtitleIsExternal: Boolean? = null
+    private var pendingSubtitleIsBitmap: Boolean? = null
+    private var pendingExternalSubtitleUrl: String? = null
+    private var pendingAudioIndex: Int? = null
     private var zoomMode = ZoomMode.FIT
     private var videoWidthPx = 0
     private var videoHeightPx = 0
@@ -665,6 +672,28 @@ class Media3VideoView(
         }
 
         override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
+            pendingSubtitleIndex?.let { index ->
+                if (selectTrack(C.TRACK_TYPE_TEXT, index)) {
+                    selectedSubtitleCodec = pendingSubtitleCodec?.trim()?.lowercase()
+                    selectedSubtitleIsExternal = pendingSubtitleIsExternal ?: false
+                    selectedSubtitleIsBitmap = pendingSubtitleIsBitmap ?: false
+                    selectedExternalSubtitleUrl = pendingExternalSubtitleUrl?.takeIf { it.isNotBlank() }
+                    subtitleTrackEnabled = true
+                    applyTrackSelectorForCurrentSource()
+                    refreshSubtitleRendererMode()
+
+                    pendingSubtitleIndex = null
+                    pendingSubtitleCodec = null
+                    pendingSubtitleIsExternal = null
+                    pendingSubtitleIsBitmap = null
+                    pendingExternalSubtitleUrl = null
+                }
+            }
+            pendingAudioIndex?.let { index ->
+                if (selectTrack(C.TRACK_TYPE_AUDIO, index)) {
+                    pendingAudioIndex = null
+                }
+            }
             emitTracksChanged()
             emitState()
         }
@@ -1028,7 +1057,11 @@ class Media3VideoView(
 
                 "setAudioTrack" -> {
                     val index = ((call.arguments as? Map<*, *>)?.get("index") as? Number)?.toInt() ?: 0
-                    selectTrack(C.TRACK_TYPE_AUDIO, index)
+                    pendingAudioIndex = index
+                    val selected = selectTrack(C.TRACK_TYPE_AUDIO, index)
+                    if (selected) {
+                        pendingAudioIndex = null
+                    }
                     result.success(null)
                 }
 
@@ -1039,6 +1072,13 @@ class Media3VideoView(
                     val isExternal = args?.get("isExternalSubtitle") as? Boolean ?: false
                     val isBitmap = args?.get("isBitmapSubtitle") as? Boolean ?: false
                     val externalUrl = args?.get("externalSubtitleUrl")?.toString()
+
+                    pendingSubtitleIndex = index
+                    pendingSubtitleCodec = codec
+                    pendingSubtitleIsExternal = isExternal
+                    pendingSubtitleIsBitmap = isBitmap
+                    pendingExternalSubtitleUrl = externalUrl
+
                     val selected = selectTrack(C.TRACK_TYPE_TEXT, index)
                     if (selected) {
                         selectedSubtitleCodec = codec?.trim()?.lowercase()
@@ -1048,6 +1088,12 @@ class Media3VideoView(
                         subtitleTrackEnabled = true
                         applyTrackSelectorForCurrentSource()
                         refreshSubtitleRendererMode()
+
+                        pendingSubtitleIndex = null
+                        pendingSubtitleCodec = null
+                        pendingSubtitleIsExternal = null
+                        pendingSubtitleIsBitmap = null
+                        pendingExternalSubtitleUrl = null
                     }
                     result.success(null)
                 }
@@ -1063,6 +1109,13 @@ class Media3VideoView(
                     selectedSubtitleIsBitmap = false
                     selectedExternalSubtitleUrl = null
                     subtitleTrackEnabled = false
+
+                    pendingSubtitleIndex = null
+                    pendingSubtitleCodec = null
+                    pendingSubtitleIsExternal = null
+                    pendingSubtitleIsBitmap = null
+                    pendingExternalSubtitleUrl = null
+
                     applyTrackSelectorForCurrentSource()
                     clearAssSubtitleScript()
                     refreshSubtitleRendererMode()
@@ -1303,6 +1356,12 @@ class Media3VideoView(
         selectedSubtitleIsBitmap = false
         selectedExternalSubtitleUrl = null
         subtitleTrackEnabled = false
+        pendingSubtitleIndex = null
+        pendingSubtitleCodec = null
+        pendingSubtitleIsExternal = null
+        pendingSubtitleIsBitmap = null
+        pendingExternalSubtitleUrl = null
+        pendingAudioIndex = null
         firstFrameRendered = false
         firstFrameCover.visibility = View.VISIBLE
         cancelPendingSubtitleCue(clearView = true)

--- a/packages/playback_core/lib/src/media_stream_resolver.dart
+++ b/packages/playback_core/lib/src/media_stream_resolver.dart
@@ -7,29 +7,29 @@ abstract class MediaStreamResolver {
   }
 
   static String applyStreamIndices(String url, int? audioStreamIndex, int? subtitleStreamIndex) {
-    var result = url;
+    try {
+      final uri = Uri.parse(url);
+      final params = Map<String, String>.from(uri.queryParameters);
 
-    if (audioStreamIndex != null) {
-      final audioRegex = RegExp(r'AudioStreamIndex=\d+');
-      if (audioRegex.hasMatch(result)) {
-        result = result.replaceFirst(audioRegex, 'AudioStreamIndex=$audioStreamIndex');
-      } else {
-        result = '$result&AudioStreamIndex=$audioStreamIndex';
+      if (audioStreamIndex != null) {
+        params['AudioStreamIndex'] = '$audioStreamIndex';
+        params['audioStreamIndex'] = '$audioStreamIndex';
       }
-    }
 
-    if (subtitleStreamIndex != null && subtitleStreamIndex >= 0) {
-      final subRegex = RegExp(r'SubtitleStreamIndex=\d+');
-      if (subRegex.hasMatch(result)) {
-        result = result.replaceFirst(subRegex, 'SubtitleStreamIndex=$subtitleStreamIndex');
-      } else {
-        result = '$result&SubtitleStreamIndex=$subtitleStreamIndex';
+      if (subtitleStreamIndex != null) {
+        if (subtitleStreamIndex >= 0) {
+          params['SubtitleStreamIndex'] = '$subtitleStreamIndex';
+          params['subtitleStreamIndex'] = '$subtitleStreamIndex';
+        } else if (subtitleStreamIndex == -1) {
+          params.remove('SubtitleStreamIndex');
+          params.remove('subtitleStreamIndex');
+        }
       }
-    } else if (subtitleStreamIndex == -1) {
-      result = result.replaceAll(RegExp(r'[&?]SubtitleStreamIndex=\d+'), '');
-    }
 
-    return result;
+      return uri.replace(queryParameters: params).toString();
+    } catch (_) {
+      return url;
+    }
   }
 
   static List<ExternalSubtitle> extractExternalSubtitles(

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -539,10 +539,10 @@ class PlaybackManager implements AudioOwnable {
     _sessionEndedController.add(null);
   }
 
-  void _applyPendingItemOverridesIfNeeded(String itemId) {
+  bool _applyPendingItemOverridesIfNeeded(String itemId) {
     final pendingItemId = _pendingItemOverrideId;
     if (pendingItemId == null || pendingItemId != itemId) {
-      return;
+      return false;
     }
 
     _audioStreamIndex = _pendingItemAudioStreamIndex;
@@ -550,6 +550,7 @@ class PlaybackManager implements AudioOwnable {
     _subtitleSelectionExplicit = false;
     _mediaSourceId = _pendingItemMediaSourceId;
     _clearPendingItemOverrides();
+    return true;
   }
 
   void _onBackendErrorEvent(Map<String, dynamic> event) {
@@ -845,8 +846,8 @@ class PlaybackManager implements AudioOwnable {
     _lastKnownPosition = Duration.zero;
     final sessionToken = ++_playbackSessionToken;
     final itemId = _traceItemId(item);
-    _applyPendingItemOverridesIfNeeded(itemId);
-    if (_lastItemId != null && _lastItemId != itemId) {
+    final appliedOverrides = _applyPendingItemOverridesIfNeeded(itemId);
+    if (!appliedOverrides && _lastItemId != null && _lastItemId != itemId) {
       _translateTrackSelectionsForNewItem(item);
     }
     _lastItemId = itemId;
@@ -895,6 +896,7 @@ class PlaybackManager implements AudioOwnable {
       enableDirectStream: enableDirectStream,
       enableTranscoding: enableTranscoding,
     );
+
     _setBringupState(
       PlaybackBringupState(
         phase: PlaybackBringupPhase.opening,
@@ -1153,7 +1155,8 @@ class PlaybackManager implements AudioOwnable {
       if (_subtitleStreamIndex == -1) {
         _waitAndDisableSubtitles(sessionToken);
       }
-    } else if (resolution.playMethod == StreamPlayMethod.transcode) {
+    } else if (resolution.playMethod == StreamPlayMethod.transcode ||
+        resolution.playMethod == StreamPlayMethod.directStream) {
       if (_subtitleStreamIndex != null && _subtitleStreamIndex != -1) {
         final isBurnedIn =
             (_isSubtitleBitmap(_subtitleStreamIndex!) &&
@@ -1576,7 +1579,8 @@ class PlaybackManager implements AudioOwnable {
       } else {
         _waitAndApplyTrackSelections(_playbackSessionToken);
       }
-    } else if (_currentResolution?.playMethod == StreamPlayMethod.transcode) {
+    } else if (_currentResolution?.playMethod == StreamPlayMethod.transcode ||
+        _currentResolution?.playMethod == StreamPlayMethod.directStream) {
       final previousWasBurned =
           (previousSubtitleStreamIndex != null &&
            previousSubtitleStreamIndex >= 0 &&

--- a/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
+++ b/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
@@ -53,11 +53,11 @@ class EmbyMediaStreamResolver implements MediaStreamResolver {
     final source = _selectBestSource(info.mediaSources, preferredId: mediaSourceId);
     var (url, playMethod) = _resolveStreamUrl(itemId, source);
 
-    if (playMethod == StreamPlayMethod.transcode) {
+    if (playMethod == StreamPlayMethod.transcode || playMethod == StreamPlayMethod.directStream) {
       url = MediaStreamResolver.applyStreamIndices(url, audioStreamIndex, subtitleStreamIndex);
       url = url
-          .replaceFirst(RegExp(r'\?StartTimeTicks=\d+&'), '?')
-          .replaceFirst(RegExp(r'[&?]StartTimeTicks=\d+'), '');
+          .replaceFirst(RegExp(r'\?StartTimeTicks=\d+&', caseSensitive: false), '?')
+          .replaceFirst(RegExp(r'[&?]StartTimeTicks=\d+', caseSensitive: false), '');
     }
 
     url = _appendAuth(url);

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -92,11 +92,11 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
     final isAudio = isAudioByStreams || _isAudioMediaItem(mediaItem);
     var (url, playMethod) = _resolveStreamUrl(itemId, source, isAudio: isAudio);
 
-    if (playMethod == StreamPlayMethod.transcode) {
+    if (playMethod == StreamPlayMethod.transcode || playMethod == StreamPlayMethod.directStream) {
       url = MediaStreamResolver.applyStreamIndices(url, audioStreamIndex, subtitleStreamIndex);
       url = url
-          .replaceFirst(RegExp(r'\?StartTimeTicks=\d+&'), '?')
-          .replaceFirst(RegExp(r'[&?]StartTimeTicks=\d+'), '');
+          .replaceFirst(RegExp(r'\?StartTimeTicks=\d+&', caseSensitive: false), '?')
+          .replaceFirst(RegExp(r'[&?]StartTimeTicks=\d+', caseSensitive: false), '');
     }
 
     // Append auth token for mpv (which doesn't use our Dio interceptors).

--- a/packages/server_emby/lib/src/api/emby_playback_api.dart
+++ b/packages/server_emby/lib/src/api/emby_playback_api.dart
@@ -41,12 +41,22 @@ class EmbyPlaybackApi implements PlaybackApi {
       'UserId': ?userId,
       ...?requestBody,
     };
+
+    final audioStreamIndex = requestBody?['AudioStreamIndex'] ?? requestBody?['audioStreamIndex'];
+    final subtitleStreamIndex = requestBody?['SubtitleStreamIndex'] ?? requestBody?['subtitleStreamIndex'];
+    final mediaSourceId = requestBody?['MediaSourceId'] ?? requestBody?['mediaSourceId'];
+    final maxStreamingBitrate = requestBody?['MaxStreamingBitrate'] ?? requestBody?['maxStreamingBitrate'];
+
     final response = await _dio.post(
       '/Items/$itemId/PlaybackInfo',
       data: body,
       queryParameters: {
         'userId': ?userId,
         'startTimeTicks': ?startTimeTicks,
+        'audioStreamIndex': ?audioStreamIndex?.toString(),
+        'subtitleStreamIndex': ?subtitleStreamIndex?.toString(),
+        'mediaSourceId': ?mediaSourceId,
+        'maxStreamingBitrate': ?maxStreamingBitrate?.toString(),
       },
     );
     return response.data as Map<String, dynamic>;

--- a/packages/server_jellyfin/lib/src/api/jellyfin_playback_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_playback_api.dart
@@ -41,12 +41,22 @@ class JellyfinPlaybackApi implements PlaybackApi {
       'UserId': ?userId,
       ...?requestBody,
     };
+
+    final audioStreamIndex = requestBody?['AudioStreamIndex'] ?? requestBody?['audioStreamIndex'];
+    final subtitleStreamIndex = requestBody?['SubtitleStreamIndex'] ?? requestBody?['subtitleStreamIndex'];
+    final mediaSourceId = requestBody?['MediaSourceId'] ?? requestBody?['mediaSourceId'];
+    final maxStreamingBitrate = requestBody?['MaxStreamingBitrate'] ?? requestBody?['maxStreamingBitrate'];
+
     final response = await _dio.post(
       '/Items/$itemId/PlaybackInfo',
       data: body,
       queryParameters: {
         'userId': ?userId,
         'startTimeTicks': ?startTimeTicks,
+        'audioStreamIndex': ?audioStreamIndex?.toString(),
+        'subtitleStreamIndex': ?subtitleStreamIndex?.toString(),
+        'mediaSourceId': ?mediaSourceId,
+        'maxStreamingBitrate': ?maxStreamingBitrate?.toString(),
       },
     );
     return response.data as Map<String, dynamic>;


### PR DESCRIPTION
# Pull Request

## Summary
*Finally* resolves the issue where user-selected subtitle and audio tracks on the details screen did not persist during server-side transcoding, direct streaming (remuxing), or when transitioning from a preroll video to the main feature video.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Updated Jellyfin & Emby `getPlaybackInfo` implementations to pass the selected audio/subtitle indices in query parameters, forcing the server to register transcoding sessions with the correct user choices.
- Leveraged Dart null-aware map elements (`?`) in server query parameters to satisfy the compiler and project-specific lint rules.
- Replaced error-prone regex replacements with robust `Uri` query parsing in `MediaStreamResolver.applyStreamIndices` that updates/syncs both `subtitleStreamIndex` (camelCase) and `SubtitleStreamIndex` (PascalCase).
- Added direct stream routing for index application and parameter stripping in resolvers and the `PlaybackManager` to match transcoding flows.
- Bypassed track selection translation when transitioning from a preroll to the main item if pending item overrides are already present, preserving user choices.
- Queued pending audio/subtitle selections in `Media3VideoView.kt` and deferred execution until track selection data is loaded via `onTracksChanged` (resolving timing/race conditions on ExoPlayer initialization). Cleared pending fields in `setSource` to prevent leaking selections to subsequent streams.
- Lifted the details page action buttons' selection indices to the persistent `ItemDetailViewModel` to avoid reset when buttons are temporarily unmounted during detail screen view model reloads.
- Configured details page to fallback to streams marked with `IsDefault == true` if preferred language user settings are empty.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play transcoded media with manual subtitle tracks selected (e.g. Bulgarian, Czech, Danish) from details page. Verify manual tracks stick correctly on first play and subsequent trials.
2. Play main media item with intro/preroll video active, verify choice is retained after preroll completes and main movie/show starts.
3. Reload details page/return from player, verify selection indicator is persisted.

## Screenshots (if applicable)

Demonstrating a file where a custom sub track was selected from Media Info page and the change reflected in both the UI and the subtitle:

<img width="600" alt="Shield_Screenshot_2026-06-12_04-20-09" src="https://github.com/user-attachments/assets/1ad7f4b4-2fa9-41ed-80f9-3bc3c3c6f36e" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
