### PR TITLE
fix(ui): delay row snapping on home screen during mouse wheel scroll

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
+import 'package:flutter/gestures.dart';
+
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -589,6 +591,7 @@ class _ContentRowsState extends State<_ContentRows>
   bool _suppressNextRowPreviewFromMediaBar = false;
   bool _forceRevealOnNextRowFocusFromMediaBar = false;
   DateTime? _lastScrollTime;
+  DateTime? _lastMouseWheelTime;
   DateTime? _lastVerticalNavAt;
   bool _verticalNavInFlight = false;
   bool _chromeFocusActive = false;
@@ -2230,13 +2233,19 @@ class _ContentRowsState extends State<_ContentRows>
       _isActivelyScrolling = true;
       if (mounted) setState(() {});
     }
+    final isMouseScroll = _lastMouseWheelTime != null &&
+        DateTime.now().difference(_lastMouseWheelTime!).inMilliseconds < 100;
+
     _scrollIdleTimer?.cancel();
-    _scrollIdleTimer = Timer(const Duration(milliseconds: 250), () {
-      if (!mounted) return;
-      _isActivelyScrolling = false;
-      _snapToNearestRow();
-      setState(() {});
-    });
+    _scrollIdleTimer = Timer(
+      Duration(milliseconds: isMouseScroll ? 1000 : 250),
+      () {
+        if (!mounted) return;
+        _isActivelyScrolling = false;
+        _snapToNearestRow();
+        setState(() {});
+      },
+    );
     if (_activePreviewKey != null) {
       final scrollDelta = (offset - _previewStartScrollOffset).abs();
       if (scrollDelta > _previewScrollThreshold) {
@@ -2731,6 +2740,11 @@ class _ContentRowsState extends State<_ContentRows>
     return Listener(
       behavior: HitTestBehavior.translucent,
       onPointerDown: (_) => _markUserGesture(),
+      onPointerSignal: (pointerSignal) {
+        if (pointerSignal is PointerScrollEvent) {
+          _lastMouseWheelTime = DateTime.now();
+        }
+      },
       child: Stack(
         children: [
         Positioned.fill(


### PR DESCRIPTION
# Pull Request

## Summary
This PR delays the snap-to-centered-row logic on the Home screen when a mouse wheel scroll is detected, preventing users from getting snapped/pulled back to the currently focused row while trying to scroll through rows using a mouse. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #531 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added a `PointerScrollEvent` listener to the `Listener` widget enclosing the Home screen row list.
- Recorded the timestamp of the last mouse wheel scroll event.
- Extended the `_scrollIdleTimer` delay to 1000ms (up from 250ms) if a mouse scroll was recently active, ensuring the centering logic only triggers when mouse wheel input has fully stopped.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested with Windows Desktop build
- [ ] Not tested (explain why):

### Test Steps
1. Open TV mode Home Screen on Windows.
2. Use the mouse wheel to scroll vertically.
3. Confirm that the viewport scrolls freely and does not snap back to a row until 1 second after mouse wheel input stops.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
