### PR TITLE
fix: resolve player audio stream switching and correct OSD remux label

### DIFF
--- a/lib/util/play_method_label.dart
+++ b/lib/util/play_method_label.dart
@@ -28,7 +28,6 @@ String playbackMethodLabel({
       .toList(growable: false);
   final isRemux =
       playMethod == StreamPlayMethod.transcode &&
-      lowerReasons.isNotEmpty &&
       !lowerReasons.any(_videoReEncodeReasons.contains);
 
   if (playMethod != null) {

--- a/packages/playback_core/lib/src/media_stream_resolver.dart
+++ b/packages/playback_core/lib/src/media_stream_resolver.dart
@@ -7,6 +7,32 @@ abstract class MediaStreamResolver {
     return mediaItem.id as String;
   }
 
+  static String? resolveStaticMediaSourceId(
+    dynamic mediaItem,
+    String? mediaSourceId,
+  ) {
+    if (mediaSourceId == null || mediaSourceId.isEmpty) return mediaSourceId;
+    final sources = _staticMediaSources(mediaItem);
+    if (sources == null || sources.isEmpty) return mediaSourceId;
+    final staticIds = sources.map(_mediaSourceId).toSet();
+    if (staticIds.contains(mediaSourceId)) return mediaSourceId;
+    return staticIds.first;
+  }
+
+  static List<dynamic>? _staticMediaSources(dynamic mediaItem) {
+    if (mediaItem is Map) return mediaItem['MediaSources'] as List<dynamic>?;
+    try {
+      return mediaItem.mediaSources as List<dynamic>?;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static String _mediaSourceId(dynamic source) {
+    if (source is Map) return (source['Id'] ?? source['id']).toString();
+    return source.id.toString();
+  }
+
   /// Whether a managed live stream (Live TV) should be played directly from its
   /// source `path` instead of the server's HLS transcode session.
   ///

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1434,14 +1434,7 @@ class PlaybackManager implements AudioOwnable {
       }
     }
 
-    if (!_isOfflinePlayback &&
-        !(_backend?.supportsRuntimeTrackSelection ?? true)) {
-      await _reResolveAtCurrentPosition();
-      return;
-    }
-
-    if (_currentResolution?.playMethod == StreamPlayMethod.directPlay ||
-        _isOfflinePlayback) {
+    if (_isOfflinePlayback) {
       final mpvId = _mpvTrackIdForStream(streamIndex, 'Audio');
       if (mpvId != null) {
         await _backend?.setAudioTrack(mpvId);

--- a/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
+++ b/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
@@ -22,9 +22,39 @@ class EmbyMediaStreamResolver implements MediaStreamResolver {
   }) async {
     final itemId = MediaStreamResolver.extractItemId(mediaItem);
 
+    String? resolvedMediaSourceId = mediaSourceId;
+    if (mediaSourceId != null && mediaSourceId.isNotEmpty) {
+      try {
+        final dynamic item = mediaItem;
+        final List<dynamic>? staticSources = item.mediaSources as List<dynamic>?;
+        if (staticSources != null && staticSources.isNotEmpty) {
+          final staticIds = staticSources
+              .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s.id).toString())
+              .toSet();
+          if (!staticIds.contains(mediaSourceId)) {
+            resolvedMediaSourceId = staticIds.first;
+          }
+        }
+      } catch (_) {
+        try {
+          if (mediaItem is Map) {
+            final List<dynamic>? staticSources = mediaItem['MediaSources'] as List<dynamic>?;
+            if (staticSources != null && staticSources.isNotEmpty) {
+              final staticIds = staticSources
+                  .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s['id']).toString())
+                  .toSet();
+              if (!staticIds.contains(mediaSourceId)) {
+                resolvedMediaSourceId = staticIds.first;
+              }
+            }
+          }
+        } catch (_) {}
+      }
+    }
+
     final request = PlaybackInfoRequest(
       itemId: itemId,
-      mediaSourceId: mediaSourceId,
+      mediaSourceId: resolvedMediaSourceId,
       deviceProfile: deviceProfile,
       maxStreamingBitrate: maxStreamingBitrate,
       audioStreamIndex: audioStreamIndex,
@@ -50,7 +80,7 @@ class EmbyMediaStreamResolver implements MediaStreamResolver {
       throw Exception('No media sources available for item $itemId');
     }
 
-    final source = _selectBestSource(info.mediaSources, preferredId: mediaSourceId);
+    final source = _selectBestSource(info.mediaSources, preferredId: resolvedMediaSourceId);
     var (url, playMethod) = _resolveStreamUrl(
       itemId,
       source,

--- a/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
+++ b/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
@@ -22,35 +22,8 @@ class EmbyMediaStreamResolver implements MediaStreamResolver {
   }) async {
     final itemId = MediaStreamResolver.extractItemId(mediaItem);
 
-    String? resolvedMediaSourceId = mediaSourceId;
-    if (mediaSourceId != null && mediaSourceId.isNotEmpty) {
-      try {
-        final dynamic item = mediaItem;
-        final List<dynamic>? staticSources = item.mediaSources as List<dynamic>?;
-        if (staticSources != null && staticSources.isNotEmpty) {
-          final staticIds = staticSources
-              .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s.id).toString())
-              .toSet();
-          if (!staticIds.contains(mediaSourceId)) {
-            resolvedMediaSourceId = staticIds.first;
-          }
-        }
-      } catch (_) {
-        try {
-          if (mediaItem is Map) {
-            final List<dynamic>? staticSources = mediaItem['MediaSources'] as List<dynamic>?;
-            if (staticSources != null && staticSources.isNotEmpty) {
-              final staticIds = staticSources
-                  .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s['id']).toString())
-                  .toSet();
-              if (!staticIds.contains(mediaSourceId)) {
-                resolvedMediaSourceId = staticIds.first;
-              }
-            }
-          }
-        } catch (_) {}
-      }
-    }
+    final resolvedMediaSourceId =
+        MediaStreamResolver.resolveStaticMediaSourceId(mediaItem, mediaSourceId);
 
     final request = PlaybackInfoRequest(
       itemId: itemId,

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -56,35 +56,8 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
   }) async {
     final itemId = MediaStreamResolver.extractItemId(mediaItem);
 
-    String? resolvedMediaSourceId = mediaSourceId;
-    if (mediaSourceId != null && mediaSourceId.isNotEmpty) {
-      try {
-        final dynamic item = mediaItem;
-        final List<dynamic>? staticSources = item.mediaSources as List<dynamic>?;
-        if (staticSources != null && staticSources.isNotEmpty) {
-          final staticIds = staticSources
-              .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s.id).toString())
-              .toSet();
-          if (!staticIds.contains(mediaSourceId)) {
-            resolvedMediaSourceId = staticIds.first;
-          }
-        }
-      } catch (_) {
-        try {
-          if (mediaItem is Map) {
-            final List<dynamic>? staticSources = mediaItem['MediaSources'] as List<dynamic>?;
-            if (staticSources != null && staticSources.isNotEmpty) {
-              final staticIds = staticSources
-                  .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s['id']).toString())
-                  .toSet();
-              if (!staticIds.contains(mediaSourceId)) {
-                resolvedMediaSourceId = staticIds.first;
-              }
-            }
-          }
-        } catch (_) {}
-      }
-    }
+    final resolvedMediaSourceId =
+        MediaStreamResolver.resolveStaticMediaSourceId(mediaItem, mediaSourceId);
 
     final request = PlaybackInfoRequest(
       itemId: itemId,

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -56,9 +56,39 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
   }) async {
     final itemId = MediaStreamResolver.extractItemId(mediaItem);
 
+    String? resolvedMediaSourceId = mediaSourceId;
+    if (mediaSourceId != null && mediaSourceId.isNotEmpty) {
+      try {
+        final dynamic item = mediaItem;
+        final List<dynamic>? staticSources = item.mediaSources as List<dynamic>?;
+        if (staticSources != null && staticSources.isNotEmpty) {
+          final staticIds = staticSources
+              .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s.id).toString())
+              .toSet();
+          if (!staticIds.contains(mediaSourceId)) {
+            resolvedMediaSourceId = staticIds.first;
+          }
+        }
+      } catch (_) {
+        try {
+          if (mediaItem is Map) {
+            final List<dynamic>? staticSources = mediaItem['MediaSources'] as List<dynamic>?;
+            if (staticSources != null && staticSources.isNotEmpty) {
+              final staticIds = staticSources
+                  .map((s) => (s is Map ? (s['Id'] ?? s['id']) : s['id']).toString())
+                  .toSet();
+              if (!staticIds.contains(mediaSourceId)) {
+                resolvedMediaSourceId = staticIds.first;
+              }
+            }
+          }
+        } catch (_) {}
+      }
+    }
+
     final request = PlaybackInfoRequest(
       itemId: itemId,
-      mediaSourceId: mediaSourceId,
+      mediaSourceId: resolvedMediaSourceId,
       deviceProfile: deviceProfile,
       maxStreamingBitrate: maxStreamingBitrate,
       audioStreamIndex: audioStreamIndex,
@@ -85,7 +115,7 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       throw Exception('No media sources available for item $itemId');
     }
 
-    final source = _selectBestSource(info.mediaSources, preferredId: mediaSourceId);
+    final source = _selectBestSource(info.mediaSources, preferredId: resolvedMediaSourceId);
     final hasKnownMediaStreams = source.mediaStreams.isNotEmpty;
     final hasVideoStream = source.mediaStreams.any((stream) => stream['Type'] == 'Video');
     final isAudioByStreams = hasKnownMediaStreams && !hasVideoStream;


### PR DESCRIPTION
# Pull Request

## Summary
Fixed audio stream switching inside the player to appropriately transition between Direct Play and Transcoding (Remuxing) states. Additionally, corrected the OSD/Playback Information dialog language to display "Direct Stream (Remux)" instead of "Transcoding" when video stream transcoding is not required.

## Related Issues
Related to Jenn and Manny's observations about codec requirement changes during playback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Playback Core**:
  - Modified `changeAudioTrack` in `PlaybackManager` to always trigger server-side re-resolution (`_reResolveAtCurrentPosition`) for online media streams instead of relying solely on local backend track switching. This ensures new audio tracks requesting different transcoding/direct play capabilities are correctly handled by the server.
- **Jellyfin & Emby Media Stream Resolvers**:
  - Before requesting `/PlaybackInfo` from the server, we inspect if the provided `mediaSourceId` corresponds to a dynamic `LiveStreamId` (transcoding session ID). If so, we map it back to the first static `MediaSourceId` of the item to prevent the server from getting stuck in transcoding mode on subsequent switches.
- **Playback OSD Label**:
  - Removed the `lowerReasons.isNotEmpty` condition when determining if a transcoding stream is a pure container/audio remux in `playbackMethodLabel`. If the transcoding reasons are empty or do not contain any video re-encoding reasons, it correctly reports `"Direct Stream (Remux)"` instead of `"Transcoding"`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Shield with Advanced Audio Options to force certain transcoding behaviors
- [ ] Not tested (explain why):

### Test Steps
1. Play a video containing multiple audio tracks requiring different capabilities (e.g. `Delicatessen (1991)` with AAC Stereo and DTS 5.1).
2. Start playback on the Direct Play compatible track (AAC Stereo) -> Switch to DTS 5.1 -> Verify stream re-resolves and switches to transcoding.
3. Switch back to AAC Stereo -> Verify stream re-resolves and switches to Direct Play.
4. Verify that when playing under remuxing conditions, the Playback Information OSD correctly shows `"Direct Stream (Remux)"` instead of `"Transcoding"`.

## Screenshots (if applicable)
AAC stream (being remuxed after a local intro):
<img width="550" alt="Shield_Screenshot_2026-06-15_09-46-25" src="https://github.com/user-attachments/assets/8602064d-f0d2-4d33-8a5b-2bfeb0b60e99" />

DTS stream (being transcoded after switching from AAC stream during playback)
<img width="550" alt="Shield_Screenshot_2026-06-15_09-35-48" src="https://github.com/user-attachments/assets/df9f0a39-4d53-4ed4-9b43-e7b48d32d13d" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
