### PR TITLE
UI - Align focus indicator boundaries and card rounding

### DIFF
--- a/lib/ui/widgets/genre_grid_card.dart
+++ b/lib/ui/widgets/genre_grid_card.dart
@@ -49,8 +49,9 @@ class GenreGridCard extends StatefulWidget {
 class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
   @override
   Widget build(BuildContext context) {
+    final borders = ThemeRegistry.active.borders;
     final borderColor =
-        widget.focusColor ?? ThemeRegistry.active.borders.focusBorder.color;
+        widget.focusColor ?? borders.focusBorder.color;
     final showMarquee = hovered || focused;
     final imageUrl = widget.genre.imageUrl ?? widget.genre.backdropUrl;
     final desktopScale = GetIt.instance<UserPreferences>()
@@ -95,23 +96,31 @@ class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
             child: Stack(
               clipBehavior: Clip.none,
               children: [
-                if (showFocusBorder && ThemeRegistry.active.borders.focusGlow.isNotEmpty)
-                  Positioned.fill(
+                if (showFocusBorder && borders.focusGlow.isNotEmpty)
+                  Positioned(
+                    top: -1.0,
+                    bottom: -1.0,
+                    left: -1.0,
+                    right: -1.0,
                     child: IgnorePointer(
                       child: Container(
                         decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          boxShadow: ThemeRegistry.active.borders.focusGlow,
+                          borderRadius: borders.cardRadius + BorderRadius.circular(1.0),
+                          boxShadow: borders.focusGlow,
                         ),
                       ),
                     ),
                   )
                 else if (showFocusBorder)
-                  Positioned.fill(
+                  Positioned(
+                    top: -1.0,
+                    bottom: -1.0,
+                    left: -1.0,
+                    right: -1.0,
                     child: IgnorePointer(
                       child: Container(
                         decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
+                          borderRadius: borders.cardRadius + BorderRadius.circular(1.0),
                           boxShadow: [
                             BoxShadow(
                               color: AppColorScheme.accent.withAlpha(145),
@@ -124,7 +133,7 @@ class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
                     ),
                   ),
                 ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
+                  borderRadius: borders.cardRadius,
                   child: Stack(
                     fit: StackFit.expand,
                     children: [
@@ -197,13 +206,17 @@ class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
                   ),
                 ),
                 if (showFocusBorder)
-                  Positioned.fill(
+                  Positioned(
+                    top: -1.0,
+                    bottom: -1.0,
+                    left: -1.0,
+                    right: -1.0,
                     child: IgnorePointer(
                       child: Container(
                         decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
+                          borderRadius: borders.cardRadius + BorderRadius.circular(1.0),
                           border: Border.fromBorderSide(
-                            ThemeRegistry.active.borders.focusBorder.copyWith(
+                            borders.focusBorder.copyWith(
                               color: borderColor,
                               width: 2.4,
                             ),

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -360,20 +360,29 @@ class _CardImage extends StatelessWidget {
       aspectRatio: aspectRatio,
       child: Stack(
         fit: StackFit.expand,
+        clipBehavior: Clip.none,
         children: [
           if (showGlow)
-            IgnorePointer(
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: isCircular
-                      ? BorderRadius.circular(radius)
-                      : borders.cardRadius,
-                  boxShadow: borders.focusGlow,
+            Positioned(
+              top: -1.0,
+              bottom: -1.0,
+              left: -1.0,
+              right: -1.0,
+              child: IgnorePointer(
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: isCircular
+                        ? BorderRadius.circular(radius + 1.0)
+                        : borders.cardRadius + BorderRadius.circular(1.0),
+                    boxShadow: borders.focusGlow,
+                  ),
                 ),
               ),
             ),
           ClipRRect(
-            borderRadius: BorderRadius.circular(radius),
+            borderRadius: isCircular
+                ? BorderRadius.circular(radius)
+                : borders.cardRadius,
             child: Stack(
               fit: StackFit.expand,
               children: [
@@ -445,14 +454,20 @@ class _CardImage extends StatelessWidget {
             ),
           ),
           if (showBorder)
-            IgnorePointer(
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: isCircular
-                      ? BorderRadius.circular(radius)
-                      : borders.cardRadius,
-                  border: Border.fromBorderSide(
-                    borders.focusBorder.copyWith(color: borderColor),
+            Positioned(
+              top: -1.0,
+              bottom: -1.0,
+              left: -1.0,
+              right: -1.0,
+              child: IgnorePointer(
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: isCircular
+                        ? BorderRadius.circular(radius + 1.0)
+                        : borders.cardRadius + BorderRadius.circular(1.0),
+                    border: Border.fromBorderSide(
+                      borders.focusBorder.copyWith(color: borderColor),
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
# Pull Request

## Summary
Aligns card image clipping (`ClipRRect` border radius) with the active theme's card corner radius, and outsets the focus indicator (border and glow) by 1.0px to completely prevent background/image leakage at the rounded corners across all platforms (Android TV, Desktop, and tvOS).

## Related Issues
Fixes visual image leakage/spillage behind focus borders on tvOS, Android TV, and Desktop platforms.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
* Aligned Clip Radius: Modified the ClipRRect inside _CardImage (lib/ui/widgets/media_card.dart) and GenreGridCard (lib/ui/widgets/genre_grid_card.dart) to use the dynamic borders.cardRadius from the active theme (e.g. 8px, 10px, or 14px) instead of hardcoded 8.0px.
* Outset Focus Indicators: Positioned the focus border and glow containers to be outset by 1.0px all around using a Positioned widget. This extends the focus highlight slightly past the card boundaries to beautifully frame it and cover any sub-pixel alignment issues.
* Concentric Outset Radius: Increased the border radius of the focus border and glow containers by +1.0px (BorderRadius.circular(1.0)) to maintain perfect concentricity with the image's rounded corner radius.
* Disabled Stack Clipping: Set clipBehavior: Clip.none on the outer Stack layouts to allow the outset focus containers to render slightly beyond their bounding boxes.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin
2. Browse the home page, libraries, genre page, etc looking for bleeds.
3. Hopefully find none!

## Screenshots (if applicable)

<img width="300" alt="2026-06-16_09-04-42_moonfin" src="https://github.com/user-attachments/assets/aca3301e-fbf8-494e-a91e-e1ef99d4ee80" />
<img width="300" alt="2026-06-16_09-05-26_moonfin" src="https://github.com/user-attachments/assets/e9a22958-44a2-4bc4-bfa4-8ff00e93fae4" />
<img width="250" alt="2026-06-16_09-05-41_moonfin" src="https://github.com/user-attachments/assets/3be703d0-fd43-4eca-bf96-605c0664cd59" />
<img width="300" alt="2026-06-16_09-05-59_moonfin" src="https://github.com/user-attachments/assets/a0dfe927-bb2e-4486-8584-92e639f55431" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
