### PR TITLE
fix: disable wrap-around focus traversal on settings menus

### DIFF
--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1156,7 +1156,7 @@ class _IntegrationsScreen extends StatefulWidget {
 class _IntegrationsScreenState extends State<_IntegrationsScreen> {
   final _integrationsScope = FocusScopeNode(
     debugLabel: 'IntegrationsSettingsScope',
-    traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+    traversalEdgeBehavior: TraversalEdgeBehavior.stop,
   );
 
   @override
@@ -1244,7 +1244,7 @@ class _PluginScreen extends StatefulWidget {
 class _PluginScreenState extends State<_PluginScreen> {
   final _pluginScope = FocusScopeNode(
     debugLabel: 'PluginSettingsScope',
-    traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+    traversalEdgeBehavior: TraversalEdgeBehavior.stop,
   );
   final _scrollController = ScrollController();
   final _refreshFocusNode = FocusNode(debugLabel: 'PluginRefreshButton');
@@ -1376,7 +1376,7 @@ class _MetadataRatingsScreen extends StatefulWidget {
 class _MetadataRatingsScreenState extends State<_MetadataRatingsScreen> {
   final _metadataScope = FocusScopeNode(
     debugLabel: 'MetadataRatingsSettingsScope',
-    traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+    traversalEdgeBehavior: TraversalEdgeBehavior.stop,
   );
   final _additionalRatingsFocusNode = FocusNode(debugLabel: 'additional_ratings');
 
@@ -1464,7 +1464,7 @@ class _OfflineDownloadsScreen extends StatefulWidget {
 class _OfflineDownloadsScreenState extends State<_OfflineDownloadsScreen> {
   final _offlineScope = FocusScopeNode(
     debugLabel: 'OfflineDownloadsSettingsScope',
-    traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+    traversalEdgeBehavior: TraversalEdgeBehavior.stop,
   );
 
   @override
@@ -2986,7 +2986,7 @@ class _AdvancedOptionsScreen extends StatefulWidget {
 class _AdvancedOptionsScreenState extends State<_AdvancedOptionsScreen> {
   final _advancedScope = FocusScopeNode(
     debugLabel: 'AdvancedOptionsSettingsScope',
-    traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+    traversalEdgeBehavior: TraversalEdgeBehavior.stop,
   );
 
   @override

--- a/lib/ui/widgets/settings/settings_panel.dart
+++ b/lib/ui/widgets/settings/settings_panel.dart
@@ -92,7 +92,7 @@ class _SettingsNavigatorState extends State<_SettingsNavigator> {
   final _navKey = GlobalKey<NavigatorState>();
   final _trapScope = FocusScopeNode(
     debugLabel: 'SettingsPanelTrap',
-    traversalEdgeBehavior: TraversalEdgeBehavior.closedLoop,
+    traversalEdgeBehavior: TraversalEdgeBehavior.stop,
   );
   bool _rootDismissInProgress = false;
 


### PR DESCRIPTION
# Pull Request

## Summary
This PR disables focus wrap-around traversal on all settings lists and submenus. It resolves the issue where pressing D-pad Up on the first menu item or D-pad Down on the last item wraps focus to the opposite end, ensuring focus is properly capped at menu boundaries instead. This catches all remaining cases.

## Related Issues
Tester feedback on Discord

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* Changed traversalEdgeBehavior of SettingsPanelTrap from closedLoop to stop in settings_panel.dart.
* Changed traversalEdgeBehavior of individual FocusScopeNodes in settings_side_panel.dart (_IntegrationsScreenState, _PluginScreenState, _MetadataRatingsScreenState, _OfflineDownloadsScreenState, and _AdvancedOptionsScreenState) from closedLoop to stop.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open settings side panel.
2. Navigate up to the top option (e.g. Server under general settings) or down to the bottom option. Verify focus is capped and does not wrap.
3. Open Playback & Syncplay -> Advanced Options.
4. Press D-pad Up on the top option (e.g. Video Start Delay). Verify focus is capped and does not wrap.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
