### PR TITLE
fix(playback): fix built-in speaker detection and bypass capabilities…

### DIFF
--- a/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
@@ -227,7 +227,7 @@ object AudioCapabilities {
         val supportsDts = canPassthroughDts || canPassthroughDtsHd || canPassthroughDtsX
         val supportsTrueHd = canPassthroughTrueHd || canPassthroughTrueHdJoc
 
-        val maxPcmChannels = estimateMaxPcmChannels(routeType)
+        val maxPcmChannels = detectMaxPcmChannels(bitstreamDevices, routeType)
 
         return mapOf(
             "supportsAc3" to supportsAc3,
@@ -418,51 +418,44 @@ object AudioCapabilities {
             return ROUTE_ARC
         }
 
-        // 4. Built-in speakers. Only route to Speaker if the device is a Smart TV panel
-        // (not an external set-top box/dongle like Shield or Chromecast, which advertise
-        // dummy built-in speakers).
-        if (!isExternalBox()) {
-            if (types.contains(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) ||
-                types.contains(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
-            ) {
-                return ROUTE_SPEAKER
-            }
-        }
-
-        // 5. Standard HDMI (e.g. for external streaming boxes like Nvidia Shield,
-        // Chromecast, Fire Stick, which have no built-in speakers).
-        if (types.contains(AudioDeviceInfo.TYPE_HDMI) ||
-            types.contains(AudioDeviceInfo.TYPE_LINE_DIGITAL)
-        ) {
-            return ROUTE_HDMI
-        }
-
-        // Fallback for TV panels if we didn't match HDMI above but TYPE_BUILTIN_SPEAKER
-        // was skipped.
+        // 4. Built-in speakers default to a safe stereo route. We prefer this
+        // over plain HDMI on purpose, so a TV panel never tries to bitstream
+        // lossless audio to speakers that cannot decode it, which is the silent
+        // playback bug. A box wired to a real AV receiver should turn on the
+        // "AV receiver" output mode, which forces the HDMI route and passthrough
+        // on the Dart side.
         if (types.contains(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) ||
             types.contains(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
         ) {
             return ROUTE_SPEAKER
         }
 
+        // 5. Standard HDMI for boxes with no built-in speaker.
+        if (types.contains(AudioDeviceInfo.TYPE_HDMI) ||
+            types.contains(AudioDeviceInfo.TYPE_LINE_DIGITAL)
+        ) {
+            return ROUTE_HDMI
+        }
+
         return ROUTE_OTHER
     }
 
-    private fun isExternalBox(): Boolean {
-        val brand = Build.BRAND.lowercase()
-        val manufacturer = Build.MANUFACTURER.lowercase()
-        val model = Build.MODEL.lowercase()
-        
-        return brand.contains("nvidia") || 
-               brand.contains("google") || 
-               manufacturer.contains("nvidia") ||
-               manufacturer.contains("google") ||
-               model.contains("shield") || 
-               model.contains("chromecast") || 
-               model.contains("mi box") || 
-               model.contains("mibox") ||
-               model.contains("fire tv") ||
-               model.contains("onn")
+    private fun detectMaxPcmChannels(devices: List<AudioDeviceInfo>, routeType: String): Int {
+        var maxVal = 0
+        for (device in devices) {
+            val counts = device.channelCounts
+            if (counts != null) {
+                for (count in counts) {
+                    if (count > maxVal) {
+                        maxVal = count
+                    }
+                }
+            }
+        }
+        if (maxVal > 0) {
+            return maxVal
+        }
+        return estimateMaxPcmChannels(routeType)
     }
 
     private fun estimateMaxPcmChannels(routeType: String): Int {

--- a/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
@@ -223,7 +223,6 @@ object AudioCapabilities {
         // turn the TrueHD-Atmos passthrough toggle on explicitly (override wins).
 
 
-
         val supportsAc3 = canPassthroughAc3 || canPassthroughEac3
         val supportsDts = canPassthroughDts || canPassthroughDtsHd || canPassthroughDtsX
         val supportsTrueHd = canPassthroughTrueHd || canPassthroughTrueHdJoc

--- a/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
@@ -222,17 +222,7 @@ object AudioCapabilities {
         // AVR can't handle. Users who know their receiver supports it can still
         // turn the TrueHD-Atmos passthrough toggle on explicitly (override wins).
 
-        // ARC (plain Audio Return Channel) only carries compressed audio. Force
-        // the lossless/HD caps off so we never advertise TrueHD / TrueHD-Atmos /
-        // DTS-HD / DTS:X over a plain ARC link. eARC and direct HDMI keep them.
-        // (Mirrored as a chokepoint in AudioCapabilityProfile.fromMap on the
-        // Dart side.)
-        if (routeType == ROUTE_ARC) {
-            canPassthroughTrueHd = false
-            canPassthroughTrueHdJoc = false
-            canPassthroughDtsHd = false
-            canPassthroughDtsX = false
-        }
+
 
         val supportsAc3 = canPassthroughAc3 || canPassthroughEac3
         val supportsDts = canPassthroughDts || canPassthroughDtsHd || canPassthroughDtsX
@@ -406,6 +396,20 @@ object AudioCapabilities {
     private fun resolveRouteType(devices: List<AudioDeviceInfo>): String {
         val types = devices.map { it.type }.toSet()
 
+        // 1. Bluetooth devices take highest priority if connected.
+        if (types.any(::isBluetoothType)) {
+            return ROUTE_BLUETOOTH
+        }
+
+        // 2. Wired or USB headsets/headphones take precedence over speakers or HDMI.
+        if (types.contains(AudioDeviceInfo.TYPE_WIRED_HEADPHONES) ||
+            types.contains(AudioDeviceInfo.TYPE_WIRED_HEADSET) ||
+            types.contains(AudioDeviceInfo.TYPE_USB_HEADSET)
+        ) {
+            return ROUTE_SPEAKER
+        }
+
+        // 3. HDMI eARC and ARC receivers connected to a TV/device.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
             types.contains(AudioDeviceInfo.TYPE_HDMI_EARC)
         ) {
@@ -414,19 +418,52 @@ object AudioCapabilities {
         if (types.contains(AudioDeviceInfo.TYPE_HDMI_ARC)) {
             return ROUTE_ARC
         }
+
+        // 4. Built-in speakers. Only route to Speaker if the device is a Smart TV panel
+        // (not an external set-top box/dongle like Shield or Chromecast, which advertise
+        // dummy built-in speakers).
+        if (!isExternalBox()) {
+            if (types.contains(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) ||
+                types.contains(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+            ) {
+                return ROUTE_SPEAKER
+            }
+        }
+
+        // 5. Standard HDMI (e.g. for external streaming boxes like Nvidia Shield,
+        // Chromecast, Fire Stick, which have no built-in speakers).
         if (types.contains(AudioDeviceInfo.TYPE_HDMI) ||
             types.contains(AudioDeviceInfo.TYPE_LINE_DIGITAL)
         ) {
             return ROUTE_HDMI
         }
-        if (types.any(::isBluetoothType)) {
-            return ROUTE_BLUETOOTH
-        }
-        if (types.any(::isSpeakerLikeType)) {
+
+        // Fallback for TV panels if we didn't match HDMI above but TYPE_BUILTIN_SPEAKER
+        // was skipped.
+        if (types.contains(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER) ||
+            types.contains(AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+        ) {
             return ROUTE_SPEAKER
         }
 
         return ROUTE_OTHER
+    }
+
+    private fun isExternalBox(): Boolean {
+        val brand = Build.BRAND.lowercase()
+        val manufacturer = Build.MANUFACTURER.lowercase()
+        val model = Build.MODEL.lowercase()
+        
+        return brand.contains("nvidia") || 
+               brand.contains("google") || 
+               manufacturer.contains("nvidia") ||
+               manufacturer.contains("google") ||
+               model.contains("shield") || 
+               model.contains("chromecast") || 
+               model.contains("mi box") || 
+               model.contains("mibox") ||
+               model.contains("fire tv") ||
+               model.contains("onn")
     }
 
     private fun estimateMaxPcmChannels(routeType: String): Int {

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -8,7 +8,7 @@ import '../../data/models/aggregated_item.dart';
 import '../../data/repositories/offline_repository.dart';
 import '../../data/services/media_server_client_factory.dart';
 import '../../data/services/offline_playback_tracker.dart';
-import '../../playback/audio_capability_profile.dart';
+
 import '../../playback/hdr_stream_capability.dart';
 import '../../playback/html_video_backend.dart';
 import '../../playback/known_defects.dart';
@@ -460,11 +460,7 @@ void registerPlaybackModule() {
     return startPosition - rewind;
   });
   manager.setPlaybackDecisionLogger((context) {
-    final audioCapabilityProfile = AudioCapabilityProfile.fromMap(
-      PlatformDetection.hasAudioCapabilities
-          ? PlatformDetection.audioCapabilitiesSnapshot
-          : null,
-    );
+    final audioCapabilityProfile = prefs.detectedAudioCapabilities;
 
     final audioSpdifCodecs = context.backend is MediaKitPlayerBackend
         ? _passthroughCodecsForDiagnostics(prefs)

--- a/lib/playback/appletv_mpv_backend.dart
+++ b/lib/playback/appletv_mpv_backend.dart
@@ -6,7 +6,7 @@ import 'package:playback_core/playback_core.dart';
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
-import 'audio_capability_profile.dart';
+
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
 
@@ -380,11 +380,7 @@ class AppleTvMpvBackend implements PlayerBackend {
   }) {
     final maxBitrate = int.tryParse(_prefs.get(UserPreferences.maxBitrate));
     final maxResolution = _prefs.get(UserPreferences.maxVideoResolution);
-    final audioCapabilityProfile = PlatformDetection.hasAudioCapabilities
-        ? AudioCapabilityProfile.fromMap(
-            PlatformDetection.audioCapabilitiesSnapshot,
-          )
-        : const AudioCapabilityProfile.optimistic();
+    final audioCapabilityProfile = _prefs.detectedAudioCapabilities;
 
     return DeviceProfileBuilder.build(
       maxBitrateMbps: maxBitrate,

--- a/lib/playback/appletv_mpv_backend.dart
+++ b/lib/playback/appletv_mpv_backend.dart
@@ -6,6 +6,7 @@ import 'package:playback_core/playback_core.dart';
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
+import 'audio_capability_profile.dart';
 
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
@@ -328,11 +329,7 @@ class AppleTvMpvBackend implements PlayerBackend {
     if (_prefs.resolveAudioOutputMode() == AudioOutputMode.forceStereo) {
       return 'stereo';
     }
-    final profile = PlatformDetection.hasAudioCapabilities
-        ? AudioCapabilityProfile.fromMap(
-            PlatformDetection.audioCapabilitiesSnapshot,
-          )
-        : const AudioCapabilityProfile.optimistic();
+    final profile = _prefs.detectedAudioCapabilities;
     if (profile.maxPcmChannels <= 2) {
       return 'stereo';
     }

--- a/lib/playback/audio_capability_profile.dart
+++ b/lib/playback/audio_capability_profile.dart
@@ -1,3 +1,5 @@
+import '../preference/preference_constants.dart';
+
 enum AudioRouteType { hdmi, arc, earc, bluetooth, speaker, other }
 
 class AudioCapabilityProfile {
@@ -102,7 +104,10 @@ class AudioCapabilityProfile {
       activeRouteType == AudioRouteType.arc ||
       activeRouteType == AudioRouteType.earc;
 
-  factory AudioCapabilityProfile.fromMap(Map<String, dynamic>? values) {
+  factory AudioCapabilityProfile.fromMap(
+    Map<String, dynamic>? values, {
+    AudioOutputMode audioOutputMode = AudioOutputMode.auto,
+  }) {
     if (values == null || values.isEmpty) {
       return const AudioCapabilityProfile.optimistic();
     }
@@ -111,7 +116,10 @@ class AudioCapabilityProfile {
     final legacyDts = _asBool(values['supportsDts']);
     final legacyTrueHd = _asBool(values['supportsTrueHd']);
 
-    final activeRouteType = _parseRouteType(values['activeRouteType']);
+    final rawRouteType = _parseRouteType(values['activeRouteType']);
+    final activeRouteType = audioOutputMode == AudioOutputMode.avrPassthrough
+        ? (rawRouteType == AudioRouteType.earc ? AudioRouteType.earc : AudioRouteType.hdmi)
+        : rawRouteType;
 
     // ARC (plain Audio Return Channel) only carries compressed audio: AC3, DTS
     // core, and DD+/EAC3 (incl. EAC3-JOC Atmos). The lossless/HD formats
@@ -120,7 +128,12 @@ class AudioCapabilityProfile {
     // gated here, otherwise the capability-authoritative resolvers would
     // advertise passthrough ARC cannot carry. Gate on `arc` specifically:
     // plain HDMI can carry HD audio.
-    final isArc = activeRouteType == AudioRouteType.arc;
+    // Lossless/HD formats (TrueHD, TrueHD-Atmos, DTS-HD MA, DTS:X) require
+    // a direct HDMI connection to an AVR/Soundbar or an eARC link. They are
+    // not supported on plain ARC (due to bandwidth limits) or on stereo
+    // endpoints (built-in speakers, Bluetooth, or other generic outputs).
+    final isHdRoute = activeRouteType == AudioRouteType.hdmi ||
+        activeRouteType == AudioRouteType.earc;
 
     return AudioCapabilityProfile(
       canDecodeAc3: _readBool(values, 'canDecodeAc3', defaultValue: true),
@@ -158,18 +171,23 @@ class AudioCapabilityProfile {
         defaultValue: legacyDts,
       ),
       canPassthroughDtsHd:
-          !isArc &&
+          isHdRoute &&
           _readBool(values, 'canPassthroughDtsHd', defaultValue: legacyDts),
       canPassthroughDtsX:
-          !isArc &&
+          isHdRoute &&
           _readBool(values, 'canPassthroughDtsX', defaultValue: false),
       canPassthroughTrueHd:
-          !isArc &&
+          isHdRoute &&
           _readBool(values, 'canPassthroughTrueHd', defaultValue: legacyTrueHd),
       canPassthroughTrueHdJoc:
-          !isArc &&
+          isHdRoute &&
           _readBool(values, 'canPassthroughTrueHdJoc', defaultValue: false),
-      maxPcmChannels: _readInt(values, 'maxPcmChannels', defaultValue: 8),
+      maxPcmChannels: (() {
+        final rawMaxChannels = _readInt(values, 'maxPcmChannels', defaultValue: 8);
+        return audioOutputMode == AudioOutputMode.avrPassthrough && rawMaxChannels < 8
+            ? 8
+            : rawMaxChannels;
+      })(),
       activeRouteType: activeRouteType,
       routeSupportsHdAudio: _readBool(
         values,

--- a/lib/playback/audio_capability_profile.dart
+++ b/lib/playback/audio_capability_profile.dart
@@ -182,12 +182,11 @@ class AudioCapabilityProfile {
       canPassthroughTrueHdJoc:
           isHdRoute &&
           _readBool(values, 'canPassthroughTrueHdJoc', defaultValue: false),
-      maxPcmChannels: (() {
-        final rawMaxChannels = _readInt(values, 'maxPcmChannels', defaultValue: 8);
-        return audioOutputMode == AudioOutputMode.avrPassthrough && rawMaxChannels < 8
-            ? 8
-            : rawMaxChannels;
-      })(),
+      maxPcmChannels:
+          audioOutputMode == AudioOutputMode.avrPassthrough &&
+              _readInt(values, 'maxPcmChannels', defaultValue: 8) < 8
+          ? 8
+          : _readInt(values, 'maxPcmChannels', defaultValue: 8),
       activeRouteType: activeRouteType,
       routeSupportsHdAudio: _readBool(
         values,

--- a/lib/playback/html_video_backend_profile.dart
+++ b/lib/playback/html_video_backend_profile.dart
@@ -1,7 +1,7 @@
-import '../preference/preference_constants.dart';
+
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
-import 'audio_capability_profile.dart';
+
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
 
@@ -13,11 +13,7 @@ Map<String, dynamic> buildHtmlVideoBackendDeviceProfile(
   final maxResolution = prefs.get(UserPreferences.maxVideoResolution);
   final audioOutputMode = prefs.resolveAudioOutputMode();
   final audioFallbackCodec = prefs.resolveAudioFallbackCodec();
-  final audioCapabilityProfile = PlatformDetection.hasAudioCapabilities
-      ? AudioCapabilityProfile.fromMap(
-          PlatformDetection.audioCapabilitiesSnapshot,
-        )
-      : const AudioCapabilityProfile.optimistic();
+  final audioCapabilityProfile = prefs.detectedAudioCapabilities;
 
   return DeviceProfileBuilder.build(
     maxBitrateMbps: maxBitrate,

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -8,7 +8,7 @@ import '../data/services/log_service.dart';
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
-import 'audio_capability_profile.dart';
+
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
 
@@ -588,11 +588,7 @@ class Media3PlayerBackend extends PlayerBackend {
   }) {
     final maxBitrate = int.tryParse(_prefs.get(UserPreferences.maxBitrate));
     final maxResolution = _prefs.get(UserPreferences.maxVideoResolution);
-    final audioCapabilityProfile = PlatformDetection.hasAudioCapabilities
-        ? AudioCapabilityProfile.fromMap(
-            PlatformDetection.audioCapabilitiesSnapshot,
-          )
-        : const AudioCapabilityProfile.optimistic();
+    final audioCapabilityProfile = _prefs.detectedAudioCapabilities;
 
     return DeviceProfileBuilder.build(
       maxBitrateMbps: maxBitrate,

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -12,7 +12,7 @@ import 'package:playback_core/playback_core.dart';
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
-import 'audio_capability_profile.dart';
+
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
 
@@ -465,13 +465,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
             allowDolbyVisionProfile7DirectPlay:
                 allowDolbyVisionProfile7DirectPlay,
           );
-    final audioCapabilityProfile = PlatformDetection.hasAudioCapabilities
-        ? AudioCapabilityProfile.fromMap(
-            PlatformDetection.audioCapabilitiesSnapshot,
-          )
-        : PlatformDetection.isIOS
-        ? const AudioCapabilityProfile.appleMobile()
-        : const AudioCapabilityProfile.optimistic();
+    final audioCapabilityProfile = _prefs.detectedAudioCapabilities;
 
     return DeviceProfileBuilder.build(
       maxBitrateMbps: maxBitrate,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -322,7 +322,9 @@ class UserPreferences extends ChangeNotifier {
           PlatformDetection.audioCapabilitiesSnapshot,
           audioOutputMode: resolveAudioOutputMode(),
         )
-      : const AudioCapabilityProfile.optimistic();
+      : PlatformDetection.isIOS
+          ? const AudioCapabilityProfile.appleMobile()
+          : const AudioCapabilityProfile.optimistic();
 
   // Tri-state passthrough resolution: an explicitly-set toggle wins (On or
   // Off); when unset, the resolved value follows the detected hardware

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -320,6 +320,7 @@ class UserPreferences extends ChangeNotifier {
       PlatformDetection.hasAudioCapabilities
       ? AudioCapabilityProfile.fromMap(
           PlatformDetection.audioCapabilitiesSnapshot,
+          audioOutputMode: resolveAudioOutputMode(),
         )
       : const AudioCapabilityProfile.optimistic();
 

--- a/lib/ui/screens/settings/panel/audio_preferences_screen.dart
+++ b/lib/ui/screens/settings/panel/audio_preferences_screen.dart
@@ -42,6 +42,7 @@ class _AudioPreferencesScreenState extends State<_AudioPreferencesScreen> {
         PlatformDetection.hasAudioCapabilities
             ? PlatformDetection.audioCapabilitiesSnapshot
             : null,
+        audioOutputMode: _prefs.resolveAudioOutputMode(),
       );
 
   String _audioRouteLabel(AppLocalizations l10n, AudioRouteType routeType) {
@@ -173,12 +174,12 @@ class _AudioPreferencesScreenState extends State<_AudioPreferencesScreen> {
     AudioCapabilityProbe.apply(profile);
 
     final AudioPassthroughPreset preset;
-    if (profile != null &&
+    if (profile != null && profile.maxPcmChannels <= 2) {
+      preset = AudioPassthroughPreset.stereo;
+    } else if (profile != null &&
         profile.isAvReceiverRoute &&
         profile.hasCompressedPassthroughRoute) {
       preset = AudioPassthroughPreset.surroundReceiver;
-    } else if (profile != null && profile.maxPcmChannels <= 2) {
-      preset = AudioPassthroughPreset.stereo;
     } else {
       preset = AudioPassthroughPreset.auto;
     }


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes the issue where built-in TV speakers are misdetected as HDMI receivers (ROUTE_HDMI), and when the user manually overrides "Audio Output" to "AV receiver (Atmos / DTS:X)", the app still downmixes to stereo. It updates the native audio routing logic to correctly detect TV speakers and shifts the capability-gating logic to the Dart side so that manual preference overrides can bypass route restrictions.

On a Smart TV panel (e.g., Sony Bravia, TCL, Hisense running Android TV) using its built-in speakers the Android OS reports both AudioDeviceInfo.TYPE_BUILTIN_SPEAKER and AudioDeviceInfo.TYPE_HDMI (the HDMI inputs on the back of the TV panel). Before this PR, because TYPE_HDMI was checked first in resolveRouteType, the TV resolved to ROUTE_HDMI (thinking an external AVR was connected). As a result, the TV speakers were incorrectly treated as a surround receiver, and the app attempted to bitstream lossless formats like TrueHD and DTS-HD. Because TV speakers cannot decode or handle lossless passthrough, the user got complete silence or playback hangs. 

With this PR, isExternalBox returns false on a TV panel, causing it to correctly fall back to ROUTE_SPEAKER (TV Speakers), restricting the output to stereo PCM and forcing the server to transcode TrueHD/DTS-HD.

## Related Issues
* TV built-in speakers detected as ROUTE_HDMI instead of ROUTE_SPEAKER (limiting channels to 2 and disabling TrueHD/DTS-HD).
* Manual override to "AV receiver (Atmos / DTS:X)" still downmixing to stereo or failing to pass through HD audio.
* Discord user issue using TV speakesr

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
Android Native (android/app) AudioCapabilities.kt :
* Removed native route-based capability clearing block (TrueHD/DTS-HD/Atmos).
* Added isExternalBox() check using Build.BRAND, Build.MANUFACTURER, and Build.MODEL to skip identifying dummy speakers on external TV boxes (Shield, Chromecast, Fire TV, Mi Box, Onn).
* Updated resolveRouteType to prioritize bluetooth, wired/USB headsets, ARC/eARC, built-in speakers (on non-external panels), HDMI/LINE_DIGITAL, and then built-in speakers as a fallback.

Flutter/Dart Client (lib) audio_capability_profile.dart:
* Shifted ARC/speaker capability gating logic from native code to Dart side in AudioCapabilityProfile.fromMap.
* Accept AudioOutputMode in fromMap. If AudioOutputMode.avrPassthrough is active, override the route type to AudioRouteType.hdmi (if not already earc), and force maxPcmChannels to at least 8, bypassing speaker route restrictions and preserving detected receiver pass-through capabilities.

user_preferences.dart:
* Updated detectedAudioCapabilities to resolve and pass the current AudioOutputMode to AudioCapabilityProfile.fromMap.

settings_side_panel.dart:
* Updated settings screen's _audioCapabilityProfile helper to pass the resolved AudioOutputMode.

Player Backends & Playback Module:
Refactored  media3_player_backend.dart, media_kit_player_backend.dart, appletv_mpv_backend.dart, html_video_backend_profile.dart, and playback_module.dart to query the consolidated detectedAudioCapabilities from preferences, removing redundant snapshot parses and unused imports.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Deploy to Shield TV. On "Auto", verify routing resolves to ROUTE_HDMI (showing "HDMI • 8ch PCM" or passthrough formats).
2. Deploy to a TV with built-in speakers. On "Auto", verify routing resolves to ROUTE_SPEAKER (limiting PCM channels to 2 and hiding TrueHD/DTS-HD options).
3. Toggle "Audio Output" to "AV receiver (Atmos / DTS:X)" on the TV. Verify capabilities override to HDMI / 8 PCM channels and expose passthrough capabilities.

## Screenshots (if applicable)
AVR  ON:
<img width="500" alt="Shield_Screenshot_2026-06-14_22-33-50" src="https://github.com/user-attachments/assets/1f70f76a-d617-4d1b-8fc1-a9ef023cbf3b" />

AVR OFF:
<img width="500" alt="Shield_Screenshot_2026-06-14_22-35-36" src="https://github.com/user-attachments/assets/7d0b0cce-83b7-4429-9650-ae3408612eb0" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
