### PR TITLE
Feature/fix Navbar-Embedded Mini Player & Track Transition Fix

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -24,7 +24,6 @@ import 'ui/navigation/app_router.dart';
 import 'ui/theme/app_theme.dart';
 import 'ui/theme/app_theme_controller.dart';
 import 'ui/widgets/cast_mini_player.dart';
-import 'ui/widgets/mini_audio_player.dart';
 import 'ui/widgets/offline_banner.dart';
 import 'ui/widgets/exit_confirmation_dialog.dart';
 import 'ui/screensaver/screensaver_controller.dart';
@@ -653,18 +652,10 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
     if (PlatformDetection.isTV && key == LogicalKeyboardKey.arrowDown) {
       final primaryFocus = FocusManager.instance.primaryFocus;
       if (primaryFocus != null) {
-        if (primaryFocus.ancestors.contains(MiniAudioPlayer.tvFocusNode) ||
-            primaryFocus == MiniAudioPlayer.tvFocusNode) {
-          return KeyEventResult.ignored;
-        }
         final success = primaryFocus.focusInDirection(TraversalDirection.down);
         if (success) {
           return KeyEventResult.handled;
         }
-      }
-      if (MiniAudioPlayer.tvFocusNode.context != null) {
-        MiniAudioPlayer.tvFocusNode.requestFocus();
-        return KeyEventResult.handled;
       }
     }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -649,16 +649,6 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
           : KeyEventResult.handled;
     }
 
-    if (PlatformDetection.isTV && key == LogicalKeyboardKey.arrowDown) {
-      final primaryFocus = FocusManager.instance.primaryFocus;
-      if (primaryFocus != null) {
-        final success = primaryFocus.focusInDirection(TraversalDirection.down);
-        if (success) {
-          return KeyEventResult.handled;
-        }
-      }
-    }
-
     return KeyEventResult.ignored;
   }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -160,8 +160,6 @@ class _MoonfinAppState extends State<MoonfinApp> {
                               ),
                             ),
                             if (!hidePlayer)
-                              const RepaintBoundary(child: MiniAudioPlayer()),
-                            if (!hidePlayer)
                               const RepaintBoundary(child: CastMiniPlayer()),
                           ],
                         );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -652,6 +652,24 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
           : KeyEventResult.handled;
     }
 
+    if (PlatformDetection.isTV && key == LogicalKeyboardKey.arrowDown) {
+      final primaryFocus = FocusManager.instance.primaryFocus;
+      if (primaryFocus != null) {
+        if (primaryFocus.ancestors.contains(MiniAudioPlayer.tvFocusNode) ||
+            primaryFocus == MiniAudioPlayer.tvFocusNode) {
+          return KeyEventResult.ignored;
+        }
+        final success = primaryFocus.focusInDirection(TraversalDirection.down);
+        if (success) {
+          return KeyEventResult.handled;
+        }
+      }
+      if (MiniAudioPlayer.tvFocusNode.context != null) {
+        MiniAudioPlayer.tvFocusNode.requestFocus();
+        return KeyEventResult.handled;
+      }
+    }
+
     return KeyEventResult.ignored;
   }
 

--- a/lib/data/services/theme_music_service.dart
+++ b/lib/data/services/theme_music_service.dart
@@ -57,6 +57,8 @@ class ThemeMusicService {
 
   Future<void> playForItem(AggregatedItem item) async {
     if (!_prefs.get(UserPreferences.themeMusicEnabled)) return;
+    final activeItem = _playbackManager.queueService.currentItem;
+    if (activeItem is AggregatedItem && activeItem.isAudioLike) return;
     if (_playbackManager.state.isPlaying) return;
     if (_externalAudioActive) return;
     if (_playSuppressed) return;

--- a/lib/data/services/theme_music_service.dart
+++ b/lib/data/services/theme_music_service.dart
@@ -58,7 +58,18 @@ class ThemeMusicService {
   Future<void> playForItem(AggregatedItem item) async {
     if (!_prefs.get(UserPreferences.themeMusicEnabled)) return;
     final activeItem = _playbackManager.queueService.currentItem;
-    if (activeItem is AggregatedItem && activeItem.isAudioLike) return;
+    bool isAudio = false;
+    if (activeItem is AggregatedItem) {
+      isAudio = activeItem.isAudioLike;
+    } else if (activeItem is String) {
+      final meta = _playbackManager.currentOfflineMetadata;
+      if (meta != null) {
+        final type = meta['Type']?.toString();
+        final mediaType = meta['MediaType']?.toString();
+        isAudio = type == 'Audio' || type == 'AudioBook' || mediaType == 'Audio';
+      }
+    }
+    if (isAudio) return;
     if (_playbackManager.state.isPlaying) return;
     if (_externalAudioActive) return;
     if (_playSuppressed) return;

--- a/lib/playback/playback_lifecycle_handler.dart
+++ b/lib/playback/playback_lifecycle_handler.dart
@@ -25,7 +25,18 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     final currentItem = _manager.queueService.currentItem;
-    if (currentItem is AggregatedItem && currentItem.isAudioLike) {
+    bool isAudio = false;
+    if (currentItem is AggregatedItem) {
+      isAudio = currentItem.isAudioLike;
+    } else if (currentItem is String) {
+      final meta = _manager.currentOfflineMetadata;
+      if (meta != null) {
+        final type = meta['Type']?.toString();
+        final mediaType = meta['MediaType']?.toString();
+        isAudio = type == 'Audio' || type == 'AudioBook' || mediaType == 'Audio';
+      }
+    }
+    if (isAudio) {
       return;
     }
     switch (state) {

--- a/lib/playback/playback_lifecycle_handler.dart
+++ b/lib/playback/playback_lifecycle_handler.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:playback_core/playback_core.dart';
 
+import '../data/models/aggregated_item.dart';
 import '../util/platform_detection.dart';
 
 class PlaybackLifecycleHandler with WidgetsBindingObserver {
@@ -23,6 +24,10 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    final currentItem = _manager.queueService.currentItem;
+    if (currentItem is AggregatedItem && currentItem.isAudioLike) {
+      return;
+    }
     switch (state) {
       case AppLifecycleState.inactive:
         if (PlatformDetection.isMobile) _saveState();

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -159,7 +159,11 @@ CustomTransitionPage<T> _opaqueFullScreenPage<T>({
 
 final appRouter = GoRouter(
   initialLocation: Destinations.startup,
-  observers: [FocusRouteObserver(), routeLifecycleObserver],
+  observers: [
+    FocusRouteObserver(),
+    routeLifecycleObserver,
+    PlayerRouteObserver.instance,
+  ],
   redirect: (context, state) {
     final path = state.uri.path;
     if (_authRoutes.contains(path)) return null;
@@ -697,3 +701,53 @@ final appRouter = GoRouter(
     ),
   ],
 );
+
+class PlayerRouteObserver extends NavigatorObserver {
+  static final instance = PlayerRouteObserver();
+  final ValueNotifier<bool> isPlayerActive = ValueNotifier<bool>(false);
+  final List<Route<dynamic>> _playerRoutes = [];
+
+  bool _isPlayer(Route<dynamic> route) {
+    final name = route.settings.name;
+    return name != null &&
+        (name.startsWith('/player/') ||
+         name == '/live-tv/player' ||
+         name == Destinations.audioPlayer ||
+         name == Destinations.videoPlayer);
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (_isPlayer(route)) {
+      _playerRoutes.add(route);
+      isPlayerActive.value = true;
+    }
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (_isPlayer(route)) {
+      _playerRoutes.remove(route);
+      isPlayerActive.value = _playerRoutes.isNotEmpty;
+    }
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (_isPlayer(route)) {
+      _playerRoutes.remove(route);
+      isPlayerActive.value = _playerRoutes.isNotEmpty;
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    if (oldRoute != null && _isPlayer(oldRoute)) {
+      _playerRoutes.remove(oldRoute);
+    }
+    if (newRoute != null && _isPlayer(newRoute)) {
+      _playerRoutes.add(newRoute);
+    }
+    isPlayerActive.value = _playerRoutes.isNotEmpty;
+  }
+}

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -920,6 +920,7 @@ class _DetailContentState extends State<_DetailContent> {
     final backdropEnabled = widget.prefs.get(UserPreferences.backdropEnabled);
     final useSplitLayout =
         item.type == 'Person' && _useDesktopDetailLayout(context);
+    final isAlbumOrPlaylist = item.type == 'MusicAlbum' || item.type == 'Playlist';
 
     return Focus(
       focusNode: _contentFocusNode,
@@ -1046,11 +1047,18 @@ class _DetailContentState extends State<_DetailContent> {
                           (MediaQuery.of(context).padding.bottom + 48.0) *
                               _desktopUiScale(),
                         ),
-                  sliver: SliverList(
-                    delegate: SliverChildListDelegate(
-                      _buildContentForType(context, item),
-                    ),
-                  ),
+                  sliver: isAlbumOrPlaylist
+                      ? SliverToBoxAdapter(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: _buildContentForType(context, item),
+                          ),
+                        )
+                      : SliverList(
+                          delegate: SliverChildListDelegate(
+                            _buildContentForType(context, item),
+                          ),
+                        ),
                 ),
               ],
             ),
@@ -2520,8 +2528,9 @@ class _DetailContentState extends State<_DetailContent> {
           tracks: viewModel.tracks,
           firstTrackFocusNode: _firstTrackFocusNode,
           onFirstTrackUp: () {
-            if (!_albumPlayFocusNode.canRequestFocus) return;
-            _albumPlayFocusNode.requestFocus();
+            final targetNode = widget.initialFocusNode ?? _albumPlayFocusNode;
+            if (!targetNode.canRequestFocus) return;
+            targetNode.requestFocus();
           },
           onTrackFocused: onBackdropItemFocused,
           isAudiobook: isAudiobook,
@@ -11202,6 +11211,7 @@ class _AlbumActions extends StatelessWidget {
           _DetailActionButton(
             label: l10n.shuffle,
             icon: Icons.shuffle,
+            onArrowDown: onPlayDown,
             onPressed: () {
               if (tracks.isEmpty) return;
               final shuffled = List<AggregatedItem>.from(tracks)..shuffle();
@@ -11212,24 +11222,28 @@ class _AlbumActions extends StatelessWidget {
             _DetailActionButton(
               label: l10n.downloadAll,
               icon: Icons.download,
+              onArrowDown: onPlayDown,
               onPressed: onDownloadAll!,
             ),
           if (onDeleteDownloaded != null && hasDownloadedTracks)
             _DetailActionButton(
               label: l10n.deleteDownloaded,
               icon: Icons.delete_sweep,
+              onArrowDown: onPlayDown,
               onPressed: onDeleteDownloaded!,
             ),
           if (onDeletePlaylist != null)
             _DetailActionButton(
               label: l10n.delete,
               icon: Icons.delete_outline,
+              onArrowDown: onPlayDown,
               onPressed: onDeletePlaylist!,
             ),
           if (showAddToPlaylist)
             _DetailActionButton(
               label: l10n.playlist,
               icon: Icons.playlist_add,
+              onArrowDown: onPlayDown,
               onPressed: () => AddToPlaylistDialog.show(
                 context,
                 itemIds: [item.id],

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -49,6 +49,7 @@ import '../../widgets/library_row.dart';
 import '../../widgets/media_bar.dart';
 import '../../widgets/mediabar/banner_media_bar.dart';
 import '../../widgets/media_card.dart';
+import '../../widgets/mini_audio_player.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/responsive_layout.dart';
 import '../../widgets/seasonal_effects.dart';
@@ -2300,20 +2301,35 @@ class _ContentRowsState extends State<_ContentRows>
 
   KeyEventResult _handleRowsKeyEvent(KeyEvent event) {
     if (event is! KeyDownEvent) return KeyEventResult.ignored;
-    if (!event.logicalKey.isUpKey) return KeyEventResult.ignored;
+    
+    final isUp = event.logicalKey.isUpKey;
+    final isDown = event.logicalKey.isDownKey;
+    if (!isUp && !isDown) return KeyEventResult.ignored;
 
     final current = FocusManager.instance.primaryFocus;
     if (current == null) return KeyEventResult.ignored;
 
-    if (_isMediaBarIncluded()) {
-      if (current == _mediaBarFocusNode) return KeyEventResult.ignored;
-      unawaited(_moveFocusFromRowsToMediaBar());
-      return KeyEventResult.handled;
-    }
+    if (isUp) {
+      if (_isMediaBarIncluded()) {
+        if (current == _mediaBarFocusNode) return KeyEventResult.ignored;
+        unawaited(_moveFocusFromRowsToMediaBar());
+        return KeyEventResult.handled;
+      }
 
-    if (_activeFocusedRowIndex == 0) {
-      _navigateFromMediaBarToNavbar();
-      return KeyEventResult.handled;
+      if (_activeFocusedRowIndex == 0) {
+        _navigateFromMediaBarToNavbar();
+        return KeyEventResult.handled;
+      }
+    } else if (isDown) {
+      final rows = widget.viewModel.rows;
+      if (_activeFocusedRowIndex == rows.length - 1) {
+        if (MiniAudioPlayer.tvFocusNode.context != null) {
+          MiniAudioPlayer.tvFocusNode.requestFocus();
+          if (MiniAudioPlayer.tvFocusNode.hasFocus) {
+            return KeyEventResult.handled;
+          }
+        }
+      }
     }
 
     return KeyEventResult.ignored;

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -49,7 +49,6 @@ import '../../widgets/library_row.dart';
 import '../../widgets/media_bar.dart';
 import '../../widgets/mediabar/banner_media_bar.dart';
 import '../../widgets/media_card.dart';
-import '../../widgets/mini_audio_player.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/responsive_layout.dart';
 import '../../widgets/seasonal_effects.dart';
@@ -2301,35 +2300,20 @@ class _ContentRowsState extends State<_ContentRows>
 
   KeyEventResult _handleRowsKeyEvent(KeyEvent event) {
     if (event is! KeyDownEvent) return KeyEventResult.ignored;
-    
-    final isUp = event.logicalKey.isUpKey;
-    final isDown = event.logicalKey.isDownKey;
-    if (!isUp && !isDown) return KeyEventResult.ignored;
+    if (!event.logicalKey.isUpKey) return KeyEventResult.ignored;
 
     final current = FocusManager.instance.primaryFocus;
     if (current == null) return KeyEventResult.ignored;
 
-    if (isUp) {
-      if (_isMediaBarIncluded()) {
-        if (current == _mediaBarFocusNode) return KeyEventResult.ignored;
-        unawaited(_moveFocusFromRowsToMediaBar());
-        return KeyEventResult.handled;
-      }
+    if (_isMediaBarIncluded()) {
+      if (current == _mediaBarFocusNode) return KeyEventResult.ignored;
+      unawaited(_moveFocusFromRowsToMediaBar());
+      return KeyEventResult.handled;
+    }
 
-      if (_activeFocusedRowIndex == 0) {
-        _navigateFromMediaBarToNavbar();
-        return KeyEventResult.handled;
-      }
-    } else if (isDown) {
-      final rows = widget.viewModel.rows;
-      if (_activeFocusedRowIndex == rows.length - 1) {
-        if (MiniAudioPlayer.tvFocusNode.context != null) {
-          MiniAudioPlayer.tvFocusNode.requestFocus();
-          if (MiniAudioPlayer.tvFocusNode.hasFocus) {
-            return KeyEventResult.handled;
-          }
-        }
-      }
+    if (_activeFocusedRowIndex == 0) {
+      _navigateFromMediaBarToNavbar();
+      return KeyEventResult.handled;
     }
 
     return KeyEventResult.ignored;

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -31,6 +31,12 @@ import 'seerr_icons.dart';
 import 'shuffle_overlay.dart';
 import 'user_menu_dialog.dart';
 
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:playback_core/playback_core.dart';
+import '../../data/models/aggregated_item.dart';
+import '../../data/services/media_server_client_factory.dart';
+import '../navigation/app_router.dart';
+
 const _kExpandedWidthDesktop = 240.0;
 const _kExpandedWidthMobile = 260.0;
 const _kExpandDuration = Duration(milliseconds: 200);
@@ -69,6 +75,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
   final _homeFocusNode = FocusNode(debugLabel: 'LeftSidebarHome');
   final _settingsFocusNode = FocusNode(debugLabel: 'LeftSidebarSettings');
   final _profileFocusNode = FocusNode(debugLabel: 'LeftSidebarProfile');
+  final _musicCardFocusNode = FocusNode(debugLabel: 'SidebarMusicCard');
   late final VoidCallback _focusNavbarCallback;
   late final VoidCallback _focusAvatarCallback;
   VoidCallback? _previousFocusNavbarCallback;
@@ -177,6 +184,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
     _homeFocusNode.dispose();
     _settingsFocusNode.dispose();
     _profileFocusNode.dispose();
+    _musicCardFocusNode.dispose();
     _sidebarFocus.dispose();
     _scrollController.dispose();
     _userSub?.cancel();
@@ -351,14 +359,34 @@ class _LeftSidebarState extends State<LeftSidebar> {
 
   KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {
     if (event is KeyDownEvent) {
+      final primary = FocusManager.instance.primaryFocus;
+      final insideMusicCard = primary != null && _isDescendantOf(primary, _musicCardFocusNode);
+
       if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+        if (insideMusicCard) {
+          final success = primary.focusInDirection(TraversalDirection.right);
+          if (success) {
+            return KeyEventResult.handled;
+          }
+        }
         _collapse();
         _restoreFocusOutsideSidebar();
         return KeyEventResult.handled;
       }
-      if (PlatformDetection.isTV &&
-          event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-        return KeyEventResult.handled;
+      if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+        if (insideMusicCard) {
+          final success = primary.focusInDirection(TraversalDirection.left);
+          if (success) {
+            return KeyEventResult.handled;
+          }
+          if (PlatformDetection.isTV) {
+            return KeyEventResult.handled;
+          }
+        } else {
+          if (PlatformDetection.isTV) {
+            return KeyEventResult.handled;
+          }
+        }
       }
       if (PlatformDetection.isTV &&
           event.logicalKey == LogicalKeyboardKey.arrowUp &&
@@ -370,6 +398,15 @@ class _LeftSidebarState extends State<LeftSidebar> {
       }
     }
     return KeyEventResult.ignored;
+  }
+
+  bool _isDescendantOf(FocusNode? child, FocusNode parent) {
+    FocusNode? current = child;
+    while (current != null) {
+      if (identical(current, parent)) return true;
+      current = current.parent;
+    }
+    return false;
   }
 
   void _trackPreviousFocus() {
@@ -1011,6 +1048,10 @@ class _LeftSidebarState extends State<LeftSidebar> {
             },
           ),
         ),
+        SidebarMusicCard(
+          isExpanded: _showLabels,
+          focusNode: _musicCardFocusNode,
+        ),
         if (showClock)
           Visibility(
             visible: _showLabels,
@@ -1432,6 +1473,317 @@ class _SidebarLibraryItemState extends State<_SidebarLibraryItem> {
                     )
                   : const SizedBox.shrink(),
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class SidebarMusicCard extends StatefulWidget {
+  final bool isExpanded;
+  final FocusNode? focusNode;
+  const SidebarMusicCard({
+    super.key,
+    required this.isExpanded,
+    this.focusNode,
+  });
+
+  @override
+  State<SidebarMusicCard> createState() => _SidebarMusicCardState();
+}
+
+class _SidebarMusicCardState extends State<SidebarMusicCard> {
+  final _manager = GetIt.instance<PlaybackManager>();
+  final _clientFactory = GetIt.instance<MediaServerClientFactory>();
+  StreamSubscription? _playSub;
+  StreamSubscription? _queueSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _playSub = _manager.state.playingStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+    _queueSub = _manager.queueService.queueChangedStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _playSub?.cancel();
+    _queueSub?.cancel();
+    super.dispose();
+  }
+
+  AggregatedItem? get _currentItem {
+    final raw = _manager.queueService.currentItem;
+    return raw is AggregatedItem ? raw : null;
+  }
+
+  String? _artUrl(AggregatedItem item) {
+    try {
+      final client = _clientFactory.getClientIfExists(item.serverId) ??
+          GetIt.instance<MediaServerClient>();
+      final albumTag = item.albumPrimaryImageTag;
+      final albumId = item.albumId;
+      if (item.type == 'Audio' && albumTag != null && albumId != null) {
+        return client.imageApi
+            .getPrimaryImageUrl(albumId, maxHeight: 120, tag: albumTag);
+      }
+      if (item.primaryImageTag != null) {
+        return client.imageApi
+            .getPrimaryImageUrl(item.id, maxHeight: 120, tag: item.primaryImageTag);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Widget _buildCardButton({
+    required IconData icon,
+    required VoidCallback onPressed,
+    bool large = false,
+  }) {
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent &&
+            (event.logicalKey == LogicalKeyboardKey.select ||
+                event.logicalKey == LogicalKeyboardKey.enter)) {
+          onPressed();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: Builder(
+        builder: (context) {
+          final focused = Focus.of(context).hasFocus;
+          final diameter = large ? 38.0 : 32.0;
+          return GestureDetector(
+            onTap: onPressed,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 90),
+              width: diameter,
+              height: diameter,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: focused
+                    ? AppColorScheme.onSurface
+                    : AppColorScheme.onSurface.withValues(alpha: 0.10),
+              ),
+              child: Icon(
+                icon,
+                size: large ? 22 : 18,
+                color: focused ? AppColorScheme.surface : AppColorScheme.onSurface,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = _currentItem;
+    if (item == null || !item.isAudioLike) {
+      return const SizedBox.shrink();
+    }
+
+    final isPlaying = _manager.state.isPlaying;
+    final artUrl = _artUrl(item);
+
+    if (!widget.isExpanded) {
+      // Collapsed layout: show a single focusable circular avatar with the album art
+      return Focus(
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent &&
+              (event.logicalKey == LogicalKeyboardKey.select ||
+                  event.logicalKey == LogicalKeyboardKey.enter)) {
+            appRouter.push(Destinations.audioPlayer);
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: Builder(
+          builder: (context) {
+            final focused = Focus.of(context).hasFocus;
+            return GestureDetector(
+              onTap: () => appRouter.push(Destinations.audioPlayer),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Center(
+                  child: Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: focused ? AppColorScheme.accent : Colors.transparent,
+                        width: 2,
+                      ),
+                      boxShadow: focused
+                          ? [
+                              BoxShadow(
+                                color: AppColorScheme.accent.withValues(alpha: 0.4),
+                                blurRadius: 8,
+                                spreadRadius: 1,
+                              )
+                            ]
+                          : null,
+                    ),
+                    child: ClipOval(
+                      child: artUrl != null
+                          ? CachedNetworkImage(
+                              imageUrl: artUrl,
+                              fit: BoxFit.cover,
+                            )
+                          : Container(
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.1),
+                              child: Icon(
+                                Icons.music_note,
+                                color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+                              ),
+                            ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    // Expanded layout: beautiful square card inside the sidebar
+    final artist = item.artists.isNotEmpty
+        ? item.artists.join(', ')
+        : item.albumArtist ?? '';
+
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final border = isNeon
+        ? Border.all(
+            color: const Color(0xFF00F0FF),
+            width: 1.5,
+          )
+        : Border.all(
+            color: AppColorScheme.onSurface.withValues(alpha: 0.15),
+            width: 1.0,
+          );
+    final boxShadow = isNeon
+        ? const [
+            BoxShadow(
+              color: Color(0x3300F0FF),
+              blurRadius: 8,
+              spreadRadius: 1,
+            )
+          ]
+        : null;
+
+    final cardContent = GlassSurface(
+      cornerRadius: 16,
+      reinforced: true,
+      fallbackColor: AppColorScheme.surfaceVariant.withValues(alpha: 0.3),
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          GestureDetector(
+            onTap: () => appRouter.push(Destinations.audioPlayer),
+            child: Row(
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: SizedBox(
+                    width: 48,
+                    height: 48,
+                    child: artUrl != null
+                        ? CachedNetworkImage(
+                            imageUrl: artUrl,
+                            fit: BoxFit.cover,
+                          )
+                        : Container(
+                            color: AppColorScheme.onSurface.withValues(alpha: 0.1),
+                            child: Icon(
+                              Icons.music_note,
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+                            ),
+                          ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.name,
+                        style: TextStyle(
+                          color: AppColorScheme.onSurface,
+                          fontSize: 13,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      if (artist.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          artist,
+                          style: TextStyle(
+                            color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+                            fontSize: 11,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _buildCardButton(
+                icon: Icons.skip_previous,
+                onPressed: _manager.previous,
+              ),
+              _buildCardButton(
+                icon: isPlaying ? Icons.pause : Icons.play_arrow,
+                onPressed: isPlaying ? _manager.pause : _manager.resume,
+                large: true,
+              ),
+              _buildCardButton(
+                icon: Icons.skip_next,
+                onPressed: _manager.next,
+              ),
+              _buildCardButton(
+                icon: Icons.stop,
+                onPressed: () => unawaited(_manager.stop(userInitiated: true)),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    return Focus(
+      focusNode: widget.focusNode,
+      canRequestFocus: false,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: FocusTraversalGroup(
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(16),
+              border: border,
+              boxShadow: boxShadow,
+            ),
+            child: cardContent,
           ),
         ),
       ),

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -19,6 +19,7 @@ import '../../preference/seerr_preferences.dart';
 import '../../preference/user_preferences.dart';
 import '../../l10n/app_localizations.dart';
 import '../../util/clock_format.dart';
+import '../../util/focus/dpad_keys.dart';
 import '../../util/overlay_color_palette.dart';
 import '../../util/platform_detection.dart';
 import '../navigation/destinations.dart';
@@ -1547,9 +1548,7 @@ class _SidebarMusicCardState extends State<SidebarMusicCard> {
   }) {
     return Focus(
       onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-            (event.logicalKey == LogicalKeyboardKey.select ||
-                event.logicalKey == LogicalKeyboardKey.enter)) {
+        if (isActivateKey(event)) {
           onPressed();
           return KeyEventResult.handled;
         }
@@ -1597,9 +1596,7 @@ class _SidebarMusicCardState extends State<SidebarMusicCard> {
       // Collapsed layout: show a single focusable circular avatar with the album art
       return Focus(
         onKeyEvent: (node, event) {
-          if (event is KeyDownEvent &&
-              (event.logicalKey == LogicalKeyboardKey.select ||
-                  event.logicalKey == LogicalKeyboardKey.enter)) {
+          if (isActivateKey(event)) {
             appRouter.push(Destinations.audioPlayer);
             return KeyEventResult.handled;
           }

--- a/lib/ui/widgets/mini_audio_player.dart
+++ b/lib/ui/widgets/mini_audio_player.dart
@@ -40,6 +40,12 @@ class _MiniAudioPlayerState extends State<MiniAudioPlayer> {
       _state.playingStream.listen((_) => _rebuild()),
       _queue.queueChangedStream.listen((_) => _rebuild()),
     ]);
+    appRouter.routerDelegate.addListener(_onRouteChanged);
+    PlayerRouteObserver.instance.isPlayerActive.addListener(_onRouteChanged);
+  }
+
+  void _onRouteChanged() {
+    if (mounted) setState(() {});
   }
 
   void _rebuild() {
@@ -55,6 +61,8 @@ class _MiniAudioPlayerState extends State<MiniAudioPlayer> {
     for (final sub in _subs) {
       sub.cancel();
     }
+    appRouter.routerDelegate.removeListener(_onRouteChanged);
+    PlayerRouteObserver.instance.isPlayerActive.removeListener(_onRouteChanged);
     super.dispose();
   }
 
@@ -83,6 +91,18 @@ class _MiniAudioPlayerState extends State<MiniAudioPlayer> {
 
   @override
   Widget build(BuildContext context) {
+    final path = appRouter.routerDelegate.currentConfiguration.uri.path;
+    final hasPlayerMatch = appRouter.routerDelegate.currentConfiguration.matches.any(
+      (m) => m.matchedLocation.startsWith('/player/') ||
+             m.matchedLocation == '/live-tv/player',
+    );
+    if (path.startsWith('/player/') ||
+        path == '/live-tv/player' ||
+        hasPlayerMatch ||
+        PlayerRouteObserver.instance.isPlayerActive.value) {
+      return const SizedBox.shrink();
+    }
+
     final item = _currentItem;
     if (item == null || !item.isAudioLike) {
       return const SizedBox.shrink();
@@ -352,60 +372,69 @@ class _TvMiniAudioBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FocusTraversalGroup(
-      child: GlassSurface(
-        cornerRadius: 0,
-        fallbackColor: AppColorScheme.surface,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            RepaintBoundary(child: _ProgressSliver(state: state)),
-            SizedBox(
-              height: 84,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 28),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: _TvFocusable(
-                        focusNode: MiniAudioPlayer.tvFocusNode,
-                        onSelect: onOpen,
-                        builder: (focused) => _TvTrackInfo(
-                          item: item,
-                          artUrl: artUrl,
-                          focused: focused,
+    return Focus(
+      canRequestFocus: false,
+      onKeyEvent: (node, event) {
+        if (event.logicalKey.isDownKey) {
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: FocusTraversalGroup(
+        child: GlassSurface(
+          cornerRadius: 0,
+          fallbackColor: AppColorScheme.surface,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RepaintBoundary(child: _ProgressSliver(state: state)),
+              SizedBox(
+                height: 84,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 28),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: _TvFocusable(
+                          focusNode: MiniAudioPlayer.tvFocusNode,
+                          onSelect: onOpen,
+                          builder: (focused) => _TvTrackInfo(
+                            item: item,
+                            artUrl: artUrl,
+                            focused: focused,
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 16),
-                    _TvFocusable(
-                      onSelect: onPrev,
-                      builder: (f) => _tvCircle(Icons.skip_previous, f),
-                    ),
-                    const SizedBox(width: 12),
-                    _TvFocusable(
-                      onSelect: onPlayPause,
-                      builder: (f) => _tvCircle(
-                        isPlaying ? Icons.pause : Icons.play_arrow,
-                        f,
-                        large: true,
+                      const SizedBox(width: 16),
+                      _TvFocusable(
+                        onSelect: onPrev,
+                        builder: (f) => _tvCircle(Icons.skip_previous, f),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    _TvFocusable(
-                      onSelect: onNext,
-                      builder: (f) => _tvCircle(Icons.skip_next, f),
-                    ),
-                    const SizedBox(width: 12),
-                    _TvFocusable(
-                      onSelect: onStop,
-                      builder: (f) => _tvCircle(Icons.stop, f),
-                    ),
-                  ],
+                      const SizedBox(width: 12),
+                      _TvFocusable(
+                        onSelect: onPlayPause,
+                        builder: (f) => _tvCircle(
+                          isPlaying ? Icons.pause : Icons.play_arrow,
+                          f,
+                          large: true,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      _TvFocusable(
+                        onSelect: onNext,
+                        builder: (f) => _tvCircle(Icons.skip_next, f),
+                      ),
+                      const SizedBox(width: 12),
+                      _TvFocusable(
+                        onSelect: onStop,
+                        builder: (f) => _tvCircle(Icons.stop, f),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/widgets/mini_audio_player.dart
+++ b/lib/ui/widgets/mini_audio_player.dart
@@ -18,6 +18,8 @@ import '../screensaver/screensaver_controller.dart';
 class MiniAudioPlayer extends StatefulWidget {
   const MiniAudioPlayer({super.key});
 
+  static final tvFocusNode = FocusNode(debugLabel: 'MiniAudioPlayerTv');
+
   @override
   State<MiniAudioPlayer> createState() => _MiniAudioPlayerState();
 }
@@ -366,6 +368,7 @@ class _TvMiniAudioBar extends StatelessWidget {
                   children: [
                     Expanded(
                       child: _TvFocusable(
+                        focusNode: MiniAudioPlayer.tvFocusNode,
                         onSelect: onOpen,
                         builder: (focused) => _TvTrackInfo(
                           item: item,
@@ -497,21 +500,27 @@ class _TvTrackInfo extends StatelessWidget {
 /// unhandled so Flutter's focus traversal moves naturally (Up escapes the bar
 /// back to content; the bar never traps focus, and never autofocuses on launch).
 class _TvFocusable extends StatefulWidget {
+  final FocusNode? focusNode;
   final VoidCallback onSelect;
   final Widget Function(bool focused) builder;
-  const _TvFocusable({required this.onSelect, required this.builder});
+  const _TvFocusable({
+    this.focusNode,
+    required this.onSelect,
+    required this.builder,
+  });
 
   @override
   State<_TvFocusable> createState() => _TvFocusableState();
 }
 
 class _TvFocusableState extends State<_TvFocusable> {
-  final _node = FocusNode();
+  late final FocusNode _node;
   bool _focused = false;
 
   @override
   void initState() {
     super.initState();
+    _node = widget.focusNode ?? FocusNode();
     _node.addListener(_onFocusChanged);
   }
 
@@ -524,7 +533,9 @@ class _TvFocusableState extends State<_TvFocusable> {
   @override
   void dispose() {
     _node.removeListener(_onFocusChanged);
-    _node.dispose();
+    if (widget.focusNode == null) {
+      _node.dispose();
+    }
     super.dispose();
   }
 

--- a/lib/ui/widgets/mini_audio_player.dart
+++ b/lib/ui/widgets/mini_audio_player.dart
@@ -18,8 +18,6 @@ import '../screensaver/screensaver_controller.dart';
 class MiniAudioPlayer extends StatefulWidget {
   const MiniAudioPlayer({super.key});
 
-  static final tvFocusNode = FocusNode(debugLabel: 'MiniAudioPlayerTv');
-
   @override
   State<MiniAudioPlayer> createState() => _MiniAudioPlayerState();
 }
@@ -396,7 +394,6 @@ class _TvMiniAudioBar extends StatelessWidget {
                     children: [
                       Expanded(
                         child: _TvFocusable(
-                          focusNode: MiniAudioPlayer.tvFocusNode,
                           onSelect: onOpen,
                           builder: (focused) => _TvTrackInfo(
                             item: item,
@@ -529,27 +526,21 @@ class _TvTrackInfo extends StatelessWidget {
 /// unhandled so Flutter's focus traversal moves naturally (Up escapes the bar
 /// back to content; the bar never traps focus, and never autofocuses on launch).
 class _TvFocusable extends StatefulWidget {
-  final FocusNode? focusNode;
   final VoidCallback onSelect;
   final Widget Function(bool focused) builder;
-  const _TvFocusable({
-    this.focusNode,
-    required this.onSelect,
-    required this.builder,
-  });
+  const _TvFocusable({required this.onSelect, required this.builder});
 
   @override
   State<_TvFocusable> createState() => _TvFocusableState();
 }
 
 class _TvFocusableState extends State<_TvFocusable> {
-  late final FocusNode _node;
+  final _node = FocusNode();
   bool _focused = false;
 
   @override
   void initState() {
     super.initState();
-    _node = widget.focusNode ?? FocusNode();
     _node.addListener(_onFocusChanged);
   }
 
@@ -562,9 +553,7 @@ class _TvFocusableState extends State<_TvFocusable> {
   @override
   void dispose() {
     _node.removeListener(_onFocusChanged);
-    if (widget.focusNode == null) {
-      _node.dispose();
-    }
+    _node.dispose();
     super.dispose();
   }
 

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -10,10 +10,10 @@ import 'mobile_bottom_nav_bar.dart';
 import 'top_toolbar.dart';
 
 import 'dart:async';
-import 'package:flutter/services.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:playback_core/playback_core.dart';
 import '../../data/models/aggregated_item.dart';
+import '../../util/focus/dpad_keys.dart';
 import '../navigation/app_router.dart';
 import '../navigation/destinations.dart';
 
@@ -68,6 +68,9 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
   final _contentFocusNode = FocusNode(debugLabel: 'NavigationContent');
   final ValueNotifier<double> _toolbarScrollOffset = ValueNotifier<double>(0.0);
   late NavbarPosition _position;
+  final _playbackManager = GetIt.instance<PlaybackManager>();
+  StreamSubscription? _playSub;
+  StreamSubscription? _queueSub;
 
   @override
   void initState() {
@@ -79,12 +82,22 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
     }
     WidgetsBinding.instance.addObserver(this);
     NavigationLayout.positionNotifier.addListener(_onPositionNotified);
+    // The top toolbar grows to host the embedded music bar; rebuild so the
+    // content inset tracks that height when playback starts or stops.
+    _playSub = _playbackManager.state.playingStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+    _queueSub = _playbackManager.queueService.queueChangedStream.listen((_) {
+      if (mounted) setState(() {});
+    });
   }
 
   @override
   void dispose() {
     NavigationLayout.positionNotifier.removeListener(_onPositionNotified);
     WidgetsBinding.instance.removeObserver(this);
+    _playSub?.cancel();
+    _queueSub?.cancel();
     _contentFocusNode.dispose();
     _toolbarScrollOffset.dispose();
     super.dispose();
@@ -176,12 +189,20 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
             child: content,
           )
         : content;
+    // The top toolbar is a fixed overlay off-TV, so content must reserve the
+    // embedded music bar's extra height or it gets occluded. On TV the toolbar
+    // translates with scroll, so its reserve belongs in the scrolling list
+    // inset instead and is handled there.
+    final musicExtra = TopToolbar.musicBarExtraHeight();
+    final insetBody = (!translateWithScroll && musicExtra > 0)
+        ? Padding(padding: EdgeInsets.only(top: musicExtra), child: body)
+        : body;
     return Column(
       children: [
         Expanded(
           child: Stack(
             children: [
-              Positioned.fill(child: body),
+              Positioned.fill(child: insetBody),
               if (translateWithScroll)
                 ValueListenableBuilder<double>(
                   valueListenable: _toolbarScrollOffset,
@@ -307,9 +328,7 @@ class _BottomMusicBarState extends State<BottomMusicBar> {
   }) {
     return Focus(
       onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-            (event.logicalKey == LogicalKeyboardKey.select ||
-                event.logicalKey == LogicalKeyboardKey.enter)) {
+        if (isActivateKey(event)) {
           onPressed();
           return KeyEventResult.handled;
         }

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -9,6 +9,14 @@ import 'left_sidebar.dart';
 import 'mobile_bottom_nav_bar.dart';
 import 'top_toolbar.dart';
 
+import 'dart:async';
+import 'package:flutter/services.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:playback_core/playback_core.dart';
+import '../../data/models/aggregated_item.dart';
+import '../navigation/app_router.dart';
+import '../navigation/destinations.dart';
+
 class NavigationLayout extends StatefulWidget {
   final String? activeRoute;
   final Widget child;
@@ -136,6 +144,7 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
       children: [
         Expanded(child: content),
         const DownloadProgressBar(),
+        const BottomMusicBar(),
         MobileBottomNavBar(activeRoute: widget.activeRoute),
       ],
     );
@@ -253,6 +262,159 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
         ),
         const DownloadProgressBar(),
       ],
+    );
+  }
+}
+
+class BottomMusicBar extends StatefulWidget {
+  const BottomMusicBar({super.key});
+
+  @override
+  State<BottomMusicBar> createState() => _BottomMusicBarState();
+}
+
+class _BottomMusicBarState extends State<BottomMusicBar> {
+  final _manager = GetIt.instance<PlaybackManager>();
+  StreamSubscription? _playSub;
+  StreamSubscription? _queueSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _playSub = _manager.state.playingStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+    _queueSub = _manager.queueService.queueChangedStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _playSub?.cancel();
+    _queueSub?.cancel();
+    super.dispose();
+  }
+
+  AggregatedItem? get _currentItem {
+    final raw = _manager.queueService.currentItem;
+    return raw is AggregatedItem ? raw : null;
+  }
+
+  Widget _buildBarButton({
+    required IconData icon,
+    required VoidCallback onPressed,
+  }) {
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent &&
+            (event.logicalKey == LogicalKeyboardKey.select ||
+                event.logicalKey == LogicalKeyboardKey.enter)) {
+          onPressed();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: Builder(
+        builder: (context) {
+          final focused = Focus.of(context).hasFocus;
+          return GestureDetector(
+            onTap: onPressed,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 90),
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: focused
+                    ? AppColorScheme.onSurface
+                    : Colors.transparent,
+              ),
+              child: Icon(
+                icon,
+                size: 20,
+                color: focused ? AppColorScheme.surface : AppColorScheme.onSurface,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = _currentItem;
+    if (item == null || !item.isAudioLike) {
+      return const SizedBox.shrink();
+    }
+
+    final isPlaying = _manager.state.isPlaying;
+    final artist = item.artists.isNotEmpty
+        ? item.artists.join(', ')
+        : item.albumArtist ?? '';
+    final displayText = artist.isNotEmpty ? '${item.name} - $artist' : item.name;
+
+    return FocusTraversalGroup(
+      child: GlassSurface(
+        cornerRadius: 0,
+        reinforced: true,
+        fallbackColor: AppColorScheme.surfaceVariant.withValues(alpha: 0.3),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        child: SizedBox(
+          height: 38,
+          child: Row(
+            children: [
+              Icon(
+                Icons.music_note,
+                size: 16,
+                color: AppColorScheme.accent,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: GestureDetector(
+                  onTap: () => appRouter.push(Destinations.audioPlayer),
+                  child: Text(
+                    displayText,
+                    style: TextStyle(
+                      color: AppColorScheme.onSurface,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildBarButton(
+                    icon: Icons.skip_previous,
+                    onPressed: _manager.previous,
+                  ),
+                  const SizedBox(width: 4),
+                  _buildBarButton(
+                    icon: isPlaying ? Icons.pause : Icons.play_arrow,
+                    onPressed: isPlaying ? _manager.pause : _manager.resume,
+                  ),
+                  const SizedBox(width: 4),
+                  _buildBarButton(
+                    icon: Icons.skip_next,
+                    onPressed: _manager.next,
+                  ),
+                  const SizedBox(width: 4),
+                  _buildBarButton(
+                    icon: Icons.stop,
+                    onPressed: () => unawaited(_manager.stop(userInitiated: true)),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -37,6 +37,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:playback_core/playback_core.dart';
 import '../../data/models/aggregated_item.dart';
 import '../../data/services/media_server_client_factory.dart';
+import '../../util/focus/dpad_keys.dart';
 import '../navigation/app_router.dart';
 
 const _kToolbarHeightTV = 95.0;
@@ -63,22 +64,26 @@ class TopToolbar extends StatefulWidget {
     this.contentFocusNode,
   });
 
-  /// Total laid-out height of the toolbar for the current platform.
-  static double heightFor(BuildContext context) {
+  /// Extra height the embedded music bar adds to the toolbar when audio is
+  /// playing, or 0 when it is not. Single source of truth so the toolbar's own
+  /// layout and the content inset stay in sync.
+  static double musicBarExtraHeight() {
     final manager = GetIt.instance<PlaybackManager>();
     final item = manager.queueService.currentItem;
     final isMusic = item is AggregatedItem && item.isAudioLike;
+    if (!isMusic) return 0.0;
+    return PlatformDetection.useLeanbackUi ? 64.0 : 54.0;
+  }
 
+  /// Total laid-out height of the toolbar for the current platform.
+  static double heightFor(BuildContext context) {
     final baseHeight = PlatformDetection.useLeanbackUi
         ? _kToolbarHeightTV
         : PlatformDetection.useMobileUi
         ? _kToolbarHeightMobile
         : _kToolbarHeightDesktop;
 
-    if (isMusic) {
-      return baseHeight + (PlatformDetection.useLeanbackUi ? 64.0 : 54.0);
-    }
-    return baseHeight;
+    return baseHeight + musicBarExtraHeight();
   }
 
   @override
@@ -463,9 +468,7 @@ class _TopToolbarState extends State<TopToolbar> {
     final manager = GetIt.instance<PlaybackManager>();
     final currentItem = manager.queueService.currentItem;
     final isMusicActive = currentItem is AggregatedItem && currentItem.isAudioLike;
-    final totalHeight = isMusicActive
-        ? toolbarHeight + (isTV ? 64.0 : 54.0)
-        : toolbarHeight;
+    final totalHeight = toolbarHeight + TopToolbar.musicBarExtraHeight();
 
     return SafeArea(
       bottom: false,
@@ -1881,9 +1884,7 @@ class _TopMusicBarState extends State<TopMusicBar> {
   }) {
     return Focus(
       onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-            (event.logicalKey == LogicalKeyboardKey.select ||
-                event.logicalKey == LogicalKeyboardKey.enter)) {
+        if (isActivateKey(event)) {
           onPressed();
           return KeyEventResult.handled;
         }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -33,6 +33,12 @@ import 'seerr_icons.dart';
 import 'shuffle_overlay.dart';
 import 'user_menu_dialog.dart';
 
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:playback_core/playback_core.dart';
+import '../../data/models/aggregated_item.dart';
+import '../../data/services/media_server_client_factory.dart';
+import '../navigation/app_router.dart';
+
 const _kToolbarHeightTV = 95.0;
 const _kToolbarHeightDesktop = 80.0;
 const _kToolbarHeightMobile = 60.0;
@@ -59,9 +65,20 @@ class TopToolbar extends StatefulWidget {
 
   /// Total laid-out height of the toolbar for the current platform.
   static double heightFor(BuildContext context) {
-    if (PlatformDetection.useLeanbackUi) return _kToolbarHeightTV;
-    if (PlatformDetection.useMobileUi) return _kToolbarHeightMobile;
-    return _kToolbarHeightDesktop;
+    final manager = GetIt.instance<PlaybackManager>();
+    final item = manager.queueService.currentItem;
+    final isMusic = item is AggregatedItem && item.isAudioLike;
+
+    final baseHeight = PlatformDetection.useLeanbackUi
+        ? _kToolbarHeightTV
+        : PlatformDetection.useMobileUi
+        ? _kToolbarHeightMobile
+        : _kToolbarHeightDesktop;
+
+    if (isMusic) {
+      return baseHeight + (PlatformDetection.useLeanbackUi ? 64.0 : 54.0);
+    }
+    return baseHeight;
   }
 
   @override
@@ -84,6 +101,7 @@ class _TopToolbarState extends State<TopToolbar> {
     canRequestFocus: false,
     skipTraversal: true,
   );
+  final _musicBarFocusNode = FocusNode(debugLabel: 'TopMusicBar');
   late final VoidCallback _focusNavbarCallback;
   late final VoidCallback _focusAvatarCallback;
   VoidCallback? _previousFocusNavbarCallback;
@@ -94,6 +112,8 @@ class _TopToolbarState extends State<TopToolbar> {
   late final ValueNotifier<String> _currentTime;
   StreamSubscription? _userSub;
   String? _userImageUrl;
+  StreamSubscription? _playSub;
+  StreamSubscription? _queueSub;
 
   @override
   void initState() {
@@ -119,6 +139,13 @@ class _TopToolbarState extends State<TopToolbar> {
     _viewsRepo.addListener(_onUserViewsChanged);
     GetIt.instance<PluginSyncService>().addListener(_onPrefsChanged);
     _loadLibraries();
+    final manager = GetIt.instance<PlaybackManager>();
+    _playSub = manager.state.playingStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+    _queueSub = manager.queueService.queueChangedStream.listen((_) {
+      if (mounted) setState(() {});
+    });
   }
 
   @override
@@ -144,6 +171,7 @@ class _TopToolbarState extends State<TopToolbar> {
     _homeFocus.dispose();
     _settingsFocus.dispose();
     _inlineLibrariesTriggerFocus.dispose();
+    _musicBarFocusNode.dispose();
     _userSub?.cancel();
     try {
       _viewsRepo.removeListener(_onUserViewsChanged);
@@ -153,6 +181,8 @@ class _TopToolbarState extends State<TopToolbar> {
     } catch (_) {}
     _prefs.removeListener(_onPrefsChanged);
     _currentTime.dispose();
+    _playSub?.cancel();
+    _queueSub?.cancel();
     super.dispose();
   }
 
@@ -261,6 +291,15 @@ class _TopToolbarState extends State<TopToolbar> {
     FocusNode? current = node;
     while (current != null) {
       if (identical(current, _toolbarScopeNode)) return true;
+      current = current.parent;
+    }
+    return false;
+  }
+
+  bool _isDescendantOf(FocusNode? child, FocusNode parent) {
+    FocusNode? current = child;
+    while (current != null) {
+      if (identical(current, parent)) return true;
       current = current.parent;
     }
     return false;
@@ -421,10 +460,17 @@ class _TopToolbarState extends State<TopToolbar> {
         ? _kToolbarHeightMobile
         : _kToolbarHeightDesktop;
 
+    final manager = GetIt.instance<PlaybackManager>();
+    final currentItem = manager.queueService.currentItem;
+    final isMusicActive = currentItem is AggregatedItem && currentItem.isAudioLike;
+    final totalHeight = isMusicActive
+        ? toolbarHeight + (isTV ? 64.0 : 54.0)
+        : toolbarHeight;
+
     return SafeArea(
       bottom: false,
       child: SizedBox(
-        height: toolbarHeight,
+        height: totalHeight,
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
           child: Focus(
@@ -432,48 +478,82 @@ class _TopToolbarState extends State<TopToolbar> {
             onKeyEvent: (_, event) {
               if (event is KeyDownEvent &&
                   event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                final primary = FocusManager.instance.primaryFocus;
+                if (primary != null) {
+                  final insideMusicBar = _isDescendantOf(primary, _musicBarFocusNode);
+                  if (!insideMusicBar && isMusicActive) {
+                    final target = _firstFocusableDescendant(_musicBarFocusNode);
+                    if (target != null) {
+                      target.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                  }
+
+                  final success = primary.focusInDirection(TraversalDirection.down);
+                  if (success) {
+                    final newFocus = FocusManager.instance.primaryFocus;
+                    if (newFocus != null && _isInsideToolbar(newFocus)) {
+                      return KeyEventResult.handled;
+                    }
+                  }
+                }
                 _restoreFocusBelowToolbar();
                 return KeyEventResult.handled;
               }
               return KeyEventResult.ignored;
             },
-            child: FocusTraversalGroup(
-              policy: WidgetOrderTraversalPolicy(),
-              child: isLandscape
-                  ? Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        Align(
-                          alignment: Alignment.center,
-                          child: Padding(
-                            padding: EdgeInsets.symmetric(
-                              horizontal: centerSidePadding,
-                            ),
-                            child: _buildCenter(),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FocusTraversalGroup(
+                  policy: WidgetOrderTraversalPolicy(),
+                  child: isLandscape
+                      ? SizedBox(
+                          height: toolbarHeight - (vPad * 2),
+                          child: Stack(
+                            alignment: Alignment.center,
+                            children: [
+                              Align(
+                                alignment: Alignment.center,
+                                child: Padding(
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: centerSidePadding,
+                                  ),
+                                  child: _buildCenter(),
+                                ),
+                              ),
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: _buildStart(),
+                              ),
+                              if (!isMobile)
+                                Align(
+                                  alignment: Alignment.centerRight,
+                                  child: _buildEnd(),
+                                ),
+                            ],
+                          ),
+                        )
+                      : SizedBox(
+                          height: toolbarHeight - (vPad * 2),
+                          child: Row(
+                            children: [
+                              _buildStart(),
+                              const SizedBox(width: 12),
+                              Expanded(child: _buildCenter()),
+                              if (!isMobile) ...[
+                                const SizedBox(width: 12),
+                                _buildEnd(),
+                              ],
+                            ],
                           ),
                         ),
-                        Align(
-                          alignment: Alignment.centerLeft,
-                          child: _buildStart(),
-                        ),
-                        if (!isMobile)
-                          Align(
-                            alignment: Alignment.centerRight,
-                            child: _buildEnd(),
-                          ),
-                      ],
-                    )
-                  : Row(
-                      children: [
-                        _buildStart(),
-                        const SizedBox(width: 12),
-                        Expanded(child: _buildCenter()),
-                        if (!isMobile) ...[
-                          const SizedBox(width: 12),
-                          _buildEnd(),
-                        ],
-                      ],
-                    ),
+                ),
+                if (isMusicActive) ...[
+                  const SizedBox(height: 8),
+                  TopMusicBar(focusNode: _musicBarFocusNode),
+                ],
+              ],
             ),
           ),
         ),
@@ -1737,5 +1817,244 @@ class _LibraryDropdownItemState extends State<_LibraryDropdownItem> {
         ),
       ),
     );
+  }
+}
+
+class TopMusicBar extends StatefulWidget {
+  final FocusNode? focusNode;
+  const TopMusicBar({super.key, this.focusNode});
+
+  @override
+  State<TopMusicBar> createState() => _TopMusicBarState();
+}
+
+class _TopMusicBarState extends State<TopMusicBar> {
+  final _manager = GetIt.instance<PlaybackManager>();
+  final _clientFactory = GetIt.instance<MediaServerClientFactory>();
+  StreamSubscription? _playSub;
+  StreamSubscription? _queueSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _playSub = _manager.state.playingStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+    _queueSub = _manager.queueService.queueChangedStream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _playSub?.cancel();
+    _queueSub?.cancel();
+    super.dispose();
+  }
+
+  AggregatedItem? get _currentItem {
+    final raw = _manager.queueService.currentItem;
+    return raw is AggregatedItem ? raw : null;
+  }
+
+  String? _artUrl(AggregatedItem item) {
+    try {
+      final client = _clientFactory.getClientIfExists(item.serverId) ??
+          GetIt.instance<MediaServerClient>();
+      final albumTag = item.albumPrimaryImageTag;
+      final albumId = item.albumId;
+      if (item.type == 'Audio' && albumTag != null && albumId != null) {
+        return client.imageApi
+            .getPrimaryImageUrl(albumId, maxHeight: 120, tag: albumTag);
+      }
+      if (item.primaryImageTag != null) {
+        return client.imageApi
+            .getPrimaryImageUrl(item.id, maxHeight: 120, tag: item.primaryImageTag);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Widget _buildBarButton({
+    required IconData icon,
+    required VoidCallback onPressed,
+  }) {
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent &&
+            (event.logicalKey == LogicalKeyboardKey.select ||
+                event.logicalKey == LogicalKeyboardKey.enter)) {
+          onPressed();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: Builder(
+        builder: (context) {
+          final focused = Focus.of(context).hasFocus;
+          return GestureDetector(
+            onTap: onPressed,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 90),
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: focused
+                    ? AppColorScheme.onSurface
+                    : Colors.transparent,
+              ),
+              child: Icon(
+                icon,
+                size: 20,
+                color: focused ? AppColorScheme.surface : AppColorScheme.onSurface,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _wrapPill({required bool isNeon, required Widget child}) {
+    final border = isNeon
+        ? Border.all(
+            color: const Color(0xFF00F0FF), // cyan outline for Neon Pulse!
+            width: 1.5,
+          )
+        : Border.all(
+            color: AppColorScheme.onSurface.withValues(alpha: 0.15),
+            width: 1.0,
+          );
+    final boxShadow = isNeon
+        ? const [
+            BoxShadow(
+              color: Color(0x3300F0FF), // cyan glow!
+              blurRadius: 8,
+              spreadRadius: 1,
+            )
+          ]
+        : null;
+
+    if (AppColorScheme.isGlass) {
+      return Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(24),
+          border: border,
+          boxShadow: boxShadow,
+        ),
+        child: GlassSurface(
+          cornerRadius: 24,
+          reinforced: true,
+          fallbackColor: Colors.transparent,
+          child: child,
+        ),
+      );
+    }
+    return Container(
+      decoration: BoxDecoration(
+        color: OverlayColorPalette.resolveColor(
+          GetIt.instance<UserPreferences>().get(UserPreferences.navbarColor),
+        ).withValues(
+          alpha: GetIt.instance<UserPreferences>().get(UserPreferences.navbarOpacity) / 100.0,
+        ),
+        borderRadius: BorderRadius.circular(24),
+        border: border,
+        boxShadow: boxShadow,
+      ),
+      child: child,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = _currentItem;
+    if (item == null || !item.isAudioLike) {
+      return const SizedBox.shrink();
+    }
+
+    final isPlaying = _manager.state.isPlaying;
+    final artUrl = _artUrl(item);
+    final artist = item.artists.isNotEmpty
+        ? item.artists.join(', ')
+        : item.albumArtist ?? '';
+    final displayText = artist.isNotEmpty ? '${item.name} - $artist' : item.name;
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+
+    return Center(
+      child: _wrapPill(
+        isNeon: isNeon,
+        child: Focus(
+          focusNode: widget.focusNode,
+          canRequestFocus: false,
+          child: FocusTraversalGroup(
+            child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(6),
+                  child: SizedBox(
+                    width: 32,
+                    height: 32,
+                    child: artUrl != null
+                        ? CachedNetworkImage(
+                            imageUrl: artUrl,
+                            fit: BoxFit.cover,
+                          )
+                        : Container(
+                            color: AppColorScheme.onSurface.withValues(alpha: 0.1),
+                            child: Icon(
+                              Icons.music_note,
+                              size: 16,
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+                            ),
+                          ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Flexible(
+                  child: GestureDetector(
+                    onTap: () => appRouter.push(Destinations.audioPlayer),
+                    child: Text(
+                      displayText,
+                      style: TextStyle(
+                        color: AppColorScheme.onSurface,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 20),
+                _buildBarButton(
+                  icon: Icons.skip_previous,
+                  onPressed: _manager.previous,
+                ),
+                const SizedBox(width: 4),
+                _buildBarButton(
+                  icon: isPlaying ? Icons.pause : Icons.play_arrow,
+                  onPressed: isPlaying ? _manager.pause : _manager.resume,
+                ),
+                const SizedBox(width: 4),
+                _buildBarButton(
+                  icon: Icons.skip_next,
+                  onPressed: _manager.next,
+                ),
+                const SizedBox(width: 4),
+                _buildBarButton(
+                  icon: Icons.stop,
+                  onPressed: () => unawaited(_manager.stop(userInitiated: true)),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
   }
 }

--- a/lib/util/focus/dpad_keys.dart
+++ b/lib/util/focus/dpad_keys.dart
@@ -12,6 +12,8 @@ final Set<LogicalKeyboardKey> _selectKeys = <LogicalKeyboardKey>{
   LogicalKeyboardKey.enter,
   LogicalKeyboardKey.numpadEnter,
   LogicalKeyboardKey.gameButtonA,
+  LogicalKeyboardKey.accept,
+  LogicalKeyboardKey.space,
 };
 
 final Set<LogicalKeyboardKey> _backKeys = <LogicalKeyboardKey>{

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3Bridge.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3Bridge.kt
@@ -75,6 +75,10 @@ object Media3Bridge {
 
     fun attachView(view: Media3VideoView) {
         mainHandler.post {
+            val oldView = activeView
+            if (oldView != null && oldView !== view) {
+                oldView.forceReleasePlayer()
+            }
             activeView = view
             emitEvent(
                 mapOf(

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -536,6 +536,8 @@ class Media3VideoView(
     // Replaced on every new cue group; cancelled on seek, source change, and dispose.
     private var pendingCueRunnable: Runnable? = null
     private var isDisposed = false
+    private var isDisposedByFlutter = false
+    private var isPlayerReleased = false
     private var firstFrameRendered = false
     private val externalSubtitleConfigurations = mutableListOf<MediaItem.SubtitleConfiguration>()
 
@@ -887,7 +889,9 @@ class Media3VideoView(
 
     override fun getView(): View = containerView
 
-    override fun dispose() {
+    fun forceReleasePlayer() {
+        if (isPlayerReleased) return
+        isPlayerReleased = true
         isDisposed = true
         cancelPendingSubtitleCue(clearView = false)
         cancelPendingAudioRekick()
@@ -902,6 +906,15 @@ class Media3VideoView(
         player.clearVideoSurface()
         Media3SessionController.releaseForPlayer(player)
         player.release()
+    }
+
+    override fun dispose() {
+        isDisposedByFlutter = true
+        if (currentMediaType == "audio") {
+            player.clearVideoSurface()
+            return
+        }
+        forceReleasePlayer()
         Media3Bridge.detachView(this)
     }
 
@@ -951,10 +964,12 @@ class Media3VideoView(
             .also {
                 attachAssOverlay(assHandler)
                 assHandler.init(it)
-                if (useSurfaceView) {
-                    it.setVideoSurfaceView(videoView as SurfaceView)
-                } else {
-                    it.setVideoTextureView(videoView as TextureView)
+                if (currentMediaType != "audio") {
+                    if (useSurfaceView) {
+                        it.setVideoSurfaceView(videoView as SurfaceView)
+                    } else {
+                        it.setVideoTextureView(videoView as TextureView)
+                    }
                 }
                 it.addListener(listener)
                 it.addAnalyticsListener(analyticsListener)
@@ -1079,11 +1094,19 @@ class Media3VideoView(
 
                 "stop" -> {
                     stopPlaybackAndRestoreDisplayMode()
+                    if (isDisposedByFlutter && currentMediaType != "audio") {
+                        forceReleasePlayer()
+                        Media3Bridge.detachView(this)
+                    }
                     result.success(null)
                 }
 
                 "release" -> {
                     releaseActivePlayer()
+                    if (isDisposedByFlutter && currentMediaType != "audio") {
+                        forceReleasePlayer()
+                        Media3Bridge.detachView(this)
+                    }
                     result.success(null)
                 }
 
@@ -1271,10 +1294,18 @@ class Media3VideoView(
 
                 "stop" -> {
                     stopPlaybackAndRestoreDisplayMode()
+                    if (isDisposedByFlutter && currentMediaType != "audio") {
+                        forceReleasePlayer()
+                        Media3Bridge.detachView(this)
+                    }
                 }
 
                 "release" -> {
                     releaseActivePlayer()
+                    if (isDisposedByFlutter && currentMediaType != "audio") {
+                        forceReleasePlayer()
+                        Media3Bridge.detachView(this)
+                    }
                 }
 
                 "seek" -> {
@@ -1400,7 +1431,13 @@ class Media3VideoView(
         restorePreferredDisplayMode()
         detectedFrameRate = null
 
-        if (decoderPreferenceDirty || playerHasLoadedSource) {
+        val nextMediaType = args["mediaType"]?.toString()?.lowercase() ?: "video"
+        val isAudio = nextMediaType == "audio"
+        val mediaTypeChanged = nextMediaType != currentMediaType
+
+        currentMediaType = nextMediaType
+
+        if (mediaTypeChanged || (!isAudio && (decoderPreferenceDirty || playerHasLoadedSource))) {
             rebuildPlayerForDecoderPreference()
             decoderPreferenceDirty = false
         }
@@ -1412,7 +1449,7 @@ class Media3VideoView(
             ?.trim()
             ?.lowercase()
             ?.takeIf { it.isNotEmpty() }
-        currentMediaType = args["mediaType"]?.toString()?.lowercase() ?: "video"
+        player.setPauseAtEndOfMediaItems(currentMediaType != "audio")
         audioOffloadRetryAttemptedForCurrentSource = false
         stereoDownmixRetryAttemptedForCurrentSource = false
         containerFallbackAttempted = false

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -398,6 +398,12 @@ class PlaybackManager implements AudioOwnable {
   @override
   Future<void> onAudioRevoked(RevokeReason reason) async {
     if (reason == RevokeReason.background) {
+      final item = queueService.currentItem;
+      bool isAudio = false;
+      try {
+        isAudio = item?.isAudioLike == true;
+      } catch (_) {}
+      if (isAudio) return;
       await pause();
     } else {
       await stop(userInitiated: false);

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -403,6 +403,16 @@ class PlaybackManager implements AudioOwnable {
       try {
         isAudio = item?.isAudioLike == true;
       } catch (_) {}
+      if (!isAudio && item is String) {
+        try {
+          final meta = currentOfflineMetadata;
+          if (meta != null) {
+            final type = meta['Type']?.toString();
+            final mediaType = meta['MediaType']?.toString();
+            isAudio = type == 'Audio' || type == 'AudioBook' || mediaType == 'Audio';
+          }
+        } catch (_) {}
+      }
       if (isAudio) return;
       await pause();
     } else {


### PR DESCRIPTION
# Pull Request

## Summary
This PR embeds the mini audio player directly within the application's navigation components (Left Sidebar, Top Toolbar, and Bottom NavBar) and resolves Android TV background audio track transition hangs by modifying native ExoPlayer lifecycle and surface handling.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

### Left Sidebar:
* Embedded SidebarMusicCard into the vertical layout.
* Collapsed state: displays a focusable circular album art avatar. Pressing select opens the audio player; focusing it expands the sidebar.
* Expanded state: displays a glassmorphic music control card. Under the Neon Pulse theme, it features a cyan outline and glow for visual pop.
* Horizontally bounded D-pad navigation: Left and Right keys traverse all music buttons (Previous, Play/Pause, Next, Stop). Pressing right on the rightmost button collapses and exits the sidebar.

### Top Toolbar:
* Embedded TopMusicBar (centered pill shape) directly below the top toolbar.
* Wrapped inside a decorated container adding a cyan border and glow under the Neon Pulse theme.
* Intercepted D-pad Down key: pressing Down from any navbar item smoothly shifts focus into the first control button of the TopMusicBar. Pressing Down again transitions focus past the toolbar into page content.

### Navigation Layout:
* Removed double/overlapping rendering of TopBottomMusicBar under the top toolbar.
* Renamed TopBottomMusicBar to BottomMusicBar and restricted its rendering exclusively to the mobile bottom navigation setup.

### Native Video Player (Media3/ExoPlayer):
* Preserved native background ExoPlayer instances on unmount/disposal when playing audio streams.
* Bypassed surface view attachment when playing audio streams to prevent Android TV player hangs on background transitions.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV via Shield
- [ ] Not tested (explain why):

### Test Steps
1. Play an album/playlist and verify that track auto-transitions play background audio sequentially without hangs.
2. Under Top Toolbar layout, verify that pressing D-pad Down from any toolbar button enters the centered music pill's buttons, and pressing Down again exits to page content.
3. Under Left Sidebar layout, expand the sidebar and verify that Left and Right traverse the music buttons, and pressing Right from the rightmost button (Stop) collapses the sidebar.
4. Verify layout borders and glows under the Neon Pulse theme.

## Screenshots (if applicable)
<img width="600" alt="Shield_Screenshot_2026-06-17_01-15-49" src="https://github.com/user-attachments/assets/e2a8964b-3ca4-419c-81fa-46c491e0f4da" />
<img width="600" alt="Shield_Screenshot_2026-06-17_01-17-39" src="https://github.com/user-attachments/assets/efdf466a-bbc4-415c-9ed1-1e8b1fcf11aa" />
<img width="600" alt="Shield_Screenshot_2026-06-17_01-17-54" src="https://github.com/user-attachments/assets/74668b20-2410-4576-9f09-4ee185ec9743" />
<img width="600" alt="Shield_Screenshot_2026-06-17_01-19-24" src="https://github.com/user-attachments/assets/b390eca0-5676-443b-832f-2e150454aa2d" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
