### PR TITLE
fix(playback): persist media info selections, track propagation, and …

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -219,6 +219,15 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
         _lastFocusedBackdropItemId = null;
         _backgroundService.setBackground(item, context: BlurContext.details);
         _backdropUrl = _backgroundService.currentUrl;
+
+        if (item.mediaSources.isNotEmpty) {
+          _selectedMediaSourceId = item.mediaSources.first['Id'] as String?;
+        } else {
+          _selectedMediaSourceId = null;
+        }
+
+        _viewModel.selectedAudioIndex = null;
+        _viewModel.selectedSubtitleIndex = null;
       }
       if (!_themeMusicStarted) {
         _themeMusicStarted = true;
@@ -5983,6 +5992,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
               startPosition: startPosition,
               audioStreamIndex: audioStreamIndex,
               subtitleStreamIndex: subtitleStreamIndex,
+              audioSelectionExplicit: viewModel.selectedAudioIndex != null,
+              subtitleSelectionExplicit: viewModel.selectedSubtitleIndex != null,
               enableDirectPlay: directAllowed,
               enableDirectStream: directAllowed,
             );
@@ -6015,6 +6026,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
               startPosition: startPosition,
               audioStreamIndex: audioStreamIndex,
               subtitleStreamIndex: subtitleStreamIndex,
+              audioSelectionExplicit: viewModel.selectedAudioIndex != null,
+              subtitleSelectionExplicit: viewModel.selectedSubtitleIndex != null,
               enableDirectPlay: directAllowed,
               enableDirectStream: directAllowed,
             );
@@ -6070,6 +6083,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
                 startPosition: startPosition,
                 audioStreamIndex: audioStreamIndex,
                 subtitleStreamIndex: subtitleStreamIndex,
+                audioSelectionExplicit: viewModel.selectedAudioIndex != null,
+                subtitleSelectionExplicit: viewModel.selectedSubtitleIndex != null,
                 mediaSourceId: widget.selectedMediaSourceId,
                 enableDirectPlay: directAllowed,
                 enableDirectStream: directAllowed,
@@ -6132,6 +6147,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
               startPosition: startPosition,
               audioStreamIndex: audioStreamIndex,
               subtitleStreamIndex: subtitleStreamIndex,
+              audioSelectionExplicit: viewModel.selectedAudioIndex != null,
+              subtitleSelectionExplicit: viewModel.selectedSubtitleIndex != null,
               enableDirectPlay: directAllowed,
               enableDirectStream: directAllowed,
             );
@@ -6176,6 +6193,10 @@ class _ActionButtonsState extends State<_ActionButtons> {
               subtitleStreamIndex: applyMainItemStreamOverrides
                   ? subtitleStreamIndex
                   : null,
+              audioSelectionExplicit: applyMainItemStreamOverrides &&
+                  viewModel.selectedAudioIndex != null,
+              subtitleSelectionExplicit: applyMainItemStreamOverrides &&
+                  viewModel.selectedSubtitleIndex != null,
               mediaSourceId: applyMainItemStreamOverrides
                   ? selectedMediaSourceId
                   : null,
@@ -6188,6 +6209,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
                 audioStreamIndex: audioStreamIndex,
                 subtitleStreamIndex: subtitleStreamIndex,
                 mediaSourceId: selectedMediaSourceId,
+                audioSelectionExplicit: viewModel.selectedAudioIndex != null,
+                subtitleSelectionExplicit: viewModel.selectedSubtitleIndex != null,
               );
             }
             await playItemsFuture;

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -221,7 +221,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
         _backdropUrl = _backgroundService.currentUrl;
 
         if (item.mediaSources.isNotEmpty) {
-          _selectedMediaSourceId = item.mediaSources.first['Id'] as String?;
+          _selectedMediaSourceId = item.mediaSources.first['Id']?.toString();
         } else {
           _selectedMediaSourceId = null;
         }
@@ -6914,7 +6914,7 @@ class _ActionButtonsState extends State<_ActionButtons> {
       selectedIndex: currentIdx >= 0 ? currentIdx : 0,
     );
     if (result != null && result < sources.length) {
-      final id = sources[result]['Id'] as String?;
+      final id = sources[result]['Id']?.toString();
       widget.onSelectedMediaSourceChanged(id);
     }
   }
@@ -6931,7 +6931,7 @@ Map<String, dynamic>? _selectedMediaSourceForItem(
     return item.mediaSources.first;
   }
   for (final source in item.mediaSources) {
-    final id = source['Id'] as String?;
+    final id = source['Id']?.toString();
     if (id == selectedMediaSourceId) {
       return source;
     }

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1025,17 +1025,20 @@ class PlaybackManager implements AudioOwnable {
       }
     }
 
-    iif (needsReResolve && !_reResolvingForTrackMatch) {
-  _reResolvingForTrackMatch = true;
-  try {
-      await _playCurrentItem(
-        startPosition: startPosition,
-        enableDirectPlay: enableDirectPlay,
-        enableDirectStream: enableDirectStream,
-        enableTranscoding: enableTranscoding,
-        allowStartupRecovery: allowStartupRecovery,
-      );
-      return;
+    if (needsReResolve && !_reResolvingForTrackMatch) {
+      _reResolvingForTrackMatch = true;
+      try {
+        await _playCurrentItem(
+          startPosition: startPosition,
+          enableDirectPlay: enableDirectPlay,
+          enableDirectStream: enableDirectStream,
+          enableTranscoding: enableTranscoding,
+          allowStartupRecovery: allowStartupRecovery,
+        );
+        return;
+      } finally {
+        _reResolvingForTrackMatch = false;
+      }
     }
 
     _currentResolution = resolution;
@@ -2472,7 +2475,6 @@ String _normalizeLanguage(String? language) {
   final normalized = language.trim().toLowerCase();
   if (normalized.isEmpty) return '';
   return normalized.split(RegExp(r'[-_]')).first;
-  return base;
 }
 
 String _toIso3(String language) {

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1024,7 +1024,9 @@ class PlaybackManager implements AudioOwnable {
       }
     }
 
-    if (needsReResolve) {
+    iif (needsReResolve && !_reResolvingForTrackMatch) {
+  _reResolvingForTrackMatch = true;
+  try {
       await _playCurrentItem(
         startPosition: startPosition,
         enableDirectPlay: enableDirectPlay,

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -45,6 +45,7 @@ class PlaybackManager implements AudioOwnable {
   StreamResolutionResult? _currentResolution;
   dynamic _lastPlaybackItem;
   StreamResolutionResult? _lastPlaybackResolution;
+  bool _reResolvingForTrackMatch = false;
   int? _audioStreamIndex;
   int? _subtitleStreamIndex;
   bool _audioSelectionExplicit = false;

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -2468,7 +2468,7 @@ String _normalizeLanguage(String? language) {
   if (language == null) return '';
   final normalized = language.trim().toLowerCase();
   if (normalized.isEmpty) return '';
-  final base = normalized.split(RegExp(r'[-_]')).first;
+  return normalized.split(RegExp(r'[-_]')).first;
   return base;
 }
 

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -47,7 +47,10 @@ class PlaybackManager implements AudioOwnable {
   StreamResolutionResult? _lastPlaybackResolution;
   int? _audioStreamIndex;
   int? _subtitleStreamIndex;
+  bool _audioSelectionExplicit = false;
   bool _subtitleSelectionExplicit = false;
+  bool _pendingItemAudioSelectionExplicit = false;
+  bool _pendingItemSubtitleSelectionExplicit = false;
   String? _mediaSourceId;
   String? _pendingItemOverrideId;
   int? _pendingItemAudioStreamIndex;
@@ -182,6 +185,8 @@ class PlaybackManager implements AudioOwnable {
     int? audioStreamIndex,
     int? subtitleStreamIndex,
     String? mediaSourceId,
+    bool audioSelectionExplicit = false,
+    bool subtitleSelectionExplicit = false,
   }) {
     final normalizedItemId = itemId.trim();
     if (normalizedItemId.isEmpty) {
@@ -195,6 +200,8 @@ class PlaybackManager implements AudioOwnable {
     _pendingItemMediaSourceId = mediaSourceId == null || mediaSourceId.isEmpty
         ? null
         : mediaSourceId;
+    _pendingItemAudioSelectionExplicit = audioSelectionExplicit;
+    _pendingItemSubtitleSelectionExplicit = subtitleSelectionExplicit;
   }
 
   List<Map<String, dynamic>> get _currentMediaStreams {
@@ -579,7 +586,8 @@ class PlaybackManager implements AudioOwnable {
 
     _audioStreamIndex = _pendingItemAudioStreamIndex;
     _subtitleStreamIndex = _pendingItemSubtitleStreamIndex;
-    _subtitleSelectionExplicit = false;
+    _audioSelectionExplicit = _pendingItemAudioSelectionExplicit;
+    _subtitleSelectionExplicit = _pendingItemSubtitleSelectionExplicit;
     _mediaSourceId = _pendingItemMediaSourceId;
     _clearPendingItemOverrides();
     return true;
@@ -756,6 +764,8 @@ class PlaybackManager implements AudioOwnable {
     int? audioStreamIndex,
     int? subtitleStreamIndex,
     String? mediaSourceId,
+    bool audioSelectionExplicit = false,
+    bool subtitleSelectionExplicit = false,
     bool enableDirectPlay = true,
     bool enableDirectStream = true,
     bool enableTranscoding = true,
@@ -783,7 +793,8 @@ class PlaybackManager implements AudioOwnable {
     _resetBackendSelectionLock();
     _audioStreamIndex = audioStreamIndex;
     _subtitleStreamIndex = subtitleStreamIndex;
-    _subtitleSelectionExplicit = false;
+    _audioSelectionExplicit = audioSelectionExplicit;
+    _subtitleSelectionExplicit = subtitleSelectionExplicit;
     _mediaSourceId = mediaSourceId;
     _forceTranscodeForQueue = !enableDirectPlay && !enableDirectStream;
     final adjuster = _startPositionAdjuster;
@@ -976,11 +987,91 @@ class PlaybackManager implements AudioOwnable {
       return;
     }
 
+    bool needsReResolve = false;
+
+    if (_lastExplicitAudioLanguage != null) {
+      final audioStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Audio').toList();
+      final targetIdx = audioStreams.indexWhere(
+        (s) => _languagesMatch(s, _lastExplicitAudioLanguage),
+      );
+      if (targetIdx >= 0) {
+        final matchedIdx = audioStreams[targetIdx]['Index'] as int?;
+        if (_audioStreamIndex != matchedIdx) {
+          _audioStreamIndex = matchedIdx;
+          if (resolution.playMethod == StreamPlayMethod.transcode) {
+            needsReResolve = true;
+          }
+        }
+      }
+    }
+
+    if (_lastExplicitSubtitleEnabled == false) {
+      if (_subtitleStreamIndex != -1) {
+        _subtitleStreamIndex = -1;
+        if (resolution.playMethod == StreamPlayMethod.transcode) {
+          needsReResolve = true;
+        }
+      }
+    } else if (_lastExplicitSubtitleLanguage != null) {
+      final subtitleStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+      final targetIdx = subtitleStreams.indexWhere(
+        (s) => _languagesMatch(s, _lastExplicitSubtitleLanguage),
+      );
+      if (targetIdx >= 0) {
+        final matchedIdx = subtitleStreams[targetIdx]['Index'] as int?;
+        if (_subtitleStreamIndex != matchedIdx) {
+          _subtitleStreamIndex = matchedIdx;
+          if (resolution.playMethod == StreamPlayMethod.transcode) {
+            needsReResolve = true;
+          }
+        }
+      }
+    }
+
+    if (needsReResolve) {
+      await _playCurrentItem(
+        startPosition: startPosition,
+        enableDirectPlay: enableDirectPlay,
+        enableDirectStream: enableDirectStream,
+        enableTranscoding: enableTranscoding,
+        allowStartupRecovery: allowStartupRecovery,
+      );
+      return;
+    }
+
     _currentResolution = resolution;
     _lastPlaybackItem = item;
     _lastPlaybackResolution = resolution;
     _mediaSourceId = resolution.mediaSourceId;
     _itemKnownDuration = _resolvedItemDuration(item, resolution.mediaSourceId);
+
+    if (_audioStreamIndex != null && _audioSelectionExplicit) {
+      final audioStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Audio').toList();
+      final stream = audioStreams.firstWhere(
+        (s) => s['Index'] == _audioStreamIndex,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (stream.isNotEmpty) {
+        _lastExplicitAudioLanguage = _extractLanguage(stream);
+      }
+    }
+
+    if (_subtitleStreamIndex != null && _subtitleSelectionExplicit) {
+      if (_subtitleStreamIndex == -1) {
+        _lastExplicitSubtitleEnabled = false;
+        _lastExplicitSubtitleLanguage = null;
+      } else {
+        _lastExplicitSubtitleEnabled = true;
+        final subtitleStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+        final stream = subtitleStreams.firstWhere(
+          (s) => s['Index'] == _subtitleStreamIndex,
+          orElse: () => const <String, dynamic>{},
+        );
+        if (stream.isNotEmpty) {
+          _lastExplicitSubtitleLanguage = _extractLanguage(stream);
+        }
+      }
+    }
 
     if (_audioStreamIndex == null) {
       // Keep the server-selected audio index for later re-resolves.
@@ -1423,6 +1514,7 @@ class PlaybackManager implements AudioOwnable {
 
   Future<void> changeAudioTrack(int streamIndex) async {
     _audioStreamIndex = streamIndex;
+    _audioSelectionExplicit = true;
     final streams = _currentMediaStreams;
     if (streams.isNotEmpty) {
       final selectedStream = streams.firstWhere(
@@ -1430,7 +1522,7 @@ class PlaybackManager implements AudioOwnable {
         orElse: () => const <String, dynamic>{},
       );
       if (selectedStream.isNotEmpty) {
-        _lastExplicitAudioLanguage = selectedStream['Language'] as String?;
+        _lastExplicitAudioLanguage = _extractLanguage(selectedStream);
       }
     }
 
@@ -1611,7 +1703,7 @@ class PlaybackManager implements AudioOwnable {
           orElse: () => const <String, dynamic>{},
         );
         if (selectedStream.isNotEmpty) {
-          _lastExplicitSubtitleLanguage = selectedStream['Language'] as String?;
+          _lastExplicitSubtitleLanguage = _extractLanguage(selectedStream);
         }
       }
     } else {
@@ -2187,7 +2279,7 @@ class PlaybackManager implements AudioOwnable {
     if (_lastExplicitAudioLanguage != null) {
       final audioStreams = newStreams.where((s) => s['Type'] == 'Audio').toList();
       final targetIdx = audioStreams.indexWhere(
-        (s) => s['Language']?.toString().toLowerCase() == _lastExplicitAudioLanguage!.toLowerCase(),
+        (s) => _languagesMatch(s, _lastExplicitAudioLanguage),
       );
       if (targetIdx >= 0) {
         _audioStreamIndex = audioStreams[targetIdx]['Index'] as int?;
@@ -2203,7 +2295,7 @@ class PlaybackManager implements AudioOwnable {
     } else if (_lastExplicitSubtitleLanguage != null) {
       final subtitleStreams = newStreams.where((s) => s['Type'] == 'Subtitle').toList();
       final targetIdx = subtitleStreams.indexWhere(
-        (s) => s['Language']?.toString().toLowerCase() == _lastExplicitSubtitleLanguage!.toLowerCase(),
+        (s) => _languagesMatch(s, _lastExplicitSubtitleLanguage),
       );
       if (targetIdx >= 0) {
         _subtitleStreamIndex = subtitleStreams[targetIdx]['Index'] as int?;
@@ -2298,3 +2390,284 @@ class PlaybackBringupState {
       playMethod = null,
       error = null;
 }
+
+bool _languagesMatch(Map? stream, String? targetLanguage) {
+  if (stream == null || targetLanguage == null) return false;
+  final candidateLang = _extractLanguage(stream);
+  if (candidateLang == null) return false;
+
+  final normCandidate = _normalizeLanguage(candidateLang);
+  final normTarget = _normalizeLanguage(targetLanguage);
+  if (normCandidate.isEmpty || normTarget.isEmpty) return false;
+  if (normCandidate == 'und' || normTarget == 'und') return false;
+  if (normCandidate == normTarget) return true;
+
+  final iso3Candidate = _toIso3(normCandidate);
+  final iso3Target = _toIso3(normTarget);
+  return iso3Candidate.isNotEmpty && iso3Candidate == iso3Target;
+}
+
+String? _extractLanguage(Map? stream) {
+  if (stream == null) return null;
+  final lang = stream['Language']?.toString();
+  if (lang != null && lang.isNotEmpty && lang.toLowerCase() != 'und') {
+    return lang;
+  }
+  for (final field in const ['Title', 'DisplayTitle']) {
+    final title = stream[field]?.toString().toLowerCase();
+    if (title != null && title.isNotEmpty) {
+      final tokens = title.split(RegExp(r'[^a-z]')).where((t) => t.isNotEmpty);
+      for (final token in tokens) {
+        if (_kLanguageKeywords.containsKey(token)) {
+          return _kLanguageKeywords[token];
+        }
+      }
+    }
+  }
+  return lang;
+}
+
+const Map<String, String> _kLanguageKeywords = {
+  'arabic': 'ara',
+  'ara': 'ara',
+  'english': 'eng',
+  'eng': 'eng',
+  'french': 'fra',
+  'fra': 'fra',
+  'fre': 'fra',
+  'german': 'deu',
+  'deu': 'deu',
+  'ger': 'deu',
+  'spanish': 'spa',
+  'spa': 'spa',
+  'italian': 'ita',
+  'ita': 'ita',
+  'japanese': 'jpn',
+  'jpn': 'jpn',
+  'chinese': 'zho',
+  'zho': 'zho',
+  'chi': 'zho',
+  'portuguese': 'por',
+  'por': 'por',
+  'russian': 'rus',
+  'rus': 'rus',
+  'korean': 'kor',
+  'kor': 'kor',
+  'dutch': 'nld',
+  'nld': 'nld',
+  'dut': 'nld',
+  'swedish': 'swe',
+  'swe': 'swe',
+  'turkish': 'tur',
+  'tur': 'tur',
+  'vietnamese': 'vie',
+  'vie': 'vie',
+  'polish': 'pol',
+  'pol': 'pol',
+  'hebrew': 'heb',
+  'heb': 'heb',
+  'hindi': 'hin',
+  'hin': 'hin',
+};
+
+String _normalizeLanguage(String? language) {
+  if (language == null) return '';
+  final normalized = language.trim().toLowerCase();
+  if (normalized.isEmpty) return '';
+  final base = normalized.split(RegExp(r'[-_]')).first;
+  if (base == 'arabic') return 'ara';
+  if (base == 'english') return 'eng';
+  return base;
+}
+
+String _toIso3(String language) {
+  if (language.length == 3) return language;
+  return _kIso6391To6392[language] ?? language;
+}
+
+const Map<String, String> _kIso6391To6392 = {
+  'aa': 'aar',
+  'ab': 'abk',
+  'af': 'afr',
+  'ak': 'aka',
+  'am': 'amh',
+  'an': 'arg',
+  'ar': 'ara',
+  'as': 'asm',
+  'av': 'ava',
+  'ae': 'ave',
+  'ay': 'aym',
+  'az': 'aze',
+  'ba': 'bak',
+  'bm': 'bam',
+  'be': 'bel',
+  'bn': 'ben',
+  'bh': 'bih',
+  'bi': 'bis',
+  'bo': 'bod',
+  'bs': 'bos',
+  'br': 'bre',
+  'bg': 'bul',
+  'ca': 'cat',
+  'cs': 'ces',
+  'ch': 'cha',
+  'ce': 'che',
+  'cu': 'chu',
+  'cv': 'chv',
+  'kw': 'cor',
+  'co': 'cos',
+  'cr': 'cre',
+  'cy': 'cym',
+  'da': 'dan',
+  'de': 'deu',
+  'dv': 'div',
+  'dz': 'dzo',
+  'el': 'ell',
+  'en': 'eng',
+  'eo': 'epo',
+  'et': 'est',
+  'eu': 'eus',
+  'ee': 'ewe',
+  'fo': 'fao',
+  'fa': 'fas',
+  'fj': 'fij',
+  'fi': 'fin',
+  'fr': 'fra',
+  'fy': 'fry',
+  'ff': 'ful',
+  'gd': 'gla',
+  'ga': 'gle',
+  'gl': 'glg',
+  'gv': 'glv',
+  'gn': 'grn',
+  'gu': 'guj',
+  'ht': 'hat',
+  'ha': 'hau',
+  'he': 'heb',
+  'hz': 'her',
+  'hi': 'hin',
+  'ho': 'hmo',
+  'hr': 'hrv',
+  'hu': 'hun',
+  'hy': 'hye',
+  'ig': 'ibo',
+  'is': 'isl',
+  'io': 'ido',
+  'ii': 'iii',
+  'iu': 'iku',
+  'ie': 'ile',
+  'ia': 'ina',
+  'id': 'ind',
+  'ik': 'ipk',
+  'it': 'ita',
+  'jv': 'jav',
+  'ja': 'jpn',
+  'kl': 'kal',
+  'kn': 'kan',
+  'ks': 'kas',
+  'ka': 'kat',
+  'kr': 'kau',
+  'kk': 'kaz',
+  'km': 'khm',
+  'ki': 'kik',
+  'rw': 'kin',
+  'ky': 'kir',
+  'kv': 'kom',
+  'kg': 'kon',
+  'ko': 'kor',
+  'kj': 'kua',
+  'ku': 'kur',
+  'lo': 'lao',
+  'la': 'lat',
+  'lv': 'lav',
+  'li': 'lim',
+  'ln': 'lin',
+  'lt': 'lit',
+  'lb': 'ltz',
+  'lu': 'lub',
+  'lg': 'lug',
+  'mh': 'mah',
+  'ml': 'mal',
+  'mr': 'mar',
+  'mk': 'mkd',
+  'mg': 'mlg',
+  'mt': 'mlt',
+  'mn': 'mon',
+  'mi': 'mri',
+  'ms': 'msa',
+  'my': 'mya',
+  'na': 'nau',
+  'nv': 'nav',
+  'nr': 'nbl',
+  'nd': 'nde',
+  'ng': 'ndo',
+  'ne': 'nep',
+  'nl': 'nld',
+  'nn': 'nno',
+  'nb': 'nob',
+  'no': 'nor',
+  'ny': 'nya',
+  'oc': 'oci',
+  'oj': 'oji',
+  'or': 'ori',
+  'om': 'orm',
+  'os': 'oss',
+  'pa': 'pan',
+  'pi': 'pli',
+  'pl': 'pol',
+  'pt': 'por',
+  'ps': 'pus',
+  'qu': 'que',
+  'rm': 'roh',
+  'ro': 'ron',
+  'rn': 'run',
+  'ru': 'rus',
+  'sg': 'sag',
+  'sa': 'san',
+  'sr': 'srp',
+  'si': 'sin',
+  'sk': 'slk',
+  'sl': 'slv',
+  'se': 'sme',
+  'sm': 'smo',
+  'sn': 'sna',
+  'sd': 'snd',
+  'so': 'som',
+  'st': 'sot',
+  'es': 'spa',
+  'sq': 'sqi',
+  'sc': 'srd',
+  'ss': 'ssw',
+  'su': 'sun',
+  'sw': 'swa',
+  'sv': 'swe',
+  'ty': 'tah',
+  'ta': 'tam',
+  'tt': 'tat',
+  'te': 'tel',
+  'tg': 'tgk',
+  'tl': 'tgl',
+  'th': 'tha',
+  'ti': 'tir',
+  'to': 'ton',
+  'tn': 'tsn',
+  'ts': 'tso',
+  'tk': 'tuk',
+  'tr': 'tur',
+  'tw': 'twi',
+  'ug': 'uig',
+  'uk': 'ukr',
+  'ur': 'urd',
+  'uz': 'uzb',
+  've': 'ven',
+  'vi': 'vie',
+  'vo': 'vol',
+  'wa': 'wln',
+  'wo': 'wol',
+  'xh': 'xho',
+  'yi': 'yid',
+  'yo': 'yor',
+  'za': 'zha',
+  'zh': 'zho',
+  'zu': 'zul',
+};

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -2469,7 +2469,6 @@ String _normalizeLanguage(String? language) {
   final normalized = language.trim().toLowerCase();
   if (normalized.isEmpty) return '';
   final base = normalized.split(RegExp(r'[-_]')).first;
-  if (base == 'english') return 'eng';
   return base;
 }
 

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -990,17 +990,15 @@ class PlaybackManager implements AudioOwnable {
     bool needsReResolve = false;
 
     if (_lastExplicitAudioLanguage != null) {
-      final audioStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Audio').toList();
-      final targetIdx = audioStreams.indexWhere(
-        (s) => _languagesMatch(s, _lastExplicitAudioLanguage),
+      final matchedIdx = _matchStreamIndexByLanguage(
+        resolution.mediaStreams,
+        _lastExplicitAudioLanguage,
+        'Audio',
       );
-      if (targetIdx >= 0) {
-        final matchedIdx = audioStreams[targetIdx]['Index'] as int?;
-        if (_audioStreamIndex != matchedIdx) {
-          _audioStreamIndex = matchedIdx;
-          if (resolution.playMethod == StreamPlayMethod.transcode) {
-            needsReResolve = true;
-          }
+      if (matchedIdx != null && _audioStreamIndex != matchedIdx) {
+        _audioStreamIndex = matchedIdx;
+        if (resolution.playMethod == StreamPlayMethod.transcode) {
+          needsReResolve = true;
         }
       }
     }
@@ -1013,17 +1011,15 @@ class PlaybackManager implements AudioOwnable {
         }
       }
     } else if (_lastExplicitSubtitleLanguage != null) {
-      final subtitleStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
-      final targetIdx = subtitleStreams.indexWhere(
-        (s) => _languagesMatch(s, _lastExplicitSubtitleLanguage),
+      final matchedIdx = _matchStreamIndexByLanguage(
+        resolution.mediaStreams,
+        _lastExplicitSubtitleLanguage,
+        'Subtitle',
       );
-      if (targetIdx >= 0) {
-        final matchedIdx = subtitleStreams[targetIdx]['Index'] as int?;
-        if (_subtitleStreamIndex != matchedIdx) {
-          _subtitleStreamIndex = matchedIdx;
-          if (resolution.playMethod == StreamPlayMethod.transcode) {
-            needsReResolve = true;
-          }
+      if (matchedIdx != null && _subtitleStreamIndex != matchedIdx) {
+        _subtitleStreamIndex = matchedIdx;
+        if (resolution.playMethod == StreamPlayMethod.transcode) {
+          needsReResolve = true;
         }
       }
     }
@@ -2277,15 +2273,11 @@ class PlaybackManager implements AudioOwnable {
     }
 
     if (_lastExplicitAudioLanguage != null) {
-      final audioStreams = newStreams.where((s) => s['Type'] == 'Audio').toList();
-      final targetIdx = audioStreams.indexWhere(
-        (s) => _languagesMatch(s, _lastExplicitAudioLanguage),
+      _audioStreamIndex = _matchStreamIndexByLanguage(
+        newStreams,
+        _lastExplicitAudioLanguage,
+        'Audio',
       );
-      if (targetIdx >= 0) {
-        _audioStreamIndex = audioStreams[targetIdx]['Index'] as int?;
-      } else {
-        _audioStreamIndex = null;
-      }
     } else {
       _audioStreamIndex = null;
     }
@@ -2293,15 +2285,11 @@ class PlaybackManager implements AudioOwnable {
     if (_lastExplicitSubtitleEnabled == false) {
       _subtitleStreamIndex = -1;
     } else if (_lastExplicitSubtitleLanguage != null) {
-      final subtitleStreams = newStreams.where((s) => s['Type'] == 'Subtitle').toList();
-      final targetIdx = subtitleStreams.indexWhere(
-        (s) => _languagesMatch(s, _lastExplicitSubtitleLanguage),
+      _subtitleStreamIndex = _matchStreamIndexByLanguage(
+        newStreams,
+        _lastExplicitSubtitleLanguage,
+        'Subtitle',
       );
-      if (targetIdx >= 0) {
-        _subtitleStreamIndex = subtitleStreams[targetIdx]['Index'] as int?;
-      } else {
-        _subtitleStreamIndex = null;
-      }
     } else {
       _subtitleStreamIndex = null;
     }
@@ -2405,6 +2393,12 @@ bool _languagesMatch(Map? stream, String? targetLanguage) {
   final iso3Candidate = _toIso3(normCandidate);
   final iso3Target = _toIso3(normTarget);
   return iso3Candidate.isNotEmpty && iso3Candidate == iso3Target;
+}
+
+int? _matchStreamIndexByLanguage(List<Map<String, dynamic>> streams, String? lang, String type) {
+  final candidates = streams.where((s) => s['Type'] == type).toList();
+  final i = candidates.indexWhere((s) => _languagesMatch(s, lang));
+  return i >= 0 ? candidates[i]['Index'] as int? : null;
 }
 
 String? _extractLanguage(Map? stream) {

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -2469,7 +2469,6 @@ String _normalizeLanguage(String? language) {
   final normalized = language.trim().toLowerCase();
   if (normalized.isEmpty) return '';
   final base = normalized.split(RegExp(r'[-_]')).first;
-  if (base == 'arabic') return 'ara';
   if (base == 'english') return 'eng';
   return base;
 }

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -2475,6 +2475,7 @@ String _normalizeLanguage(String? language) {
 }
 
 String _toIso3(String language) {
+  if (_kLanguageKeywords.containsKey(language)) return _kLanguageKeywords[language]!;
   if (language.length == 3) return language;
   return _kIso6391To6392[language] ?? language;
 }


### PR DESCRIPTION
# Pull Request

## Summary
This PR addresses details page layout state synchronization and how selected version/track details propagate to the player and subsequent queue episodes. It ensures that the selected version, audio, and subtitle tracks selected on the details screen are correctly initially passed to the player and propagate to subsequent queue episodes using robust ISO-639 language matching rules.

## Related Issues
* Playback queuing: audio/subtitle selection from media info ignored during playback unless explicitly re-selected.
* Custom track selections do not follow from one media item to the next in queue (e.g. Arabic subtitles reverting to English).

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

### Playback Core Components
* Explicit Selection Tracking: Added fields _audioSelectionExplicit, _pendingItemAudioSelectionExplicit, and _pendingItemSubtitleSelectionExplicit to track whether track selections were made explicitly by the user or auto-detected.
* Propagation of Track Selections: Updated playItems() and setPendingItemOverrides() to accept and process these explicit flags.
* ISO-639 Compliant Language Matching & Propagation:
    * In _playCurrentItem(), after successful stream resolution, if track selections are marked as explicit, we look up the stream's language and store it in _lastExplicitAudioLanguage or _lastExplicitSubtitleLanguage/_lastExplicitSubtitleEnabled.
    * Added helpers _languagesMatch(), _normalizeLanguage(), and _toIso3() along with the full _kIso6391To6392 code map to normalize and compare language tags.
    * Updated _translateTrackSelectionsForNewItem() to compare languages using the _languagesMatch() helper. This resolves issues where language tags with different ISO formats (e.g., 2-letter ar vs 3-letter ara or full name Arabic) failed to propagate track selections across queue items.

### Title and DisplayTitle Fallback Parsing:
* Added _extractLanguage(Map? stream) to parse language information from the stream's Title and DisplayTitle when the server returns undetermined (und) or null for the language tag (common for external/side-loaded SRT subtitle tracks).
* Added a token-to-ISO-639-2 keywords map (_kLanguageKeywords) to map tokens like "Arabic" or "ara" case-insensitively to 'ara'.
* Updated _languagesMatch to compare candidate streams using the extracted resolved languages, ignoring non-descriptive 'und' matching.

### User Interface Components
* Explicit Flags Injection: Modified the calls to manager.playItems() and manager.setPendingItemOverrides() across all media types (Series, Season, Episode, BoxSet, defaultCase) to pass audioSelectionExplicit: viewModel.selectedAudioIndex != null and subtitleSelectionExplicit: viewModel.selectedSubtitleIndex != null.
* Initialization & Version Selection Fix: Corrected compilation errors where widget.selectedMediaSourceId was incorrectly accessed inside _ItemDetailScreenState. Removed widget.selectedMediaSourceId from _ItemDetailScreenState.initState() and _onChanged(), allowing the state variable _selectedMediaSourceId to properly initialize to the first available media source when the item loads.
 
## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed: Tested persistence across Android TV and Windows Desktop clients.
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the Media Info/Details page of an item with multiple versions, audio, or subtitle tracks.
2. Select a specific version, audio track, or subtitle track (e.g., Arabic subtitles when English are set as default).
3. Start playback without manually toggling it inside the player. Verify that the correct tracks/versions are applied.
4. Play subsequent episodes in the queue and verify that custom selections carry over dynamically based on language matching (e.g. Arabic subtitles carry over to subsequent episodes correctly).

## Screenshots (if applicable)
N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
