### PR TITLE
add seerrrows and expandedrows toggles to plugin sync

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -841,7 +841,7 @@ class PluginSyncService extends ChangeNotifier {
         UserPreferences.homeRowsStyle,
         enumValues: prefs.HomeRowsStyle.values,
       );
-      _applyString{
+      _applyBool{
         resolved,
         'fullScreenRows',
         UserPreferences.fullScreenRows,

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -841,7 +841,7 @@ class PluginSyncService extends ChangeNotifier {
         UserPreferences.homeRowsStyle,
         enumValues: prefs.HomeRowsStyle.values,
       );
-      _applyBool{
+      _applyBool(
         resolved,
         'fullScreenRows',
         UserPreferences.fullScreenRows,

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1364,6 +1364,8 @@ class PluginSyncService extends ChangeNotifier {
         UserPreferences.displayCollectionsRows,
       ),
       'displayGenresRows': _prefs.get(UserPreferences.displayGenresRows),
+      'fullScreenRows': _prefs.get(UserPreferences.fullScreenRows),
+      'displaySeerrRows': _prefs.get(UserPreferences.displaySeerrRows),
       'useDetailedSubHeadings': _prefs.get(
         UserPreferences.useDetailedSubHeadings,
       ),

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -845,7 +845,6 @@ class PluginSyncService extends ChangeNotifier {
         resolved,
         'fullScreenRows',
         UserPreferences.fullScreenRows,
-        enumValues: prefs.fullScreenRows.values,
       );
       _applyString(
         resolved,

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -841,6 +841,12 @@ class PluginSyncService extends ChangeNotifier {
         UserPreferences.homeRowsStyle,
         enumValues: prefs.HomeRowsStyle.values,
       );
+      _applyString{
+        resolved,
+        'fullScreenRows',
+        UserPreferences.fullScreenRows,
+        enumValues: prefs.fullScreenRows.values,
+      );
       _applyString(
         resolved,
         'homeImageTypeContinueWatching',
@@ -867,6 +873,11 @@ class PluginSyncService extends ChangeNotifier {
         resolved,
         'displayGenresRows',
         UserPreferences.displayGenresRows,
+      );
+      _applyBool(
+        resolved,
+        'displaySeerrRows',
+        UserPreferences.displaySeerrRows,
       );
       _applyBool(
         resolved,


### PR DESCRIPTION
# Pull Request

## Summary
add seerrrows and expandedrows toggles to plugin sync because they were missing before 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add fullScreenRows and displaySeerrRows to plugin_sync_services.dart
- 
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): 

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
