### PR TITLE
fix: resolve pagination infinite loading loops in lists and grids

### DIFF
--- a/lib/data/viewmodels/favorites_view_model.dart
+++ b/lib/data/viewmodels/favorites_view_model.dart
@@ -247,6 +247,8 @@ class FavoritesViewModel extends ChangeNotifier {
       if (newItems.isNotEmpty) {
         _rowItems[type] = [...items, ...newItems];
         notifyListeners();
+      } else {
+        _rowTotalCounts[type] = items.length;
       }
     } catch (_) {
     } finally {
@@ -321,8 +323,12 @@ class FavoritesViewModel extends ChangeNotifier {
     _loadingMoreGrid = true;
     notifyListeners();
 
+    final prevLength = _gridItems.length;
     try {
       await _fetchGridPage(_gridItems.length);
+      if (_gridItems.length <= prevLength) {
+        _gridTotalCount = _gridItems.length;
+      }
     } catch (_) {}
 
     _loadingMoreGrid = false;

--- a/lib/data/viewmodels/folder_browse_view_model.dart
+++ b/lib/data/viewmodels/folder_browse_view_model.dart
@@ -108,8 +108,13 @@ class FolderBrowseViewModel extends ChangeNotifier {
     _loadingMore = true;
     _notify();
 
+    final prevLength = _items.length;
     try {
       await _fetchPage(currentFolderId, _items.length);
+      if (!_disposed && _items.length <= prevLength) {
+        _totalCount = _items.length;
+        _hasMoreFromPageSize = false;
+      }
     } catch (_) {}
 
     if (_disposed) return;

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -249,8 +249,13 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     _loadingMore = true;
     notifyListeners();
 
+    final prevLength = _items.length;
     try {
       await _fetchPage(_items.length);
+      if (_items.length <= prevLength) {
+        _totalCount = _items.length;
+        _hasMoreFromPageSize = false;
+      }
     } catch (_) {}
 
     _loadingMore = false;

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -464,10 +464,13 @@ class HomeViewModel extends ChangeNotifier {
       _rowOffsets[row.id] = currentOffset + 15;
 
       final filteredItems = _filterEmptyElements(result.$1);
+      final newTotalCount = filteredItems.length <= row.items.length
+          ? filteredItems.length
+          : (result.$2 - (result.$1.length - filteredItems.length));
       _rows = List.of(_rows);
       _rows[rowIndex] = row.copyWith(
         items: filteredItems,
-        totalCount: result.$2 - (result.$1.length - filteredItems.length),
+        totalCount: newTotalCount,
       );
       notifyListeners();
     } catch (_) {


### PR DESCRIPTION
# Pull Request

## Summary
Resolve pagination infinite loading loops in lists and grids on the client.

## Related Issues
Related to #525 (This is the separate, dedicated PR for the pagination fixes originally proposed there)

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* lib/data/viewmodels/favorites_view_model.dart: Cap _rowTotalCounts and _gridTotalCount when a fetch page returns empty results.
* lib/data/viewmodels/folder_browse_view_model.dart: Cap _totalCount and set _hasMoreFromPageSize to false when loaded items do not increase.
* lib/data/viewmodels/library_browse_view_model.dart: Cap _totalCount and set _hasMoreFromPageSize to false when loaded items do not increase.
* lib/ui/screens/home/home_view_model.dart: Calculate newTotalCount correctly based on the filtered elements.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a category containing filtered/empty items in the Artwork Selector.
2. Scroll to the bottom of the list/grid.
3. Verify that scrolling stops and no further empty API requests are sent once all items are loaded.

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
