### PR TITLE
feat(settings): Pretty up the Integrations

### DIFF
--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1193,13 +1193,20 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
             children: [
               _TvSettingsListTile(
                 autofocus: true,
-                leading: const Icon(Icons.extension),
+                leading: Image.asset(
+                  'assets/icons/moonfin.png',
+                  width: 24,
+                  height: 24,
+                ),
                 title: Text(l10n.pluginLabel),
                 subtitle: Text(l10n.serverSyncAndPluginStatus),
                 onTap: () => context.pushSettingsScreen(const _PluginScreen()),
               ),
               _TvSettingsListTile(
-                leading: const Icon(Icons.star),
+                leading: const Icon(
+                  Icons.star,
+                  color: Color(0xFFFFC107),
+                ),
                 title: Text(l10n.settingsMetadataAndRatings),
                 subtitle: Text(l10n.mdbListTmdbRatingSources),
                 onTap: () =>

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1195,8 +1195,8 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
                 autofocus: true,
                 leading: Image.asset(
                   'assets/icons/moonfin.png',
-                  width: 24,
-                  height: 24,
+                  width: 30,
+                  height: 30,
                 ),
                 title: Text(l10n.pluginLabel),
                 subtitle: Text(l10n.serverSyncAndPluginStatus),


### PR DESCRIPTION
# Pull Request Template

## Summary
Update the Integrations settings screen UI to use the Moonfin logo asset for the Moonbase Plugin row and a yellow/amber colored star icon for the Metadata & Ratings row.

## Related Issues
None

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Swapped `const Icon(Icons.extension)` with `Image.asset('assets/icons/moonfin.png')` for the Moonbase Plugin settings tile leading widget.
- Added `color: Color(0xFFFFC107)` (amber) to `const Icon(Icons.star)` for the Metadata & Ratings settings tile leading widget.

## Platform
- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Tested using static analysis validation.
- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [x] Not tested (explain why): WE ARE GOING FAST BOSS

### Test Steps
1. Navigate to Settings -> Integrations.
2. Verify the Moonbase Plugin tile displays the Moonfin logo asset.
3. Verify the Metadata & Ratings tile displays a yellow star icon.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced