### PR TITLE
fix: show delay/offset controls only for MPV/MediaKit backend

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -5912,10 +5912,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         options: options,
         selectedIndex: selectedIndex,
         useRootNavigator: false,
-        // Delay controls are only wired for the Media3 backend (Android).
-        // On other platforms the backend no-ops setAudioDelay/setSubtitleDelay,
-        // so the footer is hidden to avoid a confusing unresponsive control.
-        footer: _activeMedia3Backend != null
+        // Delay controls are only wired for the MPV/MediaKit backend.
+        // ExoPlayer (Media3) backend does not play/sync nicely with offsets,
+        // so the footer is hidden on other backends to avoid a confusing unresponsive control.
+        footer: _activeMediaKitBackend != null
             ? _DelayFooter(
                 initialDelay: audio ? _audioDelay : _subtitleDelay,
                 label: audio ? l10n.audioDelay : l10n.subtitleDelay,


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes the visibility logic of the Audio and Subtitle offset (delay) controls in the OSD player. Previously, the delay controls were shown when using the ExoPlayer (Media3) backend, which has known issues with offset synchronization, and hidden when using the MPV (MediaKit) backend, which implements offsets correctly. We swap this check to only show the offset controls when using the MPV (MediaKit) playback backend.

## Related Issues
Discord mentioned issue

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Swapped the OSD track selector dialog's footer check from `_activeMedia3Backend` to `_activeMediaKitBackend` in `video_player_screen.dart`.
- Updated comments in `video_player_screen.dart` to clarify that delay controls are only displayed for the MPV/MediaKit backend.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video using the MPV playback engine.
2. Open the audio or subtitle track selection panel from the player OSD.
3. Confirm that the delay adjustment footer appears at the bottom.
4. Play a video using the default ExoPlayer playback engine.
5. Open the audio or subtitle track selection panel from the player OSD.
6. Confirm that the delay adjustment footer does not appear.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

EXO:
<img width="500" alt="Shield_Screenshot_2026-06-18_07-56-53" src="https://github.com/user-attachments/assets/e776402f-5fff-485e-a12f-60892e8b27c5" />
<img width="500" alt="Shield_Screenshot_2026-06-18_07-57-05" src="https://github.com/user-attachments/assets/8b75065b-713b-4186-ba13-f7ea1f231cd3" />

MPK:
<img width="500" alt="Shield_Screenshot_2026-06-18_07-58-38" src="https://github.com/user-attachments/assets/42d652b8-9958-4a5a-ac12-79cdc238e06d" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
