### PR TITLE
fix: refine movement logic for the new director/writer/studio area

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -282,7 +282,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   @override
   Widget build(BuildContext context) {
     final type = _viewModel.item?.type;
-    final useTargetNode = type == 'Person' || type == 'BoxSet';
+    final useTargetNode = type != null && type != 'Photo';
     final node = useTargetNode ? _ensureInitialFocusNode() : null;
     final isAlbumOrPlaylist = type == 'MusicAlbum' || type == 'Playlist';
     final showNavigationChrome =
@@ -503,6 +503,9 @@ class _DetailContentState extends State<_DetailContent> {
   }
 
   bool _shouldSkipSectionEnsureVisible(FocusNode target) {
+    if (widget.viewModel.item?.type != 'Person') {
+      return false;
+    }
     final favoriteFocusNode =
         widget.initialFocusNode ?? _sectionFocusNodes['detailPersonFavorite'];
     final seerrFocusNode = _sectionFocusNodes['detailPersonSeerrButton'];
@@ -612,9 +615,23 @@ class _DetailContentState extends State<_DetailContent> {
       return;
     }
 
-    final sectionContext = _sectionContainerContext(target);
-    if (sectionContext != null && !_shouldSkipSectionEnsureVisible(target)) {
-      unawaited(_ensureSectionVisible(sectionContext, alignment: alignment));
+    final isActionButtons = target == widget.initialFocusNode ||
+        target.debugLabel == 'detailActionButtons' ||
+        target.debugLabel == 'detailBoxSetActionButtons';
+
+    if (isActionButtons) {
+      if (_scrollController.hasClients) {
+        unawaited(_scrollController.animateTo(
+          _scrollController.position.minScrollExtent,
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOut,
+        ));
+      }
+    } else {
+      final sectionContext = _sectionContainerContext(target);
+      if (sectionContext != null && !_shouldSkipSectionEnsureVisible(target)) {
+        unawaited(_ensureSectionVisible(sectionContext, alignment: alignment));
+      }
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1367,7 +1384,7 @@ class _DetailContentState extends State<_DetailContent> {
     final similarFocusNode = hasSimilar
         ? _sectionFocusNode('detailMovieSimilar')
         : null;
-    final actionButtonsFocusNode = _sectionFocusNode('detailActionButtons');
+    final actionButtonsFocusNode = widget.initialFocusNode ?? _sectionFocusNode('detailActionButtons');
     final overviewFocusNode = _headerOverviewFocusNode(item);
     final metadataFocusNode = _hasMetadata(item) ? _sectionFocusNode('detailMovieMetadata') : null;
     final movieDownTarget = hasChapters
@@ -1397,6 +1414,9 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: movieDownTarget,
+          onRequestFocus: _requestSectionFocus,
         ),
       ],
       ..._buildChapterAndFeatureSections(
@@ -1509,7 +1529,7 @@ class _DetailContentState extends State<_DetailContent> {
     final similarFocusNode = hasSimilar
         ? _sectionFocusNode('detailSeriesSimilar')
         : null;
-    final actionButtonsFocusNode = _sectionFocusNode('detailActionButtons');
+    final actionButtonsFocusNode = widget.initialFocusNode ?? _sectionFocusNode('detailActionButtons');
     final overviewFocusNode = _headerOverviewFocusNode(item);
     final metadataFocusNode = _hasMetadata(item) ? _sectionFocusNode('detailSeriesMetadata') : null;
     final seriesDownTarget =
@@ -1535,6 +1555,9 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: seriesDownTarget,
+          onRequestFocus: _requestSectionFocus,
         ),
       ],
       if (hasNextUp) ...[
@@ -1728,7 +1751,7 @@ class _DetailContentState extends State<_DetailContent> {
     final similarFocusNode = hasSimilar
         ? _sectionFocusNode('detailEpisodeSimilar')
         : null;
-    final actionButtonsFocusNode = _sectionFocusNode('detailActionButtons');
+    final actionButtonsFocusNode = widget.initialFocusNode ?? _sectionFocusNode('detailActionButtons');
     final overviewFocusNode = _headerOverviewFocusNode(item);
     final currentEpisodeIndex = viewModel.episodes.indexWhere(
       (ep) => ep.id == item.id,
@@ -1771,6 +1794,9 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: episodeDownTarget,
+          onRequestFocus: _requestSectionFocus,
         ),
       ],
       ..._buildChapterAndFeatureSections(
@@ -2317,6 +2343,7 @@ class _DetailContentState extends State<_DetailContent> {
       _AlbumActions(
         item: item,
         tracks: viewModel.tracks,
+        playFocusNode: widget.initialFocusNode,
         showAddToPlaylist: false,
         onPlayDown: () {
           _requestSectionFocus(overviewFocusNode ?? albumsFocusNode);
@@ -2405,7 +2432,7 @@ class _DetailContentState extends State<_DetailContent> {
       _AlbumActions(
         item: item,
         tracks: viewModel.tracks,
-        playFocusNode: PlatformDetection.isTV ? _albumPlayFocusNode : null,
+        playFocusNode: widget.initialFocusNode ?? _albumPlayFocusNode,
         autofocusPlay: PlatformDetection.isTV,
         onPlayDown: () {
           if (!_firstTrackFocusNode.canRequestFocus) return;
@@ -2725,6 +2752,9 @@ class _DetailContentState extends State<_DetailContent> {
         _MetadataSection(
           viewModel: viewModel,
           firstItemFocusNode: metadataFocusNode,
+          upTarget: actionButtonsFocusNode,
+          downTarget: boxSetDownTarget,
+          onRequestFocus: _requestSectionFocus,
         ),
       ],
       if (movies.isNotEmpty) ...[
@@ -4867,7 +4897,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
             : isBook
             ? Icons.menu_book
             : Icons.play_arrow,
-        focusNode: PlatformDetection.isTV ? _tvPlayFocusNode : null,
+        focusNode: _tvPlayFocusNode,
         autofocus: PlatformDetection.isTV,
         onPressed: () => _play(context, item, resume: isBoxSet ? (!boxSetAllWatched && !boxSetAllUnwatched) : (!isPhoto && hasProgress)),
         onLongPress: isVideo
@@ -8692,12 +8722,16 @@ class _MetadataChip extends StatefulWidget {
   final FocusNode? focusNode;
   final VoidCallback? onArrowLeft;
   final VoidCallback? onArrowRight;
+  final VoidCallback? onArrowUp;
+  final VoidCallback? onArrowDown;
 
   const _MetadataChip({
     required this.item,
     this.focusNode,
     this.onArrowLeft,
     this.onArrowRight,
+    this.onArrowUp,
+    this.onArrowDown,
   });
 
   @override
@@ -8744,6 +8778,18 @@ class _MetadataChipState extends State<_MetadataChip> with FocusStateMixin {
               return KeyEventResult.handled;
             }
           }
+          if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            if (widget.onArrowUp != null) {
+              widget.onArrowUp!();
+              return KeyEventResult.handled;
+            }
+          }
+          if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+            if (widget.onArrowDown != null) {
+              widget.onArrowDown!();
+              return KeyEventResult.handled;
+            }
+          }
           return KeyEventResult.ignored;
         },
         child: GestureDetector(
@@ -8784,10 +8830,16 @@ class _MetadataChipState extends State<_MetadataChip> with FocusStateMixin {
 class _MetadataSection extends StatefulWidget {
   final ItemDetailViewModel viewModel;
   final FocusNode? firstItemFocusNode;
+  final FocusNode? upTarget;
+  final FocusNode? downTarget;
+  final KeyEventResult Function(FocusNode? target)? onRequestFocus;
 
   const _MetadataSection({
     required this.viewModel,
     this.firstItemFocusNode,
+    this.upTarget,
+    this.downTarget,
+    this.onRequestFocus,
   });
 
   @override
@@ -8926,8 +8978,7 @@ class _MetadataSectionState extends State<_MetadataSection> {
       }
     }
 
-    return FocusTraversalGroup(
-      child: Container(
+    return Container(
         decoration: BoxDecoration(
           color: isNeon
               ? AppColorScheme.background.withValues(alpha: 0.25)
@@ -9051,6 +9102,24 @@ class _MetadataSectionState extends State<_MetadataSection> {
                                           onArrowRight: groupIndex == totalGroups - 1
                                               ? () {} // cap right
                                               : () => firstNodesOfGroups[groupIndex + 1].requestFocus(),
+                                          onArrowUp: itemIndexInGroup == 0
+                                              ? () {
+                                                  if (widget.onRequestFocus != null) {
+                                                    widget.onRequestFocus!(widget.upTarget);
+                                                  } else {
+                                                    widget.upTarget?.requestFocus();
+                                                  }
+                                                }
+                                              : () => _focusNodes[chipIndex - 1].requestFocus(),
+                                          onArrowDown: itemIndexInGroup == group.items.length - 1
+                                              ? () {
+                                                  if (widget.onRequestFocus != null) {
+                                                    widget.onRequestFocus!(widget.downTarget);
+                                                  } else {
+                                                    widget.downTarget?.requestFocus();
+                                                  }
+                                                }
+                                              : () => _focusNodes[chipIndex + 1].requestFocus(),
                                         ),
                                       );
                                     }).toList(),
@@ -9065,7 +9134,6 @@ class _MetadataSectionState extends State<_MetadataSection> {
                   }).toList(),
                 ),
               ),
-      ),
     );
   }
 }


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves critical focus navigation deadlocks and boundary trapping in the media details page metadata section (_MetadataSection for Directors, Writers, and Studios) across Desktop and TV platforms. It ensures spatial exits (up/down) behave consistently, properly manages top-of-page scrolling layouts to prevent unreachable focus nodes, and sets consistent initial focus.

## Related Issues
Resolves focus trapping & scroll-out-of-view deadlocks introduced in #528

- Closes #
- Fixes #
- Related to #528 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* Restricted _shouldSkipSectionEnsureVisible strictly to Person details pages. This fixes the issue where the layout engine skipped scrolling the Play button back into view on non-Person pages (e.g., Movie, Series), which previously caused the Play button's focus node to become unattached and unfocusable.
* Updated _scheduleSingleSectionFocusRetry to explicitly scroll the main vertical _scrollController to minScrollExtent (the top of the page) when trying to focus the action buttons/Play button row. This guarantees that these elements are built, laid out, and can safely receive focus.
* Configured useTargetNode in RequestInitialFocus for all media types (except Photo) rather than just Person and BoxSet.
Passed the initial focus node down to _ActionButtons and _AlbumActions so that initial page focus defaults to the main action button (e.g., Play button) on both Desktop and Android TV.
* Implemented explicit onArrowUp and onArrowDown callbacks for _MetadataChip and connected them in _MetadataSectionState to request focus on the designated upTarget (action buttons) and downTarget (e.g., Cast row or lower sections) when exiting the metadata grid.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a Movie, Series, or Album details page.
2. Verify that initial focus correctly lands on the Play/Resume action button on both Desktop (Windows) and Android TV.
3. D-pad/Arrow down to the Metadata section (Director/Writer/Studio chips) and move focus between chips.
4. Verify that pressing Arrow Up from the top row of the metadata section successfully exits upwards and focuses the Play button (scrolling the page back to the top if needed).
5. Verify that pressing Arrow Down from the bottom row of the metadata section successfully exits downwards and focuses the next section (e.g., Cast/Similar items).

## Screenshots (if applicable)
NA

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
