### PR TITLE
feat(ui/settings): allow D-pad focus on empty home sections

### DIFF
--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1432,7 +1432,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         return _HomeSectionTile(
           key: ValueKey(section.stableId),
           focusNode: _focusNodes[sectionIndex],
-          autofocus: visibleIndex == 0 && !isEmpty,
+          autofocus: visibleIndex == 0,
           label: _labelFor(section, l10n),
           subtitle: section.isPluginDynamic
               ? _pluginSubtitle(section)
@@ -1559,7 +1559,7 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
-      canRequestFocus: !widget.isEmpty,
+      canRequestFocus: true,
       onFocusChange: (f) {
         if (_focused != f && mounted) {
           setState(() => _focused = f);
@@ -1589,7 +1589,9 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
         }
         if (event.logicalKey == LogicalKeyboardKey.select ||
             event.logicalKey == LogicalKeyboardKey.enter) {
-          widget.onToggle(!widget.enabled);
+          if (!widget.isEmpty) {
+            widget.onToggle(!widget.enabled);
+          }
           return KeyEventResult.handled;
         }
         return KeyEventResult.ignored;


### PR DESCRIPTION
# Pull Request

## Summary
Allows empty Home Sections rows to receive D-pad focus on TV devices while preventing the D-pad select/enter click action from toggling them. This keeps navigation smooth and continuous across libraries with many empty rows and allows users to see what rows *could* be available if they had content for them, rather than jumping over them while navigating.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `_HomeSectionTile` (TV layout widget) in [home_sections_screen.dart](file:///C:/Moonfin-Core/lib/ui/screens/settings/home_sections_screen.dart) to always set `canRequestFocus: true` so empty rows can be navigated using D-pad.
- Updated `onKeyEvent` in `_HomeSectionTileState` to ignore click (select/enter) actions when the row is empty (`widget.isEmpty` is true).
- Updated `_buildTvList` to set `autofocus` on the first item regardless of whether it is empty.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Home Sections settings.
2. Attempt to use D-pad navigation on rows that are marked as empty.
3. Confirm that the cursor can smoothly focus on empty rows rather than skipping over them.
4. Verify that pressing Select or Enter on an empty row does not toggle the selection status.

## Screenshots (if applicable)
WE'RE IN THE DEADZONE NOW BOSS
<img width="600" alt="Shield_Screenshot_2026-06-17_15-50-55" src="https://github.com/user-attachments/assets/d04b585c-dcbe-49b6-8feb-30514fd57fb6" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
