### PR TITLE
Feature/cleaning up the SyncPlay panels

### DIFF
--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -3027,6 +3027,7 @@ class _SyncPlaySettingsScreenState extends State<_SyncPlaySettingsScreen> {
           children: [
             const _SectionHeader('Active Sessions'),
             _TvSettingsListTile(
+              autofocus: true,
               leading: const Icon(Icons.group_work),
               title: Text(l10n.settingsOpenGroups),
               subtitle: Text(l10n.settingsOpenGroupsSubtitle),
@@ -3342,35 +3343,45 @@ class _DoubleSliderTileState extends State<_DoubleSliderTile> {
             subtitleTextStyle: const TextStyle(fontSize: 12),
             child: ValueListenableBuilder<double>(
               valueListenable: widget.binding,
-              builder: (_, value, _) => ListTile(
-                focusColor: Colors.transparent,
-                hoverColor: Colors.transparent,
-                leading: Icon(widget.icon),
-                title: Text(widget.title),
-                subtitle: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      AppLocalizations.of(
-                        context,
-                      ).settingsMillisecondsValue(value.round()),
-                      style: TextStyle(
-                        color: _outerFocused
-                            ? AppColors.black.withValues(alpha: 0.54)
-                            : AppColorScheme.onSurface.withValues(alpha: 0.7),
+              builder: (context, value, _) {
+                final iconColor = _outerFocused
+                    ? AppColors.black.withValues(alpha: 0.54)
+                    : AppColorScheme.onSurface.withValues(alpha: 0.78);
+                return ListTile(
+                  focusColor: Colors.transparent,
+                  hoverColor: Colors.transparent,
+                  leading: buildSettingsLeadingIconShell(
+                    context,
+                    icon: Icon(widget.icon),
+                    focused: _outerFocused,
+                    iconColor: iconColor,
+                  ),
+                  title: Text(widget.title),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        AppLocalizations.of(
+                          context,
+                        ).settingsMillisecondsValue(value.round()),
+                        style: TextStyle(
+                          color: _outerFocused
+                              ? AppColors.black.withValues(alpha: 0.54)
+                              : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
                       ),
-                    ),
-                    Slider(
-                      focusNode: _sliderInternalNode,
-                      value: value.clamp(widget.min, widget.max),
-                      min: widget.min,
-                      max: widget.max,
-                      divisions: 40,
-                      onChanged: (v) => widget.binding.value = v,
-                    ),
-                  ],
-                ),
-              ),
+                      Slider(
+                        focusNode: _sliderInternalNode,
+                        value: value.clamp(widget.min, widget.max),
+                        min: widget.min,
+                        max: widget.max,
+                        divisions: 40,
+                        onChanged: (v) => widget.binding.value = v,
+                      ),
+                    ],
+                  ),
+                );
+              },
             ),
           ),
         ),

--- a/lib/ui/screens/syncplay/syncplay_screen.dart
+++ b/lib/ui/screens/syncplay/syncplay_screen.dart
@@ -244,7 +244,7 @@ class _ErrorBanner extends StatelessWidget {
   }
 }
 
-class _ActiveGroupSection extends StatelessWidget {
+class _ActiveGroupSection extends StatefulWidget {
   final SyncPlayManager manager;
   final FocusNode ignoreWaitFocus;
 
@@ -254,9 +254,16 @@ class _ActiveGroupSection extends StatelessWidget {
   });
 
   @override
+  State<_ActiveGroupSection> createState() => _ActiveGroupSectionState();
+}
+
+class _ActiveGroupSectionState extends State<_ActiveGroupSection> {
+  bool _pickerOpen = false;
+
+  @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final s = manager.state;
+    final s = widget.manager.state;
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -294,14 +301,14 @@ class _ActiveGroupSection extends StatelessWidget {
             _buildTileWithFocused(
               context,
               builder: (context, focused) => SwitchListTile(
-                focusNode: ignoreWaitFocus,
+                focusNode: widget.ignoreWaitFocus,
                 contentPadding: PlatformDetection.isTV
                     ? const EdgeInsets.symmetric(horizontal: 16)
                     : EdgeInsets.zero,
                 title: Text(l10n.syncPlayIgnoreWait),
                 subtitle: Text(l10n.syncPlayIgnoreWaitSubtitle),
-                value: manager.ignoreWaitEnabled,
-                onChanged: (v) => manager.requestSetIgnoreWait(v),
+                value: widget.manager.ignoreWaitEnabled,
+                onChanged: (v) => widget.manager.requestSetIgnoreWait(v),
               ),
             ),
             _buildTileWithFocused(
@@ -312,7 +319,7 @@ class _ActiveGroupSection extends StatelessWidget {
                     : EdgeInsets.zero,
                 leading: const Icon(Icons.repeat),
                 title: Text(l10n.syncPlayRepeat),
-                trailing: buildSelectionBubble(context, _repeatLabel(s.repeatMode, l10n), focused),
+                trailing: buildSettingsSelectionBubble(context, _repeatLabel(s.repeatMode, l10n), focused),
                 onTap: () => _showRepeatPicker(context, s, l10n),
               ),
             ),
@@ -328,7 +335,7 @@ class _ActiveGroupSection extends StatelessWidget {
                       : Icons.shuffle,
                 ),
                 title: Text(l10n.shuffle),
-                trailing: buildSelectionBubble(context, _shuffleLabel(s.shuffleMode, l10n), focused),
+                trailing: buildSettingsSelectionBubble(context, _shuffleLabel(s.shuffleMode, l10n), focused),
                 onTap: () => _showShufflePicker(context, s, l10n),
               ),
             ),
@@ -341,14 +348,14 @@ class _ActiveGroupSection extends StatelessWidget {
                 leading: const Icon(Icons.queue_play_next),
                 title: Text(l10n.syncPlaySyncCurrentQueue),
                 subtitle: Text(l10n.syncPlaySyncCurrentQueueSubtitle),
-                onTap: () => manager.syncCurrentPlaybackQueueToGroup(),
+                onTap: () => widget.manager.syncCurrentPlaybackQueueToGroup(),
               ),
             ),
             const SizedBox(height: 8),
             Align(
               alignment: Alignment.centerRight,
               child: FilledButton.tonalIcon(
-                onPressed: () => manager.leaveGroup(),
+                onPressed: () => widget.manager.leaveGroup(),
                 style: FilledButton.styleFrom().copyWith(
                   side: WidgetStateProperty.resolveWith<BorderSide?>((states) {
                     if (states.contains(WidgetState.focused)) {
@@ -375,7 +382,7 @@ class _ActiveGroupSection extends StatelessWidget {
                 final item = s.queue[i];
                 final isCurrent = i == s.currentItemIndex;
                 final title =
-                    manager.itemTitleFor(item.itemId) ??
+                    widget.manager.itemTitleFor(item.itemId) ??
                     l10n.syncPlayQueueItemFallback(i + 1);
                 final tile = ListTile(
                   contentPadding: PlatformDetection.isTV
@@ -391,22 +398,22 @@ class _ActiveGroupSection extends StatelessWidget {
                           fontWeight: isCurrent ? FontWeight.bold : null)),
                   subtitle: Text(item.itemId,
                       maxLines: 1, overflow: TextOverflow.ellipsis),
-                  onTap: () => manager.requestSetCurrentItem(item.playlistItemId),
+                  onTap: () => widget.manager.requestSetCurrentItem(item.playlistItemId),
                   trailing: PopupMenuButton<String>(
                     onSelected: (value) {
                       switch (value) {
                         case 'play':
-                          manager.requestSetCurrentItem(item.playlistItemId);
+                          widget.manager.requestSetCurrentItem(item.playlistItemId);
                           break;
                         case 'remove':
-                          manager.requestRemoveFromQueue(item.playlistItemId);
+                          widget.manager.requestRemoveFromQueue(item.playlistItemId);
                           break;
                         case 'up':
-                          manager.requestMoveQueueItem(
+                          widget.manager.requestMoveQueueItem(
                               item.playlistItemId, i - 1);
                           break;
                         case 'down':
-                          manager.requestMoveQueueItem(
+                          widget.manager.requestMoveQueueItem(
                               item.playlistItemId, i + 1);
                           break;
                       }
@@ -468,66 +475,84 @@ class _ActiveGroupSection extends StatelessWidget {
   }
 
   void _showRepeatPicker(BuildContext context, SyncPlayState s, AppLocalizations l10n) async {
-    final result = await showFocusRestoringDialog<SyncPlayRepeatMode>(
-      context: context,
-      useRootNavigator: false,
-      builder: (ctx) => withBackClose(
-        ctx,
-        SimpleDialog(
-          title: Text(l10n.syncPlayRepeat, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
-          children: SyncPlayRepeatMode.values.map((v) {
-            final selected = v == s.repeatMode;
-            return TvFocusHighlight(
-              builder: (_, focused) => ListTile(
-                autofocus: v == s.repeatMode,
-                title: Text(
-                  _repeatLabel(v, l10n),
-                  style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+    if (_pickerOpen) return;
+    _pickerOpen = true;
+    var picked = false;
+    try {
+      final result = await showFocusRestoringDialog<SyncPlayRepeatMode>(
+        context: context,
+        useRootNavigator: false,
+        builder: (ctx) => withBackClose(
+          ctx,
+          SimpleDialog(
+            title: Text(l10n.syncPlayRepeat, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+            children: SyncPlayRepeatMode.values.map((v) {
+              final selected = v == s.repeatMode;
+              return TvFocusHighlight(
+                builder: (_, focused) => ListTile(
+                  autofocus: v == s.repeatMode,
+                  title: Text(
+                    _repeatLabel(v, l10n),
+                    style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                  trailing: selected ? const Icon(Icons.check) : null,
+                  onTap: () {
+                    if (picked) return;
+                    picked = true;
+                    Navigator.pop(ctx, v);
+                  },
                 ),
-                trailing: selected ? const Icon(Icons.check) : null,
-                onTap: () {
-                  Navigator.pop(ctx, v);
-                },
-              ),
-            );
-          }).toList(),
+              );
+            }).toList(),
+          ),
         ),
-      ),
-    );
-    if (result != null && result != s.repeatMode) {
-      manager.requestSetRepeatMode(result);
+      );
+      if (result != null && result != s.repeatMode) {
+        widget.manager.requestSetRepeatMode(result);
+      }
+    } finally {
+      _pickerOpen = false;
     }
   }
 
   void _showShufflePicker(BuildContext context, SyncPlayState s, AppLocalizations l10n) async {
-    final result = await showFocusRestoringDialog<SyncPlayShuffleMode>(
-      context: context,
-      useRootNavigator: false,
-      builder: (ctx) => withBackClose(
-        ctx,
-        SimpleDialog(
-          title: Text(l10n.shuffle, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
-          children: SyncPlayShuffleMode.values.map((v) {
-            final selected = v == s.shuffleMode;
-            return TvFocusHighlight(
-              builder: (_, focused) => ListTile(
-                autofocus: v == s.shuffleMode,
-                title: Text(
-                  _shuffleLabel(v, l10n),
-                  style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+    if (_pickerOpen) return;
+    _pickerOpen = true;
+    var picked = false;
+    try {
+      final result = await showFocusRestoringDialog<SyncPlayShuffleMode>(
+        context: context,
+        useRootNavigator: false,
+        builder: (ctx) => withBackClose(
+          ctx,
+          SimpleDialog(
+            title: Text(l10n.shuffle, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+            children: SyncPlayShuffleMode.values.map((v) {
+              final selected = v == s.shuffleMode;
+              return TvFocusHighlight(
+                builder: (_, focused) => ListTile(
+                  autofocus: v == s.shuffleMode,
+                  title: Text(
+                    _shuffleLabel(v, l10n),
+                    style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                  trailing: selected ? const Icon(Icons.check) : null,
+                  onTap: () {
+                    if (picked) return;
+                    picked = true;
+                    Navigator.pop(ctx, v);
+                  },
                 ),
-                trailing: selected ? const Icon(Icons.check) : null,
-                onTap: () {
-                  Navigator.pop(ctx, v);
-                },
-              ),
-            );
-          }).toList(),
+              );
+            }).toList(),
+          ),
         ),
-      ),
-    );
-    if (result != null && result != s.shuffleMode) {
-      manager.requestSetShuffleMode(result);
+      );
+      if (result != null && result != s.shuffleMode) {
+        widget.manager.requestSetShuffleMode(result);
+      }
+    } finally {
+      _pickerOpen = false;
     }
   }
 

--- a/lib/ui/screens/syncplay/syncplay_screen.dart
+++ b/lib/ui/screens/syncplay/syncplay_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,6 +12,7 @@ import 'package:playback_core/playback_core.dart';
 import '../../../di/providers.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../syncplay/syncplay_manager.dart';
+import '../../../syncplay/syncplay_state.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../../../util/focus/dpad_keys.dart';
@@ -29,11 +32,29 @@ class _SyncPlayScreenState extends ConsumerState<SyncPlayScreen> {
   final _groupNameController = TextEditingController();
   final _groupNameFocus = FocusNode(debugLabel: 'syncplay_group_name');
   final _tvFieldKey = GlobalKey<CustomTVTextFieldState>();
+  final _refreshFocusNode = FocusNode(debugLabel: 'syncplay_refresh');
+  final _ignoreWaitFocus = FocusNode(debugLabel: 'syncplay_ignore_wait');
 
   @override
   void initState() {
     super.initState();
     _groupNameFocus.onKeyEvent = _onGroupNameKey;
+    _refreshFocusNode.onKeyEvent = (node, event) {
+      if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+          event.logicalKey == LogicalKeyboardKey.arrowDown) {
+        _ignoreWaitFocus.requestFocus();
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    };
+    _ignoreWaitFocus.onKeyEvent = (node, event) {
+      if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+          event.logicalKey == LogicalKeyboardKey.arrowUp) {
+        _refreshFocusNode.requestFocus();
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    };
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(syncPlayManagerProvider).fetchGroups();
     });
@@ -43,6 +64,8 @@ class _SyncPlayScreenState extends ConsumerState<SyncPlayScreen> {
   void dispose() {
     _groupNameController.dispose();
     _groupNameFocus.dispose();
+    _refreshFocusNode.dispose();
+    _ignoreWaitFocus.dispose();
     super.dispose();
   }
 
@@ -97,7 +120,9 @@ class _SyncPlayScreenState extends ConsumerState<SyncPlayScreen> {
     final isTV = PlatformDetection.isTV;
     final showCreateGroup = !manager.state.enabled;
     return RequestInitialFocus(
-      targetNode: (isTV && showCreateGroup) ? _groupNameFocus : null,
+      targetNode: isTV
+          ? (showCreateGroup ? _groupNameFocus : _ignoreWaitFocus)
+          : null,
       child: _buildContent(context),
     );
   }
@@ -112,6 +137,7 @@ class _SyncPlayScreenState extends ConsumerState<SyncPlayScreen> {
           title: Text(l10n.syncPlay),
           actions: [
             IconButton(
+              focusNode: _refreshFocusNode,
               icon: const Icon(Icons.refresh),
               onPressed: manager.isLoading ? null : () => manager.fetchGroups(),
             ),
@@ -146,14 +172,19 @@ class _SyncPlayScreenState extends ConsumerState<SyncPlayScreen> {
       children: [
         if (manager.errorMessage != null)
           _ErrorBanner(message: manager.errorMessage!),
-        if (manager.state.enabled) _ActiveGroupSection(manager: manager),
-        if (!manager.state.enabled) _CreateGroupSection(
-          controller: _groupNameController,
-          manager: manager,
-          focusNode: _groupNameFocus,
-          tvFieldKey: _tvFieldKey,
-          onKeyboardVisibilityChanged: _handleTvKeyboardVisibility,
-        ),
+        if (manager.state.enabled)
+          _ActiveGroupSection(
+            manager: manager,
+            ignoreWaitFocus: _ignoreWaitFocus,
+          ),
+        if (!manager.state.enabled)
+          _CreateGroupSection(
+            controller: _groupNameController,
+            manager: manager,
+            focusNode: _groupNameFocus,
+            tvFieldKey: _tvFieldKey,
+            onKeyboardVisibilityChanged: _handleTvKeyboardVisibility,
+          ),
         const SizedBox(height: 16),
         _AvailableGroupsSection(manager: manager),
       ],
@@ -215,7 +246,12 @@ class _ErrorBanner extends StatelessWidget {
 
 class _ActiveGroupSection extends StatelessWidget {
   final SyncPlayManager manager;
-  const _ActiveGroupSection({required this.manager});
+  final FocusNode ignoreWaitFocus;
+
+  const _ActiveGroupSection({
+    required this.manager,
+    required this.ignoreWaitFocus,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -255,9 +291,10 @@ class _ActiveGroupSection extends StatelessWidget {
                     .toList(),
               ),
             const Divider(height: 24),
-            _buildTile(
+            _buildTileWithFocused(
               context,
-              tile: SwitchListTile(
+              builder: (context, focused) => SwitchListTile(
+                focusNode: ignoreWaitFocus,
                 contentPadding: PlatformDetection.isTV
                     ? const EdgeInsets.symmetric(horizontal: 16)
                     : EdgeInsets.zero,
@@ -267,21 +304,21 @@ class _ActiveGroupSection extends StatelessWidget {
                 onChanged: (v) => manager.requestSetIgnoreWait(v),
               ),
             ),
-            _buildTile(
+            _buildTileWithFocused(
               context,
-              tile: ListTile(
+              builder: (context, focused) => ListTile(
                 contentPadding: PlatformDetection.isTV
                     ? const EdgeInsets.symmetric(horizontal: 16)
                     : EdgeInsets.zero,
                 leading: const Icon(Icons.repeat),
                 title: Text(l10n.syncPlayRepeat),
-                subtitle: Text(_repeatLabel(s.repeatMode, l10n)),
-                onTap: manager.cycleRepeatMode,
+                trailing: buildSelectionBubble(context, _repeatLabel(s.repeatMode, l10n), focused),
+                onTap: () => _showRepeatPicker(context, s, l10n),
               ),
             ),
-            _buildTile(
+            _buildTileWithFocused(
               context,
-              tile: ListTile(
+              builder: (context, focused) => ListTile(
                 contentPadding: PlatformDetection.isTV
                     ? const EdgeInsets.symmetric(horizontal: 16)
                     : EdgeInsets.zero,
@@ -291,10 +328,8 @@ class _ActiveGroupSection extends StatelessWidget {
                       : Icons.shuffle,
                 ),
                 title: Text(l10n.shuffle),
-                subtitle: Text(s.shuffleMode == SyncPlayShuffleMode.shuffle
-                    ? l10n.syncPlayShuffleModeShuffled
-                    : l10n.syncPlayShuffleModeSorted),
-                onTap: manager.toggleShuffleMode,
+                trailing: buildSelectionBubble(context, _shuffleLabel(s.shuffleMode, l10n), focused),
+                onTap: () => _showShufflePicker(context, s, l10n),
               ),
             ),
             _buildTile(
@@ -420,11 +455,93 @@ class _ActiveGroupSection extends StatelessWidget {
     return tile;
   }
 
+  Widget _buildTileWithFocused(
+    BuildContext context, {
+    required Widget Function(BuildContext context, bool focused) builder,
+  }) {
+    if (PlatformDetection.isTV) {
+      return TvFocusHighlight(
+        builder: builder,
+      );
+    }
+    return builder(context, false);
+  }
+
+  void _showRepeatPicker(BuildContext context, SyncPlayState s, AppLocalizations l10n) async {
+    final result = await showFocusRestoringDialog<SyncPlayRepeatMode>(
+      context: context,
+      useRootNavigator: false,
+      builder: (ctx) => withBackClose(
+        ctx,
+        SimpleDialog(
+          title: Text(l10n.syncPlayRepeat, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+          children: SyncPlayRepeatMode.values.map((v) {
+            final selected = v == s.repeatMode;
+            return TvFocusHighlight(
+              builder: (_, focused) => ListTile(
+                autofocus: v == s.repeatMode,
+                title: Text(
+                  _repeatLabel(v, l10n),
+                  style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                ),
+                trailing: selected ? const Icon(Icons.check) : null,
+                onTap: () {
+                  Navigator.pop(ctx, v);
+                },
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+    if (result != null && result != s.repeatMode) {
+      manager.requestSetRepeatMode(result);
+    }
+  }
+
+  void _showShufflePicker(BuildContext context, SyncPlayState s, AppLocalizations l10n) async {
+    final result = await showFocusRestoringDialog<SyncPlayShuffleMode>(
+      context: context,
+      useRootNavigator: false,
+      builder: (ctx) => withBackClose(
+        ctx,
+        SimpleDialog(
+          title: Text(l10n.shuffle, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+          children: SyncPlayShuffleMode.values.map((v) {
+            final selected = v == s.shuffleMode;
+            return TvFocusHighlight(
+              builder: (_, focused) => ListTile(
+                autofocus: v == s.shuffleMode,
+                title: Text(
+                  _shuffleLabel(v, l10n),
+                  style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                ),
+                trailing: selected ? const Icon(Icons.check) : null,
+                onTap: () {
+                  Navigator.pop(ctx, v);
+                },
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+    if (result != null && result != s.shuffleMode) {
+      manager.requestSetShuffleMode(result);
+    }
+  }
+
   String _repeatLabel(SyncPlayRepeatMode mode, AppLocalizations l10n) =>
       switch (mode) {
         SyncPlayRepeatMode.repeatNone => l10n.off,
         SyncPlayRepeatMode.repeatOne => l10n.syncPlayRepeatOne,
         SyncPlayRepeatMode.repeatAll => l10n.all,
+      };
+
+  String _shuffleLabel(SyncPlayShuffleMode mode, AppLocalizations l10n) =>
+      switch (mode) {
+        SyncPlayShuffleMode.shuffle => l10n.syncPlayShuffleModeShuffled,
+        SyncPlayShuffleMode.sorted => l10n.syncPlayShuffleModeSorted,
       };
 }
 
@@ -560,7 +677,6 @@ class _CreateGroupSection extends StatelessWidget {
   }
 
   Widget _buildCreateButton(BuildContext context, AppLocalizations l10n) {
-
     return FilledButton.icon(
       onPressed: manager.isLoading
           ? null
@@ -613,7 +729,7 @@ class _AvailableGroupsSection extends StatelessWidget {
             const SizedBox(height: 8),
             if (groups.isEmpty)
               Padding(
-                padding: EdgeInsets.symmetric(vertical: 12),
+                padding: const EdgeInsets.symmetric(vertical: 12),
                 child: Text(l10n.syncPlayNoGroupsAvailable),
               )
             else

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -8,7 +8,7 @@ import '../../../util/focus/dpad_keys.dart';
 import '../overlay_sheet.dart';
 import 'preference_binding.dart';
 
-Widget _withBackClose(BuildContext dialogContext, Widget child) {
+Widget withBackClose(BuildContext dialogContext, Widget child) {
   final closeDialog = createDialogBackCloseHandler(dialogContext);
 
   return Shortcuts(
@@ -394,7 +394,7 @@ class _EnumPreferenceTileState<T extends Enum>
     final result = await showFocusRestoringDialog<T>(
       context: context,
       useRootNavigator: false,
-      builder: (ctx) => _withBackClose(
+      builder: (ctx) => withBackClose(
         ctx,
         SimpleDialog(
           title: Text(widget.title, style: _kSettingsTitleTextStyle),
@@ -681,7 +681,7 @@ class _StringPickerPreferenceTileState
     final result = await showFocusRestoringDialog<String>(
       context: context,
       useRootNavigator: false,
-      builder: (ctx) => _withBackClose(
+      builder: (ctx) => withBackClose(
         ctx,
         SimpleDialog(
           title: Text(widget.title, style: _kSettingsTitleTextStyle),
@@ -797,7 +797,7 @@ class _IntPickerPreferenceTileState extends State<IntPickerPreferenceTile> {
     final result = await showFocusRestoringDialog<int>(
       context: context,
       useRootNavigator: false,
-      builder: (ctx) => _withBackClose(
+      builder: (ctx) => withBackClose(
         ctx,
         SimpleDialog(
           title: Text(widget.title, style: _kSettingsTitleTextStyle),


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves several focus, navigation, and styling inconsistencies inside the SyncPlay settings screen on Android TV / D-pad devices. Some settings were not gaining focus as they should or did not have proper back behavior defined. Some were missing their little decorative flourishes. This fixes all that.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `autofocus: true` to the "Open Groups" settings tile so it is highlighted instantly when entering the SyncPlay settings section.
- Wrapped the active group section inside `RequestInitialFocus` to target the "Ignore wait" tile, automatically focusing it when the active group card loads or is created.
- *Wrapped slider leading icons in `buildSettingsLeadingIconShell` to align their background styling with the other settings tiles.
- Converted the Repeat and Shuffle text toggles into standard enum tiles utilizing selection bubbles on the right and TV-friendly simple picker dialogs nested inside the settings side-panel (`useRootNavigator: false`).
- Added arrow key event hooks between the top-right refresh button and the "Ignore wait" tile to support clean vertical navigation on TV screens.
- Converted `_ActiveGroupSection` to a `StatefulWidget` and added a class-level `_pickerOpen` guard and local `picked` guards. This prevents multiple dialog routes from opening when double-clicked, and prevents duplicate pops from closing the parent screen.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested via Android TV on Shield
- [ ] Not tested (explain why):

### Test Steps
1. Navigate into Settings -> SyncPlay settings and verify focus starts on "Open Groups".
2. Create or enter a SyncPlay group and verify focus lands directly on the "Ignore wait" tile.
3. Move focus UP from "Ignore wait" and verify it navigates cleanly to the AppBar's refresh button. Verify moving DOWN returns focus to "Ignore wait".
4. Open the "Repeat" or "Shuffle" preference dialogs and verify they render nested inside the side panel.
5. Verify pressing the Back button on the remote closes the dialog properly.
6. Verify selecting a Repeat/Shuffle option updates the setting, updates the selection bubble, and dismisses the dialog cleanly without double-popping the parent screen.

## Screenshots (if applicable)

<img width="400" alt="Shield_Screenshot_2026-06-12_13-29-45" src="https://github.com/user-attachments/assets/8f5f3023-74d7-45b8-94d7-0c621a3c7adc" />
<img width="400" alt="Shield_Screenshot_2026-06-12_13-34-23" src="https://github.com/user-attachments/assets/0caf4543-88f4-4fc2-b706-1b4e892be5b7" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
