### PR TITLE
feat: map backspace to back navigation keys centrally

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -448,7 +448,7 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
         keys.contains(LogicalKeyboardKey.controlRight);
 
     final isBackspace = key == LogicalKeyboardKey.backspace;
-    if (key.isBackKey || isBackspace) {
+    if (key.isBackKey) {
       if (isBackspace && _isEditingText()) {
         return false;
       }

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2885,11 +2885,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
     if (_isCurrentPreroll) {
       if (event is KeyUpEvent) {
-        final isBackKey =
-            event.logicalKey == LogicalKeyboardKey.goBack ||
-            event.logicalKey == LogicalKeyboardKey.escape ||
-            event.logicalKey == LogicalKeyboardKey.browserBack ||
-            event.logicalKey == LogicalKeyboardKey.backspace;
+        final isBackKey = event.logicalKey.isBackKey;
         if (isBackKey) {
           return KeyEventResult.handled;
         }
@@ -2901,11 +2897,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       }
 
       if (event is KeyDownEvent) {
-        final isBackKey =
-            event.logicalKey == LogicalKeyboardKey.goBack ||
-            event.logicalKey == LogicalKeyboardKey.escape ||
-            event.logicalKey == LogicalKeyboardKey.browserBack ||
-            event.logicalKey == LogicalKeyboardKey.backspace;
+        final isBackKey = event.logicalKey.isBackKey;
 
         if (isBackKey) {
           if (!_isBackNavigationSuppressed()) {
@@ -2944,11 +2936,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       }
 
       if (event is KeyRepeatEvent) {
-        final isBackKey =
-            event.logicalKey == LogicalKeyboardKey.goBack ||
-            event.logicalKey == LogicalKeyboardKey.escape ||
-            event.logicalKey == LogicalKeyboardKey.browserBack ||
-            event.logicalKey == LogicalKeyboardKey.backspace;
+        final isBackKey = event.logicalKey.isBackKey;
         if (isBackKey) {
           return KeyEventResult.handled;
         }
@@ -2976,11 +2964,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       if (temporarySpeedResult != KeyEventResult.ignored) {
         return temporarySpeedResult;
       }
-      final isBackKey =
-          event.logicalKey == LogicalKeyboardKey.goBack ||
-          event.logicalKey == LogicalKeyboardKey.escape ||
-          event.logicalKey == LogicalKeyboardKey.browserBack ||
-          event.logicalKey == LogicalKeyboardKey.backspace;
+      final isBackKey = event.logicalKey.isBackKey;
       if (isBackKey) {
         // KeyUp for Back should be consumed to avoid a second route pop.
         return KeyEventResult.handled;

--- a/lib/util/focus/dpad_keys.dart
+++ b/lib/util/focus/dpad_keys.dart
@@ -19,6 +19,7 @@ final Set<LogicalKeyboardKey> _backKeys = <LogicalKeyboardKey>{
   LogicalKeyboardKey.goBack,
   LogicalKeyboardKey.browserBack,
   LogicalKeyboardKey.gameButtonB,
+  LogicalKeyboardKey.backspace,
 };
 
 final Set<LogicalKeyboardKey> _contextMenuKeys = <LogicalKeyboardKey>{


### PR DESCRIPTION
# Pull Request

## Summary
Add support for the `backspace` key (keycode 42) as a back-navigation key centrally. This ensures that USB keyboard-style remotes and air-mice that map their physical "Back" button to the backspace key behave consistently as back keys across dialogs, modals, and settings screens.

## Related Issues
Requested on Discord

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `LogicalKeyboardKey.backspace` to `_backKeys` in `lib/util/focus/dpad_keys.dart` so `isBackKey` centrally recognizes backspace.
- Cleaned up redundant hardcoded checks for backspace in `lib/app.dart` and simplified to rely on `isBackKey`.
- Cleaned up multiple redundant hardcoded back-key list declarations in `lib/ui/screens/playback/video_player_screen.dart` to check `isBackKey` directly.
- Preserved safety checks in `app.dart` so that backspace continues to delete characters normally if a text field is currently focused (`_isEditingText()` check).

## Platform
- [X] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Ran local static analysis checks (`flutter analyze`) to verify everything compiles cleanly with no static errors or warnings in the modified files; however, manual test on target behavior of back keys is still needed (after next test build is generated/distributed to testers) as I don't have a USB remote to use with my set-up.

### Test Steps
1. Connect USB remote
2. Test button behaviour across the various components of Moonfin

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
