### PR TITLE
feat(audio): support logical queue loading

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6327,7 +6327,17 @@ class _ActionButtonsState extends State<_ActionButtons> {
               }
               throw PlaybackStartupRecoveryAbortedException();
             }
-            await manager.playItems(tracks);
+            if (!context.mounted) return;
+            // Playlists can contain video, so honor the Dolby Vision
+            // force-transcode check before allowing direct play/stream.
+            final dvForceTranscode =
+                await _shouldForceTranscodeForDolbyVision(context, tracks);
+            final directAllowed = !dvForceTranscode && !forceTranscode;
+            await manager.playItems(
+              tracks,
+              enableDirectPlay: directAllowed,
+              enableDirectStream: directAllowed,
+            );
             break;
 
           case 'AudioBook':

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6268,10 +6268,82 @@ class _ActionButtonsState extends State<_ActionButtons> {
             );
             break;
 
-          case 'MusicAlbum':
-            final tracks = viewModel.tracks;
-            if (tracks.isEmpty) return;
+          case 'MusicArtist':
+            final client = _clientForItem(item);
+            final data = await client.itemsApi.getItems(
+              artistIds: [item.id],
+              includeItemTypes: const ['Audio'],
+              sortBy: 'Album,ParentIndexNumber,IndexNumber,SortName',
+              recursive: true,
+              fields: 'PrimaryImageAspectRatio,BasicSyncInfo',
+            );
+            final tracks = _mapRawItemsForServer(data['Items'], item.serverId);
+            if (tracks.isEmpty) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(AppLocalizations.of(context).noItemsFound)),
+                );
+              }
+              throw PlaybackStartupRecoveryAbortedException();
+            }
             await manager.playItems(tracks);
+            break;
+
+          case 'MusicAlbum':
+            var tracks = viewModel.tracks;
+            if (tracks.isEmpty) {
+              final client = _clientForItem(item);
+              final data = await client.itemsApi.getItems(
+                parentId: item.id,
+                includeItemTypes: const ['Audio'],
+                sortBy: 'ParentIndexNumber,IndexNumber,SortName',
+                fields: 'PrimaryImageAspectRatio,BasicSyncInfo',
+              );
+              tracks = _mapRawItemsForServer(data['Items'], item.serverId);
+            }
+            if (tracks.isEmpty) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(AppLocalizations.of(context).noItemsFound)),
+                );
+              }
+              throw PlaybackStartupRecoveryAbortedException();
+            }
+            await manager.playItems(tracks);
+            break;
+
+          case 'Playlist':
+            var tracks = viewModel.tracks;
+            if (tracks.isEmpty) {
+              final client = _clientForItem(item);
+              final data = await client.itemsApi.getPlaylistItems(item.id);
+              tracks = _mapRawItemsForServer(data['Items'], item.serverId);
+            }
+            if (tracks.isEmpty) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(AppLocalizations.of(context).noItemsFound)),
+                );
+              }
+              throw PlaybackStartupRecoveryAbortedException();
+            }
+            await manager.playItems(tracks);
+            break;
+
+          case 'AudioBook':
+            final client = _clientForItem(item);
+            final data = await client.itemsApi.getItems(
+              parentId: item.id,
+              includeItemTypes: const ['Audio', 'AudioBook'],
+              sortBy: 'ParentIndexNumber,IndexNumber,SortName',
+              fields: 'PrimaryImageAspectRatio,BasicSyncInfo',
+            );
+            final tracks = _mapRawItemsForServer(data['Items'], item.serverId);
+            if (tracks.isEmpty) {
+              continue defaultCase;
+            }
+            await manager.playItems(tracks);
+            break;
 
           defaultCase:
           default:

--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -349,7 +349,8 @@ class _SearchScreenState extends State<SearchScreen> {
         key == LogicalKeyboardKey.mediaPlay ||
         key == LogicalKeyboardKey.mediaPlayPause) {
       if (event is KeyDownEvent) {
-        if (rowIndex < _vm.results.length) {
+        if (rowIndex < _vm.results.length &&
+            itemIndex < _vm.results[rowIndex].items.length) {
           final group = _vm.results[rowIndex];
           final item = group.items[itemIndex];
           context.push(

--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -345,6 +345,25 @@ class _SearchScreenState extends State<SearchScreen> {
 
     final key = event.logicalKey;
 
+    if (key == LogicalKeyboardKey.play ||
+        key == LogicalKeyboardKey.mediaPlay ||
+        key == LogicalKeyboardKey.mediaPlayPause) {
+      if (event is KeyDownEvent) {
+        if (rowIndex < _vm.results.length) {
+          final group = _vm.results[rowIndex];
+          final item = group.items[itemIndex];
+          context.push(
+            Destinations.item(
+              item.id,
+              serverId: item.serverId,
+              autoPlay: true,
+            ),
+          );
+        }
+      }
+      return KeyEventResult.handled;
+    }
+
     if (key.isLeftKey && itemIndex <= 0) {
       if (event is KeyDownEvent) {
         return _tryFocusSidebar()


### PR DESCRIPTION
# Pull Request

## Summary
Implements logical queue loading (discography, album, playlist, audiobook) on playback start-up and enables the play button to also access appropriate subpage.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #563 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `_playInternal` in `item_detail_screen.dart` to query the media server and resolve full queues dynamically for:
  - **MusicArtist**: Fetches all tracks recursively (entire discography).
  - **MusicAlbum**: Fallback fetches all album tracks if not cached in the view model.
  - **Playlist**: Fallback fetches all playlist items if not cached in the view model.
  - **AudioBook**: Fetches all child audio parts recursively.
- Modified `_onResultCardKeyEvent` in `search_screen.dart` to intercept TV remote Play keys (`LogicalKeyboardKey.play`, `mediaPlay`, `mediaPlayPause`) on focused cards and navigate to them.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to search screen, search for an Artist or Album, focus the result card, and press the **Play** button on the remote control. Verify it loads into the appropriate details page.
2. Open Artist and Album detail pages and tap **Play**. Verify that the play queue contains the entire artist discography or album tracks as expected regardless of entry point.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
