### PR TITLE
Fix: Playlist page filtering and total count display

### DIFF
--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -208,6 +208,7 @@ class RowDataSource {
         playlistsOnly,
         mediaType: mediaType,
       ),
+      isAudio: mediaType == 'Audio',
     );
     return row;
   }
@@ -1036,9 +1037,7 @@ class RowDataSource {
             _parseItems(response, serverId)
                 .where((item) => item.type == 'Playlist')
                 .toList(),
-            mediaType: row.rowType == HomeRowType.audioPlaylists ||
-                    (row.items.isNotEmpty &&
-                        row.items.every(isAudioPlaylistSummary))
+            mediaType: row.rowType == HomeRowType.audioPlaylists || row.isAudio
                 ? 'Audio'
                 : null,
           )

--- a/lib/data/utils/playlist_utils.dart
+++ b/lib/data/utils/playlist_utils.dart
@@ -94,8 +94,10 @@ Future<bool> playlistHasBrowsableItems(
   }
 
   final summaryMediaType = item.rawData['MediaType'] as String?;
-  if (summaryMediaType != null) {
-    return summaryMediaType != 'Audio' && summaryMediaType != 'Unknown';
+  if (summaryMediaType != null &&
+      summaryMediaType != 'Audio' &&
+      summaryMediaType != 'Unknown') {
+    return true;
   }
 
   try {
@@ -107,6 +109,9 @@ Future<bool> playlistHasBrowsableItems(
     }
     return rawItems.any((raw) => !playlistItemMatchesMediaType(raw, 'Audio'));
   } catch (_) {
+    if (summaryMediaType != null) {
+      return summaryMediaType != 'Audio' && summaryMediaType != 'Unknown';
+    }
     return isPlaylistNonEmpty(
       item,
       assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -36,6 +36,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   int _totalCount = 0;
   int get totalCount => _totalCount;
 
+  int _filteredOutCount = 0;
+
   bool _totalCountKnown = true;
   bool _hasMoreFromPageSize = false;
 
@@ -191,6 +193,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     _state = LibraryBrowseState.loading;
     _items = const [];
     _totalCount = 0;
+    _filteredOutCount = 0;
     _totalCountKnown = true;
     _hasMoreFromPageSize = false;
     _tmdbIdByItemId.clear();
@@ -410,17 +413,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     }
 
     final rawItems = (response['Items'] as List?) ?? [];
-    final totalFromServer = response['TotalRecordCount'] as int?;
-    _totalCountKnown = totalFromServer != null;
-    if (_totalCountKnown) {
-      _totalCount = totalFromServer!;
-      _hasMoreFromPageSize = _items.length + rawItems.length < _totalCount;
-    } else {
-      _hasMoreFromPageSize = rawItems.length == pageSize;
-      final loadedCount = startIndex + rawItems.length;
-      _totalCount = loadedCount + (_hasMoreFromPageSize ? 1 : 0);
-    }
-
     final mapped = rawItems
         .whereType<Map>()
         .map((raw) => raw.cast<String, dynamic>())
@@ -437,6 +429,22 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         .toList();
 
     final filtered = await _filterLibraryItems(mapped);
+
+    if (isPlaylistBrowse) {
+      final filteredOutInBatch = mapped.length - filtered.length;
+      _filteredOutCount += filteredOutInBatch;
+    }
+
+    final totalFromServer = response['TotalRecordCount'] as int?;
+    _totalCountKnown = totalFromServer != null;
+    if (_totalCountKnown) {
+      _totalCount = totalFromServer! - _filteredOutCount;
+      _hasMoreFromPageSize = _items.length + filtered.length < _totalCount;
+    } else {
+      _hasMoreFromPageSize = rawItems.length == pageSize;
+      final loadedCount = startIndex + filtered.length;
+      _totalCount = loadedCount + (_hasMoreFromPageSize ? 1 : 0);
+    }
 
     if (startIndex == 0) {
       _items = filtered;


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves an issue where manually curated video playlists (which can be mislabelled as `'Audio'` under Jellyfin) are filtered out from the main Playlists page. It also fixes the total items count displayed at the top of the Playlists page.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `playlistHasBrowsableItems` in `lib/data/utils/playlist_utils.dart` to check the items of a playlist when its `summaryMediaType` is `'Audio'`, `'Unknown'`, or `null`. If any item is a video content item (not `'Audio'`), the playlist is considered browsable and included.
- Updated `loadPlaylists` in `lib/data/services/row_data_source.dart` to set `isAudio: mediaType == 'Audio'` on the returned `HomeRow`.
- Replaced the heuristic check in `loadMore` of `RowDataSource` with a check against `row.isAudio`.
- Updated `LibraryBrowseViewModel` in `lib/data/viewmodels/library_browse_view_model.dart` to dynamically subtract client-side filtered-out playlists from `totalCount`, ensuring the header shows the correct number of valid playlists.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Create a manual playlist containing movies in Jellyfin (which might be mislabelled as 'Audio').
2. Launch the client and navigate to the Playlists browse page.
3. Verify that the manually curated video playlist appears on the screen.
4. Verify that the count header at the top of the page displays the correct number of valid playlists rendered on the screen.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="400" alt="2026-06-17_20-59-24_moonfin" src="https://github.com/user-attachments/assets/1030fe4e-ca62-442b-89fe-00ca09ae45ce" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
