### PR TITLE
Refine metadata container rounding and singular/plural headers

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1470,6 +1470,14 @@
   "@director": {
     "description": "Metadata label for director"
   },
+  "directors": "DIRECTORS",
+  "@directors": {
+    "description": "Metadata label for directors"
+  },
+  "writer": "WRITER",
+  "@writer": {
+    "description": "Metadata label for writer"
+  },
   "writers": "WRITERS",
   "@writers": {
     "description": "Metadata label for writers"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2086,6 +2086,18 @@ abstract class AppLocalizations {
   /// **'DIRECTOR'**
   String get director;
 
+  /// Metadata label for directors
+  ///
+  /// In en, this message translates to:
+  /// **'DIRECTORS'**
+  String get directors;
+
+  /// Metadata label for writer
+  ///
+  /// In en, this message translates to:
+  /// **'WRITER'**
+  String get writer;
+
   /// Metadata label for writers
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1076,6 +1076,12 @@ class AppLocalizationsAf extends AppLocalizations {
   String get director => 'DIREKTEUR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SKRYWERS';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1065,6 +1065,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get director => 'مخرج';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'الكتاب';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1070,6 +1070,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get director => 'ДЫРЭКТАР';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ПІСЬМЕННІКІ';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1072,6 +1072,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ПИСАТЕЛИ';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1067,6 +1067,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get director => 'পরিচালক';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'লেখক';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1082,6 +1082,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get director => 'DIRECTORA';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ESCRITORS';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1071,6 +1071,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get director => 'ŘEDITEL';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SPISOVATELÉ';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1076,6 +1076,12 @@ class AppLocalizationsCy extends AppLocalizations {
   String get director => 'CYFARWYDDWR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'YSGRIFENWYR';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1068,6 +1068,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get director => 'DIREKTØR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SKRIFTERE';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1080,6 +1080,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get director => 'REGIE';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'DREHBUCH';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1085,6 +1085,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get director => 'ΔΙΕΥΘΥΝΤΗΣ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ΣΥΓΓΡΑΦΕΙΣ';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1066,6 +1066,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get director => 'DIRECTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'WRITERS';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1069,6 +1069,12 @@ class AppLocalizationsEo extends AppLocalizations {
   String get director => 'DIRECTORO';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SKRIBOJ';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1080,6 +1080,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get director => 'DIRECTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'GUIONISTAS';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'KIRJANIKUD';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1067,6 +1067,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get director => 'کارگردان';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'نویسندگان';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1075,6 +1075,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get director => 'JOHTAJA';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'KIRJOITTAJAT';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1079,6 +1079,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get director => 'RÉALISATEUR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SCÉNARISTES';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1085,6 +1085,12 @@ class AppLocalizationsGl extends AppLocalizations {
   String get director => 'DIRECTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ESCRITORES';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1057,6 +1057,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get director => 'מְנַהֵל';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'סופרים';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1068,6 +1068,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get director => 'निदेशक';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'लेखक';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1073,6 +1073,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'KNJIŽEVNICI';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get director => 'IGAZGATÓ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ÍRÓK';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1076,6 +1076,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get director => 'DIREKTUR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'PENULIS';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1073,6 +1073,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get director => 'REGISTA';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SCENEGGIATORI';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1043,6 +1043,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get director => '監督';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ライター';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1072,6 +1072,12 @@ class AppLocalizationsKk extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ЖАЗУШЫЛАР';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1073,6 +1073,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get director => 'ನಿರ್ದೇಶಕ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ಬರಹಗಾರರು';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1043,6 +1043,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get director => '감독';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => '작가';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1068,6 +1068,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get director => 'DIREKTORIAUS';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'RAŠYTOJAI';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1077,6 +1077,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get director => 'DIREKTORS';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'RAKSTNIEKI';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1076,6 +1076,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ПИСАТЕЛИ';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1078,6 +1078,12 @@ class AppLocalizationsMl extends AppLocalizations {
   String get director => 'ഡയറക്ടർ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'എഴുത്തുകാർ';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1070,6 +1070,12 @@ class AppLocalizationsMn extends AppLocalizations {
   String get director => 'ЗАХИРАЛ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ЗОХИОЛЧИД';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1069,6 +1069,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get director => 'DIREKTØR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'FORRETTER';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1076,6 +1076,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get director => 'DIRECTEUR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SCHRIJVERS';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1070,6 +1070,12 @@ class AppLocalizationsPa extends AppLocalizations {
   String get director => 'ਡਾਇਰੈਕਟਰ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ਲੇਖਕ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get director => 'DYREKTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'PISARZE';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get director => 'DIRETOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ROTEIRISTAS';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get director => 'DIRECTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SCRIITORII';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ПИСАТЕЛИ';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1065,6 +1065,12 @@ class AppLocalizationsSi extends AppLocalizations {
   String get director => 'අධ්යක්ෂක';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ලේඛකයින්';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1075,6 +1075,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get director => 'RIADITEĽ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SPISOVATELIA';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1075,6 +1075,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'PISATELJICE';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1078,6 +1078,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get director => 'DREJTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'SHKRIMTARËT';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ВРИТЕРС';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1069,6 +1069,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get director => 'DIREKTÖR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'FÖRfattare';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1080,6 +1080,12 @@ class AppLocalizationsSw extends AppLocalizations {
   String get director => 'MKURUGENZI';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'WAANDISHI';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1078,6 +1078,12 @@ class AppLocalizationsTa extends AppLocalizations {
   String get director => 'இயக்குனர்';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'எழுத்தாளர்கள்';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1073,6 +1073,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get director => 'దర్శకుడు';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'రచయితలు';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1063,6 +1063,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get director => 'ผู้อำนวยการ';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'นักเขียน';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1081,6 +1081,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get director => 'DIREKTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'MGA MANUNULAT';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1071,6 +1071,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get director => 'YÖNETMEN';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'YAZARLAR';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1070,6 +1070,12 @@ class AppLocalizationsUg extends AppLocalizations {
   String get director => 'DIRECTOR';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'يازغۇچىلار';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1071,6 +1071,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get director => 'ДИРЕКТОР';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'ПИСЬМЕННИКИ';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1074,6 +1074,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get director => 'GIÁM ĐỐC';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => 'nhà văn';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1039,6 +1039,12 @@ class AppLocalizationsYue extends AppLocalizations {
   String get director => '導演';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => '作家';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1039,6 +1039,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get director => '导演';
 
   @override
+  String get directors => 'DIRECTORS';
+
+  @override
+  String get writer => 'WRITER';
+
+  @override
   String get writers => '作家';
 
   @override

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -8864,6 +8864,7 @@ class _MetadataGroupCell extends StatefulWidget {
   final VoidCallback? onRight;
   final VoidCallback onUp;
   final VoidCallback onDown;
+  final BorderRadius borderRadius;
 
   const _MetadataGroupCell({
     required this.title,
@@ -8876,6 +8877,7 @@ class _MetadataGroupCell extends StatefulWidget {
     required this.onEnter,
     required this.onUp,
     required this.onDown,
+    required this.borderRadius,
     this.onLeft,
     this.onRight,
   });
@@ -8933,7 +8935,7 @@ class _MetadataGroupCellState extends State<_MetadataGroupCell>
             color: showCellBorder ? focusColor : Colors.transparent,
             width: 1.5,
           ),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: widget.borderRadius,
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -9042,7 +9044,9 @@ class _MetadataSectionState extends State<_MetadataSection> {
     if (widget.viewModel.directors.isNotEmpty) {
       newGroups.add(
         _MetadataGroup(
-          title: l10n.director,
+          title: widget.viewModel.directors.length == 1
+              ? l10n.director
+              : l10n.directors,
           items: widget.viewModel.directors.map((d) {
             final name = d['Name'] as String? ?? '';
             final id = d['Id'] as String?;
@@ -9061,7 +9065,9 @@ class _MetadataSectionState extends State<_MetadataSection> {
     if (widget.viewModel.writers.isNotEmpty) {
       newGroups.add(
         _MetadataGroup(
-          title: l10n.writers,
+          title: widget.viewModel.writers.length == 1
+              ? l10n.writer
+              : l10n.writers,
           items: widget.viewModel.writers.map((w) {
             final name = w['Name'] as String? ?? '';
             final id = w['Id'] as String?;
@@ -9275,6 +9281,12 @@ class _MetadataSectionState extends State<_MetadataSection> {
                                       .requestFocus(),
                               onUp: () => _focusTarget(widget.upTarget),
                               onDown: () => _focusTarget(widget.downTarget),
+                              borderRadius: BorderRadius.only(
+                                topLeft: groupIndex == 0 ? const Radius.circular(11) : Radius.zero,
+                                bottomLeft: groupIndex == 0 ? const Radius.circular(11) : Radius.zero,
+                                topRight: groupIndex == _groups.length - 1 ? const Radius.circular(11) : Radius.zero,
+                                bottomRight: groupIndex == _groups.length - 1 ? const Radius.circular(11) : Radius.zero,
+                              ),
                             ),
                           ),
                         ],


### PR DESCRIPTION
# Pull Request

## Summary
Refines the visual corners of the details page metadata row cells (Director / Writers / Studio) to align with the outer container boundary when focused, and implements dynamic singular/plural headers based on items count.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Dynamic Corner Rounding on Focus**: Modified `_MetadataGroupCell` to accept a custom `borderRadius`. We calculate this dynamically based on its position in the row:
  - Left cell rounds only the left corners (radius 11).
  - Right cell rounds only the right corners (radius 11).
  - Middle cell remains rectangular (`BorderRadius.zero`).
  - This perfectly aligns the focused highlight borders with the shared inner walls and outer borders, eliminating visual rounding overlap artifacts.
- **Dynamic Singular/Plural Headers**: Defined `"directors"` (plural) and `"writer"` (singular) translation keys in `app_en.arb`. Updated the header selection logic so that:
  - If a title has exactly 1 director/writer, it displays `Director` / `Writer`.
  - If it has multiple, it displays `Directors` / `Writers` (plural).
  - Any missing translations in other locales automatically fall back to the new English defaults.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Windows Desktop
- [ ] Not tested (explain why):

- [x] Ran `flutter gen-l10n` and verified that localizations compile cleanly.
- [x] Ran `flutter analyze` to ensure there are no compilation warnings or errors in the project.
- [x] Successfully compiled the Windows client using `build-windows.ps1` to test locally.

### Test Steps
1. Navigate to the detail page of a media item with 1 director (e.g. "Director") and verify the label is singular.
2. Navigate to the detail page of a media item with multiple directors/writers and verify the label is plural.
3. Focus each metadata cell (Director, Writers, Studio) and verify that the highlighted borders follow the outer rounding perfectly with no gaps or overlapping rounded corners on the inner boundaries.

## Screenshots (if applicable)

<img width="500" alt="2026-06-16_08-57-16_moonfin" src="https://github.com/user-attachments/assets/108690cd-ea89-4c86-9aed-860a5aae5b32" />
<img width="500" alt="Shield_Screenshot_2026-06-16_07-43-56" src="https://github.com/user-attachments/assets/2a91e9b6-4677-4b9b-a678-3351a3451832" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
