### PR TITLE
newfeat: Artwork Selector

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7458,7 +7458,6 @@
     }
   },
   "yes": "Yes",
-  "no": "No",
   "posterCategory": "Poster",
   "backdropsCategory": "Backdrops",
   "bannerCategory": "Banner",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7405,5 +7405,88 @@
   "autoHdrSwitching": "Auto HDR Switching",
   "autoHdrSwitchingDescription": "Automatically enable HDR for HDR video playback and restore display mode on exit.",
   "whenFullscreen": "When fullscreen",
-  "transcodingLimits": "Transcoding Limits"
+  "changeArtwork": "Change Artwork",
+  "missing": "Missing",
+  "transcodingLimits": "Transcoding Limits",
+  "clearAllArtworkButton": "Clear all artwork?",
+  "clearAllArtworkWarning": "Are you sure you want to clear all downloaded artwork?",
+  "confirmClear": "Confirm Clear",
+  "confirmClearMessage": "Are you sure you would like to clear this {itemType}?",
+  "@confirmClearMessage": {
+    "description": "Confirmation message when clearing a specific artwork",
+    "placeholders": {
+      "itemType": {
+        "type": "String"
+      }
+    }
+  },
+  "uploadButton": "Upload?",
+  "resolutionLabel": "Resolution: ",
+  "onlyShowInterfaceLanguage": "Only show artwork in interface language",
+  "confirmClearAll": "Confirm Clear All",
+  "imageUploadSuccess": "Image uploaded successfully!",
+  "imageUploadFailed": "Failed to upload image: {error}",
+  "@imageUploadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "imageDownloadFailed": "Failed to set image: {error}",
+  "@imageDownloadFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "imageDeleteFailed": "Failed to delete image: {error}",
+  "@imageDeleteFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "clearAllArtworkFailed": "Failed to clear all artwork: {error}",
+  "@clearAllArtworkFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "yes": "Yes",
+  "no": "No",
+  "posterCategory": "Poster",
+  "backdropsCategory": "Backdrops",
+  "bannerCategory": "Banner",
+  "logoCategory": "Logo",
+  "thumbnailCategory": "Thumbnail",
+  "artCategory": "Art",
+  "discArtCategory": "Disc Art",
+  "screenshotCategory": "Screenshot",
+  "boxCoverCategory": "Box Cover",
+  "boxRearCoverCategory": "Box Rear Cover",
+  "menuArtCategory": "Menu Art",
+  "confirmItemPoster": "poster",
+  "confirmItemBackdrop": "backdrop",
+  "confirmItemBanner": "banner",
+  "confirmItemLogo": "logo",
+  "confirmItemThumbnail": "thumbnail",
+  "confirmItemArt": "art",
+  "confirmItemDiscArt": "disc art",
+  "confirmItemScreenshot": "screenshot",
+  "confirmItemBoxCover": "box cover",
+  "confirmItemBoxRearCover": "box rear cover",
+  "confirmItemMenuArt": "menu art",
+  "resolutionAll": "All",
+  "resolutionHigh": "High (1080p+)",
+  "resolutionMedium": "Medium (720p)",
+  "resolutionLow": "Low (<720p)",
+  "sources": "Sources",
+  "@sources": {
+    "description": "Title of the artwork source-provider filter dialog"
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14399,11 +14399,269 @@ abstract class AppLocalizations {
   /// **'When fullscreen'**
   String get whenFullscreen;
 
+  /// No description provided for @changeArtwork.
+  ///
+  /// In en, this message translates to:
+  /// **'Change Artwork'**
+  String get changeArtwork;
+
+  /// No description provided for @missing.
+  ///
+  /// In en, this message translates to:
+  /// **'Missing'**
+  String get missing;
+
   /// No description provided for @transcodingLimits.
   ///
   /// In en, this message translates to:
   /// **'Transcoding Limits'**
   String get transcodingLimits;
+
+  /// No description provided for @clearAllArtworkButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all artwork?'**
+  String get clearAllArtworkButton;
+
+  /// No description provided for @clearAllArtworkWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you want to clear all downloaded artwork?'**
+  String get clearAllArtworkWarning;
+
+  /// No description provided for @confirmClear.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm Clear'**
+  String get confirmClear;
+
+  /// Confirmation message when clearing a specific artwork
+  ///
+  /// In en, this message translates to:
+  /// **'Are you sure you would like to clear this {itemType}?'**
+  String confirmClearMessage(String itemType);
+
+  /// No description provided for @uploadButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Upload?'**
+  String get uploadButton;
+
+  /// No description provided for @resolutionLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Resolution: '**
+  String get resolutionLabel;
+
+  /// No description provided for @onlyShowInterfaceLanguage.
+  ///
+  /// In en, this message translates to:
+  /// **'Only show artwork in interface language'**
+  String get onlyShowInterfaceLanguage;
+
+  /// No description provided for @confirmClearAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm Clear All'**
+  String get confirmClearAll;
+
+  /// No description provided for @imageUploadSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Image uploaded successfully!'**
+  String get imageUploadSuccess;
+
+  /// No description provided for @imageUploadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to upload image: {error}'**
+  String imageUploadFailed(String error);
+
+  /// No description provided for @imageDownloadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to set image: {error}'**
+  String imageDownloadFailed(String error);
+
+  /// No description provided for @imageDeleteFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete image: {error}'**
+  String imageDeleteFailed(String error);
+
+  /// No description provided for @clearAllArtworkFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to clear all artwork: {error}'**
+  String clearAllArtworkFailed(String error);
+
+  /// No description provided for @yes.
+  ///
+  /// In en, this message translates to:
+  /// **'Yes'**
+  String get yes;
+
+  /// No description provided for @posterCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Poster'**
+  String get posterCategory;
+
+  /// No description provided for @backdropsCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Backdrops'**
+  String get backdropsCategory;
+
+  /// No description provided for @bannerCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Banner'**
+  String get bannerCategory;
+
+  /// No description provided for @logoCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Logo'**
+  String get logoCategory;
+
+  /// No description provided for @thumbnailCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Thumbnail'**
+  String get thumbnailCategory;
+
+  /// No description provided for @artCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Art'**
+  String get artCategory;
+
+  /// No description provided for @discArtCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Disc Art'**
+  String get discArtCategory;
+
+  /// No description provided for @screenshotCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Screenshot'**
+  String get screenshotCategory;
+
+  /// No description provided for @boxCoverCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Box Cover'**
+  String get boxCoverCategory;
+
+  /// No description provided for @boxRearCoverCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Box Rear Cover'**
+  String get boxRearCoverCategory;
+
+  /// No description provided for @menuArtCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Menu Art'**
+  String get menuArtCategory;
+
+  /// No description provided for @confirmItemPoster.
+  ///
+  /// In en, this message translates to:
+  /// **'poster'**
+  String get confirmItemPoster;
+
+  /// No description provided for @confirmItemBackdrop.
+  ///
+  /// In en, this message translates to:
+  /// **'backdrop'**
+  String get confirmItemBackdrop;
+
+  /// No description provided for @confirmItemBanner.
+  ///
+  /// In en, this message translates to:
+  /// **'banner'**
+  String get confirmItemBanner;
+
+  /// No description provided for @confirmItemLogo.
+  ///
+  /// In en, this message translates to:
+  /// **'logo'**
+  String get confirmItemLogo;
+
+  /// No description provided for @confirmItemThumbnail.
+  ///
+  /// In en, this message translates to:
+  /// **'thumbnail'**
+  String get confirmItemThumbnail;
+
+  /// No description provided for @confirmItemArt.
+  ///
+  /// In en, this message translates to:
+  /// **'art'**
+  String get confirmItemArt;
+
+  /// No description provided for @confirmItemDiscArt.
+  ///
+  /// In en, this message translates to:
+  /// **'disc art'**
+  String get confirmItemDiscArt;
+
+  /// No description provided for @confirmItemScreenshot.
+  ///
+  /// In en, this message translates to:
+  /// **'screenshot'**
+  String get confirmItemScreenshot;
+
+  /// No description provided for @confirmItemBoxCover.
+  ///
+  /// In en, this message translates to:
+  /// **'box cover'**
+  String get confirmItemBoxCover;
+
+  /// No description provided for @confirmItemBoxRearCover.
+  ///
+  /// In en, this message translates to:
+  /// **'box rear cover'**
+  String get confirmItemBoxRearCover;
+
+  /// No description provided for @confirmItemMenuArt.
+  ///
+  /// In en, this message translates to:
+  /// **'menu art'**
+  String get confirmItemMenuArt;
+
+  /// No description provided for @resolutionAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get resolutionAll;
+
+  /// No description provided for @resolutionHigh.
+  ///
+  /// In en, this message translates to:
+  /// **'High (1080p+)'**
+  String get resolutionHigh;
+
+  /// No description provided for @resolutionMedium.
+  ///
+  /// In en, this message translates to:
+  /// **'Medium (720p)'**
+  String get resolutionMedium;
+
+  /// No description provided for @resolutionLow.
+  ///
+  /// In en, this message translates to:
+  /// **'Low (<720p)'**
+  String get resolutionLow;
+
+  /// Title of the artwork source-provider filter dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Sources'**
+  String get sources;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -8111,5 +8111,146 @@ class AppLocalizationsAf extends AppLocalizations {
   String get whenFullscreen => 'Wanneer volskerm';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transkoderingslimiete';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -8056,5 +8056,146 @@ class AppLocalizationsAr extends AppLocalizations {
   String get whenFullscreen => 'عندما ملء الشاشة';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'حدود تحويل الترميز';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8137,5 +8137,146 @@ class AppLocalizationsBe extends AppLocalizations {
   String get whenFullscreen => 'У поўнаэкранным рэжыме';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Абмежаванні перакадавання';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8182,5 +8182,146 @@ class AppLocalizationsBg extends AppLocalizations {
   String get whenFullscreen => 'Когато е на цял екран';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Ограничения за транскодиране';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -8098,5 +8098,146 @@ class AppLocalizationsBn extends AppLocalizations {
   String get whenFullscreen => 'যখন ফুলস্ক্রিন';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'ট্রান্সকোডিং সীমা';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8223,5 +8223,146 @@ class AppLocalizationsCa extends AppLocalizations {
   String get whenFullscreen => 'Quan a pantalla completa';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Límits de transcodificació';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8118,5 +8118,146 @@ class AppLocalizationsCs extends AppLocalizations {
   String get whenFullscreen => 'Při zobrazení na celou obrazovku';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Limity překódování';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8132,5 +8132,146 @@ class AppLocalizationsCy extends AppLocalizations {
   String get whenFullscreen => 'Pan fydd sgrin lawn';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Terfynau Trawsgodio';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8101,5 +8101,146 @@ class AppLocalizationsDa extends AppLocalizations {
   String get whenFullscreen => 'Når fuldskærm';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Omkodningsgrænser';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8174,5 +8174,146 @@ class AppLocalizationsDe extends AppLocalizations {
   String get whenFullscreen => 'Im Vollbildmodus';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transkodierungsgrenzen';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8229,5 +8229,146 @@ class AppLocalizationsEl extends AppLocalizations {
   String get whenFullscreen => 'Σε πλήρη οθόνη';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Όρια διακωδικοποίησης';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8044,7 +8044,148 @@ class AppLocalizationsEn extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -8094,5 +8094,146 @@ class AppLocalizationsEo extends AppLocalizations {
   String get whenFullscreen => 'Kiam plenekrana';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transkodigaj Limoj';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8184,7 +8184,148 @@ class AppLocalizationsEs extends AppLocalizations {
   String get whenFullscreen => 'Cuando pantalla completa';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Límites de transcodificación';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8119,5 +8119,146 @@ class AppLocalizationsEt extends AppLocalizations {
   String get whenFullscreen => 'Täisekraanil';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Ümberkodeerimise piirangud';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -8063,5 +8063,146 @@ class AppLocalizationsFa extends AppLocalizations {
   String get whenFullscreen => 'وقتی تمام صفحه';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'محدودیت های رمزگذاری';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8131,5 +8131,146 @@ class AppLocalizationsFi extends AppLocalizations {
   String get whenFullscreen => 'Kun koko näyttö';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transkoodausrajat';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8194,5 +8194,146 @@ class AppLocalizationsFr extends AppLocalizations {
   String get whenFullscreen => 'En plein écran';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Limites de transcodage';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8199,5 +8199,146 @@ class AppLocalizationsGl extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -7998,5 +7998,146 @@ class AppLocalizationsHe extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -8080,5 +8080,146 @@ class AppLocalizationsHi extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -8124,5 +8124,146 @@ class AppLocalizationsHr extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8167,5 +8167,146 @@ class AppLocalizationsHu extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -8112,5 +8112,146 @@ class AppLocalizationsId extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8143,5 +8143,146 @@ class AppLocalizationsIt extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7906,5 +7906,146 @@ class AppLocalizationsJa extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8135,5 +8135,146 @@ class AppLocalizationsKk extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8151,5 +8151,146 @@ class AppLocalizationsKn extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -7901,5 +7901,146 @@ class AppLocalizationsKo extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8136,5 +8136,146 @@ class AppLocalizationsLt extends AppLocalizations {
   String get whenFullscreen => 'Kai per visą ekraną';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Perkodavimo ribos';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8146,5 +8146,146 @@ class AppLocalizationsLv extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8153,5 +8153,146 @@ class AppLocalizationsMk extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8201,5 +8201,146 @@ class AppLocalizationsMl extends AppLocalizations {
   String get whenFullscreen => 'ഫുൾസ്ക്രീൻ ആയിരിക്കുമ്പോൾ';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'ട്രാൻസ്കോഡിംഗ് പരിധികൾ';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8132,5 +8132,146 @@ class AppLocalizationsMn extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8103,5 +8103,146 @@ class AppLocalizationsNb extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8134,5 +8134,146 @@ class AppLocalizationsNl extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -8083,5 +8083,146 @@ class AppLocalizationsPa extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -8145,5 +8145,146 @@ class AppLocalizationsPl extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8164,7 +8164,148 @@ class AppLocalizationsPt extends AppLocalizations {
   String get whenFullscreen => 'Quando em tela cheia';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Limites de transcodificação';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8148,5 +8148,146 @@ class AppLocalizationsRo extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8154,5 +8154,146 @@ class AppLocalizationsRu extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -8091,5 +8091,146 @@ class AppLocalizationsSi extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8135,5 +8135,146 @@ class AppLocalizationsSk extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8132,5 +8132,146 @@ class AppLocalizationsSl extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8163,5 +8163,146 @@ class AppLocalizationsSq extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -8128,5 +8128,146 @@ class AppLocalizationsSr extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8114,5 +8114,146 @@ class AppLocalizationsSv extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8155,5 +8155,146 @@ class AppLocalizationsSw extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8158,5 +8158,146 @@ class AppLocalizationsTa extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8156,5 +8156,146 @@ class AppLocalizationsTe extends AppLocalizations {
   String get whenFullscreen => 'పూర్తి స్క్రీన్‌లో ఉన్నప్పుడు';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'ట్రాన్స్‌కోడింగ్ పరిమితులు';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -8049,5 +8049,146 @@ class AppLocalizationsTh extends AppLocalizations {
   String get whenFullscreen => 'เมื่อเปิดเต็มจอ';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'ขีดจำกัดการแปลงรหัส';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8183,5 +8183,146 @@ class AppLocalizationsTl extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -8103,5 +8103,146 @@ class AppLocalizationsTr extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -8110,5 +8110,146 @@ class AppLocalizationsUg extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8156,5 +8156,146 @@ class AppLocalizationsUk extends AppLocalizations {
   String get whenFullscreen => 'У повноекранному режимі';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Обмеження перекодування';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -8116,5 +8116,146 @@ class AppLocalizationsVi extends AppLocalizations {
   String get whenFullscreen => 'Khi toàn màn hình';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Giới hạn chuyển mã';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -7858,7 +7858,148 @@ class AppLocalizationsYue extends AppLocalizations {
   String get whenFullscreen => 'When fullscreen';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => 'Transcoding Limits';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }
 
 /// The translations for Yue Chinese Cantonese, as used in China (`yue_CN`).

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7810,7 +7810,148 @@ class AppLocalizationsZh extends AppLocalizations {
   String get whenFullscreen => '全屏时';
 
   @override
+  String get changeArtwork => 'Change Artwork';
+
+  @override
+  String get missing => 'Missing';
+
+  @override
   String get transcodingLimits => '转码限制';
+
+  @override
+  String get clearAllArtworkButton => 'Clear all artwork?';
+
+  @override
+  String get clearAllArtworkWarning =>
+      'Are you sure you want to clear all downloaded artwork?';
+
+  @override
+  String get confirmClear => 'Confirm Clear';
+
+  @override
+  String confirmClearMessage(String itemType) {
+    return 'Are you sure you would like to clear this $itemType?';
+  }
+
+  @override
+  String get uploadButton => 'Upload?';
+
+  @override
+  String get resolutionLabel => 'Resolution: ';
+
+  @override
+  String get onlyShowInterfaceLanguage =>
+      'Only show artwork in interface language';
+
+  @override
+  String get confirmClearAll => 'Confirm Clear All';
+
+  @override
+  String get imageUploadSuccess => 'Image uploaded successfully!';
+
+  @override
+  String imageUploadFailed(String error) {
+    return 'Failed to upload image: $error';
+  }
+
+  @override
+  String imageDownloadFailed(String error) {
+    return 'Failed to set image: $error';
+  }
+
+  @override
+  String imageDeleteFailed(String error) {
+    return 'Failed to delete image: $error';
+  }
+
+  @override
+  String clearAllArtworkFailed(String error) {
+    return 'Failed to clear all artwork: $error';
+  }
+
+  @override
+  String get yes => 'Yes';
+
+  @override
+  String get posterCategory => 'Poster';
+
+  @override
+  String get backdropsCategory => 'Backdrops';
+
+  @override
+  String get bannerCategory => 'Banner';
+
+  @override
+  String get logoCategory => 'Logo';
+
+  @override
+  String get thumbnailCategory => 'Thumbnail';
+
+  @override
+  String get artCategory => 'Art';
+
+  @override
+  String get discArtCategory => 'Disc Art';
+
+  @override
+  String get screenshotCategory => 'Screenshot';
+
+  @override
+  String get boxCoverCategory => 'Box Cover';
+
+  @override
+  String get boxRearCoverCategory => 'Box Rear Cover';
+
+  @override
+  String get menuArtCategory => 'Menu Art';
+
+  @override
+  String get confirmItemPoster => 'poster';
+
+  @override
+  String get confirmItemBackdrop => 'backdrop';
+
+  @override
+  String get confirmItemBanner => 'banner';
+
+  @override
+  String get confirmItemLogo => 'logo';
+
+  @override
+  String get confirmItemThumbnail => 'thumbnail';
+
+  @override
+  String get confirmItemArt => 'art';
+
+  @override
+  String get confirmItemDiscArt => 'disc art';
+
+  @override
+  String get confirmItemScreenshot => 'screenshot';
+
+  @override
+  String get confirmItemBoxCover => 'box cover';
+
+  @override
+  String get confirmItemBoxRearCover => 'box rear cover';
+
+  @override
+  String get confirmItemMenuArt => 'menu art';
+
+  @override
+  String get resolutionAll => 'All';
+
+  @override
+  String get resolutionHigh => 'High (1080p+)';
+
+  @override
+  String get resolutionMedium => 'Medium (720p)';
+
+  @override
+  String get resolutionLow => 'Low (<720p)';
+
+  @override
+  String get sources => 'Sources';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/ui/screens/browse/library_view_screen.dart
+++ b/lib/ui/screens/browse/library_view_screen.dart
@@ -19,6 +19,7 @@ import '../../widgets/library_row.dart';
 import '../../widgets/media_card.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../util/home_row_title_localizer.dart';
+import '../../widgets/focus/context_menu_sheet.dart';
 
 Color get _navyBackground => AppColorScheme.background;
 const _horizontalPadding = 60.0;
@@ -195,6 +196,11 @@ class _LibraryViewScreenState extends State<LibraryViewScreen> {
                   serverId: item.serverId,
                   type: item.type,
                 ),
+              ),
+              onLongPress: () => showContextMenu(
+                context,
+                item,
+                onChanged: _onChanged,
               ),
             );
           }).toList(),

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -32,10 +32,12 @@ import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../ui/mixins/focus_state_mixin.dart';
 import '../../../auth/repositories/user_repository.dart';
+import '../../../util/focus/key_event_utils.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/add_to_playlist_dialog.dart';
 import '../../widgets/logo_view.dart';
 import '../../widgets/media_card.dart';
+import '../../widgets/change_artwork_dialog.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/horizontal_scroll_section.dart';
 import '../../widgets/rating_display.dart';
@@ -1584,6 +1586,7 @@ class _DetailContentState extends State<_DetailContent> {
             seasons: viewModel.seasons,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
               seasonsFocusNode,
               ctrl,
@@ -1686,7 +1689,11 @@ class _DetailContentState extends State<_DetailContent> {
         ...viewModel.episodes.map(
           (ep) => Padding(
             padding: const EdgeInsets.only(bottom: 8),
-            child: _EpisodeCard(episode: ep, imageApi: viewModel.imageApi),
+            child: _EpisodeCard(
+              episode: ep,
+              imageApi: viewModel.imageApi,
+              onChanged: () => viewModel.load(),
+            ),
           ),
         ),
       ],
@@ -1819,6 +1826,7 @@ class _DetailContentState extends State<_DetailContent> {
             episodes: viewModel.episodes,
             currentEpisodeId: item.id,
             imageApi: viewModel.imageApi,
+            onChanged: () => viewModel.load(),
             scrollController: _trackSectionScrollController(
               episodesFocusNode,
               ctrl,
@@ -1978,6 +1986,7 @@ class _DetailContentState extends State<_DetailContent> {
             items: viewModel.features,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
               _firstFeatureFocusNode,
               ctrl,
@@ -2145,6 +2154,7 @@ class _DetailContentState extends State<_DetailContent> {
             items: movies,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
               moviesFocusNode,
               ctrl,
@@ -2171,6 +2181,7 @@ class _DetailContentState extends State<_DetailContent> {
             items: series,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
               seriesFocusNode,
               ctrl,
@@ -2196,6 +2207,7 @@ class _DetailContentState extends State<_DetailContent> {
             items: guestAppearances,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
               guestAppearancesFocusNode,
               ctrl,
@@ -2218,6 +2230,7 @@ class _DetailContentState extends State<_DetailContent> {
             items: musicVideos,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
               musicVideosFocusNode,
               ctrl,
@@ -2305,6 +2318,7 @@ class _DetailContentState extends State<_DetailContent> {
             albums: viewModel.albums,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
               albumsFocusNode,
               ctrl,
@@ -5369,8 +5383,27 @@ class _ActionButtonsState extends State<_ActionButtons> {
     AggregatedItem item, {
     bool forceStartOver = false,
   }) async {
+    final l10n = AppLocalizations.of(context);
     final resume = !forceStartOver && (item.playbackPosition?.inMilliseconds ?? 0) > 0;
+    
+    final client = GetIt.instance<MediaServerClient>();
+    final canChangeArtwork = client.serverType == ServerType.jellyfin;
+
     final options = [
+      if (canChangeArtwork)
+        _AdvancedPlaybackOption(
+          label: l10n.changeArtwork,
+          icon: Icons.image_outlined,
+          onTap: () async {
+            final changed = await ChangeArtworkDialog.show(
+              context,
+              item: item,
+            );
+            if (changed == true) {
+              viewModel.load();
+            }
+          },
+        ),
       if (PlatformDetection.isAndroid &&
           GetIt.instance<UserPreferences>()
               .get(UserPreferences.externalPlayerComponentName)
@@ -8328,6 +8361,7 @@ class _FeaturesRow extends StatelessWidget {
   final ScrollController? scrollController;
   final FocusNode? firstItemFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
+  final void Function(AggregatedItem item)? onItemLongPress;
 
   const _FeaturesRow({
     required this.items,
@@ -8336,6 +8370,7 @@ class _FeaturesRow extends StatelessWidget {
     this.scrollController,
     this.firstItemFocusNode,
     this.onItemKeyEvent,
+    this.onItemLongPress,
   });
 
   @override
@@ -8385,6 +8420,9 @@ class _FeaturesRow extends StatelessWidget {
             onKeyEvent: onItemKeyEvent == null
                 ? null
                 : (_, event) => onItemKeyEvent!(index, event),
+            onLongPress: onItemLongPress != null
+                ? () => onItemLongPress!(item)
+                : null,
             onTap: () => context.push(
               Destinations.item(item.id, serverId: item.serverId),
             ),
@@ -8839,6 +8877,7 @@ class _SeasonsRow extends StatelessWidget {
   final ScrollController? scrollController;
   final FocusNode? firstItemFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
+  final void Function(AggregatedItem item)? onItemLongPress;
 
   const _SeasonsRow({
     required this.seasons,
@@ -8847,6 +8886,7 @@ class _SeasonsRow extends StatelessWidget {
     this.scrollController,
     this.firstItemFocusNode,
     this.onItemKeyEvent,
+    this.onItemLongPress,
   });
 
   @override
@@ -8895,6 +8935,9 @@ class _SeasonsRow extends StatelessWidget {
             onTap: () => context.push(
               Destinations.item(season.id, serverId: season.serverId),
             ),
+            onLongPress: onItemLongPress != null
+                ? () => onItemLongPress!(season)
+                : null,
           );
         },
       ),
@@ -8961,6 +9004,7 @@ class _EpisodesRow extends StatelessWidget {
   final ScrollController? scrollController;
   final FocusNode? firstItemFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
+  final VoidCallback? onChanged;
 
   const _EpisodesRow({
     required this.episodes,
@@ -8969,6 +9013,7 @@ class _EpisodesRow extends StatelessWidget {
     this.scrollController,
     this.firstItemFocusNode,
     this.onItemKeyEvent,
+    this.onChanged,
   });
 
   @override
@@ -8996,6 +9041,7 @@ class _EpisodesRow extends StatelessWidget {
             onKeyEvent: onItemKeyEvent == null
                 ? null
                 : (event) => onItemKeyEvent!(index, event),
+            onChanged: onChanged,
           );
         },
       ),
@@ -9010,6 +9056,7 @@ class _EpisodeListCard extends StatefulWidget {
   final bool isMobile;
   final FocusNode? focusNode;
   final KeyEventResult Function(KeyEvent event)? onKeyEvent;
+  final VoidCallback? onChanged;
 
   const _EpisodeListCard({
     required this.episode,
@@ -9018,6 +9065,7 @@ class _EpisodeListCard extends StatefulWidget {
     required this.isMobile,
     this.focusNode,
     this.onKeyEvent,
+    this.onChanged,
   });
 
   @override
@@ -9026,6 +9074,22 @@ class _EpisodeListCard extends StatefulWidget {
 
 class _EpisodeListCardState extends State<_EpisodeListCard>
     with FocusStateMixin {
+  final _selectKeyHandler = LongPressSelectKeyHandler();
+
+  @override
+  void dispose() {
+    _selectKeyHandler.dispose();
+    super.dispose();
+  }
+
+  void _handleLongPress() {
+    showContextMenu(
+      context,
+      widget.episode,
+      onChanged: widget.onChanged,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final ep = widget.episode;
@@ -9056,15 +9120,23 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
           if (customResult != null && customResult != KeyEventResult.ignored) {
             return customResult;
           }
-          if (isActivateKey(event)) {
-            context.push(Destinations.item(ep.id, serverId: ep.serverId));
-            return KeyEventResult.handled;
+          final handlerResult = _selectKeyHandler.handleKeyEvent(
+            event,
+            onTap: () => context.push(
+              Destinations.item(ep.id, serverId: ep.serverId),
+            ),
+            onLongPress: _handleLongPress,
+          );
+          if (handlerResult != KeyEventResult.ignored) {
+            return handlerResult;
           }
           return KeyEventResult.ignored;
         },
         child: GestureDetector(
           onTap: () =>
               context.push(Destinations.item(ep.id, serverId: ep.serverId)),
+          onLongPress: _handleLongPress,
+          onSecondaryTap: _handleLongPress,
           child: Container(
             width: widget.isMobile ? 180.0 : 220.0 * desktopScale,
             decoration: BoxDecoration(
@@ -9358,14 +9430,35 @@ class _NextUpCardState extends State<_NextUpCard> with FocusStateMixin {
 class _EpisodeCard extends StatefulWidget {
   final AggregatedItem episode;
   final ImageApi imageApi;
+  final VoidCallback? onChanged;
 
-  const _EpisodeCard({required this.episode, required this.imageApi});
+  const _EpisodeCard({
+    required this.episode,
+    required this.imageApi,
+    this.onChanged,
+  });
 
   @override
   State<_EpisodeCard> createState() => _EpisodeCardState();
 }
 
 class _EpisodeCardState extends State<_EpisodeCard> with FocusStateMixin {
+  final _selectKeyHandler = LongPressSelectKeyHandler();
+
+  @override
+  void dispose() {
+    _selectKeyHandler.dispose();
+    super.dispose();
+  }
+
+  void _handleLongPress() {
+    showContextMenu(
+      context,
+      widget.episode,
+      onChanged: widget.onChanged,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final episode = widget.episode;
@@ -9396,11 +9489,15 @@ class _EpisodeCardState extends State<_EpisodeCard> with FocusStateMixin {
       child: Focus(
         onFocusChange: (focused) => setFocused(focused),
         onKeyEvent: (_, event) {
-          if (isActivateKey(event)) {
-            context.push(
+          final handlerResult = _selectKeyHandler.handleKeyEvent(
+            event,
+            onTap: () => context.push(
               Destinations.item(episode.id, serverId: episode.serverId),
-            );
-            return KeyEventResult.handled;
+            ),
+            onLongPress: _handleLongPress,
+          );
+          if (handlerResult != KeyEventResult.ignored) {
+            return handlerResult;
           }
           return KeyEventResult.ignored;
         },
@@ -9408,6 +9505,8 @@ class _EpisodeCardState extends State<_EpisodeCard> with FocusStateMixin {
           onTap: () => context.push(
             Destinations.item(episode.id, serverId: episode.serverId),
           ),
+          onLongPress: _handleLongPress,
+          onSecondaryTap: _handleLongPress,
           child: AnimatedScale(
             scale: cardExpansion && showFocusBorder ? 1.02 : 1.0,
             duration: const Duration(milliseconds: 120),
@@ -9995,6 +10094,7 @@ class _FilmographyRow extends StatelessWidget {
   final ScrollController? scrollController;
   final FocusNode? firstFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
+  final void Function(AggregatedItem item)? onItemLongPress;
 
   const _FilmographyRow({
     required this.items,
@@ -10003,6 +10103,7 @@ class _FilmographyRow extends StatelessWidget {
     this.scrollController,
     this.firstFocusNode,
     this.onItemKeyEvent,
+    this.onItemLongPress,
   });
 
   @override
@@ -10086,6 +10187,9 @@ class _FilmographyRow extends StatelessWidget {
             onKeyEvent: onItemKeyEvent == null
                 ? null
                 : (_, event) => onItemKeyEvent!(index, event),
+            onLongPress: onItemLongPress != null
+                ? () => onItemLongPress!(item)
+                : null,
             onTap: () => context.push(
               Destinations.item(item.id, serverId: item.serverId),
             ),
@@ -10555,6 +10659,7 @@ class _AlbumsRow extends StatelessWidget {
   final ScrollController? scrollController;
   final FocusNode? firstItemFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
+  final void Function(AggregatedItem item)? onItemLongPress;
 
   const _AlbumsRow({
     required this.albums,
@@ -10563,6 +10668,7 @@ class _AlbumsRow extends StatelessWidget {
     this.scrollController,
     this.firstItemFocusNode,
     this.onItemKeyEvent,
+    this.onItemLongPress,
   });
 
   @override
@@ -10603,6 +10709,9 @@ class _AlbumsRow extends StatelessWidget {
             onKeyEvent: onItemKeyEvent == null
                 ? null
                 : (_, event) => onItemKeyEvent!(index, event),
+            onLongPress: onItemLongPress != null
+                ? () => onItemLongPress!(album)
+                : null,
             onTap: () => context.push(
               Destinations.item(album.id, serverId: album.serverId),
             ),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2909,6 +2909,11 @@ class _ContentRowsState extends State<_ContentRows>
         ),
         onLeftEdge: _onRowLeftEdge,
         onTap: (_, item) => _navigateToLibrary(context, item),
+        onLongPress: (_, item) => showContextMenu(
+          context,
+          item,
+          onChanged: () => setState(() {}),
+        ),
         itemBuilder: (ctx, item, idx, isFocused) {
           final collectionType =
               (item.rawData['CollectionType'] as String? ?? '').toLowerCase();
@@ -2926,6 +2931,16 @@ class _ContentRowsState extends State<_ContentRows>
                 cardFocusExpansion: cardExpansion,
                 externalIsFocused: isFocused,
                 onTap: () => _navigateToLibrary(context, item),
+                onLongPress: () => showContextMenu(
+                  context,
+                  item,
+                  onChanged: () => setState(() {}),
+                ),
+                onSecondaryTap: () => showContextMenu(
+                  context,
+                  item,
+                  onChanged: () => setState(() {}),
+                ),
               ),
             ),
           );

--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -25,6 +25,7 @@ import '../../util/search_group_title_localizer.dart';
 import '../../widgets/library_row.dart';
 import '../../widgets/media_card.dart';
 import '../../widgets/navigation_layout.dart';
+import '../../widgets/focus/context_menu_sheet.dart';
 
 class SearchScreen extends StatefulWidget {
   final String? initialQuery;
@@ -1067,6 +1068,13 @@ class _SearchScreenState extends State<SearchScreen> {
                       serverId: item.serverId,
                       type: item.type,
                     ),
+                  ),
+                  onLongPress: () => showContextMenu(
+                    context,
+                    item,
+                    onChanged: () {
+                      if (mounted) setState(() {});
+                    },
                   ),
                 );
               }).toList(),

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -1,0 +1,2286 @@
+import 'dart:io';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:server_core/server_core.dart';
+
+import '../../data/models/aggregated_item.dart';
+import '../../l10n/app_localizations.dart';
+import '../../util/focus/key_event_utils.dart';
+import '../../util/platform_detection.dart';
+import 'focus/focusable_wrapper.dart';
+import 'overlay_sheet.dart';
+
+class ImageDimensions {
+  final double width;
+  final double height;
+  const ImageDimensions(this.width, this.height);
+  double get aspectRatio => width / height;
+}
+
+class ChangeArtworkDialog extends StatefulWidget {
+  final AggregatedItem item;
+
+  const ChangeArtworkDialog({super.key, required this.item});
+
+  static Future<bool?> show(
+    BuildContext context, {
+    required AggregatedItem item,
+  }) {
+    return showFocusRestoringDialog<bool>(
+      context: context,
+      builder: (_) => ChangeArtworkDialog(item: item),
+    );
+  }
+
+  @override
+  State<ChangeArtworkDialog> createState() => _ChangeArtworkDialogState();
+}
+
+class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
+  late AggregatedItem _item;
+  late List<String> _supportedCategories;
+  final Map<String, List<Map<String, dynamic>>> _remoteImages = {};
+  final Map<String, bool> _loadingCategories = {};
+  final Map<String, String?> _categoryErrors = {};
+  final Set<String> _actionInProgress = {};
+  bool _hasChanged = false;
+
+  final Set<String> _deselectedSources = {};
+  bool _onlyShowInterfaceLanguage = true;
+  String _selectedResolution = 'All';
+  String? _focusedCategory;
+
+  final List<AggregatedItem> _history = [];
+  int _historyIndex = -1;
+
+  final FocusNode _clearAllFocusNode = FocusNode();
+  final FocusNode _sourcesFocusNode = FocusNode();
+  final FocusNode _languageFocusNode = FocusNode();
+  final FocusNode _historyBackFocusNode = FocusNode();
+  final FocusNode _historyForwardFocusNode = FocusNode();
+  final FocusNode _closeFocusNode = FocusNode();
+  final FocusNode _seriesFocusNode = FocusNode();
+  final FocusNode _seasonFocusNode = FocusNode();
+
+  bool get _isLibraryFolder =>
+      _item.type?.toLowerCase() == 'collectionfolder' ||
+      _item.type?.toLowerCase() == 'userview' ||
+      _item.type?.toLowerCase() == 'folder';
+
+  final Map<String, ScrollController> _scrollControllers = {};
+  final Map<String, FocusNode> _headerFocusNodes = {};
+  final Map<String, FocusNode> _firstCardFocusNodes = {};
+
+  ScrollController _getScrollController(String category) {
+    return _scrollControllers.putIfAbsent(category, () => ScrollController());
+  }
+
+  FocusNode _getHeaderFocusNode(String category) {
+    return _headerFocusNodes.putIfAbsent(category, () => FocusNode());
+  }
+
+  FocusNode _getFirstCardFocusNode(String category) {
+    return _firstCardFocusNodes.putIfAbsent(category, () => FocusNode());
+  }
+
+  void _scrollRow(String category, {required bool forward}) {
+    final controller = _getScrollController(category);
+    if (!controller.hasClients) return;
+    final double offset = controller.offset;
+    final double maxScrollExtent = controller.position.maxScrollExtent;
+    const double scrollAmount = 300.0;
+    final double targetOffset = forward
+        ? (offset + scrollAmount).clamp(0.0, maxScrollExtent)
+        : (offset - scrollAmount).clamp(0.0, maxScrollExtent);
+    controller.animateTo(
+      targetOffset,
+      duration: const Duration(milliseconds: 350),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _focusFirstItem() {
+    if (_supportedCategories.isNotEmpty) {
+      final firstCategory = _supportedCategories[0];
+      final node = _getFirstCardFocusNode(firstCategory);
+      node.requestFocus();
+    }
+  }
+
+  void _resetScroll(String category) {
+    final controller = _getScrollController(category);
+    if (controller.hasClients && controller.offset > 0) {
+      controller.jumpTo(0.0);
+    }
+  }
+
+  void _handleNavigateDownFromHeader(String category) {
+    _resetScroll(category);
+    final focusNode = _getFirstCardFocusNode(category);
+    focusNode.requestFocus();
+  }
+
+  void _handleNavigateUpFromHeader(String category) {
+    final index = _supportedCategories.indexOf(category);
+    if (index > 0) {
+      final prevCategory = _supportedCategories[index - 1];
+      _resetScroll(prevCategory);
+      final focusNode = _getFirstCardFocusNode(prevCategory);
+      focusNode.requestFocus();
+    } else {
+      _getFirstFilterFocusNode().requestFocus();
+    }
+  }
+
+  void _handleNavigateUpFromCard(String category) {
+    if (_focusedCategory != null) return;
+    final focusNode = _getHeaderFocusNode(category);
+    focusNode.requestFocus();
+    _resetScroll(category);
+  }
+
+  void _handleNavigateDownFromCard(String category) {
+    if (_focusedCategory != null) return;
+    final index = _supportedCategories.indexOf(category);
+    if (index < _supportedCategories.length - 1) {
+      final nextCategory = _supportedCategories[index + 1];
+      final focusNode = _getHeaderFocusNode(nextCategory);
+      focusNode.requestFocus();
+      _resetScroll(category);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _item = widget.item;
+    _history.add(_item);
+    _historyIndex = 0;
+    _supportedCategories = _getSupportedImageTypes(_item.type);
+    for (final category in _supportedCategories) {
+      _fetchRemoteImages(category);
+    }
+    _refreshItemMetadata();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusFirstItem();
+    });
+  }
+
+  @override
+  void dispose() {
+    _clearAllFocusNode.dispose();
+    _sourcesFocusNode.dispose();
+    _languageFocusNode.dispose();
+    _historyBackFocusNode.dispose();
+    _historyForwardFocusNode.dispose();
+    _closeFocusNode.dispose();
+    _seriesFocusNode.dispose();
+    _seasonFocusNode.dispose();
+    for (final controller in _scrollControllers.values) {
+      controller.dispose();
+    }
+    for (final node in _headerFocusNodes.values) {
+      node.dispose();
+    }
+    for (final node in _firstCardFocusNodes.values) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> _refreshItemMetadata() async {
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      final updatedRaw = await client.itemsApi.getItem(_item.id);
+      if (mounted) {
+        setState(() {
+          _item = AggregatedItem(
+            id: _item.id,
+            serverId: _item.serverId,
+            rawData: updatedRaw,
+          );
+          if (_historyIndex >= 0 && _historyIndex < _history.length) {
+            _history[_historyIndex] = _item;
+          }
+        });
+      }
+    } catch (e) {
+      debugPrint('Failed to refresh item metadata: $e');
+    }
+  }
+
+  Future<void> _navigateToItem(String itemId) async {
+    setState(() {
+      _focusedCategory = null;
+    });
+
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      final updatedRaw = await client.itemsApi.getItem(itemId);
+      final newItem = AggregatedItem(
+        id: itemId,
+        serverId: _item.serverId,
+        rawData: updatedRaw,
+      );
+
+      if (_historyIndex < _history.length - 1) {
+        _history.removeRange(_historyIndex + 1, _history.length);
+      }
+
+      _history.add(newItem);
+      _historyIndex = _history.length - 1;
+
+      if (!mounted) return;
+      _loadItem(newItem);
+    } catch (e) {
+      debugPrint('Failed to load item: $e');
+    }
+  }
+
+  void _loadItem(AggregatedItem item) {
+    setState(() {
+      _item = item;
+      _supportedCategories = _getSupportedImageTypes(_item.type);
+      _remoteImages.clear();
+      _loadingCategories.clear();
+      _categoryErrors.clear();
+    });
+
+    for (final category in _supportedCategories) {
+      _fetchRemoteImages(category);
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusFirstItem();
+    });
+  }
+
+  void _goBack() {
+    if (_historyIndex > 0) {
+      setState(() {
+        _historyIndex--;
+        _focusedCategory = null;
+        _loadItem(_history[_historyIndex]);
+      });
+    }
+  }
+
+  void _goForward() {
+    if (_historyIndex < _history.length - 1) {
+      setState(() {
+        _historyIndex++;
+        _focusedCategory = null;
+        _loadItem(_history[_historyIndex]);
+      });
+    }
+  }
+
+  Set<String> get _availableSources {
+    final sources = <String>{};
+    for (final list in _remoteImages.values) {
+      for (final img in list) {
+        final provider = img['ProviderName'] as String?;
+        if (provider != null && provider.isNotEmpty) {
+          sources.add(provider);
+        }
+      }
+    }
+    return sources;
+  }
+
+  bool _shouldShowImageByLanguage(Map<String, dynamic> remoteImage, String interfaceLang) {
+    if (!_onlyShowInterfaceLanguage) return true;
+    final imgLang = (remoteImage['Language'] as String?)?.toLowerCase();
+    if (imgLang == null || imgLang.isEmpty) return true;
+    return imgLang == interfaceLang || imgLang == 'all' || imgLang == 'none' || imgLang == 'mul';
+  }
+
+  List<String> _getSupportedImageTypes(String? itemType) {
+    final type = itemType?.toLowerCase();
+    switch (type) {
+      case 'movie':
+        return const ['Primary', 'Backdrop', 'Banner', 'Logo', 'Thumb', 'Art', 'Disc'];
+      case 'series':
+        return const ['Primary', 'Backdrop', 'Banner', 'Logo', 'Thumb', 'Art'];
+      case 'season':
+        return const ['Primary', 'Backdrop', 'Banner'];
+      case 'episode':
+        return const ['Primary'];
+      case 'musicvideo':
+        return const ['Primary', 'Backdrop', 'Banner', 'Logo', 'Thumb'];
+      case 'trailer':
+        return const ['Primary', 'Backdrop', 'Thumb'];
+      case 'boxset':
+        return const ['Primary', 'Backdrop', 'Banner', 'Logo', 'Thumb'];
+      case 'playlist':
+        return const ['Primary', 'Backdrop'];
+      case 'musicartist':
+        return const ['Primary', 'Backdrop', 'Banner', 'Logo'];
+      case 'musicalbum':
+        return const ['Primary', 'Backdrop', 'Disc'];
+      case 'audio':
+        return const ['Primary'];
+      case 'book':
+      case 'audiobook':
+        return const ['Primary'];
+      case 'folder':
+      case 'collectionfolder':
+      case 'userview':
+        return const ['Primary', 'Backdrop', 'Thumb'];
+      default:
+        return const ['Primary', 'Backdrop'];
+    }
+  }
+
+  String _getCategoryDisplayName(String category, AppLocalizations l10n) {
+    switch (category) {
+      case 'Primary':
+        return _item.type?.toLowerCase() == 'episode' ? l10n.thumbnailCategory : l10n.posterCategory;
+      case 'Backdrop':
+        return l10n.backdropsCategory;
+      case 'Banner':
+        return l10n.bannerCategory;
+      case 'Logo':
+        return l10n.logoCategory;
+      case 'Thumb':
+        return l10n.thumbnailCategory;
+      case 'Art':
+        return l10n.artCategory;
+      case 'Disc':
+        return l10n.discArtCategory;
+      case 'Screenshot':
+        return l10n.screenshotCategory;
+      case 'Box':
+        return l10n.boxCoverCategory;
+      case 'BoxRear':
+        return l10n.boxRearCoverCategory;
+      case 'Menu':
+        return l10n.menuArtCategory;
+      default:
+        return category;
+    }
+  }
+
+  String _getConfirmItemName(String category, AppLocalizations l10n) {
+    switch (category) {
+      case 'Primary':
+        return _item.type?.toLowerCase() == 'episode' ? l10n.confirmItemThumbnail : l10n.confirmItemPoster;
+      case 'Backdrop':
+        return l10n.confirmItemBackdrop;
+      case 'Banner':
+        return l10n.confirmItemBanner;
+      case 'Logo':
+        return l10n.confirmItemLogo;
+      case 'Thumb':
+        return l10n.confirmItemThumbnail;
+      case 'Art':
+        return l10n.confirmItemArt;
+      case 'Disc':
+        return l10n.confirmItemDiscArt;
+      case 'Screenshot':
+        return l10n.confirmItemScreenshot;
+      case 'Box':
+        return l10n.confirmItemBoxCover;
+      case 'BoxRear':
+        return l10n.confirmItemBoxRearCover;
+      case 'Menu':
+        return l10n.confirmItemMenuArt;
+      default:
+        return category.toLowerCase();
+    }
+  }
+
+  String _getResolutionDisplayName(String resolution, AppLocalizations l10n) {
+    switch (resolution) {
+      case 'All':
+        return l10n.resolutionAll;
+      case 'High (1080p+)':
+        return l10n.resolutionHigh;
+      case 'Medium (720p)':
+        return l10n.resolutionMedium;
+      case 'Low (<720p)':
+        return l10n.resolutionLow;
+      default:
+        return resolution;
+    }
+  }
+
+  ImageDimensions _getImageDimensions(String category) {
+    if (category == 'Primary' && _item.type?.toLowerCase() == 'episode') {
+      return const ImageDimensions(200, 112.5); // 16:9 for episode primary images
+    }
+    switch (category) {
+      case 'Primary':
+        return const ImageDimensions(100, 150);
+      case 'Backdrop':
+      case 'Thumb':
+      case 'Thumbnail':
+      case 'Screenshot':
+        return const ImageDimensions(200, 112.5); // 16:9
+      case 'Banner':
+        return const ImageDimensions(240, 48); // 5:1
+      case 'Logo':
+      case 'Art':
+        return const ImageDimensions(160, 64); // ~2.5:1
+      case 'Disc':
+        return const ImageDimensions(120, 120); // 1:1
+      default:
+        return const ImageDimensions(100, 150);
+    }
+  }
+
+  List<String> _getCurrentTags(String category) {
+    if (category == 'Backdrop') {
+      return _item.backdropImageTags;
+    }
+    final tag = (_item.rawData['ImageTags'] as Map?)?[category] as String?;
+    return tag != null ? [tag] : [];
+  }
+
+  String _getCurrentImageUrl(String category, String tag, {int? imageIndex}) {
+    final client = GetIt.instance<MediaServerClient>();
+    final indexParam = imageIndex != null ? '&imageIndex=$imageIndex' : '';
+    return '${client.baseUrl}/Items/${_item.id}/Images/$category?tag=$tag&maxWidth=300$indexParam';
+  }
+
+  Future<void> _fetchRemoteImages(String category) async {
+    if (!mounted) return;
+    setState(() {
+      _loadingCategories[category] = true;
+      _categoryErrors[category] = null;
+    });
+
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      final result = await client.adminItemsApi.getRemoteImages(
+        _item.id,
+        imageType: ImageType.fromServerString(category),
+        includeAllLanguages: true,
+      );
+      final list = result['Images'] as List? ?? [];
+      if (mounted) {
+        setState(() {
+          _remoteImages[category] = list.cast<Map<String, dynamic>>();
+          _loadingCategories[category] = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _categoryErrors[category] = e.toString();
+          _loadingCategories[category] = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _downloadImage(String category, Map<String, dynamic> remoteImage) async {
+    final l10n = AppLocalizations.of(context);
+    final url = remoteImage['Url'] as String?;
+    if (url == null || url.isEmpty) return;
+
+    setState(() {
+      _actionInProgress.add(category);
+    });
+
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      await client.adminItemsApi.downloadRemoteImage(
+        _item.id,
+        imageType: ImageType.fromServerString(category),
+        imageUrl: url,
+      );
+
+      final updatedRaw = await client.itemsApi.getItem(_item.id);
+      if (mounted) {
+        setState(() {
+          _item = AggregatedItem(
+            id: _item.id,
+            serverId: _item.serverId,
+            rawData: updatedRaw,
+          );
+          if (_historyIndex >= 0 && _historyIndex < _history.length) {
+            _history[_historyIndex] = _item;
+          }
+          _hasChanged = true;
+          _actionInProgress.remove(category);
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _actionInProgress.remove(category);
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.imageDownloadFailed(e.toString()))),
+        );
+      }
+    }
+  }
+
+  Future<bool> _showConfirmClear(String category) async {
+    final l10n = AppLocalizations.of(context);
+    final cleanDisplayName = _getConfirmItemName(category, l10n);
+    final message = l10n.confirmClearMessage(cleanDisplayName);
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColorScheme.surface,
+        title: Text(l10n.confirmClear),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(l10n.no),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(l10n.yes, style: const TextStyle(color: Colors.redAccent)),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  Future<void> _deleteImage(String category, {int? imageIndex}) async {
+    final confirm = await _showConfirmClear(category);
+    if (!confirm) return;
+
+    setState(() {
+      _actionInProgress.add(category);
+    });
+
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      await client.adminItemsApi.deleteItemImage(
+        _item.id,
+        imageType: ImageType.fromServerString(category),
+        imageIndex: imageIndex,
+      );
+
+      final updatedRaw = await client.itemsApi.getItem(_item.id);
+      if (mounted) {
+        setState(() {
+          _item = AggregatedItem(
+            id: _item.id,
+            serverId: _item.serverId,
+            rawData: updatedRaw,
+          );
+          if (_historyIndex >= 0 && _historyIndex < _history.length) {
+            _history[_historyIndex] = _item;
+          }
+          _hasChanged = true;
+          _actionInProgress.remove(category);
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _actionInProgress.remove(category);
+        });
+        final l10n = AppLocalizations.of(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.imageDeleteFailed(e.toString()))),
+        );
+      }
+    }
+  }
+
+  Future<void> _clearAllArtwork() async {
+    final l10n = AppLocalizations.of(context);
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColorScheme.surface,
+        title: Text(l10n.confirmClearAll),
+        content: Text(l10n.clearAllArtworkWarning),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(l10n.no),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(l10n.yes, style: const TextStyle(color: Colors.redAccent)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm != true) return;
+
+    setState(() {
+      _actionInProgress.addAll(_supportedCategories);
+    });
+
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      for (final category in _supportedCategories) {
+        final tags = _getCurrentTags(category);
+        if (tags.isEmpty) continue;
+
+        if (category == 'Backdrop') {
+          for (int i = tags.length - 1; i >= 0; i--) {
+            await client.adminItemsApi.deleteItemImage(
+              _item.id,
+              imageType: ImageType.backdrop,
+              imageIndex: i,
+            );
+          }
+        } else {
+          await client.adminItemsApi.deleteItemImage(
+            _item.id,
+            imageType: ImageType.fromServerString(category),
+            imageIndex: null,
+          );
+        }
+      }
+
+      final updatedRaw = await client.itemsApi.getItem(_item.id);
+      if (mounted) {
+        setState(() {
+          _item = AggregatedItem(
+            id: _item.id,
+            serverId: _item.serverId,
+            rawData: updatedRaw,
+          );
+          if (_historyIndex >= 0 && _historyIndex < _history.length) {
+            _history[_historyIndex] = _item;
+          }
+          _hasChanged = true;
+          _actionInProgress.clear();
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _actionInProgress.clear();
+        });
+        final l10n = AppLocalizations.of(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.clearAllArtworkFailed(e.toString()))),
+        );
+      }
+    }
+  }
+
+  Future<void> _uploadLocalImage(String category) async {
+    final l10n = AppLocalizations.of(context);
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.image,
+        withData: true,
+      );
+
+      if (result == null || result.files.isEmpty) return;
+
+      final file = result.files.first;
+      var fileBytes = file.bytes;
+
+      if (fileBytes == null && file.path != null) {
+        fileBytes = await File(file.path!).readAsBytes();
+      }
+
+      if (fileBytes == null) {
+        throw 'Could not read file bytes';
+      }
+
+      setState(() {
+        _actionInProgress.add(category);
+      });
+
+      final extension = file.extension?.toLowerCase() ?? 'jpg';
+      final mimeType = extension == 'png' ? 'image/png' : (extension == 'webp' ? 'image/webp' : 'image/jpeg');
+
+      final client = GetIt.instance<MediaServerClient>();
+      await client.adminItemsApi.uploadItemImage(
+        _item.id,
+        imageType: ImageType.fromServerString(category),
+        bytes: fileBytes,
+        contentType: mimeType,
+      );
+
+      if (mounted) {
+        _fetchRemoteImages(category);
+        setState(() {
+          _hasChanged = true;
+          _actionInProgress.remove(category);
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.imageUploadSuccess)),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _actionInProgress.remove(category);
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.imageUploadFailed(e.toString()))),
+        );
+      }
+    }
+  }
+
+  Widget _buildPathTitle(ThemeData theme) {
+    final seriesName = _item.rawData['SeriesName'] as String?;
+    final seriesId = _item.rawData['SeriesId'] as String?;
+    final seasonName = _item.rawData['SeasonName'] as String?;
+    final seasonId = _item.rawData['SeasonId'] as String?;
+
+    final textStyle = theme.textTheme.bodyMedium?.copyWith(
+      color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+    );
+
+    final linkStyle = theme.textTheme.bodyMedium?.copyWith(
+      color: AppColorScheme.accent,
+      fontWeight: FontWeight.bold,
+      decoration: TextDecoration.underline,
+    );
+
+    final parts = <Widget>[];
+
+    if (_item.type?.toLowerCase() == 'episode') {
+      final hasSeries = seriesName != null && seriesName.isNotEmpty;
+      final hasSeason = seasonName != null && seasonName.isNotEmpty;
+
+      if (hasSeries) {
+        parts.add(
+          _buildLink(
+            seriesName,
+            seriesId,
+            linkStyle,
+            textStyle,
+            focusNode: _seriesFocusNode,
+            onNavigateDown: () => _getFirstFilterFocusNode().requestFocus(),
+            onNavigateRight: () {
+              if (hasSeason) {
+                _seasonFocusNode.requestFocus();
+              } else {
+                _historyBackFocusNode.requestFocus();
+              }
+            },
+            onNavigateUp: () => _historyBackFocusNode.requestFocus(),
+            onNavigateLeft: () {},
+          ),
+        );
+        parts.add(Text(' \\ ', style: textStyle));
+      }
+      if (hasSeason) {
+        parts.add(
+          _buildLink(
+            seasonName,
+            seasonId,
+            linkStyle,
+            textStyle,
+            focusNode: _seasonFocusNode,
+            onNavigateDown: () => _getFirstFilterFocusNode().requestFocus(),
+            onNavigateLeft: () {
+              if (hasSeries) {
+                _seriesFocusNode.requestFocus();
+              }
+            },
+            onNavigateRight: () => _historyBackFocusNode.requestFocus(),
+            onNavigateUp: () => _historyBackFocusNode.requestFocus(),
+          ),
+        );
+        parts.add(Text(' \\ ', style: textStyle));
+      }
+      parts.add(
+        Text(
+          _item.name,
+          style: textStyle,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      );
+    } else if (_item.type?.toLowerCase() == 'season') {
+      final hasSeries = seriesName != null && seriesName.isNotEmpty;
+
+      if (hasSeries) {
+        parts.add(
+          _buildLink(
+            seriesName,
+            seriesId,
+            linkStyle,
+            textStyle,
+            focusNode: _seriesFocusNode,
+            onNavigateDown: () => _getFirstFilterFocusNode().requestFocus(),
+            onNavigateRight: () => _historyBackFocusNode.requestFocus(),
+            onNavigateUp: () => _historyBackFocusNode.requestFocus(),
+            onNavigateLeft: () {},
+          ),
+        );
+        parts.add(Text(' \\ ', style: textStyle));
+      }
+      parts.add(
+        Text(
+          _item.name,
+          style: textStyle,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      );
+    } else {
+      parts.add(
+        Text(
+          _item.name,
+          style: textStyle,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      );
+    }
+
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: parts,
+    );
+  }
+
+  Widget _buildLink(
+    String label,
+    String? targetId,
+    TextStyle? activeStyle,
+    TextStyle? inactiveStyle, {
+    FocusNode? focusNode,
+    VoidCallback? onNavigateLeft,
+    VoidCallback? onNavigateRight,
+    VoidCallback? onNavigateUp,
+    VoidCallback? onNavigateDown,
+  }) {
+    if (targetId == null || targetId.isEmpty) {
+      return Text(label, style: inactiveStyle);
+    }
+    return FocusableWrapper(
+      focusNode: focusNode,
+      borderRadius: 4,
+      disableScale: true,
+      useBackgroundFocus: true,
+      focusColor: AppColorScheme.accent,
+      suppressFocusGlow: true,
+      onSelect: () => _navigateToItem(targetId),
+      onNavigateLeft: onNavigateLeft,
+      onNavigateRight: onNavigateRight,
+      onNavigateUp: onNavigateUp,
+      onNavigateDown: onNavigateDown,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+        child: Text(label, style: activeStyle),
+      ),
+    );
+  }
+
+  FocusNode _getFirstFilterFocusNode() {
+    final sources = _availableSources;
+    if (sources.isNotEmpty) {
+      return _sourcesFocusNode;
+    }
+    if (!_isLibraryFolder) {
+      return _languageFocusNode;
+    }
+    return _clearAllFocusNode;
+  }
+
+  void _handleNavigateUpFromFilters() {
+    final seriesName = _item.rawData['SeriesName'] as String?;
+    final seasonName = _item.rawData['SeasonName'] as String?;
+    if (_item.type?.toLowerCase() == 'episode') {
+      if (seriesName != null && seriesName.isNotEmpty) {
+        _seriesFocusNode.requestFocus();
+      } else if (seasonName != null && seasonName.isNotEmpty) {
+        _seasonFocusNode.requestFocus();
+      } else {
+        _historyBackFocusNode.requestFocus();
+      }
+    } else if (_item.type?.toLowerCase() == 'season') {
+      if (seriesName != null && seriesName.isNotEmpty) {
+        _seriesFocusNode.requestFocus();
+      } else {
+        _historyBackFocusNode.requestFocus();
+      }
+    } else {
+      _historyBackFocusNode.requestFocus();
+    }
+  }
+
+  void _handleNavigateDownFromFilters() {
+    if (_supportedCategories.isNotEmpty) {
+      _getHeaderFocusNode(_supportedCategories[0]).requestFocus();
+    }
+  }
+
+  void _showSourcesDialog() {
+    final l10n = AppLocalizations.of(context);
+    final sources = _availableSources.toList()..sort();
+    
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              backgroundColor: AppColorScheme.surface,
+              title: Text(l10n.sources),
+              content: SizedBox(
+                width: 300,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: sources.length,
+                  itemBuilder: (context, index) {
+                    final src = sources[index];
+                    final isSelected = !_deselectedSources.contains(src);
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: FocusableWrapper(
+                        borderRadius: 8,
+                        autofocus: index == 0,
+                        suppressFocusGlow: true,
+                        onSelect: () {
+                          setState(() {
+                            if (isSelected) {
+                              _deselectedSources.add(src);
+                            } else {
+                              _deselectedSources.remove(src);
+                            }
+                          });
+                          setDialogState(() {});
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          child: Row(
+                            children: [
+                              IgnorePointer(
+                                child: Checkbox(
+                                  value: isSelected,
+                                  onChanged: (val) {},
+                                  activeColor: AppColorScheme.accent,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  src,
+                                  style: const TextStyle(fontSize: 14, color: Colors.white),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              actions: [
+                FocusableWrapper(
+                  borderRadius: 8,
+                  suppressFocusGlow: true,
+                  onSelect: () => Navigator.pop(dialogContext),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: Text(
+                      l10n.cancel,
+                      style: TextStyle(color: AppColorScheme.accent, fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      child: Container(
+        clipBehavior: Clip.antiAlias,
+        constraints: BoxConstraints(
+          minWidth: PlatformDetection.isTV ? 450 : 280,
+          maxWidth: PlatformDetection.isTV
+              ? (MediaQuery.of(context).size.width * 0.95).clamp(800.0, 1100.0)
+              : (MediaQuery.of(context).size.width * 0.95).clamp(280.0, 850.0),
+          maxHeight: PlatformDetection.isTV
+              ? (MediaQuery.of(context).size.height * 0.85).clamp(550.0, 850.0)
+              : (MediaQuery.of(context).size.height * 0.9).clamp(320.0, 650.0),
+        ),
+        decoration: BoxDecoration(
+          color: AppColorScheme.surface.withValues(alpha: 0.95),
+          borderRadius: BorderRadius.circular(24),
+          border: Border.fromBorderSide(ThemeRegistry.active.borders.chipBorder),
+        ),
+        padding: EdgeInsets.symmetric(
+          vertical: PlatformDetection.isTV ? 24 : 16,
+          horizontal: PlatformDetection.isTV ? 24 : 16,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        l10n.changeArtwork,
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      _buildPathTitle(theme),
+                    ],
+                  ),
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    FocusableWrapper(
+                      focusNode: _historyBackFocusNode,
+                      disableScale: true,
+                      borderRadius: 8,
+                      suppressFocusGlow: true,
+                      onSelect: _historyIndex > 0 ? _goBack : null,
+                      onNavigateDown: () => _getFirstFilterFocusNode().requestFocus(),
+                      onNavigateLeft: () {
+                        final seriesName = _item.rawData['SeriesName'] as String?;
+                        final seasonName = _item.rawData['SeasonName'] as String?;
+                        if (_item.type?.toLowerCase() == 'episode') {
+                          if (seasonName != null && seasonName.isNotEmpty) {
+                            _seasonFocusNode.requestFocus();
+                          } else if (seriesName != null && seriesName.isNotEmpty) {
+                            _seriesFocusNode.requestFocus();
+                          }
+                        } else if (_item.type?.toLowerCase() == 'season') {
+                          if (seriesName != null && seriesName.isNotEmpty) {
+                            _seriesFocusNode.requestFocus();
+                          }
+                        }
+                      },
+                      onNavigateRight: () => _historyForwardFocusNode.requestFocus(),
+                      child: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: Icon(
+                          Icons.chevron_left,
+                          color: _historyIndex > 0 ? Colors.white : Colors.white24,
+                        ),
+                      ),
+                    ),
+                    FocusableWrapper(
+                      focusNode: _historyForwardFocusNode,
+                      disableScale: true,
+                      borderRadius: 8,
+                      suppressFocusGlow: true,
+                      onSelect: _historyIndex < _history.length - 1 ? _goForward : null,
+                      onNavigateDown: () => _getFirstFilterFocusNode().requestFocus(),
+                      onNavigateLeft: () => _historyBackFocusNode.requestFocus(),
+                      onNavigateRight: () => _closeFocusNode.requestFocus(),
+                      child: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: Icon(
+                          Icons.chevron_right,
+                          color: _historyIndex < _history.length - 1 ? Colors.white : Colors.white24,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    FocusableWrapper(
+                      focusNode: _closeFocusNode,
+                      disableScale: true,
+                      borderRadius: 8,
+                      suppressFocusGlow: true,
+                      onSelect: () => Navigator.pop(context, _hasChanged),
+                      onNavigateDown: () => _getFirstFilterFocusNode().requestFocus(),
+                      onNavigateLeft: () => _historyForwardFocusNode.requestFocus(),
+                      onNavigateRight: () {}, // Block focus leaving to the right
+                      child: Padding(
+                        padding: const EdgeInsets.all(8),
+                        child: const Icon(Icons.close),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _buildFilters(),
+            const SizedBox(height: 16),
+            const Divider(height: 1, thickness: 1, color: Colors.white10),
+            const SizedBox(height: 8),
+            Expanded(
+              child: _focusedCategory == null
+                  ? SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: _supportedCategories
+                            .map((category) => _buildCategorySection(category))
+                            .toList(),
+                      ),
+                    )
+                  : _buildCategoryGridView(_focusedCategory!),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSourcesFilterButton(Set<String> sources) {
+    return FocusableWrapper(
+      focusNode: _sourcesFocusNode,
+      onSelect: _showSourcesDialog,
+      borderRadius: 8,
+      suppressFocusGlow: true,
+      onNavigateLeft: () {}, // Block focus leaving to the left
+      onNavigateRight: () {
+        if (!_isLibraryFolder) {
+          _languageFocusNode.requestFocus();
+        } else {
+          _clearAllFocusNode.requestFocus();
+        }
+      },
+      onNavigateUp: _handleNavigateUpFromFilters,
+      onNavigateDown: _handleNavigateDownFromFilters,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.filter_list,
+              color: Colors.white,
+              size: 18,
+            ),
+            const SizedBox(width: 6),
+            const Text(
+              'Sources',
+              style: TextStyle(
+                fontSize: 13,
+                color: Colors.white,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLanguageFilterCheckbox(AppLocalizations l10n, Set<String> sources) {
+    return FocusableWrapper(
+      focusNode: _languageFocusNode,
+      onSelect: () {
+        setState(() {
+          _onlyShowInterfaceLanguage = !_onlyShowInterfaceLanguage;
+        });
+      },
+      borderRadius: 8,
+      suppressFocusGlow: true,
+      onNavigateLeft: () {
+        if (sources.isNotEmpty) {
+          _sourcesFocusNode.requestFocus();
+        }
+      },
+      onNavigateRight: () => _clearAllFocusNode.requestFocus(),
+      onNavigateUp: _handleNavigateUpFromFilters,
+      onNavigateDown: _handleNavigateDownFromFilters,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IgnorePointer(
+              child: Checkbox(
+                value: _onlyShowInterfaceLanguage,
+                onChanged: (val) {},
+                activeColor: AppColorScheme.accent,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              l10n.onlyShowInterfaceLanguage,
+              style: const TextStyle(fontSize: 13, color: Colors.white70),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildClearAllArtworkButton(AppLocalizations l10n, Set<String> sources) {
+    return FocusableWrapper(
+      key: const ValueKey('clear_all_artwork_button'),
+      focusNode: _clearAllFocusNode,
+      onSelect: _clearAllArtwork,
+      borderRadius: 8,
+      suppressFocusGlow: true,
+      onNavigateLeft: () {
+        if (!_isLibraryFolder) {
+          _languageFocusNode.requestFocus();
+        } else if (sources.isNotEmpty) {
+          _sourcesFocusNode.requestFocus();
+        }
+      },
+      onNavigateRight: () {}, // Block focus leaving to the right
+      onNavigateUp: _handleNavigateUpFromFilters,
+      onNavigateDown: _handleNavigateDownFromFilters,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.delete_outline,
+              color: Colors.redAccent,
+              size: 18,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              l10n.clearAllArtworkButton,
+              style: const TextStyle(
+                fontSize: 13,
+                color: Colors.redAccent,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilters() {
+    final l10n = AppLocalizations.of(context);
+    final sources = _availableSources;
+    final double screenWidth = MediaQuery.of(context).size.width;
+    final bool isPortraitMobile = screenWidth < 600 ||
+        MediaQuery.of(context).orientation == Orientation.portrait;
+
+    if (isPortraitMobile) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (sources.isNotEmpty) ...[
+            _buildSourcesFilterButton(sources),
+            const SizedBox(height: 8),
+          ],
+          if (!_isLibraryFolder) ...[
+            _buildLanguageFilterCheckbox(l10n, sources),
+            const SizedBox(height: 8),
+          ],
+          _buildClearAllArtworkButton(l10n, sources),
+        ],
+      );
+    }
+
+    return Wrap(
+      spacing: 16,
+      runSpacing: 12,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        if (sources.isNotEmpty)
+          _buildSourcesFilterButton(sources),
+        if (!_isLibraryFolder)
+          _buildLanguageFilterCheckbox(l10n, sources),
+        _buildClearAllArtworkButton(l10n, sources),
+      ],
+    );
+  }
+
+  Widget _buildCategoryGridView(String category) {
+    final l10n = AppLocalizations.of(context);
+    final currentTags = _getCurrentTags(category);
+    final isCategoryLoading = _loadingCategories[category] ?? false;
+    final isActionLoading = _actionInProgress.contains(category);
+    final remoteList = _remoteImages[category] ?? [];
+    final error = _categoryErrors[category];
+    final dims = _getImageDimensions(category);
+    final interfaceLang = Localizations.localeOf(context).languageCode.toLowerCase();
+
+    final filteredRemoteList = remoteList.where((img) {
+      if (!_shouldShowImageByLanguage(img, interfaceLang)) {
+        return false;
+      }
+      final provider = img['ProviderName'] as String? ?? '';
+      if (provider.isNotEmpty && _deselectedSources.contains(provider)) {
+        return false;
+      }
+      final width = img['Width'] as int? ?? 0;
+      final height = img['Height'] as int? ?? 0;
+      if (_selectedResolution == 'High (1080p+)') {
+        if (width < 1920 && height < 1080) return false;
+      } else if (_selectedResolution == 'Medium (720p)') {
+        if (width >= 1920 || height >= 1080) return false;
+        if (width < 1280 && height < 720) return false;
+      } else if (_selectedResolution == 'Low (<720p)') {
+        if (width >= 1280 || height >= 720) return false;
+      }
+      return true;
+    }).toList();
+
+    final currentCount = currentTags.isEmpty ? 1 : currentTags.length;
+    final totalCount = currentCount + (isCategoryLoading ? 1 : (error != null ? 0 : filteredRemoteList.length));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () {
+                final categoryToFocus = _focusedCategory;
+                setState(() {
+                  _focusedCategory = null;
+                });
+                if (categoryToFocus != null) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    _getHeaderFocusNode(categoryToFocus).requestFocus();
+                  });
+                }
+              },
+            ),
+            const SizedBox(width: 8),
+            Text(
+              _getCategoryDisplayName(category, l10n),
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const Spacer(),
+            if (!PlatformDetection.isTV) ...[
+              FocusableWrapper(
+                onSelect: () => _uploadLocalImage(category),
+                borderRadius: 8,
+                onNavigateRight: () {}, // Block focus leaving to the right
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.upload_file,
+                        color: AppColorScheme.accent,
+                        size: 16,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        l10n.uploadButton,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: AppColorScheme.accent,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+            ],
+            if (isActionLoading)
+              const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              const SizedBox(width: 8),
+              Text(
+                l10n.resolutionLabel,
+                style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold, color: Colors.white54),
+              ),
+              const SizedBox(width: 8),
+              ...['All', 'High (1080p+)', 'Medium (720p)', 'Low (<720p)'].map((res) {
+                final selected = _selectedResolution == res;
+                return Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: ChoiceChip(
+                    label: Text(_getResolutionDisplayName(res, l10n)),
+                    selected: selected,
+                    onSelected: (val) {
+                      if (val) {
+                        setState(() {
+                          _selectedResolution = res;
+                        });
+                      }
+                    },
+                    selectedColor: AppColorScheme.onSurface.withValues(alpha: 0.2),
+                    backgroundColor: AppColorScheme.onSurface.withValues(alpha: 0.06),
+                    labelStyle: TextStyle(
+                      color: selected
+                          ? AppColorScheme.onSurface
+                          : AppColorScheme.onSurface.withValues(alpha: 0.5),
+                      fontSize: 12,
+                    ),
+                    side: BorderSide.none,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                  ),
+                );
+              }),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: GridView.builder(
+            padding: const EdgeInsets.all(8),
+            gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: dims.width * 1.3,
+              mainAxisSpacing: 16,
+              crossAxisSpacing: 16,
+              childAspectRatio: dims.width / (dims.height + 40),
+            ),
+            itemCount: totalCount,
+            itemBuilder: (context, i) {
+              if (i < currentCount) {
+                if (currentTags.isEmpty) {
+                  return Align(
+                    alignment: Alignment.topCenter,
+                    child: _buildCurrentCard(category, null, dims),
+                  );
+                }
+                return Align(
+                  alignment: Alignment.topCenter,
+                  child: _buildCurrentCard(
+                    category,
+                    currentTags[i],
+                    dims,
+                    imageIndex: category == 'Backdrop' ? i : null,
+                  ),
+                );
+              }
+
+              if (isCategoryLoading) {
+                return const Center(
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                );
+              }
+
+              final remoteIdx = i - currentCount;
+              final remoteImage = filteredRemoteList[remoteIdx];
+              return Align(
+                alignment: Alignment.topCenter,
+                child: _buildRemoteCard(category, remoteImage, dims, isActionLoading),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCategorySection(String category) {
+    final l10n = AppLocalizations.of(context);
+    final currentTags = _getCurrentTags(category);
+    final isCategoryLoading = _loadingCategories[category] ?? false;
+    final isActionLoading = _actionInProgress.contains(category);
+    final remoteList = _remoteImages[category] ?? [];
+    final error = _categoryErrors[category];
+    final dims = _getImageDimensions(category);
+    final interfaceLang = Localizations.localeOf(context).languageCode.toLowerCase();
+
+    final filteredRemoteList = remoteList.where((img) {
+      if (!_shouldShowImageByLanguage(img, interfaceLang)) {
+        return false;
+      }
+      final provider = img['ProviderName'] as String? ?? '';
+      if (provider.isNotEmpty && _deselectedSources.contains(provider)) {
+        return false;
+      }
+      return true;
+    }).toList();
+
+    final currentCount = currentTags.isEmpty ? 1 : currentTags.length;
+    final totalCount = currentCount + (isCategoryLoading ? 1 : (error != null ? 0 : filteredRemoteList.length));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 8, left: 8, right: 8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  FocusableWrapper(
+                    focusNode: _getHeaderFocusNode(category),
+                    autoScroll: PlatformDetection.isTV,
+                    scrollAlignment: PlatformDetection.isTV ? 0.15 : 0.5,
+                    suppressFocusGlow: true,
+                    onNavigateUp: () => _handleNavigateUpFromHeader(category),
+                    onNavigateDown: () => _handleNavigateDownFromHeader(category),
+                    onNavigateLeft: () {}, // Block focus leaving to the left
+                    onSelect: () {
+                      setState(() {
+                        _focusedCategory = category;
+                        _selectedResolution = 'All';
+                      });
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        _getFirstCardFocusNode(category).requestFocus();
+                      });
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            _getCategoryDisplayName(category, l10n),
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          const Icon(Icons.chevron_right, size: 18, color: Colors.white54),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  if (isActionLoading)
+                    const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      ),
+                    ),
+                ],
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (!PlatformDetection.isTV) ...[
+                    FocusableWrapper(
+                      onSelect: () => _uploadLocalImage(category),
+                      autoScroll: PlatformDetection.isTV,
+                      scrollAlignment: PlatformDetection.isTV ? 0.15 : 0.5,
+                      suppressFocusGlow: true,
+                      borderRadius: 8,
+                      onNavigateUp: () => _handleNavigateUpFromHeader(category),
+                      onNavigateDown: () => _handleNavigateDownFromHeader(category),
+                      onNavigateLeft: () => _getHeaderFocusNode(category).requestFocus(),
+                      onNavigateRight: () {}, // Block focus leaving to the right
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.upload_file,
+                              color: AppColorScheme.accent,
+                              size: 16,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              l10n.uploadButton,
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: AppColorScheme.accent,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                  ],
+                  if (PlatformDetection.isDesktop) ...[
+                    ExcludeFocus(
+                      child: IconButton(
+                        icon: const Icon(Icons.chevron_left),
+                        onPressed: () => _scrollRow(category, forward: false),
+                        color: AppColorScheme.accent,
+                        iconSize: 22,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    ExcludeFocus(
+                      child: IconButton(
+                        icon: const Icon(Icons.chevron_right),
+                        onPressed: () => _scrollRow(category, forward: true),
+                        color: AppColorScheme.accent,
+                        iconSize: 22,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        ),
+        SizedBox(
+          height: dims.height + 72,
+          child: ListView.builder(
+            controller: _getScrollController(category),
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.only(left: 8, right: 32, top: 8, bottom: 8),
+            clipBehavior: Clip.hardEdge,
+            itemCount: totalCount,
+            itemBuilder: (context, i) {
+              final isFirst = (i == 0);
+              final isLast = (i == totalCount - 1);
+              final cardNode = isFirst ? _getFirstCardFocusNode(category) : null;
+              KeyEventResult keyHandler(FocusNode node, KeyEvent event) =>
+                  consumeIfEdge(event, atLeftEdge: isFirst, atRightEdge: isLast);
+              final alignmentPolicy = isFirst ? ScrollPositionAlignmentPolicy.keepVisibleAtStart : ScrollPositionAlignmentPolicy.explicit;
+
+              if (i < currentCount) {
+                if (currentTags.isEmpty) {
+                  return _buildCurrentCard(
+                    category,
+                    null,
+                    dims,
+                    focusNode: cardNode,
+                    onKeyEvent: keyHandler,
+                    scrollAlignment: isFirst ? 0.0 : 0.5,
+                    alignmentPolicy: alignmentPolicy,
+                  );
+                }
+                return _buildCurrentCard(
+                  category,
+                  currentTags[i],
+                  dims,
+                  imageIndex: category == 'Backdrop' ? i : null,
+                  focusNode: cardNode,
+                  onKeyEvent: keyHandler,
+                  scrollAlignment: isFirst ? 0.0 : 0.5,
+                  alignmentPolicy: alignmentPolicy,
+                );
+              }
+
+              if (isCategoryLoading) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    child: CircularProgressIndicator(
+                      color: AppColorScheme.accent,
+                      strokeWidth: 2,
+                    ),
+                  ),
+                );
+              }
+
+              final remoteIdx = i - currentCount;
+              final remoteImage = filteredRemoteList[remoteIdx];
+              return _buildRemoteCard(
+                category,
+                remoteImage,
+                dims,
+                isActionLoading,
+                onKeyEvent: keyHandler,
+                scrollAlignment: isFirst ? 0.0 : 0.5,
+                alignmentPolicy: alignmentPolicy,
+              );
+            },
+          ),
+        ),
+        const Divider(height: 24, thickness: 1, color: Colors.white10),
+      ],
+    );
+  }
+
+  Widget _buildCardWrapper({
+    required String category,
+    required ImageDimensions dims,
+    required Widget child,
+    required VoidCallback? onSelect,
+    FocusNode? focusNode,
+    FocusOnKeyEventCallback? onKeyEvent,
+    double scrollAlignment = 0.5,
+    ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+  }) {
+    final isGridView = _focusedCategory != null;
+
+    return AspectRatio(
+      aspectRatio: dims.aspectRatio,
+      child: FocusableWrapper(
+        borderRadius: 8,
+        autoScroll: PlatformDetection.isTV,
+        suppressFocusGlow: true,
+        focusNode: focusNode,
+        onKeyEvent: onKeyEvent,
+        scrollAlignment: PlatformDetection.isTV ? 0.15 : scrollAlignment,
+        alignmentPolicy: alignmentPolicy,
+        onNavigateUp: isGridView ? null : () => _handleNavigateUpFromCard(category),
+        onNavigateDown: isGridView ? null : () => _handleNavigateDownFromCard(category),
+        onSelect: onSelect,
+        child: child,
+      ),
+    );
+  }
+
+  Widget _buildCurrentCard(
+    String category,
+    String? tag,
+    ImageDimensions dims, {
+    int? imageIndex,
+    FocusNode? focusNode,
+    FocusOnKeyEventCallback? onKeyEvent,
+    double scrollAlignment = 0.5,
+    ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+  }) {
+    final l10n = AppLocalizations.of(context);
+    final isGridView = _focusedCategory != null;
+    final double? cardWidth = isGridView ? null : dims.width;
+    final isActionLoading = _actionInProgress.contains(category);
+
+    Widget childWidget;
+    VoidCallback? selectCallback;
+
+    if (tag == null) {
+      selectCallback = null;
+      childWidget = Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.white24, width: 1.5, style: BorderStyle.solid),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.image_not_supported, color: Colors.white30, size: 28),
+            const SizedBox(height: 6),
+            Text(
+              l10n.missing,
+              style: const TextStyle(fontSize: 12, color: Colors.white30),
+            ),
+          ],
+        ),
+      );
+    } else {
+      final imageUrl = _getCurrentImageUrl(category, tag, imageIndex: imageIndex);
+      selectCallback = isActionLoading ? null : () => _deleteImage(category, imageIndex: imageIndex);
+      childWidget = ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: CachedNetworkImage(
+                imageUrl: imageUrl,
+                fit: BoxFit.cover,
+                memCacheWidth: (dims.width * MediaQuery.devicePixelRatioOf(context)).round(),
+                placeholder: (context, url) => Container(
+                  color: Colors.white12,
+                  child: const Center(
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                ),
+                errorWidget: (context, url, error) => Container(
+                  color: Colors.white12,
+                  child: const Icon(Icons.broken_image, color: Colors.white24),
+                ),
+              ),
+            ),
+            Positioned(
+              top: 4,
+              right: 4,
+              child: Container(
+                padding: const EdgeInsets.all(2),
+                decoration: const BoxDecoration(
+                  color: Colors.green,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.check,
+                  color: Colors.white,
+                  size: 14,
+                ),
+              ),
+            ),
+            Positioned(
+              top: 4,
+              left: 4,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: selectCallback,
+                child: Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.6),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.delete_outline,
+                    color: Colors.redAccent,
+                    size: 14,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final cardWidget = _buildCardWrapper(
+      category: category,
+      dims: dims,
+      child: childWidget,
+      onSelect: selectCallback,
+      focusNode: focusNode,
+      onKeyEvent: onKeyEvent,
+      scrollAlignment: scrollAlignment,
+      alignmentPolicy: alignmentPolicy,
+    );
+
+    return Container(
+      width: cardWidth,
+      margin: const EdgeInsets.only(right: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          cardWidget,
+        ],
+      ),
+    );
+  }
+
+  String _getOptimizedRemoteImageUrl(String url, String category, {int? targetWidth}) {
+    if (url.isEmpty) return url;
+
+    // 1. TMDB Optimization
+    if (url.contains('image.tmdb.org/t/p/original/')) {
+      if (targetWidth != null) {
+        if (category == 'Backdrop' || category == 'Thumb' || category == 'Screenshot') {
+          if (targetWidth <= 780) {
+            return url.replaceAll('/original/', '/w780/');
+          } else {
+            return url.replaceAll('/original/', '/w1280/');
+          }
+        } else if (category == 'Primary') {
+          if (targetWidth <= 342) {
+            return url.replaceAll('/original/', '/w342/');
+          } else if (targetWidth <= 500) {
+            return url.replaceAll('/original/', '/w500/');
+          } else {
+            return url.replaceAll('/original/', '/w780/');
+          }
+        } else if (category == 'Logo' || category == 'Art') {
+          if (targetWidth <= 300) {
+            return url.replaceAll('/original/', '/w300/');
+          } else {
+            return url.replaceAll('/original/', '/w500/');
+          }
+        }
+      } else {
+        if (category == 'Backdrop' || category == 'Thumb' || category == 'Screenshot') {
+          return url.replaceAll('/original/', '/w780/');
+        } else if (category == 'Primary') {
+          return url.replaceAll('/original/', '/w342/');
+        } else if (category == 'Logo' || category == 'Art') {
+          return url.replaceAll('/original/', '/w300/');
+        }
+      }
+    }
+
+    // 2. Jellyfin/Emby server proxy optimization
+    final client = GetIt.instance<MediaServerClient>();
+    final isJellyfinUrl = url.startsWith('/') || url.startsWith(client.baseUrl);
+    if (isJellyfinUrl) {
+      final separator = url.contains('?') ? '&' : '?';
+      final int width = targetWidth ?? ((category == 'Backdrop' || category == 'Thumb' || category == 'Screenshot') ? 780 : 342);
+      if (!url.contains('maxWidth=') && !url.contains('width=')) {
+        return '$url${separator}maxWidth=$width&quality=80';
+      }
+    }
+
+    return url;
+  }
+
+  void _showZoomPreviewDialog(
+    String category,
+    Map<String, dynamic> remoteImage,
+    ImageDimensions dims,
+  ) {
+    final l10n = AppLocalizations.of(context);
+    final provider = remoteImage['ProviderName'] as String? ?? 'Unknown';
+    final width = remoteImage['Width'] as int?;
+    final height = remoteImage['Height'] as int?;
+    final resolutionStr = (width != null && height != null) ? '${width}x$height' : '';
+    final url = remoteImage['Url'] as String;
+
+    showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        double? loadedAspectRatio;
+        bool isResolvingStarted = false;
+
+        return StatefulBuilder(
+          builder: (dialogContext, setStateDialog) {
+            final double parentWidth = PlatformDetection.isTV
+                ? (MediaQuery.of(dialogContext).size.width * 0.95).clamp(800.0, 1100.0)
+                : (MediaQuery.of(dialogContext).size.width * 0.95).clamp(320.0, 850.0);
+            final double parentHeight = PlatformDetection.isTV
+                ? (MediaQuery.of(dialogContext).size.height * 0.85).clamp(550.0, 850.0)
+                : (MediaQuery.of(dialogContext).size.height * 0.85).clamp(320.0, 650.0);
+
+            // Target image dimensions: scaled to fit nicely inside the parent container
+            final double maxImageWidth = parentWidth * 0.7;
+            final double maxImageHeight = parentHeight * 0.65;
+
+            // Calculate aspect ratio dynamically from image data, falling back to category defaults
+            final double defaultAspectRatio = (width != null && height != null && height > 0)
+                ? width / height
+                : dims.aspectRatio;
+
+            final double imageAspectRatio = loadedAspectRatio ?? defaultAspectRatio;
+
+            // Calculate bounded dimensions maintaining aspect ratio
+            double targetWidth = maxImageWidth;
+            double targetHeight = targetWidth / imageAspectRatio;
+            if (targetHeight > maxImageHeight) {
+              targetHeight = maxImageHeight;
+              targetWidth = targetHeight * imageAspectRatio;
+            }
+
+            final double dialogWidth = (targetWidth + 32).clamp(
+              (320.0).clamp(0.0, parentWidth - 64),
+              (parentWidth - 64).clamp(0.0, double.infinity),
+            );
+            final previewUrl = _getOptimizedRemoteImageUrl(
+              url,
+              category,
+              targetWidth: targetWidth.round(),
+            );
+
+            // Resolve the actual aspect ratio once
+            if (!isResolvingStarted) {
+              isResolvingStarted = true;
+              final imageProvider = CachedNetworkImageProvider(previewUrl);
+              final imageStream = imageProvider.resolve(const ImageConfiguration());
+              ImageStreamListener? listener;
+              listener = ImageStreamListener(
+                (ImageInfo info, bool _) {
+                  final int imgW = info.image.width;
+                  final int imgH = info.image.height;
+                  if (imgH > 0) {
+                    loadedAspectRatio = imgW / imgH;
+                    if (dialogContext.mounted) {
+                      setStateDialog(() {});
+                    }
+                  }
+                  if (listener != null) {
+                    imageStream.removeListener(listener);
+                  }
+                },
+                onError: (dynamic exception, StackTrace? stackTrace) {
+                  if (listener != null) {
+                    imageStream.removeListener(listener);
+                  }
+                },
+              );
+              imageStream.addListener(listener);
+            }
+
+            return Align(
+              alignment: Alignment.center,
+              child: Material(
+                color: Colors.transparent,
+                child: Container(
+                  width: dialogWidth,
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: AppColorScheme.surface,
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: Colors.white10, width: 1),
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Title
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              'Preview: $provider',
+                              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          if (resolutionStr.isNotEmpty)
+                            Text(
+                              resolutionStr,
+                              style: const TextStyle(fontSize: 14, color: Colors.white38),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+
+                      // Image
+                      Align(
+                        alignment: Alignment.center,
+                        child: Container(
+                          width: targetWidth,
+                          height: targetHeight,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: CachedNetworkImage(
+                              imageUrl: previewUrl,
+                              fit: BoxFit.contain,
+                              memCacheWidth: (targetWidth * MediaQuery.devicePixelRatioOf(dialogContext)).round().clamp(100, 1280),
+                              placeholder: (context, url) => AspectRatio(
+                                aspectRatio: imageAspectRatio,
+                                child: const Center(
+                                  child: CircularProgressIndicator(strokeWidth: 2),
+                                ),
+                              ),
+                              errorWidget: (context, url, error) => AspectRatio(
+                                aspectRatio: imageAspectRatio,
+                                child: const Center(
+                                  child: Icon(Icons.broken_image, color: Colors.white30, size: 48),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+
+                      // Action Buttons
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          // Download Button
+                          FocusableWrapper(
+                            autofocus: true,
+                            borderRadius: 8,
+                            suppressFocusGlow: true,
+                            focusColor: AppColorScheme.accent,
+                            onNavigateUp: () {},
+                            onNavigateDown: () {},
+                            onSelect: () {
+                              Navigator.pop(dialogContext, true);
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(Icons.download, size: 16, color: Colors.white),
+                                  const SizedBox(width: 8),
+                                   Text(
+                                    l10n.download,
+                                    style: const TextStyle(fontSize: 14, color: Colors.white, fontWeight: FontWeight.w500),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+
+                          // Cancel Button
+                          FocusableWrapper(
+                            borderRadius: 8,
+                            suppressFocusGlow: true,
+                            focusColor: Colors.white12,
+                            onNavigateUp: () {},
+                            onNavigateDown: () {},
+                            onSelect: () {
+                              Navigator.pop(dialogContext, false);
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(8),
+                                border: Border.all(color: Colors.white24, width: 1),
+                              ),
+                              child: Text(
+                                l10n.cancel,
+                                style: const TextStyle(fontSize: 14, color: Colors.white70, fontWeight: FontWeight.w500),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    ).then((shouldDownload) {
+      if (shouldDownload == true) {
+        _downloadImage(category, remoteImage);
+      }
+    });
+  }
+
+  Widget _buildRemoteCard(
+    String category,
+    Map<String, dynamic> remoteImage,
+    ImageDimensions dims,
+    bool isActionLoading, {
+    FocusNode? focusNode,
+    FocusOnKeyEventCallback? onKeyEvent,
+    double scrollAlignment = 0.5,
+    ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+  }) {
+    final provider = remoteImage['ProviderName'] as String? ?? '';
+    final width = remoteImage['Width'] as int?;
+    final height = remoteImage['Height'] as int?;
+    final rating = remoteImage['CommunityRating'] as num?;
+    final votes = remoteImage['VoteCount'] as int?;
+
+    final url = remoteImage['Url'] as String;
+    final thumbUrl = _getOptimizedRemoteImageUrl(
+      (remoteImage['ThumbnailUrl'] as String?) ?? url,
+      category,
+    );
+
+    final isGridView = _focusedCategory != null;
+    final double? cardWidth = isGridView ? null : dims.width;
+
+    final cardWidget = _buildCardWrapper(
+      category: category,
+      dims: dims,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: CachedNetworkImage(
+                imageUrl: thumbUrl,
+                fit: BoxFit.cover,
+                memCacheWidth: (dims.width * MediaQuery.devicePixelRatioOf(context)).round(),
+                placeholder: (context, url) => Container(
+                  color: Colors.white12,
+                  child: const Center(
+                    child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                ),
+                errorWidget: (context, url, error) => Container(
+                  color: Colors.white12,
+                  child: const Icon(Icons.broken_image, color: Colors.white24),
+                ),
+              ),
+            ),
+            Positioned.fill(
+              child: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Colors.transparent,
+                      Colors.black.withValues(alpha: 0.7),
+                    ],
+                    stops: const [0.6, 1.0],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      onSelect: isActionLoading
+          ? null
+          : () => _showZoomPreviewDialog(category, remoteImage, dims),
+      focusNode: focusNode,
+      onKeyEvent: onKeyEvent,
+      scrollAlignment: scrollAlignment,
+      alignmentPolicy: alignmentPolicy,
+    );
+
+    return Container(
+      width: cardWidth,
+      margin: const EdgeInsets.only(right: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          cardWidget,
+          const SizedBox(height: 4),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(
+                  provider,
+                  style: const TextStyle(fontSize: 10, color: Colors.white38),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (rating != null && rating > 0) ...[
+                const SizedBox(width: 4),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.favorite, color: Colors.redAccent, size: 10),
+                    const SizedBox(width: 2),
+                    Text(
+                      votes != null ? '$votes' : rating.toStringAsFixed(1),
+                      style: const TextStyle(fontSize: 10, color: Colors.white38),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+          if (width != null && height != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              '${width}x$height',
+              style: const TextStyle(fontSize: 10, color: Colors.white38),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -11,6 +11,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../navigation/destinations.dart';
 import '../add_to_collection_dialog.dart';
 import '../add_to_playlist_dialog.dart';
+import '../change_artwork_dialog.dart';
 
 class ItemContextAction {
   final IconData icon;
@@ -160,6 +161,27 @@ List<ItemContextAction> contextActionsFor(
         },
       ));
     }
+
+  }
+
+  final canChangeArtwork = (isMediaType || type == 'Folder' || type == 'CollectionFolder' || type == 'UserView') &&
+      client.serverType == ServerType.jellyfin;
+
+  if (canChangeArtwork) {
+    actions.add(ItemContextAction(
+      icon: Icons.image_outlined,
+      label: l10n.changeArtwork,
+      onSelect: () async {
+        if (!context.mounted) return;
+        final changed = await ChangeArtworkDialog.show(
+          context,
+          item: item,
+        );
+        if (changed == true) {
+          onChanged?.call();
+        }
+      },
+    ));
   }
 
   if (type == 'Episode' && (item.seriesId?.isNotEmpty ?? false)) {

--- a/lib/ui/widgets/focus/focus_theme.dart
+++ b/lib/ui/widgets/focus/focus_theme.dart
@@ -13,6 +13,7 @@ class FocusTheme {
     double radius = defaultBorderRadius,
     Color? color,
     Color? backgroundColor,
+    bool suppressFocusGlow = false,
   }) {
     final borders = ThemeRegistry.active.borders;
     return BoxDecoration(
@@ -23,7 +24,7 @@ class FocusTheme {
               borders.focusBorder.copyWith(color: color),
             )
           : null,
-      boxShadow: isFocused && borders.focusGlow.isNotEmpty
+      boxShadow: isFocused && !suppressFocusGlow && borders.focusGlow.isNotEmpty
           ? borders.focusGlow
           : null,
     );

--- a/lib/ui/widgets/focus/focusable_wrapper.dart
+++ b/lib/ui/widgets/focus/focusable_wrapper.dart
@@ -22,6 +22,7 @@ class FocusableWrapper extends StatefulWidget {
   final double borderRadius;
   final bool autoScroll;
   final double scrollAlignment;
+  final ScrollPositionAlignmentPolicy alignmentPolicy;
   final bool useComfortableZone;
   final bool descendantsAreFocusable;
   final bool disableScale;
@@ -31,6 +32,7 @@ class FocusableWrapper extends StatefulWidget {
   final Duration longPressDuration;
   final FocusOnKeyEventCallback? onKeyEvent;
   final String? semanticLabel;
+  final bool suppressFocusGlow;
 
   const FocusableWrapper({
     super.key,
@@ -48,6 +50,7 @@ class FocusableWrapper extends StatefulWidget {
     this.borderRadius = FocusTheme.defaultBorderRadius,
     this.autoScroll = false,
     this.scrollAlignment = 0.5,
+    this.alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
     this.useComfortableZone = false,
     this.descendantsAreFocusable = true,
     this.disableScale = false,
@@ -57,6 +60,7 @@ class FocusableWrapper extends StatefulWidget {
     this.longPressDuration = const Duration(milliseconds: 500),
     this.onKeyEvent,
     this.semanticLabel,
+    this.suppressFocusGlow = false,
   });
 
   @override
@@ -122,6 +126,7 @@ class _FocusableWrapperState extends State<FocusableWrapper>
         Scrollable.ensureVisible(
           ctx,
           alignment: widget.scrollAlignment,
+          alignmentPolicy: widget.alignmentPolicy,
           duration: FocusTheme.animationDuration,
           curve: Curves.easeOut,
         );
@@ -140,7 +145,7 @@ class _FocusableWrapperState extends State<FocusableWrapper>
     Scrollable.ensureVisible(
       ctx,
       alignment: widget.scrollAlignment,
-      alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+      alignmentPolicy: widget.alignmentPolicy,
       duration: FocusTheme.animationDuration,
       curve: Curves.easeOut,
     );
@@ -206,11 +211,13 @@ class _FocusableWrapperState extends State<FocusableWrapper>
             backgroundColor: _focused
                 ? color.withValues(alpha: 0.18)
                 : null,
+            suppressFocusGlow: widget.suppressFocusGlow,
           )
         : FocusTheme.focusDecoration(
             isFocused: _focused,
             radius: widget.borderRadius,
             color: color,
+            suppressFocusGlow: widget.suppressFocusGlow,
           );
 
     Widget content = AnimatedContainer(

--- a/lib/ui/widgets/grid_button_card.dart
+++ b/lib/ui/widgets/grid_button_card.dart
@@ -8,6 +8,8 @@ class GridButtonCard extends StatefulWidget {
   final Widget Function(double size, Color color)? iconBuilder;
   final String label;
   final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+  final VoidCallback? onSecondaryTap;
   final double width;
   final double height;
   final Color? focusColor;
@@ -23,6 +25,8 @@ class GridButtonCard extends StatefulWidget {
     this.iconBuilder,
     required this.label,
     required this.onTap,
+    this.onLongPress,
+    this.onSecondaryTap,
     this.width = 160,
     this.height = 120,
     this.focusColor,
@@ -66,6 +70,8 @@ class _GridButtonCardState extends State<GridButtonCard> with FocusStateMixin {
 
     final inner = GestureDetector(
       onTap: widget.onTap,
+      onLongPress: widget.onLongPress,
+      onSecondaryTap: widget.onSecondaryTap,
       child: AnimatedScale(
         scale: scale,
         duration: const Duration(milliseconds: 150),

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -1,11 +1,10 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../preference/preference_constants.dart';
 import '../../util/focus/dpad_keys.dart';
+import '../../util/focus/key_event_utils.dart';
 import 'bounded_network_image.dart';
 import 'marquee_text.dart';
 import '../mixins/focus_state_mixin.dart';
@@ -142,13 +141,11 @@ class MediaCard extends StatefulWidget {
 }
 
 class _MediaCardState extends State<MediaCard> with FocusStateMixin {
-  Timer? _longPressTimer;
-  bool _longPressFired = false;
-  bool _selectDownSeen = false;
+  final _selectKeyHandler = LongPressSelectKeyHandler();
 
   @override
   void dispose() {
-    _longPressTimer?.cancel();
+    _selectKeyHandler.dispose();
     super.dispose();
   }
 
@@ -280,46 +277,16 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
               focusNode: widget.focusNode,
               autofocus: widget.autofocus,
               onKeyEvent: (node, event) {
-                final key = event.logicalKey;
-
-                if (widget.onLongPress != null && key.isSelectKey) {
-                  if (event is KeyDownEvent) {
-                    _selectDownSeen = true;
-                    _longPressFired = false;
-                    _longPressTimer?.cancel();
-                    _longPressTimer = Timer(
-                      const Duration(milliseconds: 500),
-                      () {
-                        _longPressFired = true;
-                        widget.onLongPress!();
-                      },
-                    );
-                    return KeyEventResult.handled;
+                if (widget.onLongPress != null) {
+                  final handlerResult = _selectKeyHandler.handleKeyEvent(
+                    event,
+                    onTap: () => widget.onTap?.call(),
+                    onLongPress: () => widget.onLongPress?.call(),
+                  );
+                  if (handlerResult != KeyEventResult.ignored) {
+                    return handlerResult;
                   }
-                  if (event is KeyRepeatEvent) {
-                    return _selectDownSeen
-                        ? KeyEventResult.handled
-                        : KeyEventResult.ignored;
-                  }
-                  if (event is KeyUpEvent) {
-                    if (!_selectDownSeen) return KeyEventResult.ignored;
-                    _selectDownSeen = false;
-                    _longPressTimer?.cancel();
-                    _longPressTimer = null;
-                    if (!_longPressFired) widget.onTap?.call();
-                    _longPressFired = false;
-                    return KeyEventResult.handled;
-                  }
-                }
-
-                if (widget.onLongPress != null &&
-                    key.isContextMenuKey &&
-                    event is KeyDownEvent) {
-                  widget.onLongPress!();
-                  return KeyEventResult.handled;
-                }
-
-                if (event is KeyDownEvent && key.isSelectKey) {
+                } else if (event is KeyDownEvent && event.logicalKey.isSelectKey) {
                   widget.onTap?.call();
                   return KeyEventResult.handled;
                 }

--- a/lib/util/focus/key_event_utils.dart
+++ b/lib/util/focus/key_event_utils.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -87,4 +88,61 @@ KeyEventResult consumeIfEdge(
   if (atTopEdge && k.isUpKey) return KeyEventResult.handled;
   if (atBottomEdge && k.isDownKey) return KeyEventResult.handled;
   return KeyEventResult.ignored;
+}
+
+class LongPressSelectKeyHandler {
+  bool _selectDownSeen = false;
+  bool _longPressFired = false;
+  Timer? _longPressTimer;
+
+  void dispose() {
+    _longPressTimer?.cancel();
+  }
+
+  KeyEventResult handleKeyEvent(
+    KeyEvent event, {
+    required VoidCallback onTap,
+    required VoidCallback onLongPress,
+  }) {
+    final key = event.logicalKey;
+
+    if (key.isSelectKey) {
+      if (event is KeyDownEvent) {
+        _selectDownSeen = true;
+        _longPressFired = false;
+        _longPressTimer?.cancel();
+        _longPressTimer = Timer(
+          const Duration(milliseconds: 500),
+          () {
+            _longPressFired = true;
+            onLongPress();
+          },
+        );
+        return KeyEventResult.handled;
+      }
+      if (event is KeyRepeatEvent) {
+        return _selectDownSeen
+            ? KeyEventResult.handled
+            : KeyEventResult.ignored;
+      }
+      if (event is KeyUpEvent) {
+        if (!_selectDownSeen) return KeyEventResult.ignored;
+        _selectDownSeen = false;
+        _longPressTimer?.cancel();
+        _longPressTimer = null;
+        if (!_longPressFired) {
+          onTap();
+        }
+        _longPressFired = false;
+        return KeyEventResult.handled;
+      }
+    }
+
+    if (key.isContextMenuKey && event is KeyDownEvent) {
+      onLongPress();
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
 }

--- a/packages/server_core/lib/src/models/enums.dart
+++ b/packages/server_core/lib/src/models/enums.dart
@@ -153,7 +153,11 @@ enum ImageType {
   thumb,
   logo,
   art,
-  screenshot;
+  screenshot,
+  disc,
+  box,
+  boxRear,
+  menu;
 
   static ImageType fromServerString(String? value) => switch (value) {
         'Primary' => primary,
@@ -163,6 +167,10 @@ enum ImageType {
         'Logo' => logo,
         'Art' => art,
         'Screenshot' => screenshot,
+        'Disc' => disc,
+        'Box' => box,
+        'BoxRear' => boxRear,
+        'Menu' => menu,
         _ => primary,
       };
 
@@ -174,6 +182,10 @@ enum ImageType {
         logo => 'Logo',
         art => 'Art',
         screenshot => 'Screenshot',
+        disc => 'Disc',
+        box => 'Box',
+        boxRear => 'BoxRear',
+        menu => 'Menu',
       };
 }
 


### PR DESCRIPTION
# Pull Request

## Summary
Dream project realized: Add an Artwork Selector to Moonfin-Core. This includes a new "Change Artwork" dialog (triggered off long presses throughout the interface), localizations, context menu integrations (long press / secondary click) across browse libraries, detailed screen views, seasons, search screens, a dynamic zoom-on-click preview dialog with auto-resolving aspect ratios, and custom snapping behavior for TV.

## Related Issues
My issue.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
1. New Change Artwork Dialog (`lib/ui/widgets/change_artwork_dialog.dart`)
- Displays horizontal card rows for each image category (Poster, Backdrop, Banner, Logo, Art, Thumb, etc.) with a grid expander option. Only relevant categories for the media item are shown.
- Implements dropdown controls to filter by source provider (e.g. Fanart.tv, TheMovieDb, local) and aspect ratios/resolutions.
- Case-insensitively maps "Poster" category labels to "Thumbnail" for TV Episodes to align with backend realities.
- Sets custom scroll alignment policy (`scrollAlignment: 0.15` on TV) to ensure the category row headers remain visible above active cards when scrolling.
- Supplies clear border focus indicators and removes neon-transparent glow shadows for a cleaner aesthetic. Sets the initial focus target on the category title headers (e.g. "Poster >") for clear entry.
- Incorporates (and restricts) left/right row scroll chevrons to Desktop mode (hidden on TV and Mobile views).
- Employs `FittedBox` scale-down wrappers and extra spacing to ensure missing-image placeholder elements scale correctly on low-height banner rows.

2. Context Action Integrations & ViewModels
- Integrates "Change Artwork" options into the context actions on the main item details view (`lib/ui/screens/detail/item_detail_screen.dart`), search results (`lib/ui/screens/search/search_screen.dart`), and library browse pages (`lib/ui/screens/browse/library_view_screen.dart`).
- Updates `FavoritesViewModel`, `FolderBrowseViewModel`, and `LibraryBrowseViewModel` to register change artwork actions properly.
- Extends image types and metadata mappings inside `packages/server_core/lib/src/models/enums.dart`.

3. Localization and Generates
- Added English localization keys in `lib/l10n/app_en.arb` for all UI text, search categories, confirmation alerts, and options.
- Re-generated target language localization wrappers (`lib/l10n/app_localizations*`) to ensure the build compiles smoothly.

4. Performance & Lazy Loading Optimization 
- uses static SingleChildScrollView + Row card layouts for TV and Mobile clients with a lazy horizontal ListView.builder. Category cards are now instantiated and loaded strictly as they scroll into view.
- Image Network Resolution Optimization: Created _getOptimizedRemoteImageUrl helper to rewrite network URLs. TMDB /original/ URLs are rewritten to /w780/, /w342/, or /w300/ matching category buckets. Jellyfin/Emby servers append container-fitting maxWidth and quality=80 parameters to minimize network traffic and loading latency.
- OOM Prevention: Applied logical container memCacheWidth downscaling based on device pixel ratio on all remote/current artwork images to prevent Android LMK system crashes when scrolling large lists.

5. Custom Zoom Preview Dialog
- Clicking a card triggers _showZoomPreviewDialog display on all clients with a high-resolution preview and action buttons.
Integrated a StatefulBuilder and attached a one-time ImageStreamListener to CachedNetworkImageProvider to detect the exact loaded aspect ratio dynamically.
- Recalculates dialog dimensions on image load, shrinking the outer dialog box container snugly to targetWidth + 32 (with dynamic bounds safety protection) to remove empty purple bars on the sides of landscape or portrait images.

6. Responsive Mobile & Portrait Layout
- Optimized main dialog constraints (minWidth decreased from 450 to 280 on mobile, dynamic maxWidth/maxHeight based on screen height/width) and dynamically reduced dialog inner padding on mobile/desktop.
- Wrapped resolution chips in a horizontal SingleChildScrollView to prevent viewport clipping.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Windows Desktop, Android Mobile, and Android TV
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the My Media Row, or any Movie, Series, Season, or Episode card.
2. Long-press (or right-click / select the details menu option) to trigger the context menu.
3. Open "Change Artwork".
4. Verify you can browse, filter by source, select remote images, confirm changes, and view local uploads.
5. Verify D-pad scrolling/snapping alignment is correct on TV, drag-scroll physics work on Mobile, and navigation chevrons show on Desktop.

## Screenshots (if applicable)
<img width="500" alt="Shield_Screenshot_2026-06-13_10-49-22" src="https://github.com/user-attachments/assets/97567fcf-440f-4f58-9965-41d5cc12968c" />
<img width="500" alt="2026-06-13_12-35-15_moonfin" src="https://github.com/user-attachments/assets/c018228d-320f-49e1-8e33-f5288b9b9f60" />
<img width="500"  alt="2026-06-13_12-35-34_moonfin" src="https://github.com/user-attachments/assets/5aeee2ab-456e-49b1-a1ac-fdef2bdbaff7" />
<img width="500"  alt="2026-06-13_12-35-39_moonfin" src="https://github.com/user-attachments/assets/5b28f145-8573-4ff6-92ed-024f99dd468b" />
<img width="500"  alt="2026-06-13_12-36-17_moonfin" src="https://github.com/user-attachments/assets/d6a86761-0d86-4f38-a4fe-4e09556bc532" />
<img width="500" alt="Screenshot_20260613-141630" src="https://github.com/user-attachments/assets/e047ccf3-fe2a-4700-b555-a4b8604df6b8" />
<img width="500"  alt="Screenshot_20260613-141940" src="https://github.com/user-attachments/assets/ad9a02f1-eef9-4c87-b126-3b67761aeb5a" />
<img width="500" alt="Shield_Screenshot_2026-06-13_09-59-04" src="https://github.com/user-attachments/assets/8fdb9868-0521-4619-ac92-37fb27182510" />
<img width="500" alt="Shield_Screenshot_2026-06-13_10-49-22" src="https://github.com/user-attachments/assets/8ff04be2-e8d7-434f-bc72-78ffd22d43bb" />
<img width="500" alt="Shield_Screenshot_2026-06-13_14-07-19" src="https://github.com/user-attachments/assets/50333d1a-ec02-4dac-8672-f56644960084" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
