### PR TITLE
feat: clean up Seerr config screen

### DIFF
--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -584,6 +584,8 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
   final _passwordFocus = FocusNode(debugLabel: 'seerr_password');
   final _localAuthFocus = FocusNode(debugLabel: 'seerr_auth_local');
   final _signInFocus = FocusNode(debugLabel: 'seerr_sign_in');
+  final _signInButtonFocus = FocusNode(canRequestFocus: false, debugLabel: 'seerr_sign_in_btn');
+  final _signOutButtonFocus = FocusNode(canRequestFocus: false, debugLabel: 'seerr_sign_out_btn');
   final _usernameTvFieldKey = GlobalKey<CustomTVTextFieldState>();
   final _passwordTvFieldKey = GlobalKey<CustomTVTextFieldState>();
 
@@ -685,6 +687,8 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
     _passwordFocus.dispose();
     _localAuthFocus.dispose();
     _signInFocus.dispose();
+    _signInButtonFocus.dispose();
+    _signOutButtonFocus.dispose();
     super.dispose();
   }
 
@@ -1242,6 +1246,7 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
                                   : null,
                             ),
                             child: FilledButton(
+                              focusNode: PlatformDetection.isTV ? _signOutButtonFocus : null,
                               style: FilledButton.styleFrom(
                                 foregroundColor: colorScheme.onPrimary,
                                 backgroundColor: colorScheme.primary,
@@ -1387,6 +1392,7 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
                                   : null,
                             ),
                             child: FilledButton(
+                              focusNode: PlatformDetection.isTV ? _signInButtonFocus : null,
                               onPressed: _canSignIn ? _submitSignIn : null,
                               style: FilledButton.styleFrom(
                                 shape: RoundedRectangleBorder(

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -15,7 +15,11 @@ import '../../../preference/seerr_row_config.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
+import '../../widgets/settings/preference_tiles.dart';
 import 'settings_app_bar.dart';
 
 typedef _SeerrSignInAction =
@@ -38,6 +42,10 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
   late List<SeerrRowConfig> _rows;
   final _focusNodes = <FocusNode>[];
 
+  final _enableSeerrFocusNode = FocusNode(debugLabel: 'seerrEnableSeerr');
+  final _accountCardFocusNode = FocusNode(debugLabel: 'seerrAccountCard');
+  final _refreshFocusNode = FocusNode(debugLabel: 'seerrRefresh');
+
   @override
   void initState() {
     super.initState();
@@ -47,6 +55,38 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     _rebuildFocusNodes();
     _syncService.addListener(_onSyncStateChanged);
     _loadSeerrStatus(showLoading: true);
+
+    _enableSeerrFocusNode.onKeyEvent = (node, event) {
+      if (event is! KeyDownEvent) return KeyEventResult.ignored;
+      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+        final seerrAvailable =
+            _syncService.pluginAvailable && _syncService.seerrEnabled;
+        final showSeerrSettings = seerrAvailable && _seerrPrefs.enabled;
+        if (showSeerrSettings) {
+          _accountCardFocusNode.requestFocus();
+          return KeyEventResult.handled;
+        }
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+        final seerrAvailable =
+            _syncService.pluginAvailable && _syncService.seerrEnabled;
+        final showSeerrSettings = seerrAvailable && _seerrPrefs.enabled;
+        if (showSeerrSettings) {
+          _refreshFocusNode.requestFocus();
+          return KeyEventResult.handled;
+        }
+      }
+      return KeyEventResult.ignored;
+    };
+
+    _refreshFocusNode.onKeyEvent = (node, event) {
+      if (event is! KeyDownEvent) return KeyEventResult.ignored;
+      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+        _enableSeerrFocusNode.requestFocus();
+        return KeyEventResult.handled;
+      }
+      return KeyEventResult.ignored;
+    };
   }
 
   @override
@@ -55,6 +95,9 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     for (final n in _focusNodes) {
       n.dispose();
     }
+    _enableSeerrFocusNode.dispose();
+    _accountCardFocusNode.dispose();
+    _refreshFocusNode.dispose();
     super.dispose();
   }
 
@@ -200,6 +243,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
   }
 
   void _rebuildFocusNodes() {
+    if (_focusNodes.length == _rows.length) return;
     for (final n in _focusNodes) {
       n.dispose();
     }
@@ -248,25 +292,29 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
         _syncService.pluginAvailable && _syncService.seerrEnabled;
     final showSeerrSettings = seerrAvailable && _seerrPrefs.enabled;
 
-    return Scaffold(
-      appBar: buildSettingsAppBar(
-        context,
-        Text(l10n.seerr),
-        actions: showSeerrSettings
-          ? [
-            IconButton(
-              icon: const Icon(Icons.restore),
-              tooltip: l10n.resetRowsToDefaults,
-              onPressed: _resetRows,
-            ),
-          ]
-          : const [],
-      ),
-      body: withCleanSettingsTypography(
-        context,
-        PlatformDetection.isTV
-            ? _buildTvRows(l10n, seerrAvailable, showSeerrSettings)
-            : _buildReorderableRows(l10n, seerrAvailable, showSeerrSettings),
+    return RequestInitialFocus(
+      targetNode: _enableSeerrFocusNode,
+      child: Scaffold(
+        appBar: buildSettingsAppBar(
+          context,
+          Text(l10n.seerr),
+          actions: showSeerrSettings
+            ? [
+                IconButton(
+                  focusNode: _refreshFocusNode,
+                  icon: const Icon(Icons.restore),
+                  tooltip: l10n.resetRowsToDefaults,
+                  onPressed: _resetRows,
+                ),
+              ]
+            : const [],
+        ),
+        body: withCleanSettingsTypography(
+          context,
+          PlatformDetection.isTV
+              ? _buildTvRows(l10n, seerrAvailable, showSeerrSettings)
+              : _buildReorderableRows(l10n, seerrAvailable, showSeerrSettings),
+        ),
       ),
     );
   }
@@ -280,12 +328,37 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     return Column(
       children: [
         if (seerrAvailable)
-          SwitchListTile(
-            secondary: const Icon(Icons.movie_filter),
-            title: Text(l10n.enableSeerr),
-            subtitle: Text(l10n.showSeerrInNavigation),
-            value: _seerrPrefs.enabled,
-            onChanged: _setSeerrEnabled,
+          TvFocusHighlight(
+            builder: (context, focused) => SwitchListTile(
+              focusNode: _enableSeerrFocusNode,
+              secondary: Icon(
+                Icons.movie_filter,
+                color: focused
+                    ? AppColors.black.withValues(alpha: 0.54)
+                    : null,
+              ),
+              title: Text(
+                l10n.enableSeerr,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.87)
+                      : AppColorScheme.onSurface,
+                ),
+              ),
+              subtitle: Text(
+                l10n.showSeerrInNavigation,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.54)
+                      : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              value: _seerrPrefs.enabled,
+              onChanged: _setSeerrEnabled,
+            ),
           )
         else
           ListTile(
@@ -299,33 +372,67 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
             statusLoading: _statusLoading,
             onSignIn: _signInToSeerr,
             onSignOut: _signOutFromSeerr,
+            firstFocusNode: _accountCardFocusNode,
+            onMoveUp: () => _enableSeerrFocusNode.requestFocus(),
           ),
         if (showSeerrSettings)
-          SwitchListTile(
-            secondary: const Icon(Icons.visibility_off),
-            title: Text(l10n.nsfwFilter),
-            subtitle: Text(l10n.hideAdultContent),
-            value: _seerrPrefs.blockNsfw,
-            onChanged: _setBlockNsfw,
+          TvFocusHighlight(
+            builder: (context, focused) => SwitchListTile(
+              secondary: Icon(
+                Icons.visibility_off,
+                color: focused
+                    ? AppColors.black.withValues(alpha: 0.54)
+                    : null,
+              ),
+              title: Text(
+                l10n.nsfwFilter,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.87)
+                      : AppColorScheme.onSurface,
+                ),
+              ),
+              subtitle: Text(
+                l10n.hideAdultContent,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.54)
+                      : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              value: _seerrPrefs.blockNsfw,
+              onChanged: _setBlockNsfw,
+            ),
           ),
         if (showSeerrSettings)
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 18, 16, 6),
-            child: Text(
-              l10n.discoverRows,
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
+            padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                l10n.discoverRows.toUpperCase(),
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: 1.2,
+                    ),
+              ),
             ),
           ),
         if (showSeerrSettings)
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-            child: Text(
-              _syncService.pluginAvailable
-                  ? l10n.discoverRowsDescriptionPlugin
-                  : l10n.discoverRowsDescription,
-              style: Theme.of(context).textTheme.bodySmall,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                _syncService.pluginAvailable
+                    ? l10n.discoverRowsDescriptionPlugin
+                    : l10n.discoverRowsDescription,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
             ),
           ),
       ],
@@ -453,12 +560,16 @@ class _SeerrLoginCard extends StatefulWidget {
   final bool statusLoading;
   final _SeerrSignInAction onSignIn;
   final _SeerrAction onSignOut;
+  final FocusNode firstFocusNode;
+  final VoidCallback onMoveUp;
 
   const _SeerrLoginCard({
     required this.status,
     required this.statusLoading,
     required this.onSignIn,
     required this.onSignOut,
+    required this.firstFocusNode,
+    required this.onMoveUp,
   });
 
   @override
@@ -471,16 +582,47 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
   final _passwordController = TextEditingController();
   final _usernameFocus = FocusNode(debugLabel: 'seerr_username');
   final _passwordFocus = FocusNode(debugLabel: 'seerr_password');
-  final _jellyfinAuthFocus = FocusNode(debugLabel: 'seerr_auth_jellyfin');
   final _localAuthFocus = FocusNode(debugLabel: 'seerr_auth_local');
   final _signInFocus = FocusNode(debugLabel: 'seerr_sign_in');
-  final _signOutFocus = FocusNode(debugLabel: 'seerr_sign_out');
   final _usernameTvFieldKey = GlobalKey<CustomTVTextFieldState>();
   final _passwordTvFieldKey = GlobalKey<CustomTVTextFieldState>();
 
   String _authType = 'jellyfin';
   bool _submitting = false;
   String? _errorMessage;
+
+  BoxDecoration _boxDecoration(BuildContext context, {required bool focused}) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final borderTokens = ThemeRegistry.active.borders;
+    final baseBorder = borderTokens.cardBorder.color;
+    final unfocusedBorderColor = baseBorder.a == 0
+        ? AppColorScheme.onSurface.withValues(alpha: 0.16)
+        : baseBorder.withValues(alpha: 0.55);
+
+    return BoxDecoration(
+      color: colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
+      borderRadius: BorderRadius.circular(16),
+      border: Border.fromBorderSide(
+        (focused ? borderTokens.focusBorder : borderTokens.cardBorder).copyWith(
+          color: focused
+              ? AppColorScheme.accent.withValues(alpha: 0.72)
+              : unfocusedBorderColor,
+          width: 1.0,
+        ),
+      ),
+      boxShadow: focused
+          ? (borderTokens.focusGlow.isNotEmpty
+                ? borderTokens.focusGlow
+                : [
+                    BoxShadow(
+                      color: AppColorScheme.accent.withValues(alpha: 0.22),
+                      blurRadius: 14,
+                      spreadRadius: 0.5,
+                    ),
+                  ])
+          : null,
+    );
+  }
 
   bool get _canSignIn {
     return !_submitting && _usernameController.text.trim().isNotEmpty;
@@ -508,13 +650,24 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
     if (wasAuthenticated != isAuthenticated) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
+        final scope = FocusScope.of(context);
+        final focusedChild = scope.focusedChild;
+        final hasFocusInside = focusedChild != null &&
+            (focusedChild == widget.firstFocusNode ||
+             focusedChild == _usernameFocus ||
+             focusedChild == _passwordFocus ||
+             focusedChild == _localAuthFocus ||
+             focusedChild == _signInFocus);
+
+        if (!hasFocusInside) return;
+
         if (isAuthenticated) {
-          _signOutFocus.requestFocus();
-          _ensureFocusVisible(_signOutFocus, alignment: 0.22);
+          widget.firstFocusNode.requestFocus();
+          _ensureFocusVisible(widget.firstFocusNode, alignment: 0.22);
         } else {
           final authFocus = _authType == 'local'
               ? _localAuthFocus
-              : _jellyfinAuthFocus;
+              : widget.firstFocusNode;
           authFocus.requestFocus();
           _ensureFocusVisible(authFocus, alignment: 0.16);
         }
@@ -530,10 +683,8 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
     _passwordController.dispose();
     _usernameFocus.dispose();
     _passwordFocus.dispose();
-    _jellyfinAuthFocus.dispose();
     _localAuthFocus.dispose();
     _signInFocus.dispose();
-    _signOutFocus.dispose();
     super.dispose();
   }
 
@@ -669,7 +820,7 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
       if (_authType == 'local') {
         _localAuthFocus.requestFocus();
       } else {
-        _jellyfinAuthFocus.requestFocus();
+        widget.firstFocusNode.requestFocus();
       }
       return KeyEventResult.handled;
     }
@@ -711,7 +862,7 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
       return KeyEventResult.handled;
     }
     if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-      FocusScope.of(context).previousFocus();
+      widget.onMoveUp();
       return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;
@@ -729,7 +880,7 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
     return _onAuthOptionKey(
       event,
       currentAuthType: 'local',
-      leftFocus: _jellyfinAuthFocus,
+      leftFocus: widget.firstFocusNode,
     );
   }
 
@@ -764,10 +915,6 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
       _passwordFocus.requestFocus();
       return KeyEventResult.handled;
     }
-    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-      FocusScope.of(context).nextFocus();
-      return KeyEventResult.handled;
-    }
     return KeyEventResult.ignored;
   }
 
@@ -778,14 +925,6 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
     if (event.logicalKey == LogicalKeyboardKey.enter ||
         event.logicalKey == LogicalKeyboardKey.select) {
       _submitSignOut();
-      return KeyEventResult.handled;
-    }
-    if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-      FocusScope.of(context).previousFocus();
-      return KeyEventResult.handled;
-    }
-    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-      FocusScope.of(context).nextFocus();
       return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;
@@ -837,7 +976,7 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
                   ? colorScheme.primaryContainer
                   : colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
               borderColor: colorScheme.outline,
-              focusedBorderColor: colorScheme.primary,
+              focusedBorderColor: AppColorScheme.accent,
               hintStyle: TextStyle(
                 fontFamily: kCleanSettingsFontFamily,
                 color: colorScheme.onSurface.withValues(alpha: 0.65),
@@ -902,13 +1041,13 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
         builder: (_, _) {
           final selected = _authType == authType;
           final focused = focusNode.hasFocus;
-          final selectedBackground = colorScheme.primaryContainer;
+          final selectedBackground = AppColorScheme.accent.withValues(alpha: 0.22);
           final idleBackground = colorScheme.surfaceContainerHighest.withValues(
             alpha: 0.65,
           );
-          final focusedBackground = colorScheme.primary.withValues(alpha: 0.16);
-          final selectedBorder = colorScheme.primary;
-          final focusedBorder = colorScheme.primary;
+          final focusedBackground = AppColorScheme.accent.withValues(alpha: 0.16);
+          final selectedBorder = AppColorScheme.accent;
+          final focusedBorder = AppColorScheme.accent;
 
           return AnimatedContainer(
             duration: const Duration(milliseconds: 120),
@@ -972,7 +1111,7 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
             child: _buildAuthOption(
               authType: 'jellyfin',
               label: l10n.jellyfinAccount,
-              focusNode: _jellyfinAuthFocus,
+              focusNode: widget.firstFocusNode,
               onKeyEvent: PlatformDetection.isTV ? _onJellyfinAuthKey : null,
             ),
           ),
@@ -1034,10 +1173,11 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
         : l10n.seerr;
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
       child: FocusTraversalGroup(
         policy: OrderedTraversalPolicy(),
-        child: Card(
+        child: Container(
+          decoration: _boxDecoration(context, focused: false),
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
@@ -1073,30 +1213,62 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
                   alignment: Alignment.centerRight,
                   child: FocusTraversalOrder(
                     order: const NumericFocusOrder(1),
-                    child: Focus(
-                      focusNode: _signOutFocus,
-                      onKeyEvent: PlatformDetection.isTV ? _onSignOutKey : null,
-                      onFocusChange: (focused) {
-                        if (focused) {
-                          _ensureFocusVisible(_signOutFocus, alignment: 0.22);
-                        }
-                      },
-                      child: FilledButton(
-                        style: FilledButton.styleFrom(
-                          foregroundColor: colorScheme.onPrimary,
-                          backgroundColor: colorScheme.primary,
-                        ),
-                        onPressed: _submitting ? null : _submitSignOut,
-                        child: _submitting
-                            ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
+                    child: ListenableBuilder(
+                      listenable: widget.firstFocusNode,
+                      builder: (context, _) {
+                        final isFocused = widget.firstFocusNode.hasFocus;
+                        return Focus(
+                          focusNode: widget.firstFocusNode,
+                          onKeyEvent: (node, event) {
+                            if (event is! KeyDownEvent) return KeyEventResult.ignored;
+                            if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                              widget.onMoveUp();
+                              return KeyEventResult.handled;
+                            }
+                            return PlatformDetection.isTV ? _onSignOutKey(node, event) : KeyEventResult.ignored;
+                          },
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 120),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(24),
+                              boxShadow: isFocused
+                                  ? [
+                                      BoxShadow(
+                                        color: AppColorScheme.onSurface.withValues(alpha: 0.35),
+                                        blurRadius: 10,
+                                        spreadRadius: 1.5,
+                                      ),
+                                    ]
+                                  : null,
+                            ),
+                            child: FilledButton(
+                              style: FilledButton.styleFrom(
+                                foregroundColor: colorScheme.onPrimary,
+                                backgroundColor: colorScheme.primary,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(24),
                                 ),
-                              )
-                            : Text(l10n.signOut),
-                      ),
+                                side: isFocused
+                                    ? BorderSide(
+                                        color: AppColorScheme.onSurface.withValues(alpha: 0.72),
+                                        width: 2.0,
+                                      )
+                                    : BorderSide.none,
+                              ),
+                              onPressed: _submitting ? null : _submitSignOut,
+                              child: _submitting
+                                  ? const SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : Text(l10n.signOut),
+                            ),
+                          ),
+                        );
+                      },
                     ),
                   ),
                 ),
@@ -1122,10 +1294,11 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
     final isLocalAuth = _authType == 'local';
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
       child: FocusTraversalGroup(
         policy: OrderedTraversalPolicy(),
-        child: Card(
+        child: Container(
+          decoration: _boxDecoration(context, focused: false),
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
@@ -1192,26 +1365,53 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
                   alignment: Alignment.centerRight,
                   child: FocusTraversalOrder(
                     order: const NumericFocusOrder(3),
-                    child: Focus(
-                      focusNode: _signInFocus,
-                      onKeyEvent: PlatformDetection.isTV ? _onSignInKey : null,
-                      onFocusChange: (focused) {
-                        if (focused) {
-                          _ensureFocusVisible(_signInFocus, alignment: 0.22);
-                        }
-                      },
-                      child: FilledButton(
-                        onPressed: _canSignIn ? _submitSignIn : null,
-                        child: _submitting
-                            ? const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
+                    child: ListenableBuilder(
+                      listenable: _signInFocus,
+                      builder: (context, _) {
+                        final isFocused = _signInFocus.hasFocus;
+                        return Focus(
+                          focusNode: _signInFocus,
+                          onKeyEvent: PlatformDetection.isTV ? _onSignInKey : null,
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 120),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(24),
+                              boxShadow: isFocused
+                                  ? [
+                                      BoxShadow(
+                                        color: AppColorScheme.onSurface.withValues(alpha: 0.35),
+                                        blurRadius: 10,
+                                        spreadRadius: 1.5,
+                                      ),
+                                    ]
+                                  : null,
+                            ),
+                            child: FilledButton(
+                              onPressed: _canSignIn ? _submitSignIn : null,
+                              style: FilledButton.styleFrom(
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(24),
                                 ),
-                              )
-                            : Text(l10n.signIn),
-                      ),
+                                side: isFocused
+                                    ? BorderSide(
+                                        color: AppColorScheme.onSurface.withValues(alpha: 0.72),
+                                        width: 2.0,
+                                      )
+                                    : BorderSide.none,
+                              ),
+                              child: _submitting
+                                  ? const SizedBox(
+                                      width: 18,
+                                      height: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : Text(l10n.signIn),
+                            ),
+                          ),
+                        );
+                      },
                     ),
                   ),
                 ),


### PR DESCRIPTION
# Pull Request

## Summary
No text/localization changes but a bunch of under the hood finessing. Cleans up the Settings -> Integrations -> Seerr configuration screen layout, focus traversal behavior, and reordering logic on Android TV/mobile. This ensures visual consistency with Rating Sources config.

## Related Issues
Droid's list of UI issues.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
1. Fixed Initial Focus & D-pad Navigation Links to follow up/down logic.
2. Removed manual arrowDown overriding logic from "Sign In" and "Sign Out" buttons to allow Flutter's default 2D directional navigation traversal to land on the NSFW Filter toggle immediately.
3. Prevented the _SeerrLoginCard from stealing focus on the initial asynchronous load unless focus is already within the card.
4. Redesigned the Sign Out and Sign In buttons layout: wrapped the inner 5. AnimatedContainer in the Focus node so that the container draws a clean outer Cyan glow shadow (AppColorScheme.onSurface), while the FilledButton itself draws its Cyan border exactly along its outline (side: isFocused ? BorderSide(...) : BorderSide.none), matching the button dimensions.
5. Removed explicit scroll alignment callbacks (_ensureFocusVisible) from "Sign In" and "Sign Out" buttons to prevent jarring scroll jumps between adjacent settings elements.
6.. Re-styled _SeerrReorderableTile using the exact layout pattern of _ReorderableTile in ratings_config_screen.dart. Replaced card boundaries, borders, margins, shadows, and text color overrides with a flat background layout style where focused rows highlight with colorScheme.primary.withValues(alpha: 0.18) and unfocused rows are transparent, matching the standard full-width settings menu items.
7. Restructured row focus by attaching the focus node to the outer Focus widget of the row tile rather than the inner ListTile.
8. Prevented the page from clearing and rebuilding all row FocusNodes on every sync notification by checking if the row size has actually changed. This preserves focus on the active moving item during D-pad LEFT/RIGHT reordering.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Shield
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Integrations -> Seerr. Focus lands on "Enable Seerr".
2. Press UP to go to the Refresh button. Press DOWN to return to "Enable Seerr".
3. Press DOWN to go to the Seerr Account Type card (Jellyfin/local auth option, or Sign Out).
4. Verify the Sign Out button draws a themed Cyan outline and glow.
5. Press DOWN from the Sign Out button. Verify it navigates to the NSFW Filter toggle instantly without scrolling the viewport jarringly.
6.Check or uncheck a Discover Row. Press LEFT to move it up or RIGHT to move it down. Verify that focus stays pinned to the moving item as it transitions.

## Screenshots (if applicable)

<img width="500" alt="Shield_Screenshot_2026-06-12_15-27-25" src="https://github.com/user-attachments/assets/ea2216a8-434d-4ec3-a248-3d9df9427d43" />

<img width="500" alt="Shield_Screenshot_2026-06-12_15-27-45" src="https://github.com/user-attachments/assets/856c6bb4-e2cd-42e6-861f-a94509e928f1" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
