### PR TITLE
UI - resolve some missing initial focus states across settings screens on TV

### DIFF
--- a/lib/ui/screens/settings/appearance_theme_screen.dart
+++ b/lib/ui/screens/settings/appearance_theme_screen.dart
@@ -7,9 +7,24 @@ import '../../../preference/user_preferences.dart';
 import '../../theme/app_theme_controller.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import 'settings_app_bar.dart';
+import '../../../util/platform_detection.dart';
+import '../../widgets/focus/request_initial_focus.dart';
 
-class AppearanceThemeScreen extends StatelessWidget {
+class AppearanceThemeScreen extends StatefulWidget {
   const AppearanceThemeScreen({super.key});
+
+  @override
+  State<AppearanceThemeScreen> createState() => _AppearanceThemeScreenState();
+}
+
+class _AppearanceThemeScreenState extends State<AppearanceThemeScreen> {
+  final _moonfinFocusNode = FocusNode(debugLabel: 'theme_moonfin');
+
+  @override
+  void dispose() {
+    _moonfinFocusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -39,32 +54,36 @@ class AppearanceThemeScreen extends StatelessWidget {
                 );
               });
 
-            return ListView(
-              padding: const EdgeInsets.all(20),
-              children: [
-                Text(
-                  l10n.settingsAppearanceThemeSubtitle,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.74),
+            return RequestInitialFocus(
+              targetNode: PlatformDetection.isTV ? _moonfinFocusNode : null,
+              child: ListView(
+                padding: const EdgeInsets.all(20),
+                children: [
+                  Text(
+                    l10n.settingsAppearanceThemeSubtitle,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.74),
+                    ),
                   ),
-                ),
-                const SizedBox(height: 20),
-                for (var i = 0; i < themes.length; i++) ...[
-                  _ThemePreviewCard(
-                    themeId: themes[i].id,
-                    title: _titleForTheme(l10n, themes[i]),
-                    subtitle: _subtitleForTheme(l10n, themes[i]),
-                    selected: selectedThemeId == themes[i].id,
-                    stripes: [
-                      themes[i].colors.background,
-                      themes[i].colors.surface,
-                      themes[i].colors.accent,
-                      themes[i].colors.rangeProgress,
-                    ],
-                  ),
-                  if (i != themes.length - 1) const SizedBox(height: 16),
+                  const SizedBox(height: 20),
+                  for (var i = 0; i < themes.length; i++) ...[
+                    _ThemePreviewCard(
+                      focusNode: themes[i].id == ThemeRegistry.moonfinId ? _moonfinFocusNode : null,
+                      themeId: themes[i].id,
+                      title: _titleForTheme(l10n, themes[i]),
+                      subtitle: _subtitleForTheme(l10n, themes[i]),
+                      selected: selectedThemeId == themes[i].id,
+                      stripes: [
+                        themes[i].colors.background,
+                        themes[i].colors.surface,
+                        themes[i].colors.accent,
+                        themes[i].colors.rangeProgress,
+                      ],
+                    ),
+                    if (i != themes.length - 1) const SizedBox(height: 16),
+                  ],
                 ],
-              ],
+              ),
             );
           },
         ),
@@ -95,8 +114,9 @@ class AppearanceThemeScreen extends StatelessWidget {
   }
 }
 
-class _ThemePreviewCard extends StatelessWidget {
+class _ThemePreviewCard extends StatefulWidget {
   const _ThemePreviewCard({
+    this.focusNode,
     required this.themeId,
     required this.title,
     this.subtitle,
@@ -104,6 +124,7 @@ class _ThemePreviewCard extends StatelessWidget {
     required this.stripes,
   });
 
+  final FocusNode? focusNode;
   final String themeId;
   final String title;
   final String? subtitle;
@@ -111,45 +132,79 @@ class _ThemePreviewCard extends StatelessWidget {
   final List<Color> stripes;
 
   @override
+  State<_ThemePreviewCard> createState() => _ThemePreviewCardState();
+}
+
+class _ThemePreviewCardState extends State<_ThemePreviewCard> {
+  bool _focused = false;
+
+  @override
   Widget build(BuildContext context) {
     final prefs = GetIt.instance<UserPreferences>();
     final controller = AppThemeScope.of(context);
     final theme = Theme.of(context);
 
+    final borderTokens = ThemeRegistry.active.borders;
+
+    final borderSide = _focused
+        ? borderTokens.focusBorder.copyWith(
+            color: AppColorScheme.accent.withValues(alpha: 0.72),
+            width: 2.0,
+          )
+        : (widget.selected
+            ? borderTokens.chipBorder.copyWith(
+                color: AppColorScheme.accent,
+                width: 2.0,
+              )
+            : borderTokens.chipBorder.copyWith(
+                color: theme.colorScheme.outlineVariant,
+                width: 1.0,
+              ));
+
+    final shadow = _focused
+        ? (borderTokens.focusGlow.isNotEmpty
+            ? borderTokens.focusGlow
+            : [
+                BoxShadow(
+                  color: AppColorScheme.accent.withValues(alpha: 0.22),
+                  blurRadius: 14,
+                  spreadRadius: 0.5,
+                ),
+              ])
+        : null;
+
     return InkWell(
+      focusNode: widget.focusNode,
+      autofocus: PlatformDetection.isTV && widget.themeId == ThemeRegistry.moonfinId,
       borderRadius: BorderRadius.circular(18),
+      onFocusChange: (f) {
+        setState(() => _focused = f);
+      },
       onTap: () async {
-        await controller.applyThemeById(prefs, themeId);
+        await controller.applyThemeById(prefs, widget.themeId);
       },
       child: Ink(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
           color: theme.colorScheme.surface,
           borderRadius: BorderRadius.circular(18),
-          border: Border.fromBorderSide(
-            ThemeRegistry.active.borders.chipBorder.copyWith(
-              color: selected
-                  ? AppColorScheme.accent
-                  : theme.colorScheme.outlineVariant,
-              width: selected ? 2 : 1,
-            ),
-          ),
-          boxShadow: selected ? ThemeRegistry.active.borders.focusGlow : null,
+          border: Border.fromBorderSide(borderSide),
+          boxShadow: shadow,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
               children: [
-                Expanded(child: Text(title, style: theme.textTheme.titleMedium)),
-                if (selected)
+                Expanded(child: Text(widget.title, style: theme.textTheme.titleMedium)),
+                if (widget.selected)
                   Icon(Icons.check_circle, color: AppColorScheme.accent),
               ],
             ),
             const SizedBox(height: 6),
-            if (subtitle != null) ...[
+            if (widget.subtitle != null) ...[
               Text(
-                subtitle!,
+                widget.subtitle!,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurface.withValues(alpha: 0.74),
                 ),
@@ -166,7 +221,7 @@ class _ThemePreviewCard extends StatelessWidget {
                   children: [
                     DecoratedBox(
                       decoration: BoxDecoration(
-                        gradient: LinearGradient(colors: stripes),
+                        gradient: LinearGradient(colors: widget.stripes),
                       ),
                     ),
                     Align(
@@ -179,7 +234,7 @@ class _ThemePreviewCard extends StatelessWidget {
                           borderRadius: BorderRadius.circular(999),
                           border: Border.fromBorderSide(
                             ThemeRegistry.active.borders.chipBorder.copyWith(
-                              color: stripes.last.withValues(alpha: 0.8),
+                              color: widget.stripes.last.withValues(alpha: 0.8),
                             ),
                           ),
                         ),

--- a/lib/ui/screens/settings/library_settings_screen.dart
+++ b/lib/ui/screens/settings/library_settings_screen.dart
@@ -11,6 +11,7 @@ import '../../widgets/settings/clean_settings_typography.dart';
 import '../../widgets/settings/preference_tiles.dart';
 import 'settings_app_bar.dart';
 import '../../widgets/focus/request_initial_focus.dart';
+import '../../../util/platform_detection.dart';
 
 class LibraryVisibilityScreen extends StatefulWidget {
   const LibraryVisibilityScreen({super.key});
@@ -29,10 +30,18 @@ class _LibraryVisibilityScreenState extends State<LibraryVisibilityScreen> {
   Future<void> _saveQueue = Future.value();
   int _lastQueuedOpId = 0;
 
+  FocusNode? _firstLibraryFocusNode;
+
   @override
   void initState() {
     super.initState();
     _load();
+  }
+
+  @override
+  void dispose() {
+    _firstLibraryFocusNode?.dispose();
+    super.dispose();
   }
 
   Future<void> _load() async {
@@ -46,6 +55,11 @@ class _LibraryVisibilityScreenState extends State<LibraryVisibilityScreen> {
         _libraries = results[0] as List<AggregatedLibrary>;
         _config = results[1] as UserConfiguration;
         _isLoading = false;
+
+        _firstLibraryFocusNode?.dispose();
+        if (_libraries != null && _libraries!.isNotEmpty) {
+          _firstLibraryFocusNode = FocusNode(debugLabel: 'first_library_tile');
+        }
       });
     } catch (_) {
       if (!mounted) return;
@@ -89,7 +103,10 @@ class _LibraryVisibilityScreenState extends State<LibraryVisibilityScreen> {
 
   @override
   Widget build(BuildContext context) =>
-      RequestInitialFocus(child: _buildContent(context));
+      RequestInitialFocus(
+        targetNode: PlatformDetection.isTV ? _firstLibraryFocusNode : null,
+        child: _buildContent(context),
+      );
 
   Widget _buildContent(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -120,6 +137,7 @@ class _LibraryVisibilityScreenState extends State<LibraryVisibilityScreen> {
     final l10n = AppLocalizations.of(context);
     final config = _config!;
     final libraries = _libraries!;
+    final firstLibId = libraries.isNotEmpty ? libraries.first.id : null;
 
     return [
       for (final lib in libraries) ...[
@@ -129,6 +147,7 @@ class _LibraryVisibilityScreenState extends State<LibraryVisibilityScreen> {
         ),
         TvFocusHighlight(
           builder: (_, focused) => SwitchListTile(
+            focusNode: lib.id == firstLibId ? _firstLibraryFocusNode : null,
             secondary: Icon(Icons.visibility,
                 color: focused
                     ? AppColors.black.withValues(alpha: 0.54)

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:server_core/server_core.dart';
+import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../preference/user_preferences.dart';
@@ -10,6 +11,7 @@ import '../../../util/platform_detection.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import 'settings_app_bar.dart';
+import '../../widgets/focus/request_initial_focus.dart';
 
 const _allSources = [
   'tomatoes',
@@ -60,6 +62,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
   String _lastEnabledRatingsCsv = '';
   late List<_RatingItem> _items;
   final _focusNodes = <FocusNode>[];
+  final _restoreFocusNode = FocusNode(debugLabel: 'ratings_restore');
 
   @override
   void initState() {
@@ -74,6 +77,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
     for (final n in _focusNodes) {
       n.dispose();
     }
+    _restoreFocusNode.dispose();
     super.dispose();
   }
 
@@ -140,27 +144,36 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
     final l10n = AppLocalizations.of(context);
     return withCleanSettingsTypography(
       context,
-      Scaffold(
-        appBar: buildSettingsAppBar(
-          context,
-          Text(l10n.ratings),
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.restore),
-              tooltip: l10n.resetToDefaults,
-              onPressed: () {
-                setState(() {
-                  _store.set(
-                      UserPreferences.enabledRatings,
-                      UserPreferences.enabledRatings.defaultValue);
-                  _loadFromPrefs();
-                });
-                _save();
-              },
-            ),
-          ],
+      RequestInitialFocus(
+        targetNode: PlatformDetection.isTV
+            ? (_items.isNotEmpty ? _focusNodes[0] : _restoreFocusNode)
+            : null,
+        child: Scaffold(
+          appBar: buildSettingsAppBar(
+            context,
+            Text(l10n.ratings),
+            actions: [
+              IconButton(
+                focusNode: _restoreFocusNode,
+                style: IconButton.styleFrom(
+                  focusColor: AppColorScheme.accent.withValues(alpha: 0.18),
+                ),
+                icon: const Icon(Icons.restore),
+                tooltip: l10n.resetToDefaults,
+                onPressed: () {
+                  setState(() {
+                    _store.set(
+                        UserPreferences.enabledRatings,
+                        UserPreferences.enabledRatings.defaultValue);
+                    _loadFromPrefs();
+                  });
+                  _save();
+                },
+              ),
+            ],
+          ),
+          body: PlatformDetection.isTV ? _buildTvList(l10n) : _buildReorderableList(l10n),
         ),
-        body: PlatformDetection.isTV ? _buildTvList(l10n) : _buildReorderableList(l10n),
       ),
     );
   }

--- a/lib/ui/screens/settings/saved_themes_screen.dart
+++ b/lib/ui/screens/settings/saved_themes_screen.dart
@@ -14,6 +14,10 @@ import '../../../preference/user_preferences.dart';
 import '../../theme/app_theme_controller.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import 'settings_app_bar.dart';
+import '../../../util/platform_detection.dart';
+import '../../widgets/focus/request_initial_focus.dart';
+import '../../widgets/settings/preference_tiles.dart';
+import '../../widgets/overlay_sheet.dart';
 
 class SavedThemesScreen extends StatefulWidget {
   const SavedThemesScreen({super.key});
@@ -28,6 +32,9 @@ class _SavedThemesScreenState extends State<SavedThemesScreen> {
   final _sessionRepo = GetIt.instance<SessionRepository>();
   final _client = GetIt.instance<MediaServerClient>();
 
+  final _refreshFocusNode = FocusNode(debugLabel: 'saved_themes_refresh');
+  final _firstItemFocusNode = FocusNode(debugLabel: 'saved_themes_first_item');
+
   bool _loading = true;
   String? _statusMessage;
   String? _deletingThemeId;
@@ -37,6 +44,13 @@ class _SavedThemesScreenState extends State<SavedThemesScreen> {
   void initState() {
     super.initState();
     unawaited(_loadSavedThemes());
+  }
+
+  @override
+  void dispose() {
+    _refreshFocusNode.dispose();
+    _firstItemFocusNode.dispose();
+    super.dispose();
   }
 
   String _serverSyncKey() {
@@ -116,7 +130,7 @@ class _SavedThemesScreenState extends State<SavedThemesScreen> {
 
   Future<void> _confirmDelete(_SavedThemeFile theme) async {
     final l10n = AppLocalizations.of(context);
-    final shouldDelete = await showDialog<bool>(
+    final shouldDelete = await showFocusRestoringDialog<bool>(
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
@@ -198,90 +212,176 @@ class _SavedThemesScreenState extends State<SavedThemesScreen> {
     }
   }
 
+  Future<void> _showThemeActionsDialog(_SavedThemeFile themeSpecFile) async {
+    final l10n = AppLocalizations.of(context);
+    final controller = AppThemeScope.of(context);
+    final selectedCustomId = _prefs.get(UserPreferences.customThemeId);
+    final isCurrent = selectedCustomId == themeSpecFile.spec.id;
+
+    await showFocusRestoringDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          backgroundColor: AppColorScheme.surface.withValues(alpha: 0.9),
+          title: Text(themeSpecFile.spec.displayName),
+          actions: [
+            if (!isCurrent)
+              TextButton(
+                onPressed: () {
+                  Navigator.of(dialogContext).pop();
+                  unawaited(controller.applyThemeById(_prefs, themeSpecFile.spec.id));
+                },
+                child: Text(l10n.apply),
+              ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+                unawaited(_confirmDelete(themeSpecFile));
+              },
+              child: Text(
+                l10n.delete,
+                style: TextStyle(color: AppColorScheme.statusRequested),
+              ),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(l10n.cancel),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final selectedCustomId = _prefs.get(UserPreferences.customThemeId);
+    final themeController = AppThemeScope.of(context);
+    final selectedCustomId = themeController.activeCustomId;
 
     return withCleanSettingsTypography(
       context,
-      Scaffold(
-        appBar: buildSettingsAppBar(
-          context,
-          Text(l10n.savedThemesTitle),
-          actions: [
-            IconButton(
-              onPressed: _loading ? null : () => unawaited(_loadSavedThemes()),
-              icon: const Icon(Icons.refresh),
-              tooltip: l10n.refresh,
-            ),
-          ],
-        ),
-        body: _loading
-            ? const Center(child: CircularProgressIndicator())
-            : ListView(
-                padding: const EdgeInsets.all(20),
-                children: [
-                  Text(
-                    l10n.savedThemesDescription,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurface.withValues(
-                        alpha: 0.74,
-                      ),
-                    ),
-                  ),
-                  if (_statusMessage != null) ...[
-                    const SizedBox(height: 16),
+      RequestInitialFocus(
+        targetNode: PlatformDetection.isTV
+            ? (_savedThemes.isNotEmpty ? _firstItemFocusNode : _refreshFocusNode)
+            : null,
+        child: Scaffold(
+          appBar: buildSettingsAppBar(
+            context,
+            Text(l10n.savedThemesTitle),
+            actions: [
+              IconButton(
+                focusNode: _refreshFocusNode,
+                style: IconButton.styleFrom(
+                  focusColor: AppColorScheme.accent.withValues(alpha: 0.18),
+                ),
+                onPressed: _loading ? null : () => unawaited(_loadSavedThemes()),
+                icon: const Icon(Icons.refresh),
+                tooltip: l10n.refresh,
+              ),
+            ],
+          ),
+          body: _loading
+              ? const Center(child: CircularProgressIndicator())
+              : ListView(
+                  padding: const EdgeInsets.all(20),
+                  children: [
                     Text(
-                      _statusMessage!,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurface.withValues(
-                          alpha: 0.78,
-                        ),
-                      ),
-                    ),
-                  ],
-                  const SizedBox(height: 20),
-                  if (_savedThemes.isEmpty)
-                    Text(
-                      l10n.savedThemesEmpty,
+                      l10n.savedThemesDescription,
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: theme.colorScheme.onSurface.withValues(
                           alpha: 0.74,
                         ),
                       ),
                     ),
-                  for (final entry in _savedThemes) ...[
-                    Card(
-                      child: ListTile(
-                        leading: const Icon(Icons.download_done_outlined),
-                        title: Text(entry.spec.displayName),
-                        subtitle: Text(
-                          selectedCustomId == entry.spec.id
-                          ? l10n.savedThemesCurrentThemeId(entry.spec.id)
-                              : entry.spec.id,
+                    if (_statusMessage != null) ...[
+                      const SizedBox(height: 16),
+                      Text(
+                        _statusMessage!,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.78,
+                          ),
                         ),
-                        trailing: _deletingThemeId == entry.spec.id
-                            ? const SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
-                            : IconButton(
-                                onPressed: () =>
-                                    unawaited(_confirmDelete(entry)),
-                                icon: const Icon(Icons.delete_outline),
-                                tooltip: l10n.savedThemesDeleteTooltip,
-                              ),
                       ),
-                    ),
-                    const SizedBox(height: 8),
+                    ],
+                    const SizedBox(height: 20),
+                    if (_savedThemes.isEmpty)
+                      Text(
+                        l10n.savedThemesEmpty,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurface.withValues(
+                            alpha: 0.74,
+                          ),
+                        ),
+                      ),
+                    for (final (i, entry) in _savedThemes.indexed) ...[
+                      if (PlatformDetection.isTV) ...[
+                        TvFocusHighlight(
+                          builder: (context, focused) => ListTile(
+                            focusNode: i == 0 ? _firstItemFocusNode : null,
+                            leading: const Icon(Icons.download_done_outlined),
+                            title: Text(entry.spec.displayName),
+                            subtitle: Text(
+                              selectedCustomId == entry.spec.id
+                                  ? l10n.savedThemesCurrentThemeId(entry.spec.id)
+                                  : entry.spec.id,
+                            ),
+                            onTap: () => unawaited(_showThemeActionsDialog(entry)),
+                            trailing: _deletingThemeId == entry.spec.id
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : Icon(
+                                    Icons.delete_outline,
+                                    color: focused
+                                        ? AppColors.black.withValues(alpha: 0.54)
+                                        : null,
+                                  ),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                      ] else ...[
+                        Card(
+                          child: ListTile(
+                            leading: const Icon(Icons.download_done_outlined),
+                            title: Text(entry.spec.displayName),
+                            subtitle: Text(
+                              selectedCustomId == entry.spec.id
+                                  ? l10n.savedThemesCurrentThemeId(entry.spec.id)
+                                  : entry.spec.id,
+                            ),
+                            onTap: () async {
+                              final controller = AppThemeScope.of(context);
+                              await controller.applyThemeById(_prefs, entry.spec.id);
+                            },
+                            trailing: _deletingThemeId == entry.spec.id
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : IconButton(
+                                    onPressed: () =>
+                                        unawaited(_confirmDelete(entry)),
+                                    icon: const Icon(Icons.delete_outline),
+                                    tooltip: l10n.savedThemesDeleteTooltip,
+                                  ),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                      ],
+                    ],
                   ],
-                ],
-              ),
+                ),
+        ),
       ),
     );
   }

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1321,10 +1321,12 @@ class _MetadataRatingsScreenState extends State<_MetadataRatingsScreen> {
     debugLabel: 'MetadataRatingsSettingsScope',
     traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
   );
+  final _additionalRatingsFocusNode = FocusNode(debugLabel: 'additional_ratings');
 
   @override
   void dispose() {
     _metadataScope.dispose();
+    _additionalRatingsFocusNode.dispose();
     super.dispose();
   }
 
@@ -1335,18 +1337,21 @@ class _MetadataRatingsScreenState extends State<_MetadataRatingsScreen> {
       Builder(
         builder: (context) {
           final l10n = AppLocalizations.of(context);
-          return Scaffold(
-            appBar: buildSettingsAppBar(
-              context,
-              Text(l10n.settingsMetadataAndRatings),
-            ),
-            body: FocusScope(
-              node: _metadataScope,
-              autofocus: true,
-              child: ListView(
-                children: [
-                  SwitchPreferenceTile(
-                    preference: UserPreferences.enableAdditionalRatings,
+          return RequestInitialFocus(
+            targetNode: PlatformDetection.isTV ? _additionalRatingsFocusNode : null,
+            child: Scaffold(
+              appBar: buildSettingsAppBar(
+                context,
+                Text(l10n.settingsMetadataAndRatings),
+              ),
+              body: FocusScope(
+                node: _metadataScope,
+                autofocus: true,
+                child: ListView(
+                  children: [
+                    SwitchPreferenceTile(
+                      focusNode: _additionalRatingsFocusNode,
+                      preference: UserPreferences.enableAdditionalRatings,
                     title: l10n.additionalRatings,
                     subtitle: l10n.showMdbListAndTmdbRatings,
                     icon: Icons.star,
@@ -1383,11 +1388,12 @@ class _MetadataRatingsScreenState extends State<_MetadataRatingsScreen> {
                 ],
               ),
             ),
-          );
-        },
-      ),
-    );
-  }
+          ),
+        );
+      },
+    ),
+  );
+}
 }
 
 class _OfflineDownloadsScreen extends StatefulWidget {

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -224,6 +224,7 @@ class SwitchPreferenceTile extends StatefulWidget {
 
   final bool inverted;
   final bool enabled;
+  final FocusNode? focusNode;
 
   const SwitchPreferenceTile({
     super.key,
@@ -235,6 +236,7 @@ class SwitchPreferenceTile extends StatefulWidget {
     this.onChanged,
     this.inverted = false,
     this.enabled = true,
+    this.focusNode,
   });
 
   @override
@@ -286,6 +288,7 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
         return ValueListenableBuilder<bool>(
           valueListenable: _binding,
           builder: (context, value, _) => SwitchListTile(
+            focusNode: widget.focusNode,
             secondary: secondary,
             title: Text(widget.title, style: _kSettingsTitleTextStyle),
             subtitle: widget.subtitle != null
@@ -833,11 +836,13 @@ class _IntPickerPreferenceTileState extends State<IntPickerPreferenceTile> {
 class TvFocusHighlight extends StatefulWidget {
   final Widget Function(BuildContext context, bool focused) builder;
   final bool enabled;
+  final FocusNode? focusNode;
 
   const TvFocusHighlight({
     super.key,
     required this.builder,
     this.enabled = true,
+    this.focusNode,
   });
 
   @override
@@ -845,18 +850,21 @@ class TvFocusHighlight extends StatefulWidget {
 }
 
 class _TvFocusHighlightState extends State<TvFocusHighlight> {
-  late final FocusNode _focusNode;
+  FocusNode? _internalFocusNode;
+  FocusNode get _effectiveFocusNode =>
+      widget.focusNode ??
+      (_internalFocusNode ??= FocusNode(debugLabel: 'TvFocusHighlightScope'));
   bool _focused = false;
 
   @override
   void initState() {
     super.initState();
-    _focusNode = FocusNode(debugLabel: 'TvFocusHighlightScope');
+    _focused = _effectiveFocusNode.hasFocus;
   }
 
   @override
   void dispose() {
-    _focusNode.dispose();
+    _internalFocusNode?.dispose();
     super.dispose();
   }
 
@@ -870,7 +878,7 @@ class _TvFocusHighlightState extends State<TvFocusHighlight> {
   @override
   Widget build(BuildContext context) {
     return Focus(
-      focusNode: _focusNode,
+      focusNode: _effectiveFocusNode,
       canRequestFocus: false,
       skipTraversal: true,
       descendantsAreFocusable: widget.enabled,


### PR DESCRIPTION
# Pull Request

## Summary
This PR cleans up the initial D-pad focus states and improves theme-highlight consistency on Android TV across five settings screens: App Theme, Saved Themes, Library Visibility, Metadata & Ratings, and Rating Sources.

## Related Issues
From BrokenDroid's list of UI issues to address. These were all focus state orientated so I grouped them together.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* TvFocusHighlight Extension: Allowed passing an optional external FocusNode down to the target focusable child of TvFocusHighlight to support programmatic target focus mapping.
* Appearance Theme Screen: Covered the screen in RequestInitialFocus targeting the "Moonfin" theme card. Converted _ThemePreviewCard to track focus state and separate selection representation (flat accent outline + checkmark) from focus representation (glow highlight + focusBorder).
* Saved Themes Screen: Implemented RequestInitialFocus targeting the first custom theme item if present, or fallback to the AppBar's refresh button if empty. Configured IconButton.styleFrom on the refresh button to render a circular overlay matching the active theme's accent color (e.g., pink on Neon Pulse) when focused. Replaced reorderable cards on TV with flat TvFocusHighlight list tiles that trigger confirmation of deletion directly upon row selection.
* Library Visibility Screen: Automatically targets and focuses the first library visibility toggle once the asynchronous list of libraries completes loading.
* Metadata & Ratings Screen: Wrapped screen in RequestInitialFocus and explicitly targeted the first "Additional Ratings" SwitchPreferenceTile.
* Rating Sources Screen: Implemented RequestInitialFocus targeting the first source item, or fallback to the restore button if empty. Configured IconButton.styleFrom on the restore button to render the theme accent highlight circle when focused.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Personalization -> General Style -> App Theme. Verify "Moonfin" is focused initially, and focus transitions show clear glows distinct from selection checkmarks.
2. Navigate to Personalization -> Saved Themes. Verify focus lands on the first item (or refresh button if empty). Verify refresh button has the theme-accented circle overlay.
3. Navigate to Personalization -> Libraries -> Library Visibility. Verify focus lands on the first visible toggle under the first library once loaded.
4. Navigate to Integrations -> Metadata & Ratings. Verify focus lands on "Additional Ratings" tile on enter.
5. Navigate to Integrations -> Metadata & Ratings -> Rating Sources. Verify focus lands on the first source. Verify restore button shows the theme-accented circle overlay.

## Screenshots (if applicable)
Just focused settings, nothing too dramatic here.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
