### PR TITLE
Disable expanded rows by default

### DIFF
--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -517,7 +517,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final fullScreenRows = Preference(
     key: 'pref_home_rows_fullscreen',
-    defaultValue: true,
+    defaultValue: false,
   );
 
   static final desktopUiScale = EnumPreference(


### PR DESCRIPTION
# Pull Request

## Summary
People keep bitching about it without checking settings first, so we should probably just disable it by default to avoid the bullshit gh issues. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- fullScreenRows default false in user_preferences.dart
- 
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
