### PR TITLE
fix: resolve subtitle persistence and startup select issues on slower devices

### DIFF
--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -489,6 +489,8 @@ class Media3PlayerBackend extends PlayerBackend {
       'preferredAudioLanguage': preferredAudioLanguage,
       'preferredTextLanguage': preferredSubtitleLanguage,
       'selectUndeterminedTextLanguage': false,
+      'forceSubtitlesDisabledOnStart':
+          _prefs.get(UserPreferences.subtitlesDefaultToNone),
       'audioDelayMs': (_audioDelaySeconds * 1000).round(),
       'subtitleDelayMs': (_subtitleDelaySeconds * 1000).round(),
       'volumeBoostLevel': _volumeBoostLevel,

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -1449,7 +1449,8 @@ class Media3VideoView(
         selectedSubtitleIsExternal = false
         selectedSubtitleIsBitmap = false
         selectedExternalSubtitleUrl = null
-        subtitleTrackEnabled = false
+        val forceSubtitlesDisabledOnStart = args["forceSubtitlesDisabledOnStart"] as? Boolean ?: false
+        subtitleTrackEnabled = !forceSubtitlesDisabledOnStart
         pendingSubtitleIndex = null
         pendingSubtitleCodec = null
         pendingSubtitleIsExternal = null
@@ -1840,6 +1841,7 @@ class Media3VideoView(
             .setPreferredTextLanguage(preferredTextLanguage)
             .setSelectUndeterminedTextLanguage(selectUndeterminedTextLanguage)
             .setTunnelingEnabled(shouldEnableTunneling)
+            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, !subtitleTrackEnabled)
 
         if (mapDolbyVisionProfile7ToHevc) {
             parametersBuilder.setPreferredVideoMimeType(MimeTypes.VIDEO_H265)


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves an issue on Android TV (Media3/ExoPlayer) where subtitle settings (specifically "Default to no subtitles") are ignored upon initial video playback or playback transitions (e.g. from local intros/prerolls to the main feature), resulting in subtitles starting enabled despite the user's settings. This builds upon commit [48ec15aa](https://github.com/Moonfin-Client/Moonfin-Core/commit/48ec15aa32c6fec18994890f1a4005ee89b0fe2c) which refactored the track selector initialization to recreate the DefaultTrackSelector alongside the player on player recreation (needed during Local Intro to main feature transitions to prevent threading crashes on ExoPlayer release/rebuild). 

Because rebuilding the player creates a fresh DefaultTrackSelector with default parameters (where text tracks are enabled by default), the player would automatically select and render subtitles based on preferred language settings. On slow TV decoders (such as Sony Bravia TVs), this creates a race condition where default subtitles start rendering on screen before the asynchronous disableSubtitleTrack() command arrives from the Dart side via the method channel. By initializing subtitleTrackEnabled from the start payload and disabling text tracks inside the selector builder directly, we prevent this race condition completely.

## Related Issues
A certain Discord's users particularly frustrating set-up.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
1. Passed forceSubtitlesDisabledOnStart to Media3 Backend in `media3_player_backend.dart`
* Passed the user preference 'forceSubtitlesDisabledOnStart': _prefs.get(UserPreferences.subtitlesDefaultToNone) in the setSource payload arguments, aligning the Android backend configuration payload with the iOS/Apple TV player backend.

2. Initialized subtitleTrackEnabled from Startup Configuration in `Media3VideoView.kt`
* In the native player's setSource call, parsed the forceSubtitlesDisabledOnStart argument. Initialized subtitleTrackEnabled to !forceSubtitlesDisabledOnStart (instead of unconditionally resetting it to false which triggered automatic subtitle tracks selection).

3. Dynamic Text Track Disabling in TrackSelector in `Media3VideoView.kt`
* Updated applyTrackSelectorForCurrentSource to call .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, !subtitleTrackEnabled) on the DefaultTrackSelector.ParametersBuilder. This ensures ExoPlayer starts with text renderers completely disabled when subtitles should be off, bypassing automatic language-based subtitle selection, and re-enabling them cleanly only when the user selects a track.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Flutter analyzed but should be tested by the person with the issue.

### Test Steps
1. In settings, toggle "Default to no subtitles" to ON.
2. Play a movie or episode that contains subtitles (with or without local intros/prerolls enabled).
3. Verify that the video starts playing with no subtitles rendered on screen.
4. Open the player controls/OSD subtitle selector and verify that the active subtitle track shows as "Off".
5. Change subtitles to a specific language (e.g. English) and verify they appear immediately.
6. Stop and play another item, and verify it starts with subtitles disabled.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
