### PR TITLE
fix(ui): link Read More toggle to top navbar and fix viewport scrolling

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -601,9 +601,23 @@ class _DetailContentState extends State<_DetailContent> {
 
   void _focusSectionTarget(FocusNode target, {double alignment = 0.2}) {
     target.requestFocus();
-    final context = target.context;
-    if (context != null && !_shouldSkipSectionEnsureVisible(target)) {
-      unawaited(_ensureSectionVisible(context, alignment: alignment));
+    final isActionButtons = target == widget.initialFocusNode ||
+        target.debugLabel == 'detailActionButtons' ||
+        target.debugLabel == 'detailBoxSetActionButtons';
+
+    if (isActionButtons) {
+      if (_scrollController.hasClients) {
+        unawaited(_scrollController.animateTo(
+          _scrollController.position.minScrollExtent,
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOut,
+        ));
+      }
+    } else {
+      final context = target.context;
+      if (context != null && !_shouldSkipSectionEnsureVisible(target)) {
+        unawaited(_ensureSectionVisible(context, alignment: alignment));
+      }
     }
   }
 
@@ -1012,6 +1026,16 @@ class _DetailContentState extends State<_DetailContent> {
                       prefs: widget.prefs,
                       selectedMediaSource: selectedMediaSource,
                       overviewFocusNode: headerOverviewFocusNode,
+                      onArrowUp: _tryFocusNavbar,
+                      onArrowDown: () {
+                        final type = item.type;
+                        final targetNode = switch (type) {
+                          'BoxSet' => _sectionFocusNode('detailBoxSetActionButtons'),
+                          _ => widget.initialFocusNode ?? _sectionFocusNode('detailActionButtons'),
+                        };
+                        _requestSectionFocus(targetNode);
+                      },
+                      onArrowLeft: () => _tryFocusSidebar(),
                     ),
                   ),
                 SliverPadding(
@@ -1185,6 +1209,10 @@ class _DetailContentState extends State<_DetailContent> {
     final overviewFocusNode = hasOverview
         ? _sectionFocusNode('detailBookOverview')
         : null;
+    final actionButtonsFocusNode = widget.initialFocusNode ?? _sectionFocusNode('detailActionButtons');
+    final similarFocusNode = viewModel.similar.isNotEmpty
+        ? _sectionFocusNode('detailBookSimilar')
+        : null;
     final coverTag = item.primaryImageTag;
     final coverUrl = coverTag == null
         ? null
@@ -1285,7 +1313,7 @@ class _DetailContentState extends State<_DetailContent> {
         itemId: viewModel.item?.id,
         selectedMediaSourceId: selectedMediaSourceId,
         onSelectedMediaSourceChanged: onSelectedMediaSourceChanged,
-        tvPlayFocusNode: _sectionFocusNode('detailActionButtons'),
+        tvPlayFocusNode: actionButtonsFocusNode,
         downTarget: overviewFocusNode,
         onRequestFocus: _requestSectionFocus,
         autoPlay: widget.autoPlay,
@@ -1297,6 +1325,11 @@ class _DetailContentState extends State<_DetailContent> {
         _OverviewText(
           text: overview,
           focusNode: overviewFocusNode,
+          onArrowUp: () => _requestSectionFocus(actionButtonsFocusNode),
+          onArrowDown: similarFocusNode != null
+              ? () => _requestSectionFocus(similarFocusNode)
+              : null,
+          onArrowLeft: () => _tryFocusSidebar(),
           style: const TextStyle(
             color: Color(0xFFD7E8F6),
             fontSize: 14,
@@ -1361,6 +1394,7 @@ class _DetailContentState extends State<_DetailContent> {
             items: viewModel.similar,
             imageApi: viewModel.imageApi,
             prefs: prefs,
+            firstItemFocusNode: similarFocusNode,
             onItemLongPress: _showItemContextMenu,
             scrollController: ctrl,
           ),
@@ -2351,7 +2385,15 @@ class _DetailContentState extends State<_DetailContent> {
       ),
       if (hasOverview) ...[
         const SizedBox(height: 24),
-        _OverviewText(text: item.overview!, focusNode: overviewFocusNode),
+        _OverviewText(
+          text: item.overview!,
+          focusNode: overviewFocusNode,
+          onArrowUp: () => _requestSectionFocus(widget.initialFocusNode),
+          onArrowDown: (albumsFocusNode ?? similarFocusNode) != null
+              ? () => _requestSectionFocus(albumsFocusNode ?? similarFocusNode)
+              : null,
+          onArrowLeft: () => _tryFocusSidebar(),
+        ),
       ],
       if (viewModel.albums.isNotEmpty) ...[
         const SizedBox(height: 32),
@@ -2925,12 +2967,18 @@ class _HeaderSection extends StatelessWidget {
   final UserPreferences prefs;
   final Map<String, dynamic>? selectedMediaSource;
   final FocusNode? overviewFocusNode;
+  final VoidCallback? onArrowUp;
+  final VoidCallback? onArrowDown;
+  final VoidCallback? onArrowLeft;
 
   const _HeaderSection({
     required this.viewModel,
     required this.prefs,
     this.selectedMediaSource,
     this.overviewFocusNode,
+    this.onArrowUp,
+    this.onArrowDown,
+    this.onArrowLeft,
   });
 
   @override
@@ -3069,6 +3117,9 @@ class _HeaderSection extends StatelessWidget {
           _OverviewText(
             text: item.overview!,
             focusNode: overviewFocusNode,
+            onArrowUp: onArrowUp,
+            onArrowDown: onArrowDown,
+            onArrowLeft: onArrowLeft,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                   ? AppColorScheme.onSurface
@@ -9143,12 +9194,20 @@ class _OverviewText extends StatelessWidget {
   final TextStyle? style;
   final TextAlign? textAlign;
   final FocusNode? focusNode;
+  final FocusNode? upTarget;
+  final VoidCallback? onArrowUp;
+  final VoidCallback? onArrowDown;
+  final VoidCallback? onArrowLeft;
 
   const _OverviewText({
     required this.text,
     this.style,
     this.textAlign,
     this.focusNode,
+    this.upTarget,
+    this.onArrowUp,
+    this.onArrowDown,
+    this.onArrowLeft,
   });
 
   @override
@@ -9157,6 +9216,10 @@ class _OverviewText extends StatelessWidget {
     return _ExpandableBiography(
       text: text,
       toggleFocusNode: focusNode,
+      upTarget: upTarget,
+      onArrowUp: onArrowUp,
+      onArrowDown: onArrowDown,
+      onArrowLeft: onArrowLeft,
       style:
           style ??
           Theme.of(context).textTheme.bodyLarge?.copyWith(
@@ -10237,6 +10300,19 @@ class _ExpandableBiographyState extends State<_ExpandableBiography> {
 
     final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
     if (focusNavbar != null) {
+      final scrollable = Scrollable.maybeOf(context);
+      if (scrollable != null) {
+        try {
+          final position = scrollable.position;
+          if (position.pixels > position.minScrollExtent) {
+            position.animateTo(
+              position.minScrollExtent,
+              duration: const Duration(milliseconds: 220),
+              curve: Curves.easeOut,
+            );
+          }
+        } catch (_) {}
+      }
       focusNavbar();
       return true;
     }

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -81,6 +81,16 @@ double _desktopUiScale({UserPreferences? prefs}) {
   return effectivePrefs.get(UserPreferences.desktopUiScale).scaleFactor;
 }
 
+/// Smoothly scrolls a position back to the top. Ignore if already there.
+void _animateScrollToTop(ScrollPosition position) {
+  if (position.pixels <= position.minScrollExtent) return;
+  unawaited(position.animateTo(
+    position.minScrollExtent,
+    duration: const Duration(milliseconds: 220),
+    curve: Curves.easeOut,
+  ));
+}
+
 Future<bool> _showDeleteConfirmationDialog(
   BuildContext context, {
   required String title,
@@ -518,16 +528,7 @@ class _DetailContentState extends State<_DetailContent> {
   }
 
   bool _tryFocusNavbar() {
-    if (_scrollController.hasClients) {
-      final position = _scrollController.position;
-      if (position.pixels > position.minScrollExtent) {
-        position.animateTo(
-          position.minScrollExtent,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOut,
-        );
-      }
-    }
+    _scrollMainToTop();
 
     final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
     if (focusNavbar != null) {
@@ -599,20 +600,21 @@ class _DetailContentState extends State<_DetailContent> {
     return controller.position.context.storageContext;
   }
 
+  void _scrollMainToTop() {
+    if (_scrollController.hasClients) {
+      _animateScrollToTop(_scrollController.position);
+    }
+  }
+
+  bool _isActionButtonTarget(FocusNode target) =>
+      target == widget.initialFocusNode ||
+      target.debugLabel == 'detailActionButtons' ||
+      target.debugLabel == 'detailBoxSetActionButtons';
+
   void _focusSectionTarget(FocusNode target, {double alignment = 0.2}) {
     target.requestFocus();
-    final isActionButtons = target == widget.initialFocusNode ||
-        target.debugLabel == 'detailActionButtons' ||
-        target.debugLabel == 'detailBoxSetActionButtons';
-
-    if (isActionButtons) {
-      if (_scrollController.hasClients) {
-        unawaited(_scrollController.animateTo(
-          _scrollController.position.minScrollExtent,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOut,
-        ));
-      }
+    if (_isActionButtonTarget(target)) {
+      _scrollMainToTop();
     } else {
       final context = target.context;
       if (context != null && !_shouldSkipSectionEnsureVisible(target)) {
@@ -629,18 +631,8 @@ class _DetailContentState extends State<_DetailContent> {
       return;
     }
 
-    final isActionButtons = target == widget.initialFocusNode ||
-        target.debugLabel == 'detailActionButtons' ||
-        target.debugLabel == 'detailBoxSetActionButtons';
-
-    if (isActionButtons) {
-      if (_scrollController.hasClients) {
-        unawaited(_scrollController.animateTo(
-          _scrollController.position.minScrollExtent,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOut,
-        ));
-      }
+    if (_isActionButtonTarget(target)) {
+      _scrollMainToTop();
     } else {
       final sectionContext = _sectionContainerContext(target);
       if (sectionContext != null && !_shouldSkipSectionEnsureVisible(target)) {
@@ -725,13 +717,7 @@ class _DetailContentState extends State<_DetailContent> {
         _resetSectionHorizontalOffset(sourceFocusNode);
         if (upTarget != null) {
           if (upTarget == favoriteFocusNode) {
-            if (_scrollController.hasClients) {
-              _scrollController.animateTo(
-                _scrollController.position.minScrollExtent,
-                duration: const Duration(milliseconds: 220),
-                curve: Curves.easeOut,
-              );
-            }
+            _scrollMainToTop();
           }
           _requestSectionFocus(upTarget);
           return KeyEventResult.handled;
@@ -935,16 +921,7 @@ class _DetailContentState extends State<_DetailContent> {
             event.logicalKey == LogicalKeyboardKey.arrowUp) {
           final navbarPos = prefs.get(UserPreferences.navbarPosition);
           if (navbarPos == NavbarPosition.top) {
-            if (_scrollController.hasClients) {
-              final position = _scrollController.position;
-              if (position.pixels > position.minScrollExtent) {
-                position.animateTo(
-                  position.minScrollExtent,
-                  duration: const Duration(milliseconds: 220),
-                  curve: Curves.easeOut,
-                );
-              }
-            }
+            _scrollMainToTop();
             NavigationLayout.focusNavbarNotifier.value?.call();
             return KeyEventResult.handled;
           }
@@ -10302,16 +10279,7 @@ class _ExpandableBiographyState extends State<_ExpandableBiography> {
     if (focusNavbar != null) {
       final scrollable = Scrollable.maybeOf(context);
       if (scrollable != null) {
-        try {
-          final position = scrollable.position;
-          if (position.pixels > position.minScrollExtent) {
-            position.animateTo(
-              position.minScrollExtent,
-              duration: const Duration(milliseconds: 220),
-              curve: Curves.easeOut,
-            );
-          }
-        } catch (_) {}
+        _animateScrollToTop(scrollable.position);
       }
       focusNavbar();
       return true;


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes keyboard and D-pad focus traversal issues with the expandable overview/biography description ("Read More" toggle) on all item detail screens. It connects the description's Up/Down/Left arrow key inputs to correct focus targets (top navbar, action buttons, sidebars) and ensures that returning focus to the Play/Resume action buttons automatically scrolls the viewport back to the top of the page, avoiding "lost" or off-screen focus indicators under varying UI scales.

## Related Issues
Observation from tester on Discord

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added optional directional focus callbacks (`onArrowUp`, `onArrowDown`, `onArrowLeft`, `upTarget`) to the `_OverviewText` and `_ExpandableBiography` widgets.
- Updated `_HeaderSection` to receive and route these directional callbacks down to its overview description.
- Connected the overview text in Movie/Series, Book, and Artist layouts to focus targets (action buttons, discography, and similar rows).
- Modified `_focusSectionTarget` to automatically scroll the viewport to the top (`minScrollExtent`) when focusing the main ActionButtons (Play/Resume).
- Modified `_handleUpWithoutToggle` to scroll the nearest Scrollable ancestor to the top before focusing the navbar.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on AndroidTV
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a movie/series/book detail screen with a long overview.
2. Focus the "Read More" button/overview description.
3. Press Arrow Up and confirm focus returns smoothly to the top navbar or ActionButtons (Play/Resume), and that the viewport scrolls up appropriately.
4. Press Arrow Down and confirm focus moves to details rows below.
5. Press Arrow Left and confirm sidebar focus is requested.

## Screenshots (if applicable)
N/A but all behaviours now work as expected.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
