### PR TITLE
revert 'hide profile when collapsed' to undo the visual glitches ca…

### DIFF
--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -717,8 +717,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
 
     return Column(
       children: [
-        if (_isExpanded)
-          _buildUserSection(),
+        _buildUserSection(),
         Expanded(
           child: LayoutBuilder(
             builder: (context, constraints) {


### PR DESCRIPTION
…used by it

# Pull Request

## Summary
When centering sidebar items, I also added a condition to hide the profile pic in the top corner if the sidebar was collapsed, to reduce clutter on screen. This caused 2 issues:
1. the "center" the other sidebar items aligned to would get pushed slightly, causing a slight "jump" still
2. it affected the way neon theme counted even/odd elements for the colors, causing the colors to flip on all icons when expanded. 

So I undid that part of the change. Now the profile pic is always visible, meaning spacing/colors stay consistent. At a later point we can revisit how to hide it on both left and top navbars without affecting spacing/theme, but for now this will fix the small visual glitches. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- remove isExpanded condition for buildUserSelection call in left_sidebar.dart
- 
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
4.
5.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
