### PR TITLE
fix(playback): resolve session races and improve stopping behavior

### DIFF
--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -890,9 +890,11 @@ class PlaybackManager implements AudioOwnable {
     _externalSubsLoaded = null;
 
     await _resetSubtitleRendererMode();
+    if (sessionToken != _playbackSessionToken) return;
 
     if (_resolverConfigurator != null) {
       await _resolverConfigurator!(item);
+      if (sessionToken != _playbackSessionToken) return;
     }
 
     if (_resolver == null) {
@@ -924,6 +926,11 @@ class PlaybackManager implements AudioOwnable {
       enableDirectStream: enableDirectStream,
       enableTranscoding: enableTranscoding,
     );
+
+    if (sessionToken != _playbackSessionToken) {
+      _cleanupPreemptedSession(item, resolution);
+      return;
+    }
 
     _setBringupState(
       PlaybackBringupState(
@@ -1028,11 +1035,23 @@ class PlaybackManager implements AudioOwnable {
         normalizationGainDb: resolution.normalizationGainDb,
       );
       await _arbiter?.acquire(AudioProducer.mainPlayback);
+      if (sessionToken != _playbackSessionToken) {
+        _cleanupPreemptedSession(item, resolution);
+        return;
+      }
       await _backend!.play(
         backendMediaPayload,
         startPosition: useNativeStart ? startPosition : Duration.zero,
       );
+      if (sessionToken != _playbackSessionToken) {
+        _cleanupPreemptedSession(item, resolution);
+        return;
+      }
       await _syncBackendRepeatModeIfSupported();
+      if (sessionToken != _playbackSessionToken) {
+        _cleanupPreemptedSession(item, resolution);
+        return;
+      }
       if (_backend!.requiresStartupMediaReadyCheck) {
         _setBringupState(
           PlaybackBringupState(
@@ -1050,11 +1069,21 @@ class PlaybackManager implements AudioOwnable {
       } else {
         mediaReady = true;
       }
+      if (sessionToken != _playbackSessionToken) {
+        _cleanupPreemptedSession(item, resolution);
+        return;
+      }
     } catch (e, st) {
+      if (sessionToken != _playbackSessionToken) return;
       startupError = e;
       startupStackTrace = st;
     } finally {
       _waitingForMedia = false;
+    }
+
+    if (sessionToken != _playbackSessionToken) {
+      _cleanupPreemptedSession(item, resolution);
+      return;
     }
 
     if (!mediaReady) {
@@ -1169,7 +1198,8 @@ class PlaybackManager implements AudioOwnable {
       _externalSubsLoaded = Future.value();
     }
 
-    if (resolution.playMethod == StreamPlayMethod.directPlay) {
+    if (resolution.playMethod == StreamPlayMethod.directPlay ||
+        resolution.playMethod == StreamPlayMethod.directStream) {
       final hasRequestedTrackSelection =
           _audioStreamIndex != null ||
           (_subtitleStreamIndex != null && _subtitleStreamIndex != -1);
@@ -1183,8 +1213,7 @@ class PlaybackManager implements AudioOwnable {
       if (_subtitleStreamIndex == -1) {
         _waitAndDisableSubtitles(sessionToken);
       }
-    } else if (resolution.playMethod == StreamPlayMethod.transcode ||
-        resolution.playMethod == StreamPlayMethod.directStream) {
+    } else if (resolution.playMethod == StreamPlayMethod.transcode) {
       if (_subtitleStreamIndex != null && _subtitleStreamIndex != -1) {
         final isBurnedIn =
             (_isSubtitleBitmap(_subtitleStreamIndex!) &&
@@ -2059,9 +2088,7 @@ class PlaybackManager implements AudioOwnable {
             _lastKnownPosition.inMicroseconds,
           ].reduce((a, b) => a > b ? a : b),
         );
-        try {
-          await _service?.onPlaybackStop(reportItem, resolution, pos);
-        } catch (_) {}
+        unawaited(_service?.onPlaybackStop(reportItem, resolution, pos).catchError((_) => null));
       }
       _currentResolution = null;
       _lastPlaybackItem = null;
@@ -2085,6 +2112,12 @@ class PlaybackManager implements AudioOwnable {
       if (identical(_stopInFlight, stopFuture)) {
         _stopInFlight = null;
       }
+    }
+  }
+
+  void _cleanupPreemptedSession(dynamic item, StreamResolutionResult? resolution) {
+    if (item != null && resolution != null) {
+      unawaited(_service?.onPlaybackStop(item, resolution, Duration.zero).catchError((_) => null));
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Summary
Resolve playback queuing transitions and session token race conditions in PlaybackManager. This resolves infinite loading during fast next/prev actions, restores runtime audio/subtitle track activation under remuxing/direct stream, and speeds up queuing by making stop reporting non-blocking.

## Related Issues
Reports of broken transitions on Discord testers thread. Relates to: Playback queuing issues (next/prev episode broken in direct and transcoded) and Slow track transitions / 50-second transcoded restart infinite loading.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* Session Token Validation: Added checks for local sessionToken against _playbackSessionToken at multiple async boundaries in _playCurrentItem() (after config resolution, resolving stream URL, and waiting for player media ready). Prevents outdated/preempted play requests from loading media and corrupting the active session.
* Preempted Session Cleanup: Introduced _cleanupPreemptedSession helper to cleanly stop preempted transcodes/live streams on the server asynchronously.
* Direct Stream Track Selections: Grouped directStream remuxing together with directPlay inside the track selector block in _playCurrentItem(). This enables native track selector activation on direct remuxed containers, correcting issues where ExoPlayer's default rules ignored track selections.
* Non-blocking Stops: Updated _stopAndReportCurrent() to call onPlaybackStop in the background via unawaited(), allowing native player .stop() to execute immediately without blocking on network reporting.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play queue of transcoded/remuxed episodes.
2. Verify rapid Next/Previous transitions.
3. Verify changing audio/subtitle tracks on Direct Stream media.

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
