### PR TITLE
ui(sidebar): fix left navigation bar issues

### DIFF
--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -669,7 +669,15 @@ class _LeftSidebarState extends State<LeftSidebar> {
                     ),
                   ),
                 ),
-              _buildContent(),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: AnimatedContainer(
+                  duration: _kExpandDuration,
+                  curve: Curves.easeInOut,
+                  width: _isExpanded ? _kExpandedBackdropWidthTV : _kCollapsedWidthTV,
+                  child: _buildContent(),
+                ),
+              ),
             ],
           ),
         ),
@@ -705,29 +713,44 @@ class _LeftSidebarState extends State<LeftSidebar> {
     final showClock =
         clockBehavior == ClockBehavior.always ||
         clockBehavior == ClockBehavior.inMenus;
-    var neonSlot = 0;
-    Color? nextSidebarColor() {
-      if (!isNeon) return null;
-      final c = neonSlot.isEven
-          ? AppColorScheme.accent
-          : AppColorScheme.onSurface;
-      neonSlot += 1;
-      return c;
-    }
-
     return Column(
       children: [
-        if (_isExpanded)
-          _buildUserSection(),
+        Visibility(
+          visible: _isExpanded,
+          maintainSize: true,
+          maintainAnimation: true,
+          maintainState: true,
+          child: _buildUserSection(),
+        ),
         Expanded(
           child: LayoutBuilder(
             builder: (context, constraints) {
+              var mainNeonSlot = 0;
+              Color? nextMainSidebarColor() {
+                if (!isNeon) return null;
+                final c = mainNeonSlot.isEven
+                    ? AppColorScheme.accent
+                    : AppColorScheme.onSurface;
+                mainNeonSlot += 1;
+                return c;
+              }
+
+              var libraryNeonSlot = 0;
+              Color? nextLibrarySidebarColor() {
+                if (!isNeon) return null;
+                final c = libraryNeonSlot.isEven
+                    ? AppColorScheme.accent
+                    : AppColorScheme.onSurface;
+                libraryNeonSlot += 1;
+                return c;
+              }
+
               final items = <Widget>[
                 _SidebarItem(
                   key: const ValueKey('sidebar-home'),
                   icon: Icons.home_rounded,
                   label: l10n.home,
-                  baseColor: nextSidebarColor(),
+                  baseColor: nextMainSidebarColor(),
                   focusNode: _homeFocusNode,
                   showLabel: _showLabels,
                   onPressed: () {
@@ -746,7 +769,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                   key: const ValueKey('sidebar-search'),
                   icon: Icons.search_rounded,
                   label: l10n.search,
-                  baseColor: nextSidebarColor(),
+                  baseColor: nextMainSidebarColor(),
                   showLabel: _showLabels,
                   onPressed: () {
                     _onNavigate();
@@ -763,7 +786,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                     key: const ValueKey('sidebar-shuffle'),
                     icon: Icons.shuffle_rounded,
                     label: l10n.shuffle,
-                    baseColor: nextSidebarColor(),
+                    baseColor: nextMainSidebarColor(),
                     showLabel: _showLabels,
                     onPressed: () {
                       _onNavigate();
@@ -773,7 +796,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                 if (showGenres)
                   _SidebarItem(
                     key: const ValueKey('sidebar-genres'),
-                    baseColor: nextSidebarColor(),
+                    baseColor: nextMainSidebarColor(),
                     iconBuilder: (size, color) => Image.asset(
                       'assets/icons/genres.png',
                       width: size,
@@ -797,7 +820,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                     key: const ValueKey('sidebar-favorites'),
                     icon: Icons.favorite_rounded,
                     label: l10n.favorites,
-                    baseColor: nextSidebarColor(),
+                    baseColor: nextMainSidebarColor(),
                     showLabel: _showLabels,
                     onPressed: () {
                       _onNavigate();
@@ -814,7 +837,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                     key: const ValueKey('sidebar-folders'),
                     icon: Icons.folder_rounded,
                     label: l10n.folders,
-                    baseColor: nextSidebarColor(),
+                    baseColor: nextMainSidebarColor(),
                     showLabel: _showLabels,
                     onPressed: () {
                       _onNavigate();
@@ -831,7 +854,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                     key: const ValueKey('sidebar-syncplay'),
                     icon: Icons.groups_rounded,
                     label: l10n.syncPlay,
-                    baseColor: nextSidebarColor(),
+                    baseColor: nextMainSidebarColor(),
                     showLabel: _showLabels,
                     onPressed: () {
                       _onNavigate();
@@ -847,7 +870,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                     GetIt.instance<PluginSyncService>().seerrAvailable)
                   _SidebarItem(
                     key: const ValueKey('sidebar-seerr'),
-                    baseColor: nextSidebarColor(),
+                    baseColor: nextMainSidebarColor(),
                     iconBuilder: (size, color) => seerrPrefs.isSeerrVariant
                         ? SeerrIcon(size: size, color: color)
                         : JellyseerrIcon(size: size, color: color),
@@ -866,7 +889,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                 if (showLibraries && _libraries.isNotEmpty) ...[
                   _SidebarItem(
                     key: const ValueKey('sidebar-libraries'),
-                    baseColor: nextSidebarColor(),
+                    baseColor: nextMainSidebarColor(),
                     iconBuilder: (size, color) => Image.asset(
                       'assets/icons/clapperboard.png',
                       width: size,
@@ -906,7 +929,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                                   (lib) => _SidebarLibraryItem(
                                     key: ObjectKey(lib.id),
                                     label: lib.name,
-                                    baseColor: nextSidebarColor(),
+                                    baseColor: nextLibrarySidebarColor(),
                                     showLabel: _showLabels,
                                     onPressed: () {
                                       _onNavigate();
@@ -937,7 +960,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
                   key: const ValueKey('sidebar-settings'),
                   icon: Icons.settings_rounded,
                   label: l10n.settings,
-                  baseColor: nextSidebarColor(),
+                  baseColor: nextMainSidebarColor(),
                   focusNode: _settingsFocusNode,
                   showLabel: _showLabels,
                   onPressed: () async {
@@ -955,7 +978,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
 
               return SingleChildScrollView(
                 controller: _scrollController,
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                padding: const EdgeInsets.symmetric(vertical: 4),
                 child: ConstrainedBox(
                   constraints: BoxConstraints(
                     minHeight: math.max(0, constraints.maxHeight - 8),
@@ -969,25 +992,38 @@ class _LeftSidebarState extends State<LeftSidebar> {
             },
           ),
         ),
-        if (showClock && _showLabels)
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: ValueListenableBuilder<String>(
-              valueListenable: _currentTime,
-              builder: (context, time, _) {
-                return Text(
-                  time,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.5),
-                    fontSize: 13,
-                    fontWeight: FontWeight.w500,
+        if (showClock)
+          Visibility(
+            visible: _showLabels,
+            maintainSize: true,
+            maintainAnimation: true,
+            maintainState: true,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: ValueListenableBuilder<String>(
+                    valueListenable: _currentTime,
+                    builder: (context, time, _) {
+                      return Text(
+                        time,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.5),
+                          fontSize: 13,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      );
+                    },
                   ),
-                );
-              },
+                ),
+                const SizedBox(height: 8),
+              ],
             ),
-          ),
-        SizedBox(height: showClock && _showLabels ? 8 : 16),
+          )
+        else
+          const SizedBox(height: 16),
       ],
     );
   }
@@ -1225,7 +1261,10 @@ class _SidebarItemState extends State<_SidebarItem> {
             child: AnimatedContainer(
               duration: const Duration(milliseconds: 150),
               height: desktopSidebar ? 44 : 40,
-              padding: EdgeInsets.symmetric(horizontal: _tvCompact ? 4 : 10),
+              padding: EdgeInsets.only(
+                left: _tvCompact ? 12 : 18,
+                right: _tvCompact ? 12 : 18,
+              ),
               decoration: BoxDecoration(
                 color: tvFocused
                     ? Colors.white
@@ -1234,9 +1273,9 @@ class _SidebarItemState extends State<_SidebarItem> {
                           ? baseColor.withValues(alpha: 0.12)
                           : focusColor.withValues(alpha: 0.12))
                     : Colors.transparent,
-                borderRadius: BorderRadius.circular(
-                  PlatformDetection.isTV ? 24 : 8,
-                ),
+                borderRadius: PlatformDetection.isTV
+                    ? BorderRadius.circular(24)
+                    : BorderRadius.zero,
               ),
               child: Row(
                 children: [
@@ -1342,8 +1381,8 @@ class _SidebarLibraryItemState extends State<_SidebarLibraryItem> {
               duration: const Duration(milliseconds: 150),
               height: desktopSidebar ? 40 : 36,
               padding: EdgeInsets.only(
-                left: desktopSidebar ? 56 : 50,
-                right: 10,
+                left: desktopSidebar ? 64 : 58,
+                right: 18,
               ),
               decoration: BoxDecoration(
                 color: tvFocused
@@ -1353,9 +1392,9 @@ class _SidebarLibraryItemState extends State<_SidebarLibraryItem> {
                           ? baseColor.withValues(alpha: 0.12)
                           : focusColor.withValues(alpha: 0.1))
                     : Colors.transparent,
-                borderRadius: BorderRadius.circular(
-                  PlatformDetection.isTV ? 24 : 8,
-                ),
+                borderRadius: PlatformDetection.isTV
+                    ? BorderRadius.circular(24)
+                    : BorderRadius.zero,
               ),
               alignment: Alignment.centerLeft,
               child: widget.showLabel


### PR DESCRIPTION
# Pull Request: The one about calming the left navigation bar down

## Summary
This PR resolves three visual layout and behavior issues in the Left Navigation Bar:

1. When using the undisputed best theme, the alternating pink/cyan colors flipped when hovering or focusing on items.
2. The spacing jumped during expand/minimize transitions because the profile picture (top) and the clock widget (bottom) were completely removed from the layout tree when minimized.
3. Selection highlights had rounded corners and extended past the container in a visually unappealing way.

## Related Issues
Matt's need for order.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* Relocated mainNeonSlot and libraryNeonSlot counters inside the LayoutBuilder's builder function. This guarantees they reset to 0 on every layout rebuild pass, keeping the color order deterministic (with "Home" starting as pink).
* Wrapped the user profile section and the clock in a Visibility(maintainSize: true) widget to keep its vertical space reserved when collapsed/invisible, preventing items from shifting up or down due to their "pop-in".
* Removed horizontal padding from the navigation SingleChildScrollView.
* Removed rounded borders (BorderRadius.zero) on desktop/web hover highlights and adjusted left/right item padding to keep the text and icons visually aligned while allowing the background to stretch edge-to-edge.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Activate the Neon Pulse theme and left navbar.
2. Hover/expand and minimize the sidebar.
3. Verify that:
    - Colors remain constant across transitions and do not flip on hover.
    - Profile picture and clock visibility transitions do not trigger vertical shifting (judder).
    - The hover highlights extend fully to the right pink border with straight corners.

## Screenshots (if applicable)

<img width="100" alt="2026-06-13_22-12-46" src="https://github.com/user-attachments/assets/6a3d9206-ee45-401a-8e45-bd27d140a8ee" />
<img width="165" alt="2026-06-13_22-12-59" src="https://github.com/user-attachments/assets/37228614-7986-425f-bc12-2dcd94b03d46" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
