### PR TITLE
Refine Home Screen Row Alignment and Media Bar Visibility for Expanded Home Rows

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -667,7 +667,8 @@ class _ContentRowsState extends State<_ContentRows>
 
     final nextMediaBarVisible = isMobileUi
       ? true
-      : onMediaBar ||
+      : (_isMediaBarIncluded() && _isBannerMode()) ||
+          onMediaBar ||
           _holdMediaBarWhileSidebarFocused ||
           (_verticalNavInFlight && _mediaBarVisible) ||
           (!onSidebar && _activeFocusedRowIndex == null);
@@ -1728,10 +1729,11 @@ class _ContentRowsState extends State<_ContentRows>
     _finishSharedPreview(releaseResources: true);
     _suppressNextRowPreviewFromMediaBar = true;
     _forceRevealOnNextRowFocusFromMediaBar = true;
-    if (mounted && _mediaBarVisible) {
+    final isBanner = _isBannerMode();
+    if (mounted && _mediaBarVisible && !isBanner) {
       setState(() => _mediaBarVisible = false);
     }
-    if (_scrollController.hasClients) {
+    if (!isBanner && _scrollController.hasClients) {
       final offsetAdjustment = _isBookshelfMode() ? (_overlayBottom + 8) : 0.0;
       final target = (_mediaBarHeight() - offsetAdjustment)
           .clamp(0.0, _scrollController.position.maxScrollExtent);
@@ -1882,6 +1884,61 @@ class _ContentRowsState extends State<_ContentRows>
     return _rowKeys[rowIndex]?.currentState as LockedFocusRowState?;
   }
 
+  double _tvTargetTopForRow(int rowIndex) {
+    final defaultTop = _overlayBottom + 8.0;
+    final row = rowIndex < widget.viewModel.rows.length ? widget.viewModel.rows[rowIndex] : null;
+    final isRowsV2 = row != null &&
+        widget.prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
+        !_isSeerrFilterRow(row);
+
+    if (rowIndex == 0 && _rowTopOffsets.isNotEmpty) {
+      if (_isMediaBarIncluded() && !_isBannerMode()) {
+        return defaultTop;
+      }
+      if (!_isMediaBarIncluded() || !isRowsV2) {
+        return _rowTopOffsets[0];
+      }
+    }
+
+    final containerCtx = _rowContainerKeys[rowIndex]?.currentContext;
+    final stackRender = context.findRenderObject();
+    if (containerCtx == null || stackRender is! RenderBox) {
+      return rowIndex == 0 && _rowTopOffsets.isNotEmpty ? _rowTopOffsets[0] : defaultTop;
+    }
+    final containerRender = containerCtx.findRenderObject();
+    if (containerRender is! RenderBox ||
+        !stackRender.hasSize ||
+        !containerRender.hasSize) {
+      return rowIndex == 0 && _rowTopOffsets.isNotEmpty ? _rowTopOffsets[0] : defaultTop;
+    }
+
+    final viewportHeight = stackRender.size.height;
+    final desktopScale = widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final ratingsEnabled = widget.prefs.get(UserPreferences.enableAdditionalRatings) as bool? ?? false;
+    final extraHeight = ratingsEnabled ? (32.0 * desktopScale) : 0.0;
+    final rowHeight = containerRender.size.height + extraHeight;
+
+    if (rowIndex == 0 && _rowTopOffsets.isNotEmpty) {
+      final safeBottomMargin = 40.0 * desktopScale;
+      final preferredTop = viewportHeight - rowHeight - safeBottomMargin;
+      return preferredTop.clamp(defaultTop, _rowTopOffsets[0]);
+    }
+
+    if (isRowsV2) {
+      final safeBottomMargin = 40.0 * desktopScale;
+      final remainingHeight = viewportHeight - defaultTop;
+      if (rowHeight + safeBottomMargin > remainingHeight) {
+        double targetTop = viewportHeight - rowHeight - safeBottomMargin;
+        const minTargetTop = 8.0;
+        if (targetTop < minTargetTop) {
+          targetTop = minTargetTop;
+        }
+        return targetTop;
+      }
+    }
+    return defaultTop;
+  }
+
   Future<void> _scrollTvRowIntoOverlayBand(int rowIndex) async {
     if (!mounted || !_scrollController.hasClients) return;
 
@@ -1900,7 +1957,9 @@ class _ContentRowsState extends State<_ContentRows>
 
     final containerTopInStack =
         containerRender.localToGlobal(Offset.zero, ancestor: stackRender).dy;
-    final scrollDelta = containerTopInStack - (_overlayBottom + 8);
+
+    final targetTop = _tvTargetTopForRow(rowIndex);
+    final scrollDelta = containerTopInStack - targetTop;
     final currentOffset = _scrollController.offset;
     final targetOffset = (currentOffset + scrollDelta).clamp(
       0.0,
@@ -2184,7 +2243,7 @@ class _ContentRowsState extends State<_ContentRows>
       final indexChanged = _activeFocusedRowIndex != rowIndex;
       _activeFocusedRowIndex = rowIndex;
       final fullScreenRows = !PlatformDetection.useMobileUi && widget.prefs.get(UserPreferences.fullScreenRows);
-      if (!isMobileUi && _mediaBarVisible && !_verticalNavInFlight) {
+      if (!isMobileUi && _mediaBarVisible && !_verticalNavInFlight && !_isBannerMode()) {
         setState(() => _mediaBarVisible = false);
       } else if (indexChanged && (PlatformDetection.isTV || fullScreenRows)) {
         setState(() {});
@@ -2285,6 +2344,17 @@ class _ContentRowsState extends State<_ContentRows>
 
     if (_mediaBarFocusNode.hasFocus) return;
 
+    if (_activeFocusedRowIndex == null) {
+      if (_scrollController.hasClients && _scrollController.offset > 0.0) {
+        _scrollController.animateTo(
+          0.0,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOutCubic,
+        );
+      }
+      return;
+    }
+
     final currentOffset = _scrollController.offset;
     double minDiff = double.infinity;
     double bestOffset = currentOffset;
@@ -2294,7 +2364,8 @@ class _ContentRowsState extends State<_ContentRows>
       targets.add(0.0);
     }
     for (var i = 0; i < _rowTopOffsets.length; i++) {
-      targets.add((_rowTopOffsets[i] - (_overlayBottom + 8.0))
+      final targetTop = _tvTargetTopForRow(i);
+      targets.add((_rowTopOffsets[i] - targetTop)
           .clamp(0.0, _scrollController.position.maxScrollExtent));
     }
 
@@ -2522,7 +2593,8 @@ class _ContentRowsState extends State<_ContentRows>
     required double overlayBottom,
   }) {
     final fullScreenRows = !PlatformDetection.useMobileUi && widget.prefs.get(UserPreferences.fullScreenRows);
-    if (!showInfoOverlay || !_infoRevealed) {
+    final isRowsV2 = widget.prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2;
+    if ((!showInfoOverlay || !_infoRevealed) && !(isRowsV2 && fullScreenRows)) {
       return child;
     }
 
@@ -2534,10 +2606,18 @@ class _ContentRowsState extends State<_ContentRows>
       final focusedRowIndex = _focusedRowIndex(FocusManager.instance.primaryFocus);
       final rowViewportTop = rowTopOffsets[rowIndex] - _scrollOffset;
       final rowBottom = rowViewportTop + rowExtents[rowIndex];
-      if (focusedRowIndex != null && rowIndex < focusedRowIndex) {
-        return IgnorePointer(
-          child: Opacity(opacity: 0, child: child),
-        );
+      if (focusedRowIndex != null) {
+        if (fullScreenRows) {
+          if (rowIndex != focusedRowIndex) {
+            return IgnorePointer(
+              child: Opacity(opacity: 0, child: child),
+            );
+          }
+        } else if (rowIndex < focusedRowIndex) {
+          return IgnorePointer(
+            child: Opacity(opacity: 0, child: child),
+          );
+        }
       }
       if (rowBottom < overlayBottom - 80) {
         return IgnorePointer(
@@ -2867,8 +2947,11 @@ class _ContentRowsState extends State<_ContentRows>
 
               final contentHeight = _rowContentHeight(row, posterSize, prefs);
               final targetExtent = rowExtents[rowIndex];
+              final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
               final extraTopPadding = fullScreenRows
-                  ? ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity)
+                  ? (isRowsV2
+                      ? ((targetExtent - contentHeight) * 0.1).clamp(0.0, double.infinity)
+                      : ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity))
                   : 0.0;
 
               final paddedRowChild = extraTopPadding > 0.0


### PR DESCRIPTION
# Pull Request

## Summary
The goal of Expanded Home Rows is to have 1 home row on screen at a time. However, this logic was based on set padding values and they stopped being accurate with certain combinations of UI Scale, Home Row Image Size, and the number of ratings a movie has. This PR refines the Home Screen row alignment, scroll target calculations, and Media Bar visibility logic when using **Expanded Home Rows** (`fullScreenRows`) on TV/Desktop viewports.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Ratings Height Pre-Reservation**: Pre-allocates vertical space (adds `32.0 * desktopScale`) to the measured `rowHeight` during scroll target calculations when `enableAdditionalRatings` is true. This prevents description text from being pushed off-screen or shifting when wrapped/two-row ratings load asynchronously.
- **Hide Non-Focused Next Rows**: Updates `_buildShiftedRow` to hide all non-focused rows (both previous and next rows) when `fullScreenRows` is active. This prevents next-row titles from peeking or overlapping at the bottom of the viewport when a tall focused row is shifted up.
- **Banner Media Bar Persistence**: Guards `_mediaBarVisible` changes to keep the Banner Media Bar visible when focus changes or moves down to content rows.
- **Banner to Row-0 Positioning**: Bypasses the default off-screen scroll jump when navigating down from the Banner Media Bar, keeping the initial scroll offset at `0.0` and correctly aligning the following row directly below the banner.
- **Moonfin (Full Display) Navigation**: Configures the full-screen media bar to return the standard top overlay position (`defaultTop`) for row 0 scroll targets. This slides the full-screen media bar completely off-screen and positions `My Media` perfectly under the navigation overlay with no blank screen.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Extensively tested on the Shield with various setting combinations
- [ ] Not tested (explain why):

### Test Steps
1. Configured Home Rows style to V2, enabled Expanded Home Rows, and set Media Bar mode to Banner.
2. Verified that navigating down to `My Media` keeps the Banner visible at the top and positions the row below it.
3. Verified that focusing a row with ratings that wrap to two lines (e.g. at Medium UI scale and Medium Card size) shifts the row up pre-emptively so the description fits entirely.
4. Verified that next row headers (like `Latest Cinema` or `Latest Serials`) are completely hidden and do not peek at the bottom of the screen.
5. Switched Media Bar mode to Moonfin (full display), navigated down to `My Media`, and verified the media bar scrolls off-screen cleanly, leaving no blank space.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### DIFFERENT UI SCALING/POSTER SIZES
<img width="600" alt="Shield_Screenshot_2026-06-16_05-45-12" src="https://github.com/user-attachments/assets/eb56bcf8-4ea6-48d0-8946-72008ad007c5" />
<img width="600" alt="Shield_Screenshot_2026-06-16_05-48-39" src="https://github.com/user-attachments/assets/201b2817-de92-4dd9-b849-77f3f85c0b85" />

### FULL SCREEN MEDIA BAR
<img width="600" alt="Shield_Screenshot_2026-06-16_06-19-56" src="https://github.com/user-attachments/assets/9c4539ec-7371-494b-9013-e026381e5681" />
<img width="600" alt="Shield_Screenshot_2026-06-16_06-20-10" src="https://github.com/user-attachments/assets/1af2248f-efa3-4457-954b-263d625feb0f" />

### HALF-SCREEN MEDIA BAR
<img width="600" alt="Shield_Screenshot_2026-06-16_06-20-32" src="https://github.com/user-attachments/assets/8f2ac8bb-1cc5-495c-9247-c8cde29067c1" />
<img width="600" alt="Shield_Screenshot_2026-06-16_06-20-46" src="https://github.com/user-attachments/assets/acdd74c8-257c-4fb6-b967-834296f7fecb" />

### MULTI-LINE RATINGS
<img width="600" alt="Shield_Screenshot_2026-06-16_06-59-11" src="https://github.com/user-attachments/assets/b078ef90-c9d8-46d6-9ddc-adf2c62d230d" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
