### PR TITLE
refactor: refining the onboarding

### DIFF
--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -607,7 +607,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final mergeContinueWatchingNextUp = Preference(
     key: 'pref_merge_continue_watching_next_up',
-    defaultValue: false,
+    defaultValue: true,
   );
 
   static final focusColor = EnumPreference(
@@ -1041,7 +1041,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final subtitlesBackgroundColor = Preference(
     key: 'subtitles_background_color',
-    defaultValue: 0xAA000000,
+    defaultValue: 0x00000000,
   );
 
   static final subtitlesTextWeight = Preference(
@@ -1061,12 +1061,12 @@ class UserPreferences extends ChangeNotifier {
 
   static final subtitlesTextSize = Preference(
     key: 'subtitles_text_size',
-    defaultValue: 24.0,
+    defaultValue: 20.0,
   );
 
   static final subtitlesOffsetPosition = Preference(
     key: 'subtitles_offset_position',
-    defaultValue: 0.08,
+    defaultValue: 0.04,
   );
 
   static final subtitlesDefaultToNone = Preference(
@@ -1141,7 +1141,9 @@ class UserPreferences extends ChangeNotifier {
 
   static final mediaBarMode = Preference(
     key: 'mediaBarMode',
-    defaultValue: mediaBarModeMoonfin,
+    defaultValue: PlatformDetection.useMobileUi
+        ? mediaBarModeGallery
+        : mediaBarModeMoonfin,
   );
 
   static final mediaBarContentType = Preference(
@@ -1211,7 +1213,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final episodePreviewEnabled = Preference(
     key: 'episodePreviewEnabled',
-    defaultValue: true,
+    defaultValue: false,
   );
 
   static final previewAudioEnabled = Preference(


### PR DESCRIPTION
# Pull Request

## Summary
Refines the default values for several client preferences to optimize the out-of-the-box user experience on new installations or clean connections to a basic unconfigured Moonbase server.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
 **Subtitles**:
  - Changed default background opacity to fully transparent (`0x00000000`).
  - Reduced default font size from 24pt to 20pt.
  - Adjusted default vertical offset position from 8% to 4% (`0.04`).
- **Media Bar Mode**:
  - Dynamically switches the default mode based on platform detection: defaults to `gallery` on mobile platforms and `moonfin` on TV and desktop environments.
- **Episode Previews**:
  - Disabled by default (`false`).
- **Home Rows**:
  - Enabled merging of "Continue Watching" and "Next Up" rows by default.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Perform a clean client configuration initialization.
2. Launch the application and observe that the default settings for subtitle size/background/offset, media bar mode, episode preview toggles, and continue watching row behavior match the new definitions.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
