### PR TITLE
ui/fix: Make sure the Exit Prompt gains focus when triggered from left navbar

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -28,6 +28,7 @@ import '../../../playback/media3_player_backend.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../widgets/exit_confirmation_dialog.dart';
+import '../../widgets/overlay_sheet.dart';
 import '../../../util/app_exit.dart';
 import '../../../util/global_shortcut_focus.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
@@ -1420,7 +1421,9 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   bool _mayRestoreHomeFocus() {
-    return _isHomeRouteActive() && !SettingsPanel.isOpenNotifier.value;
+    return _isHomeRouteActive() &&
+        !SettingsPanel.isOpenNotifier.value &&
+        !OverlaySheetController.hasOpenSheet;
   }
 
   bool _isHomeRowsStyleV2() {


### PR DESCRIPTION
# Pull Request

## Summary
Fixed focus restoration behavior when the exit confirmation dialog (overlay sheet) is triggered from the Left Navbar. Previously, when focus left the sidebar to the overlay sheet, the home screen's global focus listener would immediately restore focus back to the previously active home row, leaving the exit confirmation dialog unfocused.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Home Screen**:
  - Imported `overlay_sheet.dart` in `HomeScreen`.
  - Updated `_mayRestoreHomeFocus()` to check `!OverlaySheetController.hasOpenSheet`. This blocks home row focus recovery while an overlay sheet (like the exit confirmation dialog) is actively displayed.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - built and tested on Android TV client
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the left navbar on the Home screen to focus it.
2. Press Back on the TV remote or Esc on a keyboard.
3. Confirm that the exit confirmation popup appears and is immediately focused (the Cancel button should be highlighted).

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
