### PR TITLE
feat: Music Library UI Fixes

### DIFF
--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -189,8 +189,9 @@ class RowDataSource {
       includeItemTypes: const ['Playlist'],
       sortBy: sortBy ?? 'SortName',
       sortOrder: sortOrder ?? 'Ascending',
-      recursive: false,
+      recursive: true,
       limit: _defaultLimit,
+      fields: '$_fields,ChildCount,RecursiveItemCount',
     );
     var row = _buildRow(
       id: 'playlists',
@@ -199,10 +200,11 @@ class RowDataSource {
       serverId: serverId,
       rowType: HomeRowType.playlists,
     );
+    final playlistsOnly = row.items.where((item) => item.type == 'Playlist').toList();
     row = row.copyWith(
       items: await filterBrowsablePlaylists(
         _client,
-        row.items,
+        playlistsOnly,
         mediaType: mediaType,
       ),
     );
@@ -551,12 +553,14 @@ class RowDataSource {
     String parentId,
     String serverId, {
     List<String>? includeItemTypes,
+    String sortBy = 'SortName',
+    String sortOrder = 'Ascending',
   }) async {
     final response = await _getItemsWithFallback(
       parentId: parentId,
       isFavorite: true,
-      sortBy: 'SortName',
-      sortOrder: 'Ascending',
+      sortBy: sortBy,
+      sortOrder: sortOrder,
       recursive: true,
       limit: _defaultLimit,
       includeItemTypes: includeItemTypes,
@@ -715,13 +719,16 @@ class RowDataSource {
         } else {
           final pageCount = (currentOffset / _defaultLimit).ceil();
           final startIndex = pageCount * _defaultLimit;
+          final sortOpt = prefs?.get(UserPreferences.audioSortOption) ?? 'name';
+          final (querySortBy, querySortOrder) = _resolveAudioSort(sortOpt, 'Playlist');
           response = await _getItemsWithFallback(
             includeItemTypes: const ['Playlist'],
-            sortBy: 'SortName',
-            sortOrder: 'Ascending',
-            recursive: false,
+            sortBy: querySortBy,
+            sortOrder: querySortOrder,
+            recursive: true,
             startIndex: startIndex,
             limit: _defaultLimit,
+            fields: '$_fields,ChildCount,RecursiveItemCount',
           );
         }
       case HomeRowType.favorites:
@@ -838,11 +845,13 @@ class RowDataSource {
           return (items, totalCount);
         } else if (row.id.startsWith('favorites_')) {
           final parentId = row.id.substring('favorites_'.length);
+          final sortOpt = prefs?.get(UserPreferences.audioSortOption) ?? 'name';
+          final (querySortBy, querySortOrder) = _resolveAudioSort(sortOpt, 'Favorites');
           response = await _getItemsWithFallback(
             parentId: parentId,
             isFavorite: true,
-            sortBy: 'SortName',
-            sortOrder: 'Ascending',
+            sortBy: querySortBy,
+            sortOrder: querySortOrder,
             recursive: true,
             startIndex: currentOffset,
             limit: _defaultLimit,
@@ -871,11 +880,13 @@ class RowDataSource {
           );
         } else if (row.id.startsWith('albumartist_')) {
           final parentId = row.id.substring('albumartist_'.length);
+          final sortOpt = prefs?.get(UserPreferences.audioSortOption) ?? 'name';
+          final (querySortBy, querySortOrder) = _resolveAudioSort(sortOpt, 'AlbumArtist');
           response = await _client.itemsApi.getAlbumArtists(
             parentId: parentId,
             userId: _client.userId,
-            sortBy: 'SortName',
-            sortOrder: 'Ascending',
+            sortBy: querySortBy,
+            sortOrder: querySortOrder,
             recursive: true,
             startIndex: currentOffset,
             limit: _defaultLimit,
@@ -886,14 +897,20 @@ class RowDataSource {
           if (underscoreIndex >= 0) {
             final type = row.id.substring(0, underscoreIndex);
             final parentId = row.id.substring(underscoreIndex + 1);
-            final itemType = type.isEmpty
+            var itemType = type.isEmpty
                 ? ''
                 : '${type[0].toUpperCase()}${type.substring(1)}';
+            if (itemType == 'Musicartist') itemType = 'MusicArtist';
+            if (itemType == 'Musicalbum') itemType = 'MusicAlbum';
+
+            final sortOpt = prefs?.get(UserPreferences.audioSortOption) ?? 'name';
+            final (querySortBy, querySortOrder) = _resolveAudioSort(sortOpt, itemType);
+
             response = await _getItemsWithFallback(
               parentId: parentId,
               includeItemTypes: [itemType],
-              sortBy: 'SortName',
-              sortOrder: 'Ascending',
+              sortBy: querySortBy,
+              sortOrder: querySortOrder,
               recursive: true,
               startIndex: currentOffset,
               limit: _defaultLimit,
@@ -943,6 +960,7 @@ class RowDataSource {
     int? startIndex,
     int? limit,
     bool? isFavorite,
+    String? fields,
   }) async {
     try {
       final response = await _client.itemsApi.getItems(
@@ -957,7 +975,7 @@ class RowDataSource {
         startIndex: startIndex,
         limit: limit,
         isFavorite: isFavorite,
-        fields: _fields,
+        fields: fields ?? _fields,
         enableImageTypes: _imageTypes,
         imageTypeLimit: _imageTypeLimit,
       );
@@ -982,7 +1000,7 @@ class RowDataSource {
         startIndex: startIndex,
         limit: limit,
         isFavorite: isFavorite,
-        fields: _fallbackFields,
+        fields: fields ?? _fallbackFields,
         enableImageTypes: _imageTypes,
         imageTypeLimit: _imageTypeLimit,
         enableTotalRecordCount: false,
@@ -1705,6 +1723,16 @@ class RowDataSource {
   Future<List<AggregatedItem>> _enrichNextUpItemsWithSeriesLastPlayed(
     List<AggregatedItem> items,
   ) => enrichNextUpItemsWithSeriesLastPlayed(items, _client);
+
+  (String, String) _resolveAudioSort(String? sortOpt, String itemType) {
+    if (sortOpt == 'release_year' &&
+        (itemType == 'MusicAlbum' || itemType == 'Favorites')) {
+      return ('ProductionYear,SortName', 'Descending');
+    } else if (sortOpt == 'date_added') {
+      return ('DateCreated', 'Descending');
+    }
+    return ('SortName', 'Ascending');
+  }
 }
 
 class _ParsedStableId {

--- a/lib/data/utils/playlist_utils.dart
+++ b/lib/data/utils/playlist_utils.dart
@@ -48,15 +48,19 @@ Future<bool> playlistContainsOnlyMediaType(
   String mediaType, {
   bool assumeNonEmptyWhenUnknown = false,
 }) async {
-  if (item.type != 'Playlist' ||
-      !isPlaylistNonEmpty(
-        item,
-        assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
-      )) {
+  if (item.type != 'Playlist') {
+    return false;
+  }
+
+  final count = item.childCount ?? item.recursiveItemCount;
+  if (count == 0) {
     return false;
   }
 
   final summaryMediaType = item.rawData['MediaType'] as String?;
+  if (summaryMediaType != null && summaryMediaType != mediaType) {
+    return false;
+  }
 
   try {
     final response = await client.itemsApi.getPlaylistItems(item.id);
@@ -69,6 +73,9 @@ Future<bool> playlistContainsOnlyMediaType(
       (raw) => playlistItemMatchesMediaType(raw, mediaType),
     );
   } catch (_) {
+    if (count == null) {
+      return assumeNonEmptyWhenUnknown && summaryMediaType == mediaType;
+    }
     return summaryMediaType == mediaType;
   }
 }
@@ -87,10 +94,8 @@ Future<bool> playlistHasBrowsableItems(
   }
 
   final summaryMediaType = item.rawData['MediaType'] as String?;
-  if (summaryMediaType != null &&
-      summaryMediaType != 'Audio' &&
-      summaryMediaType != 'Unknown') {
-    return true;
+  if (summaryMediaType != null) {
+    return summaryMediaType != 'Audio' && summaryMediaType != 'Unknown';
   }
 
   try {

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -105,7 +105,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     return filterBrowsablePlaylists(
       _client,
       items,
-      assumeNonEmptyWhenUnknown: true,
+      mediaType: isMusicBrowse ? 'Audio' : null,
+      assumeNonEmptyWhenUnknown: !isMusicBrowse,
     );
   }
 

--- a/lib/data/viewmodels/music_browse_view_model.dart
+++ b/lib/data/viewmodels/music_browse_view_model.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../l10n/current_app_localizations.dart';
+import '../../preference/user_preferences.dart';
 import '../models/aggregated_item.dart';
 import '../models/home_row.dart';
 import '../services/row_data_source.dart';
@@ -13,6 +15,9 @@ class MusicBrowseViewModel extends ChangeNotifier {
 
   List<HomeRow> _rows = [];
   List<HomeRow> get rows => _rows;
+
+  final Map<String, int> _rowOffsets = {};
+  final Set<String> _inFlightPagingRowIds = {};
 
   bool _isLoading = true;
   bool get isLoading => _isLoading;
@@ -41,7 +46,9 @@ class MusicBrowseViewModel extends ChangeNotifier {
   Future<void> load() async {
     _isLoading = true;
     notifyListeners();
+    _rowOffsets.clear();
     final l10n = currentAppLocalizations();
+    final prefs = GetIt.instance<UserPreferences>();
 
     try {
       final itemData = await _client.itemsApi.getItem(libraryId);
@@ -51,41 +58,75 @@ class MusicBrowseViewModel extends ChangeNotifier {
     }
 
     try {
+      final showLatest = prefs.get(UserPreferences.displayAudioLatest);
+      final showLastPlayed = prefs.get(UserPreferences.displayAudioLastPlayed);
+      final showFavorites = prefs.get(UserPreferences.displayAudioFavorites);
+      final showPlaylists = prefs.get(UserPreferences.displayAudioPlaylists);
+      final showAlbumArtists = prefs.get(UserPreferences.displayAudioAlbumArtists);
+      final showArtists = prefs.get(UserPreferences.displayAudioArtists);
+      final showAlbums = prefs.get(UserPreferences.displayAudioAlbums);
+
+      final sortOpt = prefs.get(UserPreferences.audioSortOption);
+
+      final (albumArtistSortBy, albumArtistSortOrder) = _resolveSort(sortOpt, 'AlbumArtist');
+      final (artistSortBy, artistSortOrder) = _resolveSort(sortOpt, 'MusicArtist');
+      final (albumSortBy, albumSortOrder) = _resolveSort(sortOpt, 'MusicAlbum');
+      final (playlistSortBy, playlistSortOrder) = _resolveSort(sortOpt, 'Playlist');
+      final (favoritesSortBy, favoritesSortOrder) = _resolveSort(sortOpt, 'Favorites');
+
       final results = await Future.wait([
-        _dataSource.loadLatestMedia(libraryId, _libraryName, _serverId),
-        _dataSource.loadLibraryLastPlayed(
-          libraryId,
-          _serverId,
-          includeItemTypes: ['Audio'],
-        ),
-        _dataSource.loadLibraryFavorites(
-          libraryId,
-          _serverId,
-          includeItemTypes: ['MusicAlbum'],
-        ),
-        _dataSource.loadPlaylists(_serverId, mediaType: 'Audio'),
-        _dataSource.loadLibraryItemsByType(
-          libraryId,
-          _serverId,
-          title: l10n.albumArtists,
-          includeItemTypes: ['AlbumArtist'],
-          sortBy: 'SortName',
-        ),
-        _dataSource.loadLibraryItemsByType(
-          libraryId,
-          _serverId,
-          title: l10n.artists,
-          includeItemTypes: ['MusicArtist'],
-          sortBy: 'SortName',
-        ),
-        _dataSource.loadLibraryItemsByType(
-          libraryId,
-          _serverId,
-          title: l10n.albums,
-          includeItemTypes: ['MusicAlbum'],
-          sortBy: 'DateCreated',
-          sortOrder: 'Descending',
-        ),
+        showLatest
+            ? _dataSource.loadLatestMedia(libraryId, _libraryName, _serverId)
+            : Future.value(HomeRow(id: 'latest_$libraryId', title: '', items: const [], rowType: HomeRowType.latestMedia)),
+        showLastPlayed
+            ? _dataSource.loadLibraryLastPlayed(
+                libraryId,
+                _serverId,
+                includeItemTypes: const ['Audio'],
+              )
+            : Future.value(HomeRow(id: 'lastPlayed_$libraryId', title: '', items: const [], rowType: HomeRowType.latestMedia)),
+        showFavorites
+            ? _dataSource.loadLibraryFavorites(
+                libraryId,
+                _serverId,
+                includeItemTypes: const ['MusicAlbum'],
+                sortBy: favoritesSortBy,
+                sortOrder: favoritesSortOrder,
+              )
+            : Future.value(HomeRow(id: 'favorites_$libraryId', title: '', items: const [], rowType: HomeRowType.favorites)),
+        showPlaylists
+            ? _dataSource.loadPlaylists(_serverId, mediaType: 'Audio', sortBy: playlistSortBy, sortOrder: playlistSortOrder)
+            : Future.value(HomeRow(id: 'playlists', title: '', items: const [], rowType: HomeRowType.playlists)),
+        showAlbumArtists
+            ? _dataSource.loadLibraryItemsByType(
+                libraryId,
+                _serverId,
+                title: l10n.albumArtists,
+                includeItemTypes: const ['AlbumArtist'],
+                sortBy: albumArtistSortBy,
+                sortOrder: albumArtistSortOrder,
+              )
+            : Future.value(HomeRow(id: 'albumartist_$libraryId', title: '', items: const [], rowType: HomeRowType.latestMedia)),
+        showArtists
+            ? _dataSource.loadLibraryItemsByType(
+                libraryId,
+                _serverId,
+                title: l10n.artists,
+                includeItemTypes: const ['MusicArtist'],
+                sortBy: artistSortBy,
+                sortOrder: artistSortOrder,
+              )
+            : Future.value(HomeRow(id: 'musicartist_$libraryId', title: '', items: const [], rowType: HomeRowType.latestMedia)),
+        showAlbums
+            ? _dataSource.loadLibraryItemsByType(
+                libraryId,
+                _serverId,
+                title: l10n.albums,
+                includeItemTypes: const ['MusicAlbum'],
+                sortBy: albumSortBy,
+                sortOrder: albumSortOrder,
+              )
+            : Future.value(HomeRow(id: 'musicalbum_$libraryId', title: '', items: const [], rowType: HomeRowType.latestMedia)),
       ]);
 
       _rows = results.where((r) => r.items.isNotEmpty).toList();
@@ -156,5 +197,43 @@ class MusicBrowseViewModel extends ChangeNotifier {
       );
     }
     return null;
+  }
+
+  Future<void> loadMoreForRow(int rowIndex) async {
+    if (rowIndex < 0 || rowIndex >= _rows.length) return;
+    final row = _rows[rowIndex];
+    if (!row.hasMore || _inFlightPagingRowIds.contains(row.id)) return;
+
+    _inFlightPagingRowIds.add(row.id);
+    try {
+      final int currentOffset = _rowOffsets[row.id] ?? row.items.length;
+      final (List<AggregatedItem> items, int totalCount) result = await _dataSource.loadMore(
+        row: row,
+        serverId: _serverId,
+        offset: currentOffset,
+      );
+      _rowOffsets[row.id] = currentOffset + 15;
+
+      _rows = List.of(_rows);
+      _rows[rowIndex] = row.copyWith(
+        items: result.$1,
+        totalCount: result.$2,
+      );
+      notifyListeners();
+    } catch (e) {
+      debugPrint('Failed to load more for music row ${row.id}: $e');
+    } finally {
+      _inFlightPagingRowIds.remove(row.id);
+    }
+  }
+
+  (String, String) _resolveSort(String? sortOpt, String type) {
+    if (sortOpt == 'release_year' &&
+        (type == 'MusicAlbum' || type == 'Favorites')) {
+      return ('ProductionYear,SortName', 'Descending');
+    } else if (sortOpt == 'date_added') {
+      return ('DateCreated', 'Descending');
+    }
+    return ('SortName', 'Ascending');
   }
 }

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -190,6 +190,14 @@ class UserPreferences extends ChangeNotifier {
     'jellyseerrBlockNsfw',
     'enabledRatings',
     'home_sections_config',
+    'pref_audio_display_latest',
+    'pref_audio_display_last_played',
+    'pref_audio_display_favorites',
+    'pref_audio_display_playlists',
+    'pref_audio_display_album_artists',
+    'pref_audio_display_artists',
+    'pref_audio_display_albums',
+    'pref_audio_sort_option',
   };
 
   bool _isScopedPreference<T>(Preference<T> pref) {
@@ -1557,5 +1565,45 @@ class UserPreferences extends ChangeNotifier {
   static final syncPlayAdvancedCorrectionEnabled = Preference(
     key: 'syncplay_advanced_correction_enabled',
     defaultValue: true,
+  );
+
+  static final displayAudioLatest = Preference(
+    key: 'pref_audio_display_latest',
+    defaultValue: true,
+  );
+
+  static final displayAudioLastPlayed = Preference(
+    key: 'pref_audio_display_last_played',
+    defaultValue: true,
+  );
+
+  static final displayAudioFavorites = Preference(
+    key: 'pref_audio_display_favorites',
+    defaultValue: true,
+  );
+
+  static final displayAudioPlaylists = Preference(
+    key: 'pref_audio_display_playlists',
+    defaultValue: true,
+  );
+
+  static final displayAudioAlbumArtists = Preference(
+    key: 'pref_audio_display_album_artists',
+    defaultValue: true,
+  );
+
+  static final displayAudioArtists = Preference(
+    key: 'pref_audio_display_artists',
+    defaultValue: true,
+  );
+
+  static final displayAudioAlbums = Preference(
+    key: 'pref_audio_display_albums',
+    defaultValue: true,
+  );
+
+  static final audioSortOption = Preference<String>(
+    key: 'pref_audio_sort_option',
+    defaultValue: 'name',
   );
 }

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -3999,7 +3999,20 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
           Column(
             children: [
               _LibraryHeader(
-                libraryName: _vm.libraryName,
+                libraryName: () {
+                  if (_vm.includeItemTypes != null &&
+                      _vm.includeItemTypes!.isNotEmpty) {
+                    final type = _vm.includeItemTypes!.first;
+                    if (type == 'MusicAlbum') {
+                      return AppLocalizations.of(context).albums;
+                    } else if (type == 'AlbumArtist') {
+                      return AppLocalizations.of(context).albumArtists;
+                    } else if (type == 'MusicArtist') {
+                      return AppLocalizations.of(context).artists;
+                    }
+                  }
+                  return _vm.libraryName;
+                }(),
                 totalCount: _vm.totalCount,
                 focusedItem: _vm.focusedItem,
                 focusedRatings: _vm.focusedRatings,
@@ -4390,6 +4403,20 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
   String? _cardSubtitle(AggregatedItem item) {
     final parts = <String>[];
+    if (item.type == 'MusicAlbum') {
+      if (item.artists.isNotEmpty) return item.artists.join(', ');
+      if (item.albumArtists.isNotEmpty) {
+        return item.albumArtists
+            .map((a) => a['Name'] as String? ?? '')
+            .where((n) => n.isNotEmpty)
+            .join(', ');
+      }
+      final albumArtist = item.albumArtist;
+      if (albumArtist != null && albumArtist.isNotEmpty) {
+        return albumArtist;
+      }
+    }
+
     if (_vm.isNavigableFolder(item)) {
       if (item.childCount != null) {
         parts.add(
@@ -5002,9 +5029,15 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                         LibrarySortBy.dateAdded,
                         LibrarySortBy.random,
                       ]
-                    : LibrarySortBy.values)
+                    : LibrarySortBy.values.where((o) => !vm.isMusicBrowse || (
+                        o != LibrarySortBy.rating &&
+                        o != LibrarySortBy.criticRating &&
+                        o != LibrarySortBy.communityRating
+                      )))
               _radioTile(
-                label: option.displayName,
+                label: (vm.isMusicBrowse && option == LibrarySortBy.premiereDate)
+                    ? 'Release Date'
+                    : option.displayName,
                 selected: vm.sortBy == option,
                 trailing: vm.sortBy == option
                     ? IconButton(
@@ -5036,25 +5069,27 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
               accent: accent,
               onSurface: onSurface,
             ),
-            Divider(color: dividerColor),
-            _sectionHeader(
-              isBookBrowse ? l10n.readingStatus : l10n.playedStatus,
-              sectionColor,
-            ),
-            for (final status in PlayedStatusFilter.values)
-              _radioTile(
-                label: switch (status) {
-                  PlayedStatusFilter.all => l10n.all,
-                  PlayedStatusFilter.watched =>
-                    isBookBrowse ? l10n.readStatus : l10n.watched,
-                  PlayedStatusFilter.unwatched =>
-                    isBookBrowse ? l10n.unread : l10n.unwatched,
-                },
-                selected: vm.playedFilter == status,
-                onTap: () => vm.setPlayedFilter(status),
-                accent: accent,
-                onSurface: onSurface,
+            if (!vm.isMusicBrowse) ...[
+              Divider(color: dividerColor),
+              _sectionHeader(
+                isBookBrowse ? l10n.readingStatus : l10n.playedStatus,
+                sectionColor,
               ),
+              for (final status in PlayedStatusFilter.values)
+                _radioTile(
+                  label: switch (status) {
+                    PlayedStatusFilter.all => l10n.all,
+                    PlayedStatusFilter.watched =>
+                      isBookBrowse ? l10n.readStatus : l10n.watched,
+                    PlayedStatusFilter.unwatched =>
+                      isBookBrowse ? l10n.unread : l10n.unwatched,
+                  },
+                  selected: vm.playedFilter == status,
+                  onTap: () => vm.setPlayedFilter(status),
+                  accent: accent,
+                  onSurface: onSurface,
+                ),
+            ],
             if (vm.isSeriesLibrary) ...[
               Divider(color: dividerColor),
               _sectionHeader(l10n.seriesStatus, sectionColor),

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -103,6 +103,9 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
                   (data['ArtistCount'] as int? ?? 0) +
                   (data['MusicVideoCount'] as int? ?? 0),
         );
+      }).where((genre) {
+        if (_collectionType == 'music') return true;
+        return genre.itemCount > 0;
       }).toList();
     } catch (_) {}
 
@@ -156,6 +159,16 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
         imageTypeLimit: 1,
       );
       final items = (response['Items'] as List?) ?? [];
+
+      final rawTotalCount = response['TotalRecordCount'];
+      final totalCount =
+          rawTotalCount is num ? rawTotalCount.toInt() : items.length;
+      if (totalCount <= 0 || items.isEmpty) {
+        if (_genres.remove(genre) && !_disposed && mounted) {
+          setState(() {});
+        }
+        return;
+      }
 
       if (_collectionType == 'music') {
         for (final raw in items) {
@@ -361,6 +374,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
             children: [
               _GenresHeader(
                 libraryName: _libraryName,
+                isMusic: _collectionType == 'music',
                 onBack: () => PlatformDetection.isWeb
                     ? context.popOrHome()
                     : context.pop(),
@@ -458,9 +472,14 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
 class _GenresHeader extends StatelessWidget {
   final String libraryName;
+  final bool isMusic;
   final VoidCallback onBack;
 
-  const _GenresHeader({required this.libraryName, required this.onBack});
+  const _GenresHeader({
+    required this.libraryName,
+    this.isMusic = false,
+    required this.onBack,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -504,7 +523,9 @@ class _GenresHeader extends StatelessWidget {
             ),
           SizedBox(width: 12 * desktopScale),
           Text(
-            AppLocalizations.of(context).libraryGenresTitle(libraryName),
+            isMusic
+                ? AppLocalizations.of(context).genres
+                : AppLocalizations.of(context).libraryGenresTitle(libraryName),
             style: TextStyle(
               fontSize: 26 * desktopScale,
               fontWeight: FontWeight.w300,

--- a/lib/ui/screens/browse/music_browse_screen.dart
+++ b/lib/ui/screens/browse/music_browse_screen.dart
@@ -17,10 +17,11 @@ import '../../widgets/focus/focusable_toolbar_button.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../util/home_row_title_localizer.dart';
+import '../../widgets/overlay_sheet.dart';
 
 Color get _navyBackground => AppColorScheme.background;
 const _cardSize = 140.0;
-const _horizontalPadding = 20.0;
+const _horizontalPadding = 60.0;
 const _cardSpacing = 12.0;
 
 class MusicBrowseScreen extends StatefulWidget {
@@ -87,6 +88,16 @@ class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
     } catch (_) {}
   }
 
+  void _showFilterDialog(BuildContext context) {
+    OverlaySheetController.show<void>(
+      context,
+      builder: (sheetContext) => _MusicRowVisibilityDialog(
+        libraryName: _vm.libraryName,
+        onChanged: () => _vm.load(),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) =>
       RequestInitialFocus(child: _buildContent(context));
@@ -103,6 +114,8 @@ class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
               _MusicHeader(
                 libraryName: _vm.libraryName,
                 focusedItem: _vm.focusedItem,
+                vm: _vm,
+                onFilterTap: () => _showFilterDialog(context),
               ),
               const SizedBox(height: 10),
               Expanded(
@@ -114,28 +127,39 @@ class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
                       )
                     : RefreshIndicator(
                         onRefresh: _vm.refresh,
-                        child: ListView(
-                          padding: const EdgeInsets.only(top: 4, bottom: 32),
-                          children: [
-                            _MusicViewsRow(
-                              libraryId: widget.libraryId,
-                              onRandomAlbum: _onRandomAlbum,
-                            ),
-                            ..._vm.rows.map(
-                              (row) => _MusicItemRow(
-                                title: localizeHomeRowTitle(
-                                  row: row,
-                                  l10n: l10n,
-                                ),
-                                items: row.items,
-                                imageApi: _vm.imageApi,
-                                getSubtitle: _vm.getMusicSubtitle,
-                                getImageUrl: _vm.getMusicImageUrl,
-                                onFocused: _onItemFocused,
-                                onTap: _onItemTap,
-                              ),
-                            ),
-                          ],
+                        child: LayoutBuilder(
+                          builder: (context, constraints) {
+                            final screenHeight = MediaQuery.of(context).size.height;
+                            final bottomPadding = screenHeight > 0 ? screenHeight / 2 : 400.0;
+                            return ListView.builder(
+                              padding: EdgeInsets.only(top: 24, bottom: bottomPadding),
+                              itemCount: _vm.rows.length + 1,
+                              itemBuilder: (context, index) {
+                                if (index == 0) {
+                                  return _MusicViewsRow(
+                                    key: const ValueKey('views_row'),
+                                    libraryId: widget.libraryId,
+                                    onRandomAlbum: _onRandomAlbum,
+                                  );
+                                }
+                                final row = _vm.rows[index - 1];
+                                return _MusicItemRow(
+                                  key: ValueKey(row.id),
+                                  title: localizeHomeRowTitle(
+                                    row: row,
+                                    l10n: l10n,
+                                  ),
+                                  items: row.items,
+                                  imageApi: _vm.imageApi,
+                                  getSubtitle: _vm.getMusicSubtitle,
+                                  getImageUrl: _vm.getMusicImageUrl,
+                                  onFocused: _onItemFocused,
+                                  onTap: _onItemTap,
+                                  onLoadMore: () => _vm.loadMoreForRow(index - 1),
+                                );
+                              },
+                            );
+                          },
                         ),
                       ),
               ),
@@ -150,8 +174,33 @@ class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
 class _MusicHeader extends StatelessWidget {
   final String libraryName;
   final AggregatedItem? focusedItem;
+  final MusicBrowseViewModel vm;
+  final VoidCallback onFilterTap;
 
-  const _MusicHeader({required this.libraryName, this.focusedItem});
+  const _MusicHeader({
+    required this.libraryName,
+    this.focusedItem,
+    required this.vm,
+    required this.onFilterTap,
+  });
+
+  String? _getHeaderSubtitle(AggregatedItem item, MusicBrowseViewModel vm) {
+    final sub = vm.getMusicSubtitle(item);
+    final year = item.productionYear;
+    if (item.type == 'MusicAlbum' || item.type == 'Audio') {
+      if (sub.isNotEmpty && year != null) {
+        return '$sub ($year)';
+      } else if (sub.isNotEmpty) {
+        return sub;
+      } else if (year != null) {
+        return '$year';
+      }
+      return null;
+    }
+    if (sub.isNotEmpty) return sub;
+    if (year != null) return '$year';
+    return null;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -178,38 +227,6 @@ class _MusicHeader extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
-          SizedBox(
-            height: 56,
-            child: focusedItem != null
-                ? Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        focusedItem!.name,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.w600,
-                          height: 1.05,
-                          color: AppColorScheme.onSurface,
-                        ),
-                      ),
-                      if (focusedItem!.productionYear != null)
-                        Text(
-                          '${focusedItem!.productionYear}',
-                          style: TextStyle(
-                            fontSize: 14,
-                            height: 1.0,
-                            color: AppColorScheme.onSurface.withAlpha(179),
-                          ),
-                        ),
-                    ],
-                  )
-                : const SizedBox.shrink(),
-          ),
-          const SizedBox(height: 6),
           Row(
             children: [
               FocusableToolbarButton(
@@ -225,6 +242,61 @@ class _MusicHeader extends StatelessWidget {
                     : 1.0,
                 onTap: () => context.go(Destinations.home),
               ),
+              const SizedBox(width: 12),
+              FocusableToolbarButton(
+                icon: Icons.filter_alt,
+                size: 52,
+                iconSize: 28,
+                variant: ToolbarButtonVariant.translucent,
+                scaleOnFocus:
+                    GetIt.instance<UserPreferences>().get(
+                      UserPreferences.cardFocusExpansion,
+                    )
+                    ? 1.05
+                    : 1.0,
+                onTap: onFilterTap,
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: SizedBox(
+                  height: 56,
+                  child: focusedItem != null
+                      ? Builder(
+                          builder: (context) {
+                            final subtitle = _getHeaderSubtitle(focusedItem!, vm);
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  focusedItem!.name,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    fontSize: 20,
+                                    fontWeight: FontWeight.w600,
+                                    height: 1.1,
+                                    color: AppColorScheme.onSurface,
+                                  ),
+                                ),
+                                if (subtitle != null)
+                                  Text(
+                                    subtitle,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      height: 1.1,
+                                      color: AppColorScheme.onSurface.withAlpha(179),
+                                    ),
+                                  ),
+                              ],
+                            );
+                          }
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ),
             ],
           ),
         ],
@@ -233,14 +305,55 @@ class _MusicHeader extends StatelessWidget {
   }
 }
 
-class _MusicViewsRow extends StatelessWidget {
+class _MusicViewsRow extends StatefulWidget {
   final String libraryId;
   final VoidCallback onRandomAlbum;
 
-  const _MusicViewsRow({required this.libraryId, required this.onRandomAlbum});
+  const _MusicViewsRow({super.key, required this.libraryId, required this.onRandomAlbum});
+
+  @override
+  State<_MusicViewsRow> createState() => _MusicViewsRowState();
+}
+
+class _MusicViewsRowState extends State<_MusicViewsRow> with AutomaticKeepAliveClientMixin {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+
+  void _onFocused(bool isFirst) {
+    if (mounted) {
+      Scrollable.ensureVisible(
+        context,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 240),
+        curve: Curves.easeInOut,
+      );
+      if (isFirst && _scrollController.hasClients) {
+        _scrollController.animateTo(
+          0,
+          duration: const Duration(milliseconds: 240),
+          curve: Curves.easeInOut,
+        );
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -264,6 +377,7 @@ class _MusicViewsRow extends StatelessWidget {
         SizedBox(
           height: 104,
           child: ListView(
+            controller: _scrollController,
             scrollDirection: Axis.horizontal,
             clipBehavior: Clip.none,
             padding: const EdgeInsets.fromLTRB(
@@ -276,9 +390,11 @@ class _MusicViewsRow extends StatelessWidget {
               _ViewButton(
                 icon: Icons.album,
                 label: AppLocalizations.of(context).albums,
+                isFirst: true,
+                onFocused: () => _onFocused(true),
                 onTap: () => context.push(
                   Destinations.library(
-                    libraryId,
+                    widget.libraryId,
                     includeItemTypes: ['MusicAlbum'],
                   ),
                 ),
@@ -287,9 +403,10 @@ class _MusicViewsRow extends StatelessWidget {
               _ViewButton(
                 icon: Icons.person,
                 label: AppLocalizations.of(context).albumArtists,
+                onFocused: () => _onFocused(false),
                 onTap: () => context.push(
                   Destinations.library(
-                    libraryId,
+                    widget.libraryId,
                     includeItemTypes: ['AlbumArtist'],
                   ),
                 ),
@@ -298,9 +415,10 @@ class _MusicViewsRow extends StatelessWidget {
               _ViewButton(
                 icon: Icons.groups,
                 label: AppLocalizations.of(context).artists,
+                onFocused: () => _onFocused(false),
                 onTap: () => context.push(
                   Destinations.library(
-                    libraryId,
+                    widget.libraryId,
                     includeItemTypes: ['MusicArtist'],
                   ),
                 ),
@@ -309,8 +427,10 @@ class _MusicViewsRow extends StatelessWidget {
               _ViewButton(
                 icon: Icons.album,
                 label: AppLocalizations.of(context).genres,
+                isLast: true,
+                onFocused: () => _onFocused(false),
                 onTap: () =>
-                    context.push(Destinations.libraryGenresOf(libraryId)),
+                    context.push(Destinations.libraryGenresOf(widget.libraryId)),
               ),
             ],
           ),
@@ -324,11 +444,17 @@ class _ViewButton extends StatefulWidget {
   final IconData icon;
   final String label;
   final VoidCallback onTap;
+  final VoidCallback? onFocused;
+  final bool isFirst;
+  final bool isLast;
 
   const _ViewButton({
     required this.icon,
     required this.label,
     required this.onTap,
+    this.onFocused,
+    this.isFirst = false,
+    this.isLast = false,
   });
 
   @override
@@ -351,11 +477,22 @@ class _ViewButtonState extends State<_ViewButton> with FocusStateMixin {
       onEnter: (_) => setHovered(true),
       onExit: (_) => setHovered(false),
       child: Focus(
-        onFocusChange: (hasFocus) => setFocused(hasFocus),
+        onFocusChange: (hasFocus) {
+          setFocused(hasFocus);
+          if (hasFocus) widget.onFocused?.call();
+        },
         onKeyEvent: (_, event) {
           if (isActivateKey(event)) {
             widget.onTap();
             return KeyEventResult.handled;
+          }
+          if (event.isActionable) {
+            if (widget.isFirst && event.logicalKey.isLeftKey) {
+              return KeyEventResult.handled;
+            }
+            if (widget.isLast && event.logicalKey.isRightKey) {
+              return KeyEventResult.handled;
+            }
           }
           return KeyEventResult.ignored;
         },
@@ -422,7 +559,7 @@ class _ViewButtonState extends State<_ViewButton> with FocusStateMixin {
   }
 }
 
-class _MusicItemRow extends StatelessWidget {
+class _MusicItemRow extends StatefulWidget {
   final String title;
   final List<AggregatedItem> items;
   final ImageApi imageApi;
@@ -430,8 +567,10 @@ class _MusicItemRow extends StatelessWidget {
   final String? Function(AggregatedItem) getImageUrl;
   final ValueChanged<AggregatedItem> onFocused;
   final ValueChanged<AggregatedItem> onTap;
+  final VoidCallback? onLoadMore;
 
   const _MusicItemRow({
+    super.key,
     required this.title,
     required this.items,
     required this.imageApi,
@@ -439,11 +578,54 @@ class _MusicItemRow extends StatelessWidget {
     required this.getImageUrl,
     required this.onFocused,
     required this.onTap,
+    this.onLoadMore,
   });
 
   @override
+  State<_MusicItemRow> createState() => _MusicItemRowState();
+}
+
+class _MusicItemRowState extends State<_MusicItemRow> with AutomaticKeepAliveClientMixin {
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+
+  void _onCardFocused(AggregatedItem item, bool isFirst) {
+    widget.onFocused(item);
+    if (mounted) {
+      Scrollable.ensureVisible(
+        context,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 240),
+        curve: Curves.easeInOut,
+      );
+      if (isFirst && _scrollController.hasClients) {
+        _scrollController.animateTo(
+          0,
+          duration: const Duration(milliseconds: 240),
+          curve: Curves.easeInOut,
+        );
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (items.isEmpty) return const SizedBox.shrink();
+    super.build(context);
+    if (widget.items.isEmpty) return const SizedBox.shrink();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -456,7 +638,7 @@ class _MusicItemRow extends StatelessWidget {
             8,
           ),
           child: Text(
-            title,
+            widget.title,
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.w600,
@@ -467,19 +649,28 @@ class _MusicItemRow extends StatelessWidget {
         SizedBox(
           height: _cardSize + 72,
           child: ListView.separated(
+            controller: _scrollController,
             scrollDirection: Axis.horizontal,
             clipBehavior: Clip.none,
-            padding: const EdgeInsets.fromLTRB(_horizontalPadding, 6, 24, 12),
-            itemCount: items.length,
+            padding: const EdgeInsets.fromLTRB(_horizontalPadding, 6, _horizontalPadding, 12),
+            itemCount: widget.items.length,
             separatorBuilder: (_, _) => const SizedBox(width: _cardSpacing),
             itemBuilder: (_, i) {
-              final item = items[i];
+              final item = widget.items[i];
+              final isFirst = i == 0;
               return _MusicSquareCard(
                 title: item.name,
-                subtitle: getSubtitle(item),
-                imageUrl: getImageUrl(item),
-                onFocus: () => onFocused(item),
-                onTap: () => onTap(item),
+                subtitle: widget.getSubtitle(item),
+                imageUrl: widget.getImageUrl(item),
+                onFocus: () {
+                  _onCardFocused(item, isFirst);
+                  if (i >= widget.items.length - 8) {
+                    widget.onLoadMore?.call();
+                  }
+                },
+                onTap: () => widget.onTap(item),
+                isFirst: isFirst,
+                isLast: i == widget.items.length - 1,
               );
             },
           ),
@@ -495,6 +686,8 @@ class _MusicSquareCard extends StatefulWidget {
   final String? imageUrl;
   final VoidCallback? onFocus;
   final VoidCallback? onTap;
+  final bool isFirst;
+  final bool isLast;
 
   const _MusicSquareCard({
     required this.title,
@@ -502,6 +695,8 @@ class _MusicSquareCard extends StatefulWidget {
     this.imageUrl,
     this.onFocus,
     this.onTap,
+    this.isFirst = false,
+    this.isLast = false,
   });
 
   @override
@@ -535,6 +730,14 @@ class _MusicSquareCardState extends State<_MusicSquareCard>
             if (isActivateKey(event)) {
               widget.onTap?.call();
               return KeyEventResult.handled;
+            }
+            if (event.isActionable) {
+              if (widget.isFirst && event.logicalKey.isLeftKey) {
+                return KeyEventResult.handled;
+              }
+              if (widget.isLast && event.logicalKey.isRightKey) {
+                return KeyEventResult.handled;
+              }
             }
             return KeyEventResult.ignored;
           },
@@ -627,6 +830,340 @@ class _MusicSquareCardState extends State<_MusicSquareCard>
         Icons.album,
         size: 48,
         color: AppColorScheme.onSurface.withAlpha(51),
+      ),
+    );
+  }
+}
+
+class _MusicRowVisibilityDialog extends StatefulWidget {
+  final String libraryName;
+  final VoidCallback onChanged;
+
+  const _MusicRowVisibilityDialog({
+    required this.libraryName,
+    required this.onChanged,
+  });
+
+  @override
+  State<_MusicRowVisibilityDialog> createState() => _MusicRowVisibilityDialogState();
+}
+
+class _MusicRowVisibilityDialogState extends State<_MusicRowVisibilityDialog> {
+  final _prefs = GetIt.instance<UserPreferences>();
+  late final ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final surfaceColor = AppColorScheme.surface.withValues(alpha: 0.92);
+    final onSurface = AppColorScheme.onSurface;
+    final accent = AppColorScheme.accent;
+    final dividerColor = onSurface.withValues(alpha: 0.12);
+    final dialogWidth = (MediaQuery.sizeOf(context).width - 32).clamp(280.0, 380.0);
+
+    final sortOpt = _prefs.get(UserPreferences.audioSortOption);
+
+    final showLatest = _prefs.get(UserPreferences.displayAudioLatest);
+    final showLastPlayed = _prefs.get(UserPreferences.displayAudioLastPlayed);
+    final showFavorites = _prefs.get(UserPreferences.displayAudioFavorites);
+    final showPlaylists = _prefs.get(UserPreferences.displayAudioPlaylists);
+    final showAlbumArtists = _prefs.get(UserPreferences.displayAudioAlbumArtists);
+    final showArtists = _prefs.get(UserPreferences.displayAudioArtists);
+    final showAlbums = _prefs.get(UserPreferences.displayAudioAlbums);
+
+    return Dialog(
+      backgroundColor: surfaceColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: ThemeRegistry.active.borders.chipBorder.copyWith(
+          color: onSurface.withValues(alpha: 0.18),
+        ),
+      ),
+      child: SizedBox(
+        width: dialogWidth,
+        child: ListView(
+          controller: _scrollController,
+          shrinkWrap: true,
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+              child: Text(
+                l10n.sortAndFilter,
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w600,
+                  color: onSurface,
+                ),
+              ),
+            ),
+            Divider(color: dividerColor),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+              child: Text(
+                'Sort By',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: accent,
+                ),
+              ),
+            ),
+            _DialogCheckboxTile(
+              label: 'Name',
+              checked: sortOpt == 'name',
+              isRadio: true,
+              autofocus: true,
+              onFocused: () {
+                if (_scrollController.hasClients) {
+                  _scrollController.animateTo(
+                    0.0,
+                    duration: const Duration(milliseconds: 150),
+                    curve: Curves.easeOut,
+                  );
+                }
+              },
+              onChanged: (val) async {
+                if (val) {
+                  await _prefs.set(UserPreferences.audioSortOption, 'name');
+                  setState(() {});
+                  widget.onChanged();
+                }
+              },
+            ),
+            _DialogCheckboxTile(
+              label: 'Release Year',
+              checked: sortOpt == 'release_year',
+              isRadio: true,
+              onChanged: (val) async {
+                if (val) {
+                  await _prefs.set(UserPreferences.audioSortOption, 'release_year');
+                  setState(() {});
+                  widget.onChanged();
+                }
+              },
+            ),
+            _DialogCheckboxTile(
+              label: 'Date Added to Library',
+              checked: sortOpt == 'date_added',
+              isRadio: true,
+              onChanged: (val) async {
+                if (val) {
+                  await _prefs.set(UserPreferences.audioSortOption, 'date_added');
+                  setState(() {});
+                  widget.onChanged();
+                }
+              },
+            ),
+            Divider(color: dividerColor),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+              child: Text(
+                'Row Visibility',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: accent,
+                ),
+              ),
+            ),
+            _DialogCheckboxTile(
+              label: l10n.latestLibraryName(widget.libraryName),
+              checked: showLatest,
+              onChanged: (val) async {
+                await _prefs.set(UserPreferences.displayAudioLatest, val);
+                setState(() {});
+                widget.onChanged();
+              },
+            ),
+            _DialogCheckboxTile(
+              label: l10n.lastPlayed,
+              checked: showLastPlayed,
+              onChanged: (val) async {
+                await _prefs.set(UserPreferences.displayAudioLastPlayed, val);
+                setState(() {});
+                widget.onChanged();
+              },
+            ),
+            _DialogCheckboxTile(
+              label: l10n.favorites,
+              checked: showFavorites,
+              onChanged: (val) async {
+                await _prefs.set(UserPreferences.displayAudioFavorites, val);
+                setState(() {});
+                widget.onChanged();
+              },
+            ),
+            _DialogCheckboxTile(
+              label: l10n.playlists,
+              checked: showPlaylists,
+              onChanged: (val) async {
+                await _prefs.set(UserPreferences.displayAudioPlaylists, val);
+                setState(() {});
+                widget.onChanged();
+              },
+            ),
+            _DialogCheckboxTile(
+              label: l10n.albumArtists,
+              checked: showAlbumArtists,
+              onChanged: (val) async {
+                await _prefs.set(UserPreferences.displayAudioAlbumArtists, val);
+                setState(() {});
+                widget.onChanged();
+              },
+            ),
+            _DialogCheckboxTile(
+              label: l10n.artists,
+              checked: showArtists,
+              onChanged: (val) async {
+                await _prefs.set(UserPreferences.displayAudioArtists, val);
+                setState(() {});
+                widget.onChanged();
+              },
+            ),
+            _DialogCheckboxTile(
+              label: l10n.albums,
+              checked: showAlbums,
+              onChanged: (val) async {
+                await _prefs.set(UserPreferences.displayAudioAlbums, val);
+                setState(() {});
+                widget.onChanged();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DialogCheckboxTile extends StatefulWidget {
+  final String label;
+  final bool checked;
+  final ValueChanged<bool> onChanged;
+  final bool autofocus;
+  final bool isRadio;
+  final VoidCallback? onFocused;
+
+  const _DialogCheckboxTile({
+    required this.label,
+    required this.checked,
+    required this.onChanged,
+    this.autofocus = false,
+    this.isRadio = false,
+    this.onFocused,
+  });
+
+  @override
+  State<_DialogCheckboxTile> createState() => _DialogCheckboxTileState();
+}
+
+class _DialogCheckboxTileState extends State<_DialogCheckboxTile> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final onSurface = AppColorScheme.onSurface;
+    final accent = AppColorScheme.accent;
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+
+    return Focus(
+      autofocus: widget.autofocus,
+      onFocusChange: (f) {
+        setState(() => _focused = f);
+        if (f && widget.onFocused != null) {
+          widget.onFocused!();
+        }
+      },
+      onKeyEvent: (node, event) {
+        if (isActivateKey(event)) {
+          widget.onChanged(!widget.checked);
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: () => widget.onChanged(!widget.checked),
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: _focused ? onSurface.withAlpha(36) : Colors.transparent,
+            borderRadius: BorderRadius.circular(8),
+            border: _focused
+                ? Border.fromBorderSide(
+                    ThemeRegistry.active.borders.focusBorder.copyWith(
+                      color: focusColor,
+                      width: 1.8,
+                    ),
+                  )
+                : null,
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 20,
+                height: 20,
+                decoration: BoxDecoration(
+                  shape: widget.isRadio ? BoxShape.circle : BoxShape.rectangle,
+                  borderRadius: widget.isRadio ? null : BorderRadius.circular(4),
+                  border: Border.fromBorderSide(
+                    ThemeRegistry.active.borders.chipBorder.copyWith(
+                      color: widget.checked ? accent : onSurface.withAlpha(128),
+                      width: 2,
+                    ),
+                  ),
+                  color: widget.checked ? accent : Colors.transparent,
+                ),
+                child: widget.checked
+                    ? Center(
+                        child: widget.isRadio
+                            ? Container(
+                                width: 8,
+                                height: 8,
+                                decoration: const BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: Colors.black,
+                                ),
+                              )
+                            : const Icon(
+                                Icons.check,
+                                size: 14,
+                                color: Colors.black,
+                              ),
+                      )
+                    : null,
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Text(
+                  widget.label,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: _focused ? FontWeight.w600 : FontWeight.normal,
+                    color: widget.checked ? onSurface : onSurface.withAlpha(179),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
# Pull Request

## Summary
This is the first of 3 PRs related to the Music library, and the most substantial. This one pertains to the Music UI when accessed as a library. This includes multi-option sorting (Name, Release Year, Date Added) and row visibility toggles in the Sort & Filter dialog, auto-focus and auto-scroll adjustments for list headers, dynamically displaying localized titles for subpages, paging horizontal rows, and resolving a music genres loading/filtering bug.

PR2 will address playback queuing and PR3 will address home screen visibility for music content.

## Related Issues
Discord feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Sort & Filter dialog**: Added radio options for Name, Release Year, and Date Added to Library, and visibility toggles for rows. Configured the Name checkbox to receive focus on mount and dynamically scroll the list view to `0.0` when focused, keeping the "Sort & Filter" and "Sort By" headers in view.
- **Subpage titles override**: Configured `LibraryBrowseScreen` and `LibraryGenresScreen` to dynamically display the localized subpage names ("Albums", "Album Artists", "Artists", "Genres") instead of the generic library name ("Audio").
- **Music genres empty/loading fix**: Bypassed initial child count checks for music genres during `/Genres` fetching (since Emby/Jellyfin returns null/0). In `_loadGenreArtwork`, if the queried results for a music genre are empty, the genre is dynamically removed to filter out empty items.
- **Pagination & Casing Fixes**: Added horizontal paging to `MusicBrowseScreen` rows (allows for same scrolling behaviour as on the main page), and fixed a server type casing serialization bug for `MusicArtist` and `MusicAlbum`.
- **DRY Refactoring**: Extracted duplicated sorting logic inside `RowDataSource` and `MusicBrowseViewModel` into private helper functions (`_resolveAudioSort` and `_resolveSort`).

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the Music Library (Audio).
2. Press the Filter button. Verify that the "Name" option is focused on open, and scrolling down/back up scrolls the headers ("Sort & Filter" / "Sort By") cleanly back into view. Verify that switching sorting re-orders items correctly.
3. Open any subpage (Albums, Album Artists, Artists, Genres). Verify that the header title at the top displays the specific subpage name.
4. On the Genres page, verify that the list of genres is populated and that empty genres (like "Ska" containing 0 tracks) are filtered out and do not appear.

## Screenshots (if applicable)

<img width="600" alt="Shield_Screenshot_2026-06-17_10-20-00" src="https://github.com/user-attachments/assets/336e3f36-96e1-437d-9b43-c17a23d2a123" />
<img width="600" alt="Shield_Screenshot_2026-06-17_10-20-15" src="https://github.com/user-attachments/assets/3771235c-a92d-4d41-9636-58f1c1e8afe1" />
<img width="600" alt="Shield_Screenshot_2026-06-17_10-20-25" src="https://github.com/user-attachments/assets/0bfa4a3e-b00a-4210-bcd6-2322fa4b2649" />
<img width="600" alt="Shield_Screenshot_2026-06-17_10-20-53" src="https://github.com/user-attachments/assets/82191386-1d5e-4235-8b08-fb0619aad6bb" />
<img width="600" alt="Shield_Screenshot_2026-06-17_10-21-06" src="https://github.com/user-attachments/assets/4c8ad828-ce96-46da-86ec-46ba067c1f8e" />
<img width="600" alt="Shield_Screenshot_2026-06-17_10-22-46" src="https://github.com/user-attachments/assets/bce9b32d-47fc-40fc-b448-e715b592eac2" />
<img width="600" alt="Shield_Screenshot_2026-06-17_10-38-59" src="https://github.com/user-attachments/assets/38ab32c3-5db4-47db-b0c0-6368744ee7ff" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
