### PR TITLE
feat: UI Scaling & Interactive Details Metadata

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -196,12 +196,9 @@ class _MoonfinAppState extends State<MoonfinApp> {
                   ],
                 );
 
-                if (!PlatformDetection.useDesktopUi) {
-                  if (PlatformDetection.isAppleTV) {
-                    return _TvUiScale(child: overlay);
-                  }
-                  return overlay;
-                }
+                final mainChild = PlatformDetection.isAppleTV
+                    ? _TvUiScale(child: overlay)
+                    : overlay;
 
                 return ListenableBuilder(
                   listenable: _prefs,
@@ -209,10 +206,10 @@ class _MoonfinAppState extends State<MoonfinApp> {
                     final scale =
                         _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
                     return MediaQuery(
-                      data: MediaQuery.of(
-                        context,
-                      ).copyWith(textScaler: TextScaler.linear(scale)),
-                      child: overlay,
+                      data: MediaQuery.of(context).copyWith(
+                        textScaler: TextScaler.linear(scale),
+                      ),
+                      child: mainChild,
                     );
                   },
                 );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -205,9 +205,11 @@ class _MoonfinAppState extends State<MoonfinApp> {
                   builder: (context, _) {
                     final scale =
                         _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+                    final systemScale =
+                        MediaQuery.textScalerOf(context).scale(1.0);
                     return MediaQuery(
                       data: MediaQuery.of(context).copyWith(
-                        textScaler: TextScaler.linear(scale),
+                        textScaler: TextScaler.linear(scale * systemScale),
                       ),
                       child: mainChild,
                     );

--- a/lib/data/repositories/search_repository.dart
+++ b/lib/data/repositories/search_repository.dart
@@ -19,6 +19,7 @@ class SearchRepository {
   }) async {
     final trimmed = query.trim();
     if (trimmed.isEmpty) return const [];
+    if (trimmed.toLowerCase().startsWith('studio:')) return const [];
     final normalizedQuery = trimmed.toLowerCase();
 
     final response = await _client.itemsApi.getItems(
@@ -54,13 +55,18 @@ class SearchRepository {
     String? parentId,
     int? limit,
   }) async {
+    final isStudioQuery = query.toLowerCase().startsWith('studio:');
+    final searchTerm = isStudioQuery ? null : query;
+    final studios = isStudioQuery ? [query.substring('studio:'.length)] : null;
+
     final response = await _client.itemsApi.getItems(
-      searchTerm: query,
+      searchTerm: searchTerm,
       parentId: parentId,
       includeItemTypes: includeItemTypes,
       limit: limit ?? 24,
       recursive: true,
       fields: _searchFields,
+      studios: studios,
     );
 
     final items = response['Items'] as List? ?? [];

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -700,8 +700,18 @@ class ItemDetailViewModel extends ChangeNotifier {
   List<Map<String, dynamic>> get writers =>
       _item?.people.where((p) => p['Type'] == 'Writer').toList() ?? const [];
 
-  List<Map<String, dynamic>> get actors =>
-      _item?.people.where((p) => p['Type'] == 'Actor').toList() ?? const [];
+  List<Map<String, dynamic>> get actors {
+    final list = _item?.people ?? const [];
+    final dirNames = directors.map((d) => d['Name'] as String?).toSet();
+    final writNames = writers.map((w) => w['Name'] as String?).toSet();
+    return list.where((p) {
+      final type = p['Type'] as String?;
+      if (type != 'Actor' && type != 'GuestStar') return false;
+      final name = p['Name'] as String?;
+      if (dirNames.contains(name) || writNames.contains(name)) return false;
+      return true;
+    }).toList();
+  }
 
   List<AggregatedItem> get filmographyMovies =>
       _filmography.where((i) => i.type == 'Movie').toList();

--- a/lib/data/viewmodels/search_view_model.dart
+++ b/lib/data/viewmodels/search_view_model.dart
@@ -202,6 +202,7 @@ class SearchViewModel extends ChangeNotifier {
 
   Future<List<SeerrDiscoverItem>> _fetchSeerrResults(String query) async {
     if (_scopedParentId != null) return const [];
+    if (query.trim().toLowerCase().startsWith('studio:')) return const [];
     final repo = _seerrRepository;
     if (repo == null) return const [];
     try {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2825,9 +2825,9 @@
   "@focusExpansionAnimation": {
     "description": "Setting for focus expansion animation"
   },
-  "desktopUiScale": "Desktop UI Scale",
+  "desktopUiScale": "UI Scaling",
   "@desktopUiScale": {
-    "description": "Setting for desktop UI scale"
+    "description": "Setting for UI scaling"
   },
   "scaleFocusedCards": "Scale focused or hovered cards and tiles",
   "@scaleFocusedCards": {

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -6723,7 +6723,7 @@
   "libraryNameWithServer": "{libraryName} ({serverName})",
   "latestLibraryName": "Latest {libraryName}",
   "discNumber": "Disc {number}",
-  "desktopUiScale": "Desktop UI Scale",
+  "desktopUiScale": "UI Scaling",
   "nextUpDisplay": "Next Up Display",
   "settingsNextUpDisplayDescription": "Extended shows a full card with episode artwork and description. Minimal shows a compact countdown overlay. Disabled hides the prompt entirely.",
   "@discNumber": {
@@ -6735,7 +6735,7 @@
     }
   },
   "@desktopUiScale": {
-    "description": "Setting for desktop UI scale"
+    "description": "Setting for UI scaling"
   },
   "@nextUpDisplay": {
     "description": "Setting for next up behavior"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3611,10 +3611,10 @@ abstract class AppLocalizations {
   /// **'Focus Expansion Animation'**
   String get focusExpansionAnimation;
 
-  /// Setting for desktop UI scale
+  /// Setting for UI scaling
   ///
   /// In en, this message translates to:
-  /// **'Desktop UI Scale'**
+  /// **'UI Scaling'**
   String get desktopUiScale;
 
   /// Description for focus expansion animation

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1980,7 +1980,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get focusExpansionAnimation => 'Focus Expansion Animation';
 
   @override
-  String get desktopUiScale => 'Desktop UI Scale';
+  String get desktopUiScale => 'UI Scaling';
 
   @override
   String get scaleFocusedCards => 'Scale focused or hovered cards and tiles';
@@ -10147,7 +10147,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get focusExpansionAnimation => 'Focus Expansion Animation';
 
   @override
-  String get desktopUiScale => 'Desktop UI Scale';
+  String get desktopUiScale => 'UI Scaling';
 
   @override
   String get scaleFocusedCards => 'Scale focused or hovered cards and tiles';

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -288,7 +288,6 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   }
 
   double _desktopUiScaleFactor() {
-    if (!PlatformDetection.useDesktopUi) return 1.0;
     return _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
   }
 

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -36,7 +36,6 @@ bool _isCompact(BuildContext context) =>
     MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
 
 double _desktopUiScaleFactor() {
-  if (!PlatformDetection.useDesktopUi) return 1.0;
   return GetIt.instance<UserPreferences>()
       .get(UserPreferences.desktopUiScale)
       .scaleFactor;
@@ -492,9 +491,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
         final hasSubtitles = _vm.gridItems.any(
           (item) => (_cardSubtitle(item)?.isNotEmpty ?? false),
         );
-        final desktopTextScale = PlatformDetection.useDesktopUi
-            ? MediaQuery.textScalerOf(context).scale(1.0)
-            : 1.0;
+        final desktopTextScale = MediaQuery.textScalerOf(context).scale(1.0);
         final textHeight = (hasSubtitles ? 42.0 : 24.0) * desktopTextScale;
         final childAspectRatio = cellWidth / (cellWidth / ar + textHeight);
         final focusColor = Color(

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -714,7 +714,6 @@ bool _isCompact(BuildContext context) =>
     MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
 
 double _desktopUiScaleFactor() {
-  if (!PlatformDetection.useDesktopUi) return 1.0;
   return GetIt.instance<UserPreferences>()
       .get(UserPreferences.desktopUiScale)
       .scaleFactor;
@@ -3981,9 +3980,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         final hasSubtitles = _vm.items.any(
           (item) => (_cardSubtitle(item)?.isNotEmpty ?? false),
         );
-        final desktopTextScale = PlatformDetection.useDesktopUi
-            ? MediaQuery.textScalerOf(context).scale(1.0)
-            : 1.0;
+        final desktopTextScale = MediaQuery.textScalerOf(context).scale(1.0);
         final textHeight = (hasSubtitles ? 42.0 : 24.0) * desktopTextScale;
         final childAspectRatio = cellWidth / (cellWidth / ar + textHeight);
 

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -331,7 +331,6 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
   }
 
   double _desktopUiScaleFactor() {
-    if (!PlatformDetection.useDesktopUi) return 1.0;
     return _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
   }
 
@@ -466,11 +465,9 @@ class _GenresHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isMobile = _isCompact(context);
-    final desktopScale = PlatformDetection.useDesktopUi
-        ? GetIt.instance<UserPreferences>()
-              .get(UserPreferences.desktopUiScale)
-              .scaleFactor
-        : 1.0;
+    final desktopScale = GetIt.instance<UserPreferences>()
+          .get(UserPreferences.desktopUiScale)
+          .scaleFactor;
     final topPadding = isMobile ? MediaQuery.of(context).padding.top : 8.0;
     final horizontalPadding = isMobile
         ? _mobileHorizontalPadding

--- a/lib/ui/screens/browse/library_view_screen.dart
+++ b/lib/ui/screens/browse/library_view_screen.dart
@@ -11,7 +11,6 @@ import '../../../data/services/background_service.dart';
 import '../../../data/services/row_data_source.dart';
 import '../../../data/viewmodels/library_view_view_model.dart';
 import '../../../preference/user_preferences.dart';
-import '../../../util/platform_detection.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/fullscreen_backdrop_switcher.dart';
@@ -76,7 +75,6 @@ class _LibraryViewScreenState extends State<LibraryViewScreen> {
   }
 
   double _desktopUiScaleFactor() {
-    if (!PlatformDetection.useDesktopUi) return 1.0;
     return _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
   }
 
@@ -247,7 +245,7 @@ class _LibraryViewHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scale = PlatformDetection.useDesktopUi ? desktopScale : 1.0;
+    final scale = desktopScale;
     return Padding(
       padding: EdgeInsets.fromLTRB(
         _horizontalPadding * scale,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -8798,7 +8798,6 @@ class _MetadataSection extends StatefulWidget {
   const _MetadataSection({
     required this.viewModel,
     this.firstItemFocusNode,
-    this.downTarget,
   });
 
   @override

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -8793,7 +8793,6 @@ class _MetadataSection extends StatefulWidget {
   final ItemDetailViewModel viewModel;
   final FocusNode? firstItemFocusNode;
   final FocusNode? upTarget;
-  final FocusNode? downTarget;
 
   const _MetadataSection({
     required this.viewModel,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -77,7 +77,6 @@ bool _useDesktopDetailLayout(BuildContext context) {
 }
 
 double _desktopUiScale({UserPreferences? prefs}) {
-  if (!PlatformDetection.useDesktopUi) return 1.0;
   final effectivePrefs = prefs ?? GetIt.instance<UserPreferences>();
   return effectivePrefs.get(UserPreferences.desktopUiScale).scaleFactor;
 }
@@ -967,7 +966,7 @@ class _DetailContentState extends State<_DetailContent> {
                           48,
                           MediaQuery.of(context).padding.top + 80.0,
                           48,
-                          48,
+                          48 * _desktopUiScale(),
                         ),
                         sliver: SliverList(
                           delegate: SliverChildListDelegate(
@@ -1011,7 +1010,7 @@ class _DetailContentState extends State<_DetailContent> {
                           _isCompact(context) ? 16 : 48,
                           0,
                           _isCompact(context) ? 16 : 48,
-                          MediaQuery.of(context).padding.bottom + 32,
+                          (MediaQuery.of(context).padding.bottom + 48.0) * _desktopUiScale(),
                         ),
                   sliver: SliverList(
                     delegate: SliverChildListDelegate(
@@ -1370,9 +1369,13 @@ class _DetailContentState extends State<_DetailContent> {
         : null;
     final actionButtonsFocusNode = _sectionFocusNode('detailActionButtons');
     final overviewFocusNode = _headerOverviewFocusNode(item);
+    final metadataFocusNode = _hasMetadata(item) ? _sectionFocusNode('detailMovieMetadata') : null;
+    final movieDownTarget = hasChapters
+        ? _firstChapterFocusNode
+        : (hasFeatures ? _firstFeatureFocusNode : (castFocusNode ?? collectionFocusNode ?? similarFocusNode));
     final chapterFeatureLastNode = hasFeatures
         ? _firstFeatureFocusNode
-        : (hasChapters ? _firstChapterFocusNode : actionButtonsFocusNode);
+        : (hasChapters ? _firstChapterFocusNode : (metadataFocusNode ?? actionButtonsFocusNode));
     final chapterFeatureNextNode =
         castFocusNode ?? collectionFocusNode ?? similarFocusNode;
     final collectionUpTarget = castFocusNode ?? chapterFeatureLastNode;
@@ -1386,26 +1389,29 @@ class _DetailContentState extends State<_DetailContent> {
         tvPlayFocusNode: actionButtonsFocusNode,
         upTarget: overviewFocusNode,
         onRequestFocus: _requestSectionFocus,
-        downTarget: hasChapters
-            ? _firstChapterFocusNode
-            : (hasFeatures ? _firstFeatureFocusNode : chapterFeatureNextNode),
+        downTarget: metadataFocusNode ?? movieDownTarget,
         autoPlay: widget.autoPlay,
       ),
       if (_hasMetadata(item)) ...[
         const SizedBox(height: 24),
-        _MetadataSection(viewModel: viewModel),
+        _MetadataSection(
+          viewModel: viewModel,
+          firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: movieDownTarget,
+        ),
       ],
       ..._buildChapterAndFeatureSections(
         context,
         item,
         selectedMediaSourceId: selectedMediaSourceId,
-        prevSectionFocusNode: actionButtonsFocusNode,
+        prevSectionFocusNode: metadataFocusNode ?? actionButtonsFocusNode,
         nextSectionFocusNode: chapterFeatureNextNode,
       ),
       if (viewModel.actors.isNotEmpty) ...[
         const SizedBox(height: 32),
         HorizontalScrollSection(
-          title: l10n.castAndCrew,
+          title: l10n.cast,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
             color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                 ? AppColorScheme.onSurface
@@ -1507,6 +1513,12 @@ class _DetailContentState extends State<_DetailContent> {
         : null;
     final actionButtonsFocusNode = _sectionFocusNode('detailActionButtons');
     final overviewFocusNode = _headerOverviewFocusNode(item);
+    final metadataFocusNode = _hasMetadata(item) ? _sectionFocusNode('detailSeriesMetadata') : null;
+    final seriesDownTarget =
+        seriesNextUpFocusNode ??
+        seasonsFocusNode ??
+        castFocusNode ??
+        similarFocusNode;
 
     return [
       _ActionButtons(
@@ -1517,16 +1529,17 @@ class _DetailContentState extends State<_DetailContent> {
         tvPlayFocusNode: actionButtonsFocusNode,
         upTarget: overviewFocusNode,
         onRequestFocus: _requestSectionFocus,
-        downTarget:
-            seriesNextUpFocusNode ??
-            seasonsFocusNode ??
-            castFocusNode ??
-            similarFocusNode,
+        downTarget: metadataFocusNode ?? seriesDownTarget,
         autoPlay: widget.autoPlay,
       ),
       if (_hasMetadata(item)) ...[
         const SizedBox(height: 24),
-        _MetadataSection(viewModel: viewModel),
+        _MetadataSection(
+          viewModel: viewModel,
+          firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: seriesDownTarget,
+        ),
       ],
       if (hasNextUp) ...[
         const SizedBox(height: 32),
@@ -1561,7 +1574,7 @@ class _DetailContentState extends State<_DetailContent> {
               return KeyEventResult.handled;
             }
             if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-              return _requestSectionFocus(actionButtonsFocusNode);
+              return _requestSectionFocus(metadataFocusNode ?? actionButtonsFocusNode);
             }
             if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
               return _requestSectionFocus(
@@ -1594,7 +1607,7 @@ class _DetailContentState extends State<_DetailContent> {
             firstItemFocusNode: seasonsFocusNode,
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: seasonsFocusNode,
-              upTarget: seriesNextUpFocusNode ?? actionButtonsFocusNode,
+              upTarget: seriesNextUpFocusNode ?? metadataFocusNode ?? actionButtonsFocusNode,
               downTarget: castFocusNode ?? similarFocusNode,
               itemCount: viewModel.seasons.length,
             ),
@@ -1604,7 +1617,7 @@ class _DetailContentState extends State<_DetailContent> {
       if (hasCast) ...[
         const SizedBox(height: 32),
         HorizontalScrollSection(
-          title: l10n.castAndCrew,
+          title: l10n.cast,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
             color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                 ? AppColorScheme.onSurface
@@ -1625,6 +1638,7 @@ class _DetailContentState extends State<_DetailContent> {
               upTarget:
                   seasonsFocusNode ??
                   seriesNextUpFocusNode ??
+                  metadataFocusNode ??
                   actionButtonsFocusNode,
               downTarget: similarFocusNode,
               itemCount: viewModel.actors.length,
@@ -1658,6 +1672,7 @@ class _DetailContentState extends State<_DetailContent> {
                   castFocusNode ??
                   seasonsFocusNode ??
                   seriesNextUpFocusNode ??
+                  metadataFocusNode ??
                   actionButtonsFocusNode,
               itemCount: viewModel.similar.length,
               consumeDownWhenNoTarget: true,
@@ -1730,14 +1745,18 @@ class _DetailContentState extends State<_DetailContent> {
     final nextEpisodeFocusNode = nextEpisode != null
         ? _nextEpisodeFocusNode
         : null;
-    final chapterFeatureLastNode = hasFeatures
-        ? _firstFeatureFocusNode
-        : (hasChapters ? _firstChapterFocusNode : actionButtonsFocusNode);
+    final metadataFocusNode = _hasMetadata(item) ? _sectionFocusNode('detailEpisodeMetadata') : null;
     final chapterFeatureNextNode =
         nextEpisodeFocusNode ??
         episodesFocusNode ??
         castFocusNode ??
         similarFocusNode;
+    final episodeDownTarget = hasChapters
+        ? _firstChapterFocusNode
+        : (hasFeatures ? _firstFeatureFocusNode : chapterFeatureNextNode);
+    final chapterFeatureLastNode = hasFeatures
+        ? _firstFeatureFocusNode
+        : (hasChapters ? _firstChapterFocusNode : (metadataFocusNode ?? actionButtonsFocusNode));
 
     return [
       _ActionButtons(
@@ -1748,20 +1767,23 @@ class _DetailContentState extends State<_DetailContent> {
         tvPlayFocusNode: actionButtonsFocusNode,
         upTarget: overviewFocusNode,
         onRequestFocus: _requestSectionFocus,
-        downTarget: hasChapters
-            ? _firstChapterFocusNode
-            : (hasFeatures ? _firstFeatureFocusNode : chapterFeatureNextNode),
+        downTarget: metadataFocusNode ?? episodeDownTarget,
         autoPlay: widget.autoPlay,
       ),
       if (_hasMetadata(item)) ...[
         const SizedBox(height: 24),
-        _MetadataSection(viewModel: viewModel),
+        _MetadataSection(
+          viewModel: viewModel,
+          firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: episodeDownTarget,
+        ),
       ],
       ..._buildChapterAndFeatureSections(
         context,
         item,
         selectedMediaSourceId: selectedMediaSourceId,
-        prevSectionFocusNode: actionButtonsFocusNode,
+        prevSectionFocusNode: metadataFocusNode ?? actionButtonsFocusNode,
         nextSectionFocusNode: chapterFeatureNextNode,
       ),
       if (nextEpisode != null) ...[
@@ -1844,7 +1866,7 @@ class _DetailContentState extends State<_DetailContent> {
       if (hasCast) ...[
         const SizedBox(height: 32),
         HorizontalScrollSection(
-          title: l10n.castAndCrew,
+          title: l10n.cast,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
             color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                 ? AppColorScheme.onSurface
@@ -2686,6 +2708,11 @@ class _DetailContentState extends State<_DetailContent> {
     final castFocusNode = viewModel.actors.isNotEmpty
         ? _sectionFocusNode('detailBoxSetCast')
         : null;
+    final metadataFocusNode = _hasMetadata(item) ? _sectionFocusNode('detailBoxSetMetadata') : null;
+    final boxSetDownTarget = moviesFocusNode ??
+        seriesFocusNode ??
+        otherFocusNode ??
+        castFocusNode;
 
     return [
       if (!_hasMetadata(item)) _NavbarFocusPoint(focusNode: firstFocus),
@@ -2696,16 +2723,16 @@ class _DetailContentState extends State<_DetailContent> {
         onSelectedMediaSourceChanged: onSelectedMediaSourceChanged,
         tvPlayFocusNode: actionButtonsFocusNode,
         onRequestFocus: _requestSectionFocus,
-        downTarget: moviesFocusNode ??
-            seriesFocusNode ??
-            otherFocusNode ??
-            castFocusNode,
+        downTarget: metadataFocusNode ?? boxSetDownTarget,
         autoPlay: widget.autoPlay,
       ),
       if (_hasMetadata(item)) ...[
         const SizedBox(height: 24),
         _MetadataSection(
           viewModel: viewModel,
+          firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: boxSetDownTarget,
         ),
       ],
       if (movies.isNotEmpty) ...[
@@ -2724,7 +2751,7 @@ class _DetailContentState extends State<_DetailContent> {
             firstItemFocusNode: moviesFocusNode,
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: moviesFocusNode,
-              upTarget: actionButtonsFocusNode,
+              upTarget: metadataFocusNode ?? actionButtonsFocusNode,
               downTarget: seriesFocusNode ?? otherFocusNode ?? castFocusNode,
               itemCount: movies.length,
             ),
@@ -2747,7 +2774,7 @@ class _DetailContentState extends State<_DetailContent> {
             firstItemFocusNode: seriesFocusNode,
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: seriesFocusNode,
-              upTarget: moviesFocusNode ?? actionButtonsFocusNode,
+              upTarget: moviesFocusNode ?? metadataFocusNode ?? actionButtonsFocusNode,
               downTarget: otherFocusNode ?? castFocusNode,
               itemCount: series.length,
             ),
@@ -2770,7 +2797,7 @@ class _DetailContentState extends State<_DetailContent> {
             firstItemFocusNode: otherFocusNode,
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: otherFocusNode,
-              upTarget: seriesFocusNode ?? moviesFocusNode ?? actionButtonsFocusNode,
+              upTarget: seriesFocusNode ?? moviesFocusNode ?? metadataFocusNode ?? actionButtonsFocusNode,
               downTarget: castFocusNode,
               itemCount: other.length,
             ),
@@ -2780,7 +2807,7 @@ class _DetailContentState extends State<_DetailContent> {
       if (viewModel.actors.isNotEmpty) ...[
         const SizedBox(height: 32),
         HorizontalScrollSection(
-          title: l10n.castAndCrew,
+          title: l10n.cast,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
             color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                 ? AppColorScheme.onSurface
@@ -2798,7 +2825,7 @@ class _DetailContentState extends State<_DetailContent> {
             firstItemFocusNode: castFocusNode,
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: castFocusNode,
-              upTarget: otherFocusNode ?? seriesFocusNode ?? moviesFocusNode ?? actionButtonsFocusNode,
+              upTarget: otherFocusNode ?? seriesFocusNode ?? moviesFocusNode ?? metadataFocusNode ?? actionButtonsFocusNode,
               itemCount: viewModel.actors.length,
             ),
           ),
@@ -4575,7 +4602,9 @@ class _ActionButtonsState extends State<_ActionButtons> {
 
   int _calculateMaxVisibleButtons(BuildContext context) {
     if (PlatformDetection.isTV) {
-      return 7;
+      final desktopScale = _desktopUiScale();
+      final maxTVButtons = (7 / desktopScale).floor();
+      return maxTVButtons > 2 ? maxTVButtons : 2;
     }
     final screenWidth = MediaQuery.sizeOf(context).width;
     final compact = !_useDesktopDetailLayout(context);
@@ -8644,179 +8673,412 @@ class _ChapterListCardState extends State<_ChapterListCard>
   }
 }
 
-class _MetadataSection extends StatelessWidget {
-  final ItemDetailViewModel viewModel;
+class _MetadataItem {
+  final String name;
+  final String? id;
+  final VoidCallback? onTap;
 
-  const _MetadataSection({
-    required this.viewModel,
+  const _MetadataItem({
+    required this.name,
+    this.id,
+    this.onTap,
+  });
+}
+
+class _MetadataGroup {
+  final String title;
+  final List<_MetadataItem> items;
+
+  const _MetadataGroup({
+    required this.title,
+    required this.items,
+  });
+}
+
+class _MetadataChip extends StatefulWidget {
+  final _MetadataItem item;
+  final FocusNode? focusNode;
+  final VoidCallback? onArrowLeft;
+  final VoidCallback? onArrowRight;
+
+  const _MetadataChip({
+    required this.item,
+    this.focusNode,
+    this.onArrowLeft,
+    this.onArrowRight,
   });
 
   @override
+  State<_MetadataChip> createState() => _MetadataChipState();
+}
+
+class _MetadataChipState extends State<_MetadataChip> with FocusStateMixin {
+  @override
   Widget build(BuildContext context) {
-    final item = viewModel.item!;
-    final entries = <MapEntry<String, String>>[];
+    final theme = Theme.of(context);
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+
+    return MouseRegion(
+      cursor: widget.item.onTap != null
+          ? SystemMouseCursors.click
+          : SystemMouseCursors.basic,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        focusNode: widget.focusNode,
+        onFocusChange: (focused) => setFocused(focused),
+        onKeyEvent: (node, event) {
+          if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+            return KeyEventResult.ignored;
+          }
+          if (isActivateKey(event)) {
+            widget.item.onTap?.call();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+            if (widget.onArrowLeft != null) {
+              widget.onArrowLeft!();
+              return KeyEventResult.handled;
+            }
+          }
+          if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+            if (widget.onArrowRight != null) {
+              widget.onArrowRight!();
+              return KeyEventResult.handled;
+            }
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.item.onTap,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: showFocusBorder
+                  ? focusColor.withValues(alpha: 0.15)
+                  : Colors.white.withValues(alpha: 0.04),
+              border: Border.all(
+                color: showFocusBorder
+                    ? focusColor
+                    : (isNeon
+                        ? AppColorScheme.accent.withValues(alpha: 0.3)
+                        : Colors.white.withValues(alpha: 0.1)),
+                width: showFocusBorder ? 1.5 : 1.0,
+              ),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              widget.item.name,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: showFocusBorder
+                    ? (isNeon ? AppColorScheme.onSurface : Colors.white)
+                    : Colors.white.withValues(alpha: 0.85),
+                fontWeight: showFocusBorder ? FontWeight.bold : FontWeight.normal,
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MetadataSection extends StatefulWidget {
+  final ItemDetailViewModel viewModel;
+  final FocusNode? firstItemFocusNode;
+  final FocusNode? upTarget;
+  final FocusNode? downTarget;
+
+  const _MetadataSection({
+    required this.viewModel,
+    this.firstItemFocusNode,
+    this.upTarget,
+    this.downTarget,
+  });
+
+  @override
+  State<_MetadataSection> createState() => _MetadataSectionState();
+}
+
+class _MetadataSectionState extends State<_MetadataSection> {
+  final List<FocusNode> _focusNodes = [];
+  List<_MetadataGroup> _groups = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _buildGroupsAndFocusNodes();
+  }
+
+  @override
+  void didUpdateWidget(covariant _MetadataSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.viewModel.item != oldWidget.viewModel.item) {
+      _buildGroupsAndFocusNodes();
+    }
+  }
+
+  void _buildGroupsAndFocusNodes() {
+    for (final node in _focusNodes) {
+      if (node != widget.firstItemFocusNode) {
+        node.dispose();
+      }
+    }
+    _focusNodes.clear();
+
+    final item = widget.viewModel.item!;
     final l10n = AppLocalizations.of(context);
+    final serverId = widget.viewModel.item?.serverId;
+    final newGroups = <_MetadataGroup>[];
 
-    if (viewModel.directors.isNotEmpty) {
-      entries.add(
-        MapEntry(
-          l10n.director,
-          viewModel.directors.map((d) => d['Name'] as String).join(', '),
+    if (widget.viewModel.directors.isNotEmpty) {
+      newGroups.add(
+        _MetadataGroup(
+          title: l10n.director,
+          items: widget.viewModel.directors.map((d) {
+            final name = d['Name'] as String? ?? '';
+            final id = d['Id'] as String?;
+            return _MetadataItem(
+              name: name,
+              id: id,
+              onTap: id != null
+                  ? () => context.push(Destinations.item(id, serverId: serverId))
+                  : null,
+            );
+          }).toList(),
         ),
       );
     }
-    if (viewModel.writers.isNotEmpty) {
-      entries.add(
-        MapEntry(
-          l10n.writers,
-          viewModel.writers.map((w) => w['Name'] as String).join(', '),
+
+    if (widget.viewModel.writers.isNotEmpty) {
+      newGroups.add(
+        _MetadataGroup(
+          title: l10n.writers,
+          items: widget.viewModel.writers.map((w) {
+            final name = w['Name'] as String? ?? '';
+            final id = w['Id'] as String?;
+            return _MetadataItem(
+              name: name,
+              id: id,
+              onTap: id != null
+                  ? () => context.push(Destinations.item(id, serverId: serverId))
+                  : null,
+            );
+          }).toList(),
         ),
       );
     }
+
     if (item.studios.isNotEmpty) {
-      final studioNames = item.studios.map((s) => s['Name'] as String).toList();
-      final display = studioNames.length > 5
-          ? '${studioNames.take(5).join(', ')} ${l10n.studioMoreCount(studioNames.length - 5)}'
-          : studioNames.join(', ');
-      entries.add(MapEntry(l10n.studio, display));
+      newGroups.add(
+        _MetadataGroup(
+          title: l10n.studio,
+          items: item.studios.map((s) {
+            final name = s['Name'] as String? ?? '';
+            final id = s['Id'] as String?;
+            return _MetadataItem(
+              name: name,
+              id: id,
+              onTap: name.isNotEmpty
+                  ? () => context.push(Destinations.searchWith('studio:$name'))
+                  : null,
+            );
+          }).toList(),
+        ),
+      );
     }
 
-    if (entries.isEmpty) return const SizedBox.shrink();
+    _groups = newGroups;
+
+    int index = 0;
+    for (final group in _groups) {
+      for (final _ in group.items) {
+        FocusNode node;
+        if (index == 0 && widget.firstItemFocusNode != null) {
+          node = widget.firstItemFocusNode!;
+        } else {
+          node = FocusNode(debugLabel: 'metadata_chip_$index');
+        }
+        _focusNodes.add(node);
+        index++;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final node in _focusNodes) {
+      if (node != widget.firstItemFocusNode) {
+        node.dispose();
+      }
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_groups.isEmpty) return const SizedBox.shrink();
 
     final isMobile = _isCompact(context);
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
-    final cellPadding = isMobile
-        ? const EdgeInsets.symmetric(horizontal: 12, vertical: 10)
-        : const EdgeInsets.symmetric(horizontal: 16, vertical: 14);
 
-    final mainContent = entries.isEmpty
-        ? const SizedBox.shrink()
-        : Container(
-            decoration: BoxDecoration(
+    // Calculate first FocusNode of each group
+    final List<FocusNode> firstNodesOfGroups = [];
+    int runningIndex = 0;
+    for (final group in _groups) {
+      if (group.items.isNotEmpty && runningIndex < _focusNodes.length) {
+        firstNodesOfGroups.add(_focusNodes[runningIndex]);
+        runningIndex += group.items.length;
+      }
+    }
+
+    return FocusTraversalGroup(
+      child: Container(
+        decoration: BoxDecoration(
+          color: isNeon
+              ? AppColorScheme.background.withValues(alpha: 0.25)
+              : Colors.white.withValues(alpha: 0.03),
+          border: Border.fromBorderSide(
+            ThemeRegistry.active.borders.cardBorder.copyWith(
               color: isNeon
-                  ? AppColorScheme.background.withValues(alpha: 0.25)
-                  : Colors.white.withValues(alpha: 0.03),
-              border: Border.fromBorderSide(
-                ThemeRegistry.active.borders.cardBorder.copyWith(
-                  color: isNeon
-                      ? AppColorScheme.accent.withValues(alpha: 0.95)
-                      : Colors.white.withValues(alpha: 0.06),
-                  width: isNeon ? 1.2 : null,
+                  ? AppColorScheme.accent.withValues(alpha: 0.95)
+                  : Colors.white.withValues(alpha: 0.06),
+              width: isNeon ? 1.2 : null,
+            ),
+          ),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: isMobile
+            ? Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: _groups.map((group) {
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            group.title,
+                            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                              color: isNeon
+                                  ? AppColorScheme.accent
+                                  : Colors.white.withValues(alpha: 0.4),
+                              fontWeight: FontWeight.w600,
+                              letterSpacing: 1.0,
+                              fontSize: 10,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: group.items.map((item) {
+                              return Padding(
+                                padding: const EdgeInsets.only(bottom: 6),
+                                child: _MetadataChip(item: item),
+                              );
+                            }).toList(),
+                          ),
+                        ],
+                      ),
+                    );
+                  }).toList(),
+                ),
+              )
+            : IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: _groups.asMap().entries.map((e) {
+                    final groupIndex = e.key;
+                    final group = e.value;
+                    return Expanded(
+                      child: Row(
+                        children: [
+                          if (groupIndex > 0)
+                            Container(
+                              width: 1,
+                              color: isNeon
+                                  ? AppColorScheme.accent.withValues(alpha: 0.8)
+                                  : Colors.white.withValues(alpha: 0.08),
+                            ),
+                          Expanded(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                                vertical: 14,
+                              ),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisAlignment: MainAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    group.title,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .labelSmall
+                                        ?.copyWith(
+                                          color: isNeon
+                                              ? AppColorScheme.accent
+                                              : Colors.white.withValues(alpha: 0.4),
+                                          fontWeight: FontWeight.w600,
+                                          letterSpacing: 1.0,
+                                        ),
+                                  ),
+                                  const SizedBox(height: 8),
+                                  Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: group.items.asMap().entries.map((itemEntry) {
+                                      final itemIndexInGroup = itemEntry.key;
+                                      final item = itemEntry.value;
+
+                                      int chipIndex = 0;
+                                      for (int i = 0; i < groupIndex; i++) {
+                                        chipIndex += _groups[i].items.length;
+                                      }
+                                      chipIndex += itemIndexInGroup;
+                                      if (chipIndex >= _focusNodes.length) {
+                                        return Padding(
+                                          padding: const EdgeInsets.only(bottom: 8),
+                                          child: _MetadataChip(item: item),
+                                        );
+                                      }
+                                      final node = _focusNodes[chipIndex];
+                                      final totalGroups = _groups.length;
+
+                                      return Padding(
+                                        padding: const EdgeInsets.only(bottom: 8),
+                                        child: _MetadataChip(
+                                          item: item,
+                                          focusNode: node,
+                                          onArrowLeft: groupIndex == 0
+                                              ? () {} // cap left
+                                              : () => firstNodesOfGroups[groupIndex - 1].requestFocus(),
+                                          onArrowRight: groupIndex == totalGroups - 1
+                                              ? () {} // cap right
+                                              : () => firstNodesOfGroups[groupIndex + 1].requestFocus(),
+                                        ),
+                                      );
+                                    }).toList(),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }).toList(),
                 ),
               ),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            child: isMobile
-                ? Wrap(
-                    children: entries.asMap().entries.map((e) {
-                      final entry = e.value;
-                      return FractionallySizedBox(
-                        widthFactor: entries.length <= 2 ? 1.0 : 0.5,
-                        child: Padding(
-                          padding: cellPadding,
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                entry.key,
-                                style: Theme.of(context).textTheme.labelSmall
-                                    ?.copyWith(
-                                      color: isNeon
-                                          ? AppColorScheme.accent
-                                          : Colors.white.withValues(alpha: 0.4),
-                                      fontWeight: FontWeight.w600,
-                                      letterSpacing: 1.0,
-                                      fontSize: 10,
-                                    ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                entry.value,
-                                style: Theme.of(context).textTheme.bodySmall
-                                    ?.copyWith(
-                                      color: isNeon
-                                          ? AppColorScheme.onSurface
-                                          : Colors.white.withValues(alpha: 0.9),
-                                      fontSize: 12,
-                                    ),
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ],
-                          ),
-                        ),
-                      );
-                    }).toList(),
-                  )
-                : IntrinsicHeight(
-                    child: Row(
-                      children: [
-                        ...entries.asMap().entries.map((e) {
-                          final index = e.key;
-                          final entry = e.value;
-                          return Expanded(
-                            child: Row(
-                              children: [
-                                if (index > 0)
-                                  Container(
-                                    width: 1,
-                                    color: isNeon
-                                        ? AppColorScheme.accent.withValues(alpha: 0.8)
-                                        : Colors.white.withValues(alpha: 0.08),
-                                  ),
-                                Expanded(
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 16,
-                                      vertical: 14,
-                                    ),
-                                    child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      mainAxisAlignment: MainAxisAlignment.center,
-                                      children: [
-                                        Text(
-                                          entry.key,
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .labelSmall
-                                              ?.copyWith(
-                                                color: isNeon
-                                                    ? AppColorScheme.accent
-                                                    : Colors.white.withValues(
-                                                        alpha: 0.4,
-                                                      ),
-                                                fontWeight: FontWeight.w600,
-                                                letterSpacing: 1.0,
-                                              ),
-                                        ),
-                                        const SizedBox(height: 4),
-                                        Text(
-                                          entry.value,
-                                          style: Theme.of(context).textTheme.bodySmall
-                                              ?.copyWith(
-                                                color: isNeon
-                                                    ? AppColorScheme.onSurface
-                                                    : Colors.white.withValues(
-                                                        alpha: 0.9,
-                                                      ),
-                                              ),
-                                          maxLines: 2,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          );
-                        }),
-                      ],
-                    ),
-                  ),
-          );
-
-    return mainContent;
+      ),
+    );
   }
 }
 
@@ -10118,8 +10380,8 @@ class _FilmographyRow extends StatelessWidget {
     final desktopScale = _desktopUiScale(prefs: prefs);
 
     // Aligned with the Home Screen's scaling logic:
-    final platformScale = PlatformDetection.isTV ? 0.8 : desktopScale;
-    final metadataScale = PlatformDetection.useDesktopUi ? desktopScale : 1.0;
+    final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
+    final metadataScale = desktopScale;
     final isRowsV2 =
         prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2;
     final rowScale = isRowsV2 ? 2.0 : 1.0;
@@ -10226,8 +10488,8 @@ class _SeerrAppearancesRow extends StatelessWidget {
     final desktopScale = _desktopUiScale(prefs: prefs);
 
     // Aligned with the Home Screen's scaling logic:
-    final platformScale = PlatformDetection.isTV ? 0.8 : desktopScale;
-    final metadataScale = PlatformDetection.useDesktopUi ? desktopScale : 1.0;
+    final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
+    final metadataScale = desktopScale;
     final isRowsV2 =
         prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2;
     final rowScale = isRowsV2 ? 2.0 : 1.0;

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -8798,7 +8798,6 @@ class _MetadataSection extends StatefulWidget {
   const _MetadataSection({
     required this.viewModel,
     this.firstItemFocusNode,
-    this.upTarget,
     this.downTarget,
   });
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1397,8 +1397,6 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
-          upTarget: actionButtonsFocusNode,
-          downTarget: movieDownTarget,
         ),
       ],
       ..._buildChapterAndFeatureSections(
@@ -1537,8 +1535,6 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
-          upTarget: actionButtonsFocusNode,
-          downTarget: seriesDownTarget,
         ),
       ],
       if (hasNextUp) ...[
@@ -1775,8 +1771,6 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
-          upTarget: actionButtonsFocusNode,
-          downTarget: episodeDownTarget,
         ),
       ],
       ..._buildChapterAndFeatureSections(
@@ -2731,8 +2725,6 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
-          upTarget: actionButtonsFocusNode,
-          downTarget: boxSetDownTarget,
         ),
       ],
       if (movies.isNotEmpty) ...[

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -8792,7 +8792,6 @@ class _MetadataChipState extends State<_MetadataChip> with FocusStateMixin {
 class _MetadataSection extends StatefulWidget {
   final ItemDetailViewModel viewModel;
   final FocusNode? firstItemFocusNode;
-  final FocusNode? upTarget;
 
   const _MetadataSection({
     required this.viewModel,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2277,41 +2277,70 @@ class _ContentRowsState extends State<_ContentRows>
   ) {
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
+    double extent;
     if (row.isLoading) {
-      return _libraryRowExtent(220 * metadataScale, metadataScale: metadataScale);
-    }
-
-    if (row.rowType == HomeRowType.liveTv ||
+      extent = _libraryRowExtent(220 * metadataScale, metadataScale: metadataScale);
+    } else if (row.rowType == HomeRowType.liveTv ||
         row.rowType == HomeRowType.libraryTilesSmall) {
       final squarePosterSide = _squarePosterSide(posterSize);
       final rowHeight = squarePosterSide + (56 * metadataScale);
-      return _libraryRowExtent(rowHeight, metadataScale: metadataScale);
+      extent = _libraryRowExtent(rowHeight, metadataScale: metadataScale);
+    } else {
+      final isSeerrRowOverride = _isSeerrFilterRow(row);
+      final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !isSeerrRowOverride;
+      final rowImageType = isSeerrRowOverride
+          ? ImageType.thumb
+          : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
+      final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
+      var maxCardHeight = 220.0 * metadataScale;
+      if (isRowsV2) {
+        final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
+        maxCardHeight = imageHeight + (_v2MetadataHeightBudget(prefs) * metadataScale);
+      } else {
+        for (final item in row.items) {
+          final aspectRatio = _aspectRatioForRowItem(item, row, rowImageType);
+          final imageHeight = (aspectRatio > 1
+              ? posterSize.landscapeHeight.toDouble()
+              : posterSize.portraitHeight.toDouble()) * platformScale;
+          final cardHeight = imageHeight + (46 * metadataScale);
+          if (cardHeight > maxCardHeight) {
+            maxCardHeight = cardHeight;
+          }
+        }
+      }
+      extent = _libraryRowExtent(maxCardHeight, metadataScale: metadataScale);
     }
 
-    final isSeerrRowOverride = _isSeerrFilterRow(row);
-    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !isSeerrRowOverride;
-    final rowImageType = isSeerrRowOverride
-        ? ImageType.thumb
-        : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
-    final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
-    var maxCardHeight = 220.0 * metadataScale;
-    if (isRowsV2) {
-      final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
-      maxCardHeight = imageHeight + (_v2MetadataHeightBudget(prefs) * metadataScale);
-    } else {
-      for (final item in row.items) {
-        final aspectRatio = _aspectRatioForRowItem(item, row, rowImageType);
-        final imageHeight = (aspectRatio > 1
-            ? posterSize.landscapeHeight.toDouble()
-            : posterSize.portraitHeight.toDouble()) * platformScale;
-        final cardHeight = imageHeight + (46 * metadataScale);
-        if (cardHeight > maxCardHeight) {
-          maxCardHeight = cardHeight;
+    final fullScreenRows = PlatformDetection.isTV && prefs.get(UserPreferences.fullScreenRows);
+    if (fullScreenRows) {
+      final viewportHeight = MediaQuery.sizeOf(context).height;
+      final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
+      final navbarHeight = 95.0;
+      double overlayBottom;
+      if (isRowsV2) {
+        overlayBottom = navbarHeight;
+      } else {
+        final showInfoOverlay = prefs.get(UserPreferences.homeRowInfoOverlay);
+        if (showInfoOverlay) {
+          final safeTop = MediaQuery.paddingOf(context).top;
+          final infoTopBasePadding = (navbarHeight == 0) ? 14.0 : 8.0;
+          final infoTopPadding = safeTop + navbarHeight + infoTopBasePadding;
+          final infoAreaHeight = InfoArea.fixedHeight(
+            isMobile: false,
+            desktopScale: desktopScale,
+          );
+          overlayBottom = infoTopPadding + infoAreaHeight;
+        } else {
+          overlayBottom = 0.0;
         }
+      }
+      final targetExtent = viewportHeight - overlayBottom - 8.0;
+      if (extent < targetExtent) {
+        extent = targetExtent;
       }
     }
 
-    return _libraryRowExtent(maxCardHeight, metadataScale: metadataScale);
+    return extent;
   }
 
   List<double> _computeRowExtents(
@@ -2374,14 +2403,10 @@ class _ContentRowsState extends State<_ContentRows>
   double _v2MetadataHeightBudget(UserPreferences prefs) {
     final hasAdditionalRatings =
         prefs.get(UserPreferences.enableAdditionalRatings);
-    final fullScreenRows =
-        PlatformDetection.isTV && prefs.get(UserPreferences.fullScreenRows);
     final hasAdditionalRatingsPadding =
         hasAdditionalRatings ? 8.0 : 0.0;
-    final fullScreenRowsPadding =
-        fullScreenRows ? 156.0 : 0.0;
     final heightBudget =
-        136.0 + hasAdditionalRatingsPadding + fullScreenRowsPadding;
+        136.0 + hasAdditionalRatingsPadding;
     return heightBudget;
   }
 
@@ -2710,7 +2735,7 @@ class _ContentRowsState extends State<_ContentRows>
                   isLoading: true,
                   children: const [],
                 );
-                return Padding(
+                final itemWidget = Padding(
                   padding: EdgeInsets.only(left: rowLeftInset),
                   child: _buildShiftedRow(
                     child: rowChild,
@@ -2721,6 +2746,13 @@ class _ContentRowsState extends State<_ContentRows>
                     overlayBottom: overlayBottom,
                   ),
                 );
+                if (fullScreenRows) {
+                  return SizedBox(
+                    height: rowExtents[rowIndex],
+                    child: itemWidget,
+                  );
+                }
+                return itemWidget;
               } else if (row.rowType == HomeRowType.liveTv) {
                 rowChild = _buildLiveTvRow(
                   row,
@@ -2753,7 +2785,7 @@ class _ContentRowsState extends State<_ContentRows>
                   l10n: l10n,
                 );
               }
-              return Padding(
+              final itemWidget = Padding(
                 padding: EdgeInsets.only(left: rowLeftInset),
                 child: AnimatedPadding(
                   duration: _focusedRowSpacingDuration,
@@ -2775,6 +2807,17 @@ class _ContentRowsState extends State<_ContentRows>
                   ),
                 ),
               );
+              if (fullScreenRows) {
+                return SizedBox(
+                  height: rowExtents[rowIndex] +
+                      ((PlatformDetection.isTV &&
+                              rowIndex == _activeFocusedRowIndex)
+                          ? _focusedRowExtraSpacing * 2
+                          : 0.0),
+                  child: itemWidget,
+                );
+              }
+              return itemWidget;
               },
             ),
           ),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2261,12 +2261,12 @@ class _ContentRowsState extends State<_ContentRows>
       rowHeight + (34 * metadataScale);
 
   double _desktopUiScaleFactor() {
-    if (!PlatformDetection.useDesktopUi) return 1.0;
     return widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
   }
 
   double _squarePosterSide(PosterSize posterSize) {
-    final platformScale = PlatformDetection.isTV ? 0.8 : _desktopUiScaleFactor();
+    final scaleFactor = _desktopUiScaleFactor();
+    final platformScale = PlatformDetection.isTV ? 0.8 * scaleFactor : scaleFactor;
     return posterSize.portraitHeight.toDouble() * platformScale;
   }
 
@@ -2276,7 +2276,7 @@ class _ContentRowsState extends State<_ContentRows>
     UserPreferences prefs,
   ) {
     final desktopScale = _desktopUiScaleFactor();
-    final metadataScale = PlatformDetection.useDesktopUi ? desktopScale : 1.0;
+    final metadataScale = desktopScale;
     if (row.isLoading) {
       return _libraryRowExtent(220 * metadataScale, metadataScale: metadataScale);
     }
@@ -2293,7 +2293,7 @@ class _ContentRowsState extends State<_ContentRows>
     final rowImageType = isSeerrRowOverride
         ? ImageType.thumb
         : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
-    final platformScale = PlatformDetection.isTV ? 0.8 : desktopScale;
+    final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
     var maxCardHeight = 220.0 * metadataScale;
     if (isRowsV2) {
       final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
@@ -2505,7 +2505,6 @@ class _ContentRowsState extends State<_ContentRows>
 
     final includeMediaBar = _isMediaBarIncluded();
     final bannerMode = _isBannerMode();
-    final includeBigMediaBar = includeMediaBar && !bannerMode;
     final mediaBarHeight = _mediaBarHeight();
     final carouselPaused =
       widget.isHoverPaused ||
@@ -2814,9 +2813,7 @@ class _ContentRowsState extends State<_ContentRows>
     required List<HomeRow> rows,
   }) {
     final l10n = AppLocalizations.of(context);
-    final metadataScale = PlatformDetection.useDesktopUi
-        ? _desktopUiScaleFactor()
-        : 1.0;
+    final metadataScale = _desktopUiScaleFactor();
     final squarePosterSide = _squarePosterSide(posterSize);
     final rowHeight = squarePosterSide + (56 * metadataScale);
     final actions = <_LiveTvAction>[
@@ -2886,9 +2883,7 @@ class _ContentRowsState extends State<_ContentRows>
     required List<HomeRow> rows,
   }) {
     final l10n = AppLocalizations.of(context);
-    final metadataScale = PlatformDetection.useDesktopUi
-        ? _desktopUiScaleFactor()
-        : 1.0;
+    final metadataScale = _desktopUiScaleFactor();
     final squarePosterSide = _squarePosterSide(posterSize);
     final rowHeight = squarePosterSide + (56 * metadataScale);
     return _buildTitledRow(
@@ -2977,8 +2972,8 @@ class _ContentRowsState extends State<_ContentRows>
         ? ImageType.thumb
         : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
     final desktopScale = _desktopUiScaleFactor();
-    final metadataScale = PlatformDetection.useDesktopUi ? desktopScale : 1.0;
-    final platformScale = PlatformDetection.isTV ? 0.8 : desktopScale;
+    final metadataScale = desktopScale;
+    final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
     final v2ImageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
     final v2MetadataHeightBudget = _v2MetadataHeightBudget(prefs);
     const v2PortraitAspect = 2 / 3;

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2270,21 +2270,20 @@ class _ContentRowsState extends State<_ContentRows>
     return posterSize.portraitHeight.toDouble() * platformScale;
   }
 
-  double _estimatedRowExtent(
+  double _rowContentHeight(
     HomeRow row,
     PosterSize posterSize,
     UserPreferences prefs,
   ) {
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
-    double extent;
     if (row.isLoading) {
-      extent = _libraryRowExtent(220 * metadataScale, metadataScale: metadataScale);
+      return _libraryRowExtent(220 * metadataScale, metadataScale: metadataScale);
     } else if (row.rowType == HomeRowType.liveTv ||
         row.rowType == HomeRowType.libraryTilesSmall) {
       final squarePosterSide = _squarePosterSide(posterSize);
       final rowHeight = squarePosterSide + (56 * metadataScale);
-      extent = _libraryRowExtent(rowHeight, metadataScale: metadataScale);
+      return _libraryRowExtent(rowHeight, metadataScale: metadataScale);
     } else {
       final isSeerrRowOverride = _isSeerrFilterRow(row);
       final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !isSeerrRowOverride;
@@ -2308,33 +2307,50 @@ class _ContentRowsState extends State<_ContentRows>
           }
         }
       }
-      extent = _libraryRowExtent(maxCardHeight, metadataScale: metadataScale);
+      return _libraryRowExtent(maxCardHeight, metadataScale: metadataScale);
     }
+  }
+
+  double _estimatedRowExtent(
+    HomeRow row,
+    PosterSize posterSize,
+    UserPreferences prefs,
+  ) {
+    var extent = _rowContentHeight(row, posterSize, prefs);
 
     final fullScreenRows = PlatformDetection.isTV && prefs.get(UserPreferences.fullScreenRows);
     if (fullScreenRows) {
+      final desktopScale = _desktopUiScaleFactor();
       final viewportHeight = MediaQuery.sizeOf(context).height;
+      final safeTop = MediaQuery.paddingOf(context).top;
       final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
-      final navbarHeight = 95.0;
-      double overlayBottom;
+
+      final navbarIsTop = prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
+      final navbarHeight = PlatformDetection.isTV
+          ? 95.0
+          : (navbarIsTop
+              ? (PlatformDetection.useMobileUi ? 60.0 : 80.0)
+              : 0.0);
+
+      double topOffset;
       if (isRowsV2) {
-        overlayBottom = navbarHeight;
+        topOffset = safeTop + navbarHeight + 8.0;
       } else {
         final showInfoOverlay = prefs.get(UserPreferences.homeRowInfoOverlay);
         if (showInfoOverlay) {
-          final safeTop = MediaQuery.paddingOf(context).top;
           final infoTopBasePadding = (navbarHeight == 0) ? 14.0 : 8.0;
           final infoTopPadding = safeTop + navbarHeight + infoTopBasePadding;
           final infoAreaHeight = InfoArea.fixedHeight(
             isMobile: false,
             desktopScale: desktopScale,
           );
-          overlayBottom = infoTopPadding + infoAreaHeight;
+          topOffset = infoTopPadding + infoAreaHeight + 8.0;
         } else {
-          overlayBottom = 0.0;
+          topOffset = safeTop + 56.0;
         }
       }
-      final targetExtent = viewportHeight - overlayBottom - 8.0;
+
+      final targetExtent = viewportHeight - topOffset;
       if (extent < targetExtent) {
         extent = targetExtent;
       }
@@ -2548,9 +2564,9 @@ class _ContentRowsState extends State<_ContentRows>
             : (navbarIsTop
                 ? 45.0
                 : 15.0))
-        : (PlatformDetection.useMobileUi
-            ? 60.0
-            : 80.0);
+        : (navbarIsTop
+            ? (PlatformDetection.useMobileUi ? 60.0 : 80.0)
+            : (fullScreenRows ? 0.0 : 80.0));
     final listTopPadding = includeMediaBar || showInfoOverlay
         ? 0.0
         : _isHomeRowsStyleV2()
@@ -2586,7 +2602,7 @@ class _ContentRowsState extends State<_ContentRows>
         ? navbarHeight
         : showInfoOverlay
             ? infoTopPadding + infoAreaHeight
-            : 0.0;
+            : (fullScreenRows ? safeTop + 48.0 : 0.0);
     final rowExtents = _computeRowExtents(rows, posterSize, prefs);
     final rowTopOffsets = <double>[];
     var currentTop = listTopPadding + infoPlaceholderHeight;
@@ -2735,24 +2751,6 @@ class _ContentRowsState extends State<_ContentRows>
                   isLoading: true,
                   children: const [],
                 );
-                final itemWidget = Padding(
-                  padding: EdgeInsets.only(left: rowLeftInset),
-                  child: _buildShiftedRow(
-                    child: rowChild,
-                    rowIndex: rowIndex,
-                    rowTopOffsets: rowTopOffsets,
-                    rowExtents: rowExtents,
-                    showInfoOverlay: showInfoOverlay,
-                    overlayBottom: overlayBottom,
-                  ),
-                );
-                if (fullScreenRows) {
-                  return SizedBox(
-                    height: rowExtents[rowIndex],
-                    child: itemWidget,
-                  );
-                }
-                return itemWidget;
               } else if (row.rowType == HomeRowType.liveTv) {
                 rowChild = _buildLiveTvRow(
                   row,
@@ -2785,6 +2783,41 @@ class _ContentRowsState extends State<_ContentRows>
                   l10n: l10n,
                 );
               }
+
+              final contentHeight = _rowContentHeight(row, posterSize, prefs);
+              final targetExtent = rowExtents[rowIndex];
+              final extraTopPadding = fullScreenRows
+                  ? ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity)
+                  : 0.0;
+
+              final paddedRowChild = extraTopPadding > 0.0
+                  ? Padding(
+                      padding: EdgeInsets.only(top: extraTopPadding),
+                      child: rowChild,
+                    )
+                  : rowChild;
+
+              if (row.isLoading) {
+                final itemWidget = Padding(
+                  padding: EdgeInsets.only(left: rowLeftInset),
+                  child: _buildShiftedRow(
+                    child: paddedRowChild,
+                    rowIndex: rowIndex,
+                    rowTopOffsets: rowTopOffsets,
+                    rowExtents: rowExtents,
+                    showInfoOverlay: showInfoOverlay,
+                    overlayBottom: overlayBottom,
+                  ),
+                );
+                if (fullScreenRows) {
+                  return SizedBox(
+                    height: rowExtents[rowIndex],
+                    child: itemWidget,
+                  );
+                }
+                return itemWidget;
+              }
+
               final itemWidget = Padding(
                 padding: EdgeInsets.only(left: rowLeftInset),
                 child: AnimatedPadding(
@@ -2798,7 +2831,7 @@ class _ContentRowsState extends State<_ContentRows>
                         : 0,
                   ),
                   child: _buildShiftedRow(
-                    child: rowChild,
+                    child: paddedRowChild,
                     rowIndex: rowIndex,
                     rowTopOffsets: rowTopOffsets,
                     rowExtents: rowExtents,

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -697,19 +697,18 @@ class _GeneralStyleScreenState extends State<_GeneralStyleScreen> {
                 subtitle: l10n.scaleFocusedCards,
                 icon: Icons.zoom_in,
               ),
-            if (PlatformDetection.useDesktopUi)
-              EnumPreferenceTile<DesktopUiScale>(
-                preference: UserPreferences.desktopUiScale,
-                title: l10n.desktopUiScale,
-                icon: Icons.zoom_out_map,
-                labelOf: (v) => switch (v) {
-                  DesktopUiScale.small => l10n.small,
-                  DesktopUiScale.medium => l10n.medium,
-                  DesktopUiScale.large => l10n.large,
-                  DesktopUiScale.extraLarge => l10n.extraLarge,
-                },
-                onChanged: _pushPersonalizationSync,
-              ),
+            EnumPreferenceTile<DesktopUiScale>(
+              preference: UserPreferences.desktopUiScale,
+              title: l10n.desktopUiScale,
+              icon: Icons.zoom_out_map,
+              labelOf: (v) => switch (v) {
+                DesktopUiScale.small => l10n.small,
+                DesktopUiScale.medium => l10n.medium,
+                DesktopUiScale.large => l10n.large,
+                DesktopUiScale.extraLarge => l10n.extraLarge,
+              },
+              onChanged: _pushPersonalizationSync,
+            ),
             SwitchPreferenceTile(
               preference: UserPreferences.backdropEnabled,
               title: l10n.backgroundBackdrops,

--- a/lib/ui/widgets/expandable_icon_button.dart
+++ b/lib/ui/widgets/expandable_icon_button.dart
@@ -128,11 +128,9 @@ class _ExpandableIconButtonState extends State<ExpandableIconButton> {
   Widget build(BuildContext context) {
     final isMobile = PlatformDetection.useMobileUi;
     final isTV = PlatformDetection.isTV;
-    final desktopScale = PlatformDetection.useDesktopUi
-        ? _prefs.get(UserPreferences.desktopUiScale).scaleFactor
-        : 1.0;
-    final btnSize = isMobile ? 40.0 : (isTV ? 44.0 : 56.0 * desktopScale);
-    final iconSize = isMobile ? 22.0 : (isTV ? 24.0 : 30.0 * desktopScale);
+    final desktopScale = _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final btnSize = (isMobile ? 40.0 : (isTV ? 44.0 : 56.0)) * desktopScale;
+    final iconSize = (isMobile ? 22.0 : (isTV ? 24.0 : 30.0)) * desktopScale;
     final focusColor = Color(_prefs.get(UserPreferences.focusColor).colorValue);
 
     final hoverActive = _isHovered && !isTV;

--- a/lib/ui/widgets/genre_grid_card.dart
+++ b/lib/ui/widgets/genre_grid_card.dart
@@ -3,7 +3,6 @@ import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../preference/user_preferences.dart';
-import '../../util/platform_detection.dart';
 import 'bounded_network_image.dart';
 import 'marquee_text.dart';
 import '../../util/focus/dpad_keys.dart';
@@ -54,11 +53,9 @@ class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
         widget.focusColor ?? ThemeRegistry.active.borders.focusBorder.color;
     final showMarquee = hovered || focused;
     final imageUrl = widget.genre.imageUrl ?? widget.genre.backdropUrl;
-    final desktopScale = PlatformDetection.useDesktopUi
-        ? GetIt.instance<UserPreferences>()
-            .get(UserPreferences.desktopUiScale)
-            .scaleFactor
-        : 1.0;
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
     final titleStyle = TextStyle(
       fontSize: (widget.centerTitle ? 15 : 16) * desktopScale,
       fontWeight: FontWeight.w600,

--- a/lib/ui/widgets/info_area.dart
+++ b/lib/ui/widgets/info_area.dart
@@ -63,18 +63,16 @@ class InfoArea extends StatelessWidget {
     required bool isMobile,
     double desktopScale = 1.0,
   }) {
-    return isMobile ? 184.0 : 212.0 * desktopScale;
+    return (isMobile ? 184.0 : 212.0) * desktopScale;
   }
 
   @override
   Widget build(BuildContext context) {
     final item = this.item;
     final isMobile = PlatformDetection.useMobileUi;
-    final desktopScale = PlatformDetection.useDesktopUi
-        ? GetIt.instance<UserPreferences>()
-              .get(UserPreferences.desktopUiScale)
-              .scaleFactor
-        : 1.0;
+    final desktopScale = GetIt.instance<UserPreferences>()
+          .get(UserPreferences.desktopUiScale)
+          .scaleFactor;
     final fixedHeight = InfoArea.fixedHeight(
       isMobile: isMobile,
       desktopScale: desktopScale,

--- a/lib/ui/widgets/library_row.dart
+++ b/lib/ui/widgets/library_row.dart
@@ -35,11 +35,9 @@ class _LibraryRowState extends State<LibraryRow> {
     final l10n = AppLocalizations.of(context);
     final hasItems = widget.children.isNotEmpty;
     final showControls = hasItems && PlatformDetection.useDesktopUi;
-    final desktopScale = PlatformDetection.useDesktopUi
-        ? GetIt.instance<UserPreferences>()
-            .get(UserPreferences.desktopUiScale)
-            .scaleFactor
-        : 1.0;
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
     final rowHeight = (widget.rowHeight ?? 220) * desktopScale;
     return HorizontalScrollSection(
       title: widget.title,


### PR DESCRIPTION
# Pull Request: The one about Randall's Eyesight

## Summary
This PR enables global UI Scaling unconditionally across all device form factors and replaces the static metadata block on the Media Details page with interactive, focusable vertical columns (for Directors, Writers, and Studios). It also polishes D-pad directional navigation within the metadata cards on TV and refines Studio search filters.

## Related Issues
Randall complaining on Discord.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Applied UI Scaling unconditionally via `MediaQuery` on all platforms and enabled the settings slider unconditionally.
- Adjusted library rows, genre cards, and browse screens to dynamically resize based on the active scale factor.
- Converted Directors, Writers, and Studios fields into individual, focusable chips.
- Aligned columns horizontally at the top.
- Arranged chips vertically in a `Column` under each header to support standard D-pad Up/Down selection list flows.
- Intercepted Left/Right navigation to move focus directly to the first/top chip of the adjacent column.
- Capped Left navigation on the first column and Right navigation on the last column to prevent focus from exiting the details card.
- Guided Studio clicks to route with `'studio:$name'`. Modified the search repository to filter search results by the Jellyfin/Emby server-side `studios` argument instead of doing a general text search.
- Filtered out directors and writers from the actors list to prevent duplicates and renamed the page section from "Cast & Crew" to "Cast".

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open settings on Android TV (Nvidia Shield) and adjust the "UI Scaling" factor. Verify all cards and text scale proportionally.
2. Navigate to a movie's details page. Verify Director, Writers, and Studio fields are top-aligned.
3. Move focus to the first interactive chip and navigate with D-pad Left/Right/Up/Down. Verify vertical listing traversal, top-column jumping, and capping at the left and right boundaries.
4. Press Enter/OK on a writer/director to navigate to their Person page.
5. Press Enter/OK on a studio (e.g. Bad Robot) and verify search results return only media items from that studio.
6. Verify directors and writers do not duplicate in the "Cast" section.

## Screenshots (if applicable)
<img width="500" alt="Shield_Screenshot_2026-06-13_18-13-17" src="https://github.com/user-attachments/assets/809ac826-cd3f-4c13-a030-b59e5a3e1a3d" />
<img width="500" alt="Shield_Screenshot_2026-06-13_18-15-17" src="https://github.com/user-attachments/assets/15a7f330-494d-4324-8bac-ed610be9b8ff" />
<img width="500" alt="2-medium2" src="https://github.com/user-attachments/assets/a81edd4f-162d-4231-be51-6edcf562abef" />
<img width="500" alt="3-large" src="https://github.com/user-attachments/assets/2a2ba201-6b9c-4990-ae2c-dd60a2c8db13" />
<img width="500" alt="4-extralarge" src="https://github.com/user-attachments/assets/8c670d77-18d8-4ff6-aa07-0d80e7f2ffef" />
<img width="500" alt="Shield_Screenshot_2026-06-13_17-14-00" src="https://github.com/user-attachments/assets/5c7fabfc-90a9-411b-87de-7d95f6998d3f" />
<img width="500" alt="Shield_Screenshot_2026-06-13_17-14-20" src="https://github.com/user-attachments/assets/6b0818fe-854e-4310-b4e1-14f245bcac04" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
