### PR TITLE
Fix remote PlayNow route startup on Android TV

### DIFF
--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -102,6 +102,7 @@ class SessionRepository {
     if (serverId.isEmpty || userId.isEmpty) return null;
     return _authStore.getUser(serverId, userId)?.name;
   }
+
   SessionState get state => _state;
   Stream<SessionState> get stateStream => _stateController.stream;
 
@@ -161,7 +162,9 @@ class SessionRepository {
     final accessToken = user.accessToken.isNotEmpty ? user.accessToken : token;
 
     if (accessToken == null || accessToken.isEmpty) {
-      _logger.w('No access token available for user $userId on server $serverId');
+      _logger.w(
+        'No access token available for user $userId on server $serverId',
+      );
       _setState(SessionState.ready);
       return false;
     }
@@ -188,14 +191,15 @@ class SessionRepository {
     await _authPrefs.setLastServerId(serverId);
     await _authPrefs.setLastUserId(userId);
 
-    final shouldPrioritizeInitialSync =
-        !_pluginSyncService.isSyncInitializedForServer(
-          client,
-          serverId: serverId,
-        );
-    final Future<void> postLoginSyncFuture =
-        _postLoginSync(client, user, serverId, username, password)
-        .catchError((_) {});
+    final shouldPrioritizeInitialSync = !_pluginSyncService
+        .isSyncInitializedForServer(client, serverId: serverId);
+    final Future<void> postLoginSyncFuture = _postLoginSync(
+      client,
+      user,
+      serverId,
+      username,
+      password,
+    ).catchError((_) {});
 
     if (shouldPrioritizeInitialSync) {
       // Give first-login server sync a short head start so Home can build
@@ -245,10 +249,11 @@ class SessionRepository {
         _userRepository.setCurrentUser(updatedUser);
       }
 
-       // init language prefs if not already set
+      // init language prefs if not already set
       if (serverUser.configuration != null) {
-        GetIt.instance<UserPreferences>()
-            .initLanguagePrefs(serverUser.configuration!);
+        GetIt.instance<UserPreferences>().initLanguagePrefs(
+          serverUser.configuration!,
+        );
       }
     } on DioException catch (e) {
       if (e.response?.statusCode == 401) {
@@ -259,8 +264,7 @@ class SessionRepository {
         );
         return;
       }
-    } catch (_) {
-    }
+    } catch (_) {}
 
     await _pluginSyncService.syncOnLogin(client, serverId: serverId);
 
@@ -426,10 +430,63 @@ class SessionRepository {
       return;
     }
 
+    final startIndex = message.startIndex.clamp(0, items.length - 1).toInt();
     final manager = GetIt.instance<PlaybackManager>();
-    await manager.playItems(
-      items,
-      startPosition: _durationFromTicks(message.startPositionTicks) ?? Duration.zero,
+    final command = message.playCommand.toLowerCase();
+
+    switch (command) {
+      case 'playnow':
+        _ensurePlayerRouteForItem(items[startIndex]);
+        await manager.playItems(
+          items,
+          startIndex: startIndex,
+          startPosition:
+              _durationFromTicks(message.startPositionTicks) ?? Duration.zero,
+          audioStreamIndex: message.audioStreamIndex,
+          subtitleStreamIndex: message.subtitleStreamIndex,
+          mediaSourceId: message.mediaSourceId,
+        );
+        break;
+      case 'playnext':
+        for (final item in items.reversed) {
+          manager.queueService.insertNext(item);
+        }
+        break;
+      case 'playlast':
+      case 'enqueue':
+        manager.queueService.addItems(items);
+        break;
+      default:
+        _ensurePlayerRouteForItem(items[startIndex]);
+        await manager.playItems(
+          items,
+          startIndex: startIndex,
+          startPosition:
+              _durationFromTicks(message.startPositionTicks) ?? Duration.zero,
+          audioStreamIndex: message.audioStreamIndex,
+          subtitleStreamIndex: message.subtitleStreamIndex,
+          mediaSourceId: message.mediaSourceId,
+        );
+        break;
+    }
+  }
+
+  void _ensurePlayerRouteForItem(AggregatedItem item) {
+    final currentPath = appRouter.routerDelegate.currentConfiguration.uri.path;
+    if (currentPath == Destinations.videoPlayer ||
+        currentPath == Destinations.audioPlayer) {
+      return;
+    }
+
+    final mediaType = item.rawData['MediaType'] as String?;
+    final isAudio =
+        item.type == 'Audio' ||
+        item.type == 'MusicAlbum' ||
+        item.type == 'AudioBook' ||
+        mediaType == 'Audio';
+
+    appRouter.push(
+      isAudio ? Destinations.audioPlayer : Destinations.videoPlayer,
     );
   }
 
@@ -457,7 +514,9 @@ class SessionRepository {
     }
   }
 
-  Future<void> _handleGeneralCommandMessage(GeneralCommandMessage message) async {
+  Future<void> _handleGeneralCommandMessage(
+    GeneralCommandMessage message,
+  ) async {
     final manager = GetIt.instance<PlaybackManager>();
     switch (message.name.toLowerCase()) {
       case 'displaymessage':

--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -436,16 +436,7 @@ class SessionRepository {
 
     switch (command) {
       case 'playnow':
-        _ensurePlayerRouteForItem(items[startIndex]);
-        await manager.playItems(
-          items,
-          startIndex: startIndex,
-          startPosition:
-              _durationFromTicks(message.startPositionTicks) ?? Duration.zero,
-          audioStreamIndex: message.audioStreamIndex,
-          subtitleStreamIndex: message.subtitleStreamIndex,
-          mediaSourceId: message.mediaSourceId,
-        );
+        await _playRemoteItems(manager, items, startIndex, message);
         break;
       case 'playnext':
         for (final item in items.reversed) {
@@ -457,18 +448,47 @@ class SessionRepository {
         manager.queueService.addItems(items);
         break;
       default:
-        _ensurePlayerRouteForItem(items[startIndex]);
-        await manager.playItems(
-          items,
-          startIndex: startIndex,
-          startPosition:
-              _durationFromTicks(message.startPositionTicks) ?? Duration.zero,
-          audioStreamIndex: message.audioStreamIndex,
-          subtitleStreamIndex: message.subtitleStreamIndex,
-          mediaSourceId: message.mediaSourceId,
-        );
+        await _playRemoteItems(manager, items, startIndex, message);
         break;
     }
+  }
+
+  Future<void> _playRemoteItems(
+    PlaybackManager manager,
+    List<AggregatedItem> items,
+    int startIndex,
+    PlayMessage message,
+  ) async {
+    final item = items[startIndex];
+    final isLiveTv = _isLiveTvItem(item);
+    final allowDirect = isLiveTv
+        ? GetIt.instance<UserPreferences>().get(
+            UserPreferences.liveTvDirectPlayEnabled,
+          )
+        : true;
+
+    _ensurePlayerRouteForItem(item);
+    await manager.playItems(
+      items,
+      startIndex: startIndex,
+      startPosition:
+          _durationFromTicks(message.startPositionTicks) ?? Duration.zero,
+      audioStreamIndex: message.audioStreamIndex,
+      subtitleStreamIndex: message.subtitleStreamIndex,
+      mediaSourceId: message.mediaSourceId,
+      enableDirectPlay: allowDirect,
+      enableDirectStream: allowDirect,
+      enableTranscoding: !isLiveTv || !allowDirect,
+    );
+  }
+
+  bool _isLiveTvItem(AggregatedItem item) {
+    final type = item.type;
+    return type == 'TvChannel' ||
+        type == 'LiveTvChannel' ||
+        type == 'Program' ||
+        item.rawData['ChannelId'] != null ||
+        item.rawData['TimerId'] != null;
   }
 
   void _ensurePlayerRouteForItem(AggregatedItem item) {

--- a/lib/data/services/websocket_message_parser.dart
+++ b/lib/data/services/websocket_message_parser.dart
@@ -44,9 +44,9 @@ class WebSocketMessageParser {
       'UserDeleted' ||
       'UserUpdated' ||
       'ActivityLogEntry' => ServerEventMessage(
-          type: type,
-          data: data is Map<String, dynamic> ? data : const {},
-        ),
+        type: type,
+        data: data is Map<String, dynamic> ? data : const {},
+      ),
       _ => null,
     };
   }
@@ -64,7 +64,8 @@ class WebSocketMessageParser {
     if (data is! Map<String, dynamic>) return null;
     final userId = data['UserId'] as String?;
     if (userId == null) return null;
-    final itemIds = (data['UserDataList'] as List<dynamic>?)
+    final itemIds =
+        (data['UserDataList'] as List<dynamic>?)
             ?.map((e) => (e as Map<String, dynamic>)['ItemId'] as String?)
             .whereType<String>()
             .toList() ??
@@ -78,8 +79,12 @@ class WebSocketMessageParser {
     if (itemIds.isEmpty) return null;
     return PlayMessage(
       itemIds: itemIds,
-      startPositionTicks: data['StartPositionTicks'] as int?,
+      startPositionTicks: _intValue(data['StartPositionTicks']),
       playCommand: data['PlayCommand'] as String? ?? 'PlayNow',
+      startIndex: _intValue(data['StartIndex']) ?? 0,
+      audioStreamIndex: _intValue(data['AudioStreamIndex']),
+      subtitleStreamIndex: _intValue(data['SubtitleStreamIndex']),
+      mediaSourceId: data['MediaSourceId'] as String?,
     );
   }
 
@@ -97,8 +102,10 @@ class WebSocketMessageParser {
     if (data is! Map<String, dynamic>) return null;
     final name = data['Name'] as String?;
     if (name == null) return null;
-    final arguments = (data['Arguments'] as Map<String, dynamic>?)
-            ?.map((k, v) => MapEntry(k, v.toString())) ??
+    final arguments =
+        (data['Arguments'] as Map<String, dynamic>?)?.map(
+          (k, v) => MapEntry(k, v.toString()),
+        ) ??
         const {};
     return GeneralCommandMessage(name: name, arguments: arguments);
   }
@@ -124,10 +131,15 @@ class WebSocketMessageParser {
   }
 
   static List<String> _stringList(Map<String, dynamic> data, String key) =>
-      (data[key] as List<dynamic>?)
-          ?.map((e) => e.toString())
-          .toList() ??
+      (data[key] as List<dynamic>?)?.map((e) => e.toString()).toList() ??
       const [];
+
+  static int? _intValue(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value);
+    return null;
+  }
 
   static SyncPlayCommandMessage? _parseSyncPlayCommand(dynamic data) {
     if (data is! Map<String, dynamic>) return null;

--- a/packages/server_core/lib/src/models/websocket_models.dart
+++ b/packages/server_core/lib/src/models/websocket_models.dart
@@ -20,21 +20,26 @@ class UserDataChangedMessage extends ServerWebSocketMessage {
   final String userId;
   final List<String> itemIds;
 
-  const UserDataChangedMessage({
-    required this.userId,
-    this.itemIds = const [],
-  });
+  const UserDataChangedMessage({required this.userId, this.itemIds = const []});
 }
 
 class PlayMessage extends ServerWebSocketMessage {
   final List<String> itemIds;
   final int? startPositionTicks;
   final String playCommand;
+  final int startIndex;
+  final int? audioStreamIndex;
+  final int? subtitleStreamIndex;
+  final String? mediaSourceId;
 
   const PlayMessage({
     required this.itemIds,
     this.startPositionTicks,
     this.playCommand = 'PlayNow',
+    this.startIndex = 0,
+    this.audioStreamIndex,
+    this.subtitleStreamIndex,
+    this.mediaSourceId,
   });
 }
 
@@ -42,20 +47,14 @@ class PlaystateMessage extends ServerWebSocketMessage {
   final String command;
   final int? seekPositionTicks;
 
-  const PlaystateMessage({
-    required this.command,
-    this.seekPositionTicks,
-  });
+  const PlaystateMessage({required this.command, this.seekPositionTicks});
 }
 
 class GeneralCommandMessage extends ServerWebSocketMessage {
   final String name;
   final Map<String, String> arguments;
 
-  const GeneralCommandMessage({
-    required this.name,
-    this.arguments = const {},
-  });
+  const GeneralCommandMessage({required this.name, this.arguments = const {}});
 }
 
 class ServerRestartingMessage extends ServerWebSocketMessage {
@@ -87,10 +86,7 @@ class ServerEventMessage extends ServerWebSocketMessage {
   final String type;
   final Map<String, dynamic> data;
 
-  const ServerEventMessage({
-    required this.type,
-    this.data = const {},
-  });
+  const ServerEventMessage({required this.type, this.data = const {}});
 }
 
 class SyncPlayCommandMessage extends ServerWebSocketMessage {


### PR DESCRIPTION
# Pull Request

## Summary
Fixes Android TV remote `PlayNow` startup from an idle/home Moonfin client.

Before this change, Jellyfin remote playback could update the server session but fail to bring Moonfin to the player screen. This PR routes remote `PlayNow` to the correct player before starting playback, preserves Jellyfin playback payload fields, and makes remote Live TV respect Moonfin's Live TV Direct setting.

## Related Issues
- Fixes #524

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Preserve `StartIndex`, `MediaSourceId`, `AudioStreamIndex`, and `SubtitleStreamIndex` from Jellyfin websocket `PlayMessage` payloads.
- Ensure remote `PlayNow` pushes the audio/video player route before calling `PlaybackManager.playItems(...)`.
- For Live TV / Tunarr channels, pass playback flags matching `LiveTvPlayerScreen` so Live TV Direct OFF uses transcoding instead of direct play.

## Platform
- [x] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built and installed a side-by-side Android TV beta debug APK on a Fire TV Cube (`org.moonfin.androidtv.beta`).
2. Sent Jellyfin remote `PlayNow` to movie `Airplane!` while Moonfin was idle/home; verified Jellyfin `IsPaused=false`, Android focus on Moonfin, and Android Media3 `PlaybackState state=3` with `Airplane!` metadata.
3. With Live TV Direct OFF, sent Jellyfin remote `PlayNow` to Tunarr channel `Seinfeld`; verified Jellyfin `PlayMethod=Transcode`, `IsPaused=false`, and Android Media3 `PlaybackState state=3` with `Seinfeld` metadata.
4. Repeated Live TV validation with Tunarr channel `Stand-Up Comedy`; verified Jellyfin `PlayMethod=Transcode`, `IsPaused=false`, and Android Media3 `PlaybackState state=3` with `Stand-Up Comedy` metadata.
5. Ran `dart format` and `flutter analyze lib/auth/repositories/session_repository.dart` successfully.

## Screenshots (if applicable)
N/A. This is a remote playback/session routing fix; validation was done via Jellyfin session state and Android Media3 playback state on physical hardware.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
