### PR TITLE
feat(settings): clean up Moonbase Plugin settings

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3668,7 +3668,7 @@
   "@syncing": {
     "description": "Label while syncing"
   },
-  "syncToProfile": "Sync To Profile",
+  "syncToProfile": "Sync Profile",
   "@syncToProfile": {
     "description": "Button to sync to a profile"
   },
@@ -4419,7 +4419,7 @@
   "@ratingSourcesDescription": {
     "description": "Description for rating sources"
   },
-  "pluginLabel": "Plugin",
+  "pluginLabel": "Moonbase Plugin",
   "@pluginLabel": {
     "description": "Settings title for plugin"
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4808,7 +4808,7 @@ abstract class AppLocalizations {
   /// Button to sync to a profile
   ///
   /// In en, this message translates to:
-  /// **'Sync To Profile'**
+  /// **'Sync Profile'**
   String get syncToProfile;
 
   /// Title when profile sync is hidden
@@ -5876,7 +5876,7 @@ abstract class AppLocalizations {
   /// Settings title for plugin
   ///
   /// In en, this message translates to:
-  /// **'Plugin'**
+  /// **'Moonbase Plugin'**
   String get pluginLabel;
 
   /// Status when plugin is detected

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2623,7 +2623,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get syncing => 'Syncing...';
 
   @override
-  String get syncToProfile => 'Sync To Profile';
+  String get syncToProfile => 'Sync Profile';
 
   @override
   String get profileSyncHidden => 'Profile Sync Hidden';
@@ -3189,7 +3189,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enable and reorder the rating sources shown throughout the app';
 
   @override
-  String get pluginLabel => 'Plugin';
+  String get pluginLabel => 'Moonbase Plugin';
 
   @override
   String get pluginDetected => 'Plugin Detected';

--- a/lib/ui/screens/settings/plugin_settings_screen.dart
+++ b/lib/ui/screens/settings/plugin_settings_screen.dart
@@ -8,7 +8,6 @@ import '../../../preference/user_preferences.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import '../../widgets/settings/preference_tiles.dart';
 import '../../../l10n/app_localizations.dart';
-import '../../widgets/focus/request_initial_focus.dart';
 
 class PluginSettingsSection extends StatefulWidget {
   const PluginSettingsSection({super.key});
@@ -120,8 +119,7 @@ class _PluginSettingsSectionState extends State<PluginSettingsSection> {
   }
 
   @override
-  Widget build(BuildContext context) =>
-      RequestInitialFocus(child: _buildContent(context));
+  Widget build(BuildContext context) => _buildContent(context);
 
   Widget _buildContent(BuildContext context) {
     return withCleanSettingsTypography(
@@ -249,15 +247,72 @@ class _PluginSettingsSectionState extends State<PluginSettingsSection> {
                   ),
                   child: Column(
                     children: [
-                      SwitchPreferenceTile(
-                        preference: UserPreferences.pluginSyncEnabled,
-                        title: l10n.serverPluginSync,
-                        subtitle: l10n.syncSettingsWithPlugin,
-                        icon: Icons.sync,
-                        onChanged: _pushSync,
+                      Focus(
+                        canRequestFocus: false,
+                        skipTraversal: true,
+                        onFocusChange: (focused) {
+                          if (focused) {
+                            WidgetsBinding.instance.addPostFrameCallback((_) {
+                              if (!context.mounted) return;
+                              Scrollable.ensureVisible(
+                                context,
+                                alignment: 0.1,
+                                alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+                                duration: const Duration(milliseconds: 120),
+                                curve: Curves.easeOut,
+                              );
+                            });
+                          }
+                        },
+                        child: SwitchPreferenceTile(
+                          preference: UserPreferences.pluginSyncEnabled,
+                          title: l10n.serverPluginSync,
+                          subtitle: l10n.syncSettingsWithPlugin,
+                          icon: Icons.sync,
+                          onChanged: _pushSync,
+                        ),
                       ),
-                      if (showProfileSync)
-                        const Divider(height: 1),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+                        child: Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.35),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Icon(
+                                Icons.info_outline,
+                                size: 20,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                              const SizedBox(width: 10),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      l10n.whatSyncControls,
+                                      style: theme.textTheme.titleSmall?.copyWith(
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      l10n.syncControlsDescription,
+                                      style: theme.textTheme.bodySmall?.copyWith(
+                                        color: colorScheme.onSurfaceVariant,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
                       if (showProfileSync)
                         _ProfileSyncSection(
                           syncService: _syncService,
@@ -266,45 +321,6 @@ class _PluginSettingsSectionState extends State<PluginSettingsSection> {
                           onLoad: _pullSelectedProfile,
                           onSave: _pushSelectedProfile,
                         ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Container(
-                  padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
-                  decoration: BoxDecoration(
-                    color: colorScheme.surfaceContainerLow,
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Icon(
-                        Icons.info_outline,
-                        size: 20,
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              l10n.whatSyncControls,
-                              style: theme.textTheme.titleSmall?.copyWith(
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              l10n.syncControlsDescription,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
                     ],
                   ),
                 ),
@@ -337,7 +353,6 @@ class _ProfileSyncSection extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final borders = ThemeRegistry.active.borders;
     final selected = syncService.selectedCustomizationProfile;
     final currentDeviceProfile = syncService.currentDeviceProfile;
     final profiles = PluginSyncService.supportedProfiles;
@@ -366,31 +381,21 @@ class _ProfileSyncSection extends StatelessWidget {
             runSpacing: 8,
             children: [
               for (final profile in profiles)
-                ChoiceChip(
+                _ProfileChip(
+                  label: profileLabel(profile),
                   selected: selected == profile,
-                  showCheckmark: false,
-                  avatar: currentDeviceProfile == profile
-                      ? Icon(
-                          Icons.circle,
-                          size: 10,
-                          color: AppColorScheme.statusAvailable,
-                        )
-                      : null,
-                  label: Text(profileLabel(profile)),
-                  side: borders.chipBorder,
-                  shape: RoundedRectangleBorder(borderRadius: borders.chipRadius),
-                  backgroundColor: borders.chipBackground,
-                  selectedColor: AppColorScheme.accent.withValues(alpha: 0.22),
-                  onSelected: (_) {
+                  isCurrentDevice: currentDeviceProfile == profile,
+                  onSelected: () {
                     syncService.setSelectedCustomizationProfile(profile);
                   },
                 ),
             ],
           ),
           const SizedBox(height: 12),
-          Row(
+          Column(
             children: [
-              Expanded(
+              SizedBox(
+                width: double.infinity,
                 child: OutlinedButton.icon(
                   style: OutlinedButton.styleFrom(
                     minimumSize: const Size.fromHeight(42),
@@ -400,15 +405,18 @@ class _ProfileSyncSection extends StatelessWidget {
                   label: Text(l10n.loadProfile),
                 ),
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: FilledButton.icon(
-                  style: FilledButton.styleFrom(
+              const SizedBox(height: 10),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  style: OutlinedButton.styleFrom(
                     minimumSize: const Size.fromHeight(42),
                   ),
                   onPressed: busy ? null : onSave,
                   icon: const Icon(Icons.cloud_upload),
-                  label: Text(l10n.serverPluginSync),
+                  label: Text(l10n.localeName.startsWith('en')
+                      ? 'Sync Profile'
+                      : l10n.syncToProfile),
                 ),
               ),
             ],
@@ -423,3 +431,109 @@ class _ProfileSyncSection extends StatelessWidget {
     );
   }
 }
+
+class _ProfileChip extends StatefulWidget {
+  final String label;
+  final bool selected;
+  final bool isCurrentDevice;
+  final VoidCallback onSelected;
+
+  const _ProfileChip({
+    required this.label,
+    required this.selected,
+    required this.isCurrentDevice,
+    required this.onSelected,
+  });
+
+  @override
+  State<_ProfileChip> createState() => _ProfileChipState();
+}
+
+class _ProfileChipState extends State<_ProfileChip> {
+  late final FocusNode _focusNode;
+  bool _focused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(debugLabel: 'ProfileChip_${widget.label}');
+    _focusNode.addListener(_onFocusChange);
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    if (!mounted) return;
+    setState(() {
+      _focused = _focusNode.hasFocus;
+    });
+    if (_focusNode.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        Scrollable.ensureVisible(
+          context,
+          alignment: 0.15,
+          alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+          duration: const Duration(milliseconds: 120),
+          curve: Curves.easeOut,
+        );
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final borders = ThemeRegistry.active.borders;
+
+    final borderSide = _focused
+        ? BorderSide(
+            color: AppColorScheme.accent.withValues(alpha: 0.82),
+            width: 1.5,
+          )
+        : borders.chipBorder;
+
+    final glow = _focused
+        ? (borders.focusGlow.isNotEmpty
+            ? borders.focusGlow
+            : [
+                BoxShadow(
+                  color: AppColorScheme.accent.withValues(alpha: 0.22),
+                  blurRadius: 10,
+                  spreadRadius: 1.0,
+                )
+              ])
+        : null;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      decoration: BoxDecoration(
+        borderRadius: borders.chipRadius,
+        boxShadow: glow,
+      ),
+      child: ChoiceChip(
+        focusNode: _focusNode,
+        selected: widget.selected,
+        showCheckmark: false,
+        avatar: widget.isCurrentDevice
+            ? Icon(
+                Icons.circle,
+                size: 10,
+                color: AppColorScheme.statusAvailable,
+              )
+            : null,
+        label: Text(widget.label),
+        side: borderSide,
+        shape: RoundedRectangleBorder(borderRadius: borders.chipRadius),
+        backgroundColor: borders.chipBackground,
+        selectedColor: AppColorScheme.accent.withValues(alpha: 0.22),
+        onSelected: (_) => widget.onSelected(),
+      ),
+    );
+  }
+}
+

--- a/lib/ui/screens/settings/plugin_settings_screen.dart
+++ b/lib/ui/screens/settings/plugin_settings_screen.dart
@@ -247,29 +247,30 @@ class _PluginSettingsSectionState extends State<PluginSettingsSection> {
                   ),
                   child: Column(
                     children: [
-                      Focus(
-                        canRequestFocus: false,
-                        skipTraversal: true,
-                        onFocusChange: (focused) {
-                          if (focused) {
+                      Builder(
+                        builder: (tileContext) => Focus(
+                          canRequestFocus: false,
+                          skipTraversal: true,
+                          onFocusChange: (focused) {
+                            if (!focused) return;
                             WidgetsBinding.instance.addPostFrameCallback((_) {
-                              if (!context.mounted) return;
+                              if (!tileContext.mounted) return;
                               Scrollable.ensureVisible(
-                                context,
+                                tileContext,
                                 alignment: 0.1,
                                 alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
                                 duration: const Duration(milliseconds: 120),
                                 curve: Curves.easeOut,
                               );
                             });
-                          }
-                        },
-                        child: SwitchPreferenceTile(
-                          preference: UserPreferences.pluginSyncEnabled,
-                          title: l10n.serverPluginSync,
-                          subtitle: l10n.syncSettingsWithPlugin,
-                          icon: Icons.sync,
-                          onChanged: _pushSync,
+                          },
+                          child: SwitchPreferenceTile(
+                            preference: UserPreferences.pluginSyncEnabled,
+                            title: l10n.serverPluginSync,
+                            subtitle: l10n.syncSettingsWithPlugin,
+                            icon: Icons.sync,
+                            onChanged: _pushSync,
+                          ),
                         ),
                       ),
                       Padding(
@@ -414,9 +415,7 @@ class _ProfileSyncSection extends StatelessWidget {
                   ),
                   onPressed: busy ? null : onSave,
                   icon: const Icon(Icons.cloud_upload),
-                  label: Text(l10n.localeName.startsWith('en')
-                      ? 'Sync Profile'
-                      : l10n.syncToProfile),
+                  label: Text(l10n.syncToProfile),
                 ),
               ),
             ],

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1180,7 +1180,7 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
               _TvSettingsListTile(
                 autofocus: true,
                 leading: const Icon(Icons.extension),
-                title: const Text('Moonbase Plugin'),
+                title: Text(l10n.pluginLabel),
                 subtitle: Text(l10n.serverSyncAndPluginStatus),
                 onTap: () => context.pushSettingsScreen(const _PluginScreen()),
               ),
@@ -1294,7 +1294,7 @@ class _PluginScreenState extends State<_PluginScreen> {
             child: Scaffold(
               appBar: buildSettingsAppBar(
                 context,
-                const Text('Moonbase Plugin'),
+                Text(l10n.pluginLabel),
                 actions: [
                   IconButton(
                     focusNode: _refreshFocusNode,

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1180,7 +1180,7 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
               _TvSettingsListTile(
                 autofocus: true,
                 leading: const Icon(Icons.extension),
-                title: Text(l10n.pluginLabel),
+                title: const Text('Moonbase Plugin'),
                 subtitle: Text(l10n.serverSyncAndPluginStatus),
                 onTap: () => context.pushSettingsScreen(const _PluginScreen()),
               ),
@@ -1246,11 +1246,37 @@ class _PluginScreenState extends State<_PluginScreen> {
     debugLabel: 'PluginSettingsScope',
     traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
   );
+  final _scrollController = ScrollController();
+  final _refreshFocusNode = FocusNode(debugLabel: 'PluginRefreshButton');
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshFocusNode.addListener(_onRefreshFocusChange);
+  }
 
   @override
   void dispose() {
+    _refreshFocusNode.removeListener(_onRefreshFocusChange);
+    _refreshFocusNode.dispose();
+    _scrollController.dispose();
     _pluginScope.dispose();
     super.dispose();
+  }
+
+  void _onRefreshFocusChange() {
+    if (_refreshFocusNode.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (_scrollController.hasClients) {
+          _scrollController.animateTo(
+            0,
+            duration: const Duration(milliseconds: 150),
+            curve: Curves.easeOut,
+          );
+        }
+      });
+    }
   }
 
   @override
@@ -1262,12 +1288,43 @@ class _PluginScreenState extends State<_PluginScreen> {
           final theme = Theme.of(context);
           final colorScheme = theme.colorScheme;
           final l10n = AppLocalizations.of(context);
-          return Scaffold(
-            appBar: buildSettingsAppBar(context, Text(l10n.pluginLabel)),
-            body: FocusScope(
-              node: _pluginScope,
-              autofocus: true,
-              child: ListView(
+          return FocusScope(
+            node: _pluginScope,
+            autofocus: true,
+            child: Scaffold(
+              appBar: buildSettingsAppBar(
+                context,
+                const Text('Moonbase Plugin'),
+                actions: [
+                  IconButton(
+                    focusNode: _refreshFocusNode,
+                    autofocus: true,
+                    icon: const Icon(Icons.refresh),
+                    onPressed: () async {
+                      if (GetIt.instance.isRegistered<MediaServerClient>()) {
+                        final client = GetIt.instance<MediaServerClient>();
+                        final syncService = GetIt.instance<PluginSyncService>();
+                        await syncService.refreshAvailability(client);
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                syncService.pluginAvailable
+                                    ? l10n.pluginDetected
+                                    : l10n.pluginNotDetected,
+                              ),
+                              duration: const Duration(seconds: 2),
+                            ),
+                          );
+                        }
+                      }
+                    },
+                  ),
+                ],
+              ),
+              body: ListView(
+                controller: _scrollController,
+                padding: const EdgeInsets.only(bottom: 48),
                 children: [
                   Padding(
                     padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),


### PR DESCRIPTION
# Pull Request

## Summary
This PR cleans up the layout, naming, D-pad focus, and scrolling behavior on the plugin settings screen (renamed to Moonbase Plugin) to ensure all content is visible and all interactable elements are apparent.

## Related Issues
This one is a Matt special. On the house.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix (some settings did not have focus indicators to show they were selectable)
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update (we made it pretty, ok)
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
1. Renamed settings category and screen titles from "Plugin" to "Moonbase Plugin" for clarity.
2. Added a circular "Refresh" button in the AppBar actions list (IconButton with Icons.refresh) to act as an anchor and to also trigger a rescan for the plugin.
3. Added a focus listener to the Refresh button. When the user navigates UP from list cards back to the Refresh button, the viewport automatically scrolls to the top offset (0) via a post-frame callback.
4. Relocated the "What Sync Controls" info container directly inside the sync preference card below the switch tile for better visual grouping.
5. Overrode focus-scrolling on the "Server Plugin Sync" switch tile to align at 0.1 (high up in the viewport) so the underlying info card remains fully visible.
6. Configured customization profile chips to automatically scroll the screen down (alignment: 0.15) when focused, revealing the full set of action buttons.
4. Arranged action buttons vertically in a Column to prevent the English label "Sync Profile" from wrapping into two lines.
Added a 48px bottom padding to the main scrollable ListView to prevent the final buttons from clipping at the screen's bottom edge.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Push to the Moonbase Plugin screen.
2. Confirm focus starts on the header Refresh button and the viewport is aligned at the top.
3. D-pad Down to the Server Plugin Sync card. Verify it positions itself at 10% offset, keeping the sync details fully visible.
4. D-pad Down to the customization chips. Select a profile chip and confirm the screen automatically scrolls down to reveal the load and save action buttons with a bottom padding.
5. D-pad UP from the first card and confirm focus returns to the circular Refresh button, smoothly scrolling the viewport back to the top.

## Screenshots (if applicable)

TOP
<img width="3840" height="2160" alt="Shield_Screenshot_2026-06-12_16-19-52" src="https://github.com/user-attachments/assets/cd067ec9-ffb7-40ab-9747-fadbefe7f9dd" />

BOTTOM
<img width="3840" height="2160" alt="Shield_Screenshot_2026-06-12_16-20-03" src="https://github.com/user-attachments/assets/ceb70a52-9a3c-41bd-95e3-c328de589f74" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
