### PR TITLE
UI adjustments & video_player new features

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7230,7 +7230,7 @@
   "alwaysOn": "Always on.",
   "replaceSkipOutroWithNextUpDisplay": "Replace Skip Outro with Next Up Display",
   "replaceSkipOutroWithNextUpDisplaySubtitle": "Show the Next Up overlay instead of the Skip Outro button.",
-  "nextUpIgnoreRemainingContentDisplay": "Play Next (Ignore Remaining Content After Outro)",
+  "nextUpIgnoreRemainingContentDisplay": "Next Up Forced (Ignore Remaining Content After Outro)",
   "nextUpIgnoreRemainingContentDisplaySubtitle": "Trigger Next Up pop-up even if there's remaining content after outro.",
   "playerRouting": "Player Routing",
   "preferSoftwareDecoders": "Prefer software decoders",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7230,6 +7230,8 @@
   "alwaysOn": "Always on.",
   "replaceSkipOutroWithNextUpDisplay": "Replace Skip Outro with Next Up Display",
   "replaceSkipOutroWithNextUpDisplaySubtitle": "Show the Next Up overlay instead of the Skip Outro button.",
+  "nextUpIgnoreRemainingContentDisplay": "Play Next (Ignore Remaining Content After Outro)",
+  "nextUpIgnoreRemainingContentDisplaySubtitle": "Trigger Next Up pop-up even if there's remaining content after outro.",
   "playerRouting": "Player Routing",
   "preferSoftwareDecoders": "Prefer software decoders",
   "preferSoftwareDecodersSubtitle": "Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11494,6 +11494,18 @@ abstract class AppLocalizations {
   /// **'No Jellyfin servers reporting the plugin yet.'**
   String get homeScreenSectionsIntegrationNoServers;
 
+  /// No description provided for @kefinTweaksIntegrationDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Detect rows configured via ranaldsgift\'s \"KefinTweaks\" plugin. Custom sections, recently released, watch again, seasonal, and recently added in library are mirrored from the KefinTweaks configuration on each Jellyfin server.'**
+  String get kefinTweaksIntegrationDescription;
+
+  /// No description provided for @kefinTweaksIntegrationNoServers.
+  ///
+  /// In en, this message translates to:
+  /// **'No Jellyfin servers reporting KefinTweaks yet.'**
+  String get kefinTweaksIntegrationNoServers;
+
   /// No description provided for @integrationOpenHomeSections.
   ///
   /// In en, this message translates to:
@@ -13216,66 +13228,6 @@ abstract class AppLocalizations {
   /// **'Remove \"{themeName}\" from this device cache?'**
   String savedThemesDeleteDialogMessage(String themeName);
 
-  /// No description provided for @themeStore.
-  ///
-  /// In en, this message translates to:
-  /// **'Theme Store'**
-  String get themeStore;
-
-  /// No description provided for @themeStoreSubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Browse and save community themes'**
-  String get themeStoreSubtitle;
-
-  /// No description provided for @themeStoreDescription.
-  ///
-  /// In en, this message translates to:
-  /// **'Save a theme to use it like your other saved themes.'**
-  String get themeStoreDescription;
-
-  /// No description provided for @themeStoreEmpty.
-  ///
-  /// In en, this message translates to:
-  /// **'No themes are available right now.'**
-  String get themeStoreEmpty;
-
-  /// No description provided for @themeStoreLoadFailed.
-  ///
-  /// In en, this message translates to:
-  /// **'Couldn\'t load the Theme Store. Check your connection and try again.'**
-  String get themeStoreLoadFailed;
-
-  /// No description provided for @themeStoreSave.
-  ///
-  /// In en, this message translates to:
-  /// **'Save'**
-  String get themeStoreSave;
-
-  /// No description provided for @themeStoreSaveAndApply.
-  ///
-  /// In en, this message translates to:
-  /// **'Save & apply'**
-  String get themeStoreSaveAndApply;
-
-  /// No description provided for @themeStoreSaved.
-  ///
-  /// In en, this message translates to:
-  /// **'Saved'**
-  String get themeStoreSaved;
-
-  /// No description provided for @themeStoreInvalidMessage.
-  ///
-  /// In en, this message translates to:
-  /// **'This theme couldn\'t be loaded.'**
-  String get themeStoreInvalidMessage;
-
-  /// Status message shown after saving a Theme Store theme
-  ///
-  /// In en, this message translates to:
-  /// **'Saved \"{themeName}\".'**
-  String themeStoreSavedMessage(String themeName);
-
   /// Status message shown after deleting a saved custom theme
   ///
   /// In en, this message translates to:
@@ -13323,6 +13275,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Manage downloaded plugin themes on this device'**
   String get savedThemesManageSubtitle;
+
+  /// No description provided for @kefinTweaksTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'KefinTweaks'**
+  String get kefinTweaksTitle;
 
   /// No description provided for @homeScreenSectionsTitle.
   ///
@@ -13521,36 +13479,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sort Playlist rows by date added, release date, alphabetically, and more.'**
   String get playlistsRowSortingDescription;
-
-  /// No description provided for @displayAudioRows.
-  ///
-  /// In en, this message translates to:
-  /// **'Display Audio Rows'**
-  String get displayAudioRows;
-
-  /// No description provided for @displayAudioRowsSubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Show Audio rows in Home Sections.'**
-  String get displayAudioRowsSubtitle;
-
-  /// No description provided for @audioRowsSorting.
-  ///
-  /// In en, this message translates to:
-  /// **'Audio Rows sorting'**
-  String get audioRowsSorting;
-
-  /// No description provided for @audioRowsSortingDescription.
-  ///
-  /// In en, this message translates to:
-  /// **'Sort Audio rows by date added, release date, alphabetically, and more.'**
-  String get audioRowsSortingDescription;
-
-  /// No description provided for @audioPlaylists.
-  ///
-  /// In en, this message translates to:
-  /// **'Audio Playlists'**
-  String get audioPlaylists;
 
   /// No description provided for @displaySeerrRows.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11494,18 +11494,6 @@ abstract class AppLocalizations {
   /// **'No Jellyfin servers reporting the plugin yet.'**
   String get homeScreenSectionsIntegrationNoServers;
 
-  /// No description provided for @kefinTweaksIntegrationDescription.
-  ///
-  /// In en, this message translates to:
-  /// **'Detect rows configured via ranaldsgift\'s \"KefinTweaks\" plugin. Custom sections, recently released, watch again, seasonal, and recently added in library are mirrored from the KefinTweaks configuration on each Jellyfin server.'**
-  String get kefinTweaksIntegrationDescription;
-
-  /// No description provided for @kefinTweaksIntegrationNoServers.
-  ///
-  /// In en, this message translates to:
-  /// **'No Jellyfin servers reporting KefinTweaks yet.'**
-  String get kefinTweaksIntegrationNoServers;
-
   /// No description provided for @integrationOpenHomeSections.
   ///
   /// In en, this message translates to:
@@ -13228,6 +13216,66 @@ abstract class AppLocalizations {
   /// **'Remove \"{themeName}\" from this device cache?'**
   String savedThemesDeleteDialogMessage(String themeName);
 
+  /// No description provided for @themeStore.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme Store'**
+  String get themeStore;
+
+  /// No description provided for @themeStoreSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Browse and save community themes'**
+  String get themeStoreSubtitle;
+
+  /// No description provided for @themeStoreDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Save a theme to use it like your other saved themes.'**
+  String get themeStoreDescription;
+
+  /// No description provided for @themeStoreEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No themes are available right now.'**
+  String get themeStoreEmpty;
+
+  /// No description provided for @themeStoreLoadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load the Theme Store. Check your connection and try again.'**
+  String get themeStoreLoadFailed;
+
+  /// No description provided for @themeStoreSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get themeStoreSave;
+
+  /// No description provided for @themeStoreSaveAndApply.
+  ///
+  /// In en, this message translates to:
+  /// **'Save & apply'**
+  String get themeStoreSaveAndApply;
+
+  /// No description provided for @themeStoreSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved'**
+  String get themeStoreSaved;
+
+  /// No description provided for @themeStoreInvalidMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This theme couldn\'t be loaded.'**
+  String get themeStoreInvalidMessage;
+
+  /// Status message shown after saving a Theme Store theme
+  ///
+  /// In en, this message translates to:
+  /// **'Saved \"{themeName}\".'**
+  String themeStoreSavedMessage(String themeName);
+
   /// Status message shown after deleting a saved custom theme
   ///
   /// In en, this message translates to:
@@ -13275,12 +13323,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Manage downloaded plugin themes on this device'**
   String get savedThemesManageSubtitle;
-
-  /// No description provided for @kefinTweaksTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'KefinTweaks'**
-  String get kefinTweaksTitle;
 
   /// No description provided for @homeScreenSectionsTitle.
   ///
@@ -13479,6 +13521,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sort Playlist rows by date added, release date, alphabetically, and more.'**
   String get playlistsRowSortingDescription;
+
+  /// No description provided for @displayAudioRows.
+  ///
+  /// In en, this message translates to:
+  /// **'Display Audio Rows'**
+  String get displayAudioRows;
+
+  /// No description provided for @displayAudioRowsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Audio rows in Home Sections.'**
+  String get displayAudioRowsSubtitle;
+
+  /// No description provided for @audioRowsSorting.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio Rows sorting'**
+  String get audioRowsSorting;
+
+  /// No description provided for @audioRowsSortingDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Sort Audio rows by date added, release date, alphabetically, and more.'**
+  String get audioRowsSortingDescription;
+
+  /// No description provided for @audioPlaylists.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio Playlists'**
+  String get audioPlaylists;
 
   /// No description provided for @displaySeerrRows.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13681,7 +13681,7 @@ abstract class AppLocalizations {
   /// No description provided for @nextUpIgnoreRemainingContentDisplay.
   ///
   /// In en, this message translates to:
-  /// **'Play Next (Ignore Remaining Content After Outro)'**
+  /// **'Next Up Forced (Ignore Remaining Content After Outro)'**
   String get nextUpIgnoreRemainingContentDisplay;
 
   /// No description provided for @nextUpIgnoreRemainingContentDisplaySubtitle.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13678,6 +13678,18 @@ abstract class AppLocalizations {
   /// **'Show the Next Up overlay instead of the Skip Outro button.'**
   String get replaceSkipOutroWithNextUpDisplaySubtitle;
 
+  /// No description provided for @nextUpIgnoreRemainingContentDisplay.
+  ///
+  /// In en, this message translates to:
+  /// **'Play Next (Ignore Remaining Content After Outro)'**
+  String get nextUpIgnoreRemainingContentDisplay;
+
+  /// No description provided for @nextUpIgnoreRemainingContentDisplaySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Trigger Next Up pop-up even if there\'s remaining content after outro.'**
+  String get nextUpIgnoreRemainingContentDisplaySubtitle;
+
   /// No description provided for @playerRouting.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1710,7 +1710,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Siener';
 
   @override
   String get seerrAccountType => 'Seerr Rekening Tipe';
@@ -6433,6 +6433,14 @@ class AppLocalizationsAf extends AppLocalizations {
       'Geen Jellyfin-bedieners wat die inprop nog rapporteer nie.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Bespeur rye wat gekonfigureer is via ranaldsgift se \"KefinTweaks\"-inprop. Gepasmaakte afdelings, wat onlangs vrygestel is, weer kyk, seisoenaal en onlangs in die biblioteek bygevoeg is, word weerspieël vanaf die KefinTweaks-konfigurasie op elke Jellyfin-bediener.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Geen Jellyfin-bedieners wat KefinTweaks rapporteer nie.';
+
+  @override
   String get integrationOpenHomeSections => 'Maak Tuisafdelings oop';
 
   @override
@@ -6469,7 +6477,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Sien Alles';
@@ -7428,40 +7436,6 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Het \"$themeName\" van hierdie toestel uitgevee.';
   }
@@ -7493,6 +7467,9 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Bestuur afgelaaide inprop-temas op hierdie toestel';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Tuisskerm-afdelings';
@@ -7604,22 +7581,6 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -7693,6 +7693,14 @@ class AppLocalizationsAf extends AppLocalizations {
       'Wys die Next Up-oorleg in plaas van die Skip Outro-knoppie.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Spelerroetering';
 
   @override

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -7694,7 +7694,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1710,7 +1710,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Siener';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Seerr Rekening Tipe';
@@ -6433,14 +6433,6 @@ class AppLocalizationsAf extends AppLocalizations {
       'Geen Jellyfin-bedieners wat die inprop nog rapporteer nie.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Bespeur rye wat gekonfigureer is via ranaldsgift se \"KefinTweaks\"-inprop. Gepasmaakte afdelings, wat onlangs vrygestel is, weer kyk, seisoenaal en onlangs in die biblioteek bygevoeg is, word weerspieël vanaf die KefinTweaks-konfigurasie op elke Jellyfin-bediener.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Geen Jellyfin-bedieners wat KefinTweaks rapporteer nie.';
-
-  @override
   String get integrationOpenHomeSections => 'Maak Tuisafdelings oop';
 
   @override
@@ -6477,7 +6469,7 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Sien Alles';
@@ -7436,6 +7428,40 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Het \"$themeName\" van hierdie toestel uitgevee.';
   }
@@ -7467,9 +7493,6 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Bestuur afgelaaide inprop-temas op hierdie toestel';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Tuisskerm-afdelings';
@@ -7581,6 +7604,22 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1695,7 +1695,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'سير';
 
   @override
   String get seerrAccountType => 'نوع حساب السير';
@@ -6394,6 +6394,14 @@ class AppLocalizationsAr extends AppLocalizations {
       'لا توجد خوادم Jellyfin تقوم بالإبلاغ عن المكون الإضافي حتى الآن.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'اكتشاف الصفوف التي تم تكوينها عبر البرنامج المساعد \"KefinTweaks\" الخاص بـ ranaldsgift. يتم عكس الأقسام المخصصة، التي تم إصدارها مؤخرًا، والمشاهدة مرة أخرى، والموسمية، والتي تمت إضافتها مؤخرًا في المكتبة من تكوين KefinTweaks على كل خادم Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'لا توجد خوادم Jellyfin تقوم بالإبلاغ عن KefinTweaks حتى الآن.';
+
+  @override
   String get integrationOpenHomeSections => 'فتح الأقسام الرئيسية';
 
   @override
@@ -6429,7 +6437,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'رؤية الكل';
@@ -7379,40 +7387,6 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'تم حذف \"$themeName\" من هذا الجهاز.';
   }
@@ -7443,6 +7417,9 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'إدارة سمات المكونات الإضافية التي تم تنزيلها على هذا الجهاز';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'أقسام الشاشة الرئيسية';
@@ -7554,22 +7531,6 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -7641,6 +7641,14 @@ class AppLocalizationsAr extends AppLocalizations {
       'قم بإظهار تراكب Next Up بدلاً من زر Skip Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'توجيه اللاعب';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1695,7 +1695,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'سير';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'نوع حساب السير';
@@ -6394,14 +6394,6 @@ class AppLocalizationsAr extends AppLocalizations {
       'لا توجد خوادم Jellyfin تقوم بالإبلاغ عن المكون الإضافي حتى الآن.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'اكتشاف الصفوف التي تم تكوينها عبر البرنامج المساعد \"KefinTweaks\" الخاص بـ ranaldsgift. يتم عكس الأقسام المخصصة، التي تم إصدارها مؤخرًا، والمشاهدة مرة أخرى، والموسمية، والتي تمت إضافتها مؤخرًا في المكتبة من تكوين KefinTweaks على كل خادم Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'لا توجد خوادم Jellyfin تقوم بالإبلاغ عن KefinTweaks حتى الآن.';
-
-  @override
   String get integrationOpenHomeSections => 'فتح الأقسام الرئيسية';
 
   @override
@@ -6437,7 +6429,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'رؤية الكل';
@@ -7387,6 +7379,40 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'تم حذف \"$themeName\" من هذا الجهاز.';
   }
@@ -7417,9 +7443,6 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'إدارة سمات المكونات الإضافية التي تم تنزيلها على هذا الجهاز';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'أقسام الشاشة الرئيسية';
@@ -7531,6 +7554,22 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -7642,7 +7642,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -6440,6 +6440,14 @@ class AppLocalizationsBe extends AppLocalizations {
       'Пакуль няма сервераў Jellyfin, якія паведамляюць пра плагін.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Выяўляць радкі, настроеныя з дапамогай плагіна \"KefinTweaks\" ranaldsgift. Карыстальніцкія раздзелы, нядаўна выпушчаныя, яшчэ раз, сезонныя і нядаўна дададзеныя ў бібліятэку, адлюстроўваюцца з канфігурацыі KefinTweaks на кожным серверы Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Пакуль няма сервераў Jellyfin, якія паведамляюць пра KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Адкрыйце хатнія раздзелы';
 
   @override
@@ -6475,7 +6483,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Глядзець усе';
@@ -7450,40 +7458,6 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Выдалены \"$themeName\" з гэтай прылады.';
   }
@@ -7515,6 +7489,9 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Кіруйце спампаванымі тэмамі плагінаў на гэтай прыладзе';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Раздзелы галоўнага экрана';
@@ -7627,22 +7604,6 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -6440,14 +6440,6 @@ class AppLocalizationsBe extends AppLocalizations {
       'Пакуль няма сервераў Jellyfin, якія паведамляюць пра плагін.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Выяўляць радкі, настроеныя з дапамогай плагіна \"KefinTweaks\" ranaldsgift. Карыстальніцкія раздзелы, нядаўна выпушчаныя, яшчэ раз, сезонныя і нядаўна дададзеныя ў бібліятэку, адлюстроўваюцца з канфігурацыі KefinTweaks на кожным серверы Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Пакуль няма сервераў Jellyfin, якія паведамляюць пра KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Адкрыйце хатнія раздзелы';
 
   @override
@@ -6483,7 +6475,7 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Глядзець усе';
@@ -7458,6 +7450,40 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Выдалены \"$themeName\" з гэтай прылады.';
   }
@@ -7489,9 +7515,6 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Кіруйце спампаванымі тэмамі плагінаў на гэтай прыладзе';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Раздзелы галоўнага экрана';
@@ -7604,6 +7627,22 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -7716,6 +7716,14 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказваць накладанне Next Up замест кнопкі Skip Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Маршрутызацыя гульцоў';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -7717,7 +7717,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -6482,6 +6482,14 @@ class AppLocalizationsBg extends AppLocalizations {
       'Все още няма Jellyfin сървъри, които да докладват плъгина.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Откриване на редове, конфигурирани чрез плъгина „KefinTweaks“ на ranaldsgift. Персонализирани раздели, наскоро пуснати, гледайте отново, сезонни и наскоро добавени в библиотеката се отразяват от конфигурацията на KefinTweaks на всеки Jellyfin сървър.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Все още няма Jellyfin сървъри, съобщаващи за KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Отворете началните секции';
 
   @override
@@ -6517,7 +6525,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Вижте всички';
@@ -7494,40 +7502,6 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return '„$themeName“ е изтрит от това устройство.';
   }
@@ -7558,6 +7532,9 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Управлявайте изтеглените теми на приставката на това устройство';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Секции на началния екран';
@@ -7670,22 +7647,6 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -6482,14 +6482,6 @@ class AppLocalizationsBg extends AppLocalizations {
       'Все още няма Jellyfin сървъри, които да докладват плъгина.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Откриване на редове, конфигурирани чрез плъгина „KefinTweaks“ на ranaldsgift. Персонализирани раздели, наскоро пуснати, гледайте отново, сезонни и наскоро добавени в библиотеката се отразяват от конфигурацията на KefinTweaks на всеки Jellyfin сървър.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Все още няма Jellyfin сървъри, съобщаващи за KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Отворете началните секции';
 
   @override
@@ -6525,7 +6517,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Вижте всички';
@@ -7502,6 +7494,40 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return '„$themeName“ е изтрит от това устройство.';
   }
@@ -7532,9 +7558,6 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Управлявайте изтеглените теми на приставката на това устройство';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Секции на началния екран';
@@ -7647,6 +7670,22 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7758,6 +7758,14 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на наслагването Next Up вместо бутона Skip Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Насочване на играчи';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7759,7 +7759,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1701,7 +1701,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'সেয়ার';
 
   @override
   String get seerrAccountType => 'Seerr অ্যাকাউন্টের ধরন';
@@ -6423,6 +6423,14 @@ class AppLocalizationsBn extends AppLocalizations {
       'কোন Jellyfin সার্ভার এখনো প্লাগইন রিপোর্ট করছে।';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Ranaldsgift-এর \"KefinTweaks\" প্লাগইনের মাধ্যমে কনফিগার করা সারিগুলি সনাক্ত করুন৷ কাস্টম বিভাগগুলি, সম্প্রতি প্রকাশিত, আবার দেখুন, মৌসুমী এবং সম্প্রতি লাইব্রেরিতে যোগ করা প্রতিটি Jellyfin সার্ভারে KefinTweaks কনফিগারেশন থেকে মিরর করা হয়েছে।';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'কোন Jellyfin সার্ভার এখনও কেফিনটুইক্স রিপোর্ট করছে।';
+
+  @override
   String get integrationOpenHomeSections => 'হোম বিভাগ খুলুন';
 
   @override
@@ -6458,7 +6466,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'সব দেখুন';
@@ -7416,40 +7424,6 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'এই ডিভাইস থেকে \"$themeName\" মুছে ফেলা হয়েছে।';
   }
@@ -7481,6 +7455,9 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'এই ডিভাইসে ডাউনলোড করা প্লাগইন থিম পরিচালনা করুন';
+
+  @override
+  String get kefinTweaksTitle => 'কেফিনটুইকস';
 
   @override
   String get homeScreenSectionsTitle => 'হোম স্ক্রীন বিভাগ';
@@ -7591,22 +7568,6 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -7679,6 +7679,14 @@ class AppLocalizationsBn extends AppLocalizations {
       'Skip Outro বোতামের পরিবর্তে Next Up ওভারলে দেখান।';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'প্লেয়ার রাউটিং';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1701,7 +1701,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'সেয়ার';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Seerr অ্যাকাউন্টের ধরন';
@@ -6423,14 +6423,6 @@ class AppLocalizationsBn extends AppLocalizations {
       'কোন Jellyfin সার্ভার এখনো প্লাগইন রিপোর্ট করছে।';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Ranaldsgift-এর \"KefinTweaks\" প্লাগইনের মাধ্যমে কনফিগার করা সারিগুলি সনাক্ত করুন৷ কাস্টম বিভাগগুলি, সম্প্রতি প্রকাশিত, আবার দেখুন, মৌসুমী এবং সম্প্রতি লাইব্রেরিতে যোগ করা প্রতিটি Jellyfin সার্ভারে KefinTweaks কনফিগারেশন থেকে মিরর করা হয়েছে।';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'কোন Jellyfin সার্ভার এখনও কেফিনটুইক্স রিপোর্ট করছে।';
-
-  @override
   String get integrationOpenHomeSections => 'হোম বিভাগ খুলুন';
 
   @override
@@ -6466,7 +6458,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'সব দেখুন';
@@ -7424,6 +7416,40 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'এই ডিভাইস থেকে \"$themeName\" মুছে ফেলা হয়েছে।';
   }
@@ -7455,9 +7481,6 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'এই ডিভাইসে ডাউনলোড করা প্লাগইন থিম পরিচালনা করুন';
-
-  @override
-  String get kefinTweaksTitle => 'কেফিনটুইকস';
 
   @override
   String get homeScreenSectionsTitle => 'হোম স্ক্রীন বিভাগ';
@@ -7568,6 +7591,22 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -7680,7 +7680,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -6518,6 +6518,14 @@ class AppLocalizationsCa extends AppLocalizations {
       'Encara no hi ha cap servidor Jellyfin que informi del connector.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecteu les files configurades mitjançant el connector \"KefinTweaks\" de ranaldsgift. Les seccions personalitzades, llançades recentment, tornar a veure, estacionals i afegides recentment a la biblioteca es reflecteixen des de la configuració de KefinTweaks a cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Encara no hi ha cap servidor Jellyfin que informi de KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Obriu les seccions d\'inici';
 
   @override
@@ -6553,7 +6561,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Veure-ho tot';
@@ -7532,40 +7540,6 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'S\'ha suprimit \"$themeName\" d\'aquest dispositiu.';
   }
@@ -7597,6 +7571,9 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Gestiona els temes de connectors baixats en aquest dispositiu';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Seccions de la pantalla d\'inici';
@@ -7709,22 +7686,6 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -7799,6 +7799,14 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra la superposició Next Up en lloc del botó Salta Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Encaminament del jugador';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -7800,7 +7800,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -6518,14 +6518,6 @@ class AppLocalizationsCa extends AppLocalizations {
       'Encara no hi ha cap servidor Jellyfin que informi del connector.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecteu les files configurades mitjançant el connector \"KefinTweaks\" de ranaldsgift. Les seccions personalitzades, llançades recentment, tornar a veure, estacionals i afegides recentment a la biblioteca es reflecteixen des de la configuració de KefinTweaks a cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Encara no hi ha cap servidor Jellyfin que informi de KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Obriu les seccions d\'inici';
 
   @override
@@ -6561,7 +6553,7 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Veure-ho tot';
@@ -7540,6 +7532,40 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'S\'ha suprimit \"$themeName\" d\'aquest dispositiu.';
   }
@@ -7571,9 +7597,6 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Gestiona els temes de connectors baixats en aquest dispositiu';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Seccions de la pantalla d\'inici';
@@ -7686,6 +7709,22 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1706,7 +1706,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Serr';
 
   @override
   String get seerrAccountType => 'Typ účtu Seerr';
@@ -6433,6 +6433,14 @@ class AppLocalizationsCs extends AppLocalizations {
       'Plugin zatím nehlásí žádné servery Jellyfin.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Zjistěte řádky nakonfigurované prostřednictvím pluginu „KefinTweaks“ ranaldsgift. Vlastní sekce, nedávno vydané, znovu shlédnuté, sezónní a nedávno přidané do knihovny, jsou zrcadleny z konfigurace KefinTweaks na každém serveru Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaks zatím žádné servery Jellyfin nehlásí.';
+
+  @override
   String get integrationOpenHomeSections => 'Otevřete domovské sekce';
 
   @override
@@ -6468,7 +6476,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Zobrazit vše';
@@ -7431,40 +7439,6 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Z tohoto zařízení bylo smazáno „$themeName“.';
   }
@@ -7496,6 +7470,9 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Spravujte stažená témata pluginů na tomto zařízení';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Sekce domovské obrazovky';
@@ -7608,22 +7585,6 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7698,7 +7698,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1706,7 +1706,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Serr';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Typ účtu Seerr';
@@ -6433,14 +6433,6 @@ class AppLocalizationsCs extends AppLocalizations {
       'Plugin zatím nehlásí žádné servery Jellyfin.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Zjistěte řádky nakonfigurované prostřednictvím pluginu „KefinTweaks“ ranaldsgift. Vlastní sekce, nedávno vydané, znovu shlédnuté, sezónní a nedávno přidané do knihovny, jsou zrcadleny z konfigurace KefinTweaks na každém serveru Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaks zatím žádné servery Jellyfin nehlásí.';
-
-  @override
   String get integrationOpenHomeSections => 'Otevřete domovské sekce';
 
   @override
@@ -6476,7 +6468,7 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Zobrazit vše';
@@ -7439,6 +7431,40 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Z tohoto zařízení bylo smazáno „$themeName“.';
   }
@@ -7470,9 +7496,6 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Spravujte stažená témata pluginů na tomto zařízení';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Sekce domovské obrazovky';
@@ -7585,6 +7608,22 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7697,6 +7697,14 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zobrazte překryvnou vrstvu Next Up namísto tlačítka Skip Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Směrování hráčů';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -6445,6 +6445,14 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dim gweinyddwyr Jellyfin yn adrodd am yr ategyn eto.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Canfod rhesi sydd wedi\'u ffurfweddu trwy ategyn \"KefinTweaks\" ranaldsgift. Mae adrannau personol, a ryddhawyd yn ddiweddar, gwylio eto, tymhorol, ac a ychwanegwyd yn ddiweddar yn y llyfrgell yn cael eu hadlewyrchu o gyfluniad KefinTweaks ar bob gweinydd Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Dim gweinyddwyr Jellyfin yn adrodd am KefinTweaks eto.';
+
+  @override
   String get integrationOpenHomeSections => 'Adrannau Cartref Agored';
 
   @override
@@ -6481,7 +6489,7 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Gwel Pawb';
@@ -7445,40 +7453,6 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Wedi dileu \"$themeName\" o\'r ddyfais hon.';
   }
@@ -7510,6 +7484,9 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Rheoli themâu ategyn wedi\'u lawrlwytho ar y ddyfais hon';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Adrannau Sgrin Cartref';
@@ -7622,22 +7599,6 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -7712,7 +7712,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -6445,14 +6445,6 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dim gweinyddwyr Jellyfin yn adrodd am yr ategyn eto.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Canfod rhesi sydd wedi\'u ffurfweddu trwy ategyn \"KefinTweaks\" ranaldsgift. Mae adrannau personol, a ryddhawyd yn ddiweddar, gwylio eto, tymhorol, ac a ychwanegwyd yn ddiweddar yn y llyfrgell yn cael eu hadlewyrchu o gyfluniad KefinTweaks ar bob gweinydd Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Dim gweinyddwyr Jellyfin yn adrodd am KefinTweaks eto.';
-
-  @override
   String get integrationOpenHomeSections => 'Adrannau Cartref Agored';
 
   @override
@@ -6489,7 +6481,7 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Gwel Pawb';
@@ -7453,6 +7445,40 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Wedi dileu \"$themeName\" o\'r ddyfais hon.';
   }
@@ -7484,9 +7510,6 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Rheoli themâu ategyn wedi\'u lawrlwytho ar y ddyfais hon';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Adrannau Sgrin Cartref';
@@ -7599,6 +7622,22 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -7711,6 +7711,14 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dangoswch y troshaen Next Up yn lle\'r botwm Skip Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Llwybro Chwaraewr';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -225,23 +225,23 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get exitApp => 'Afslut Moonfin?';
+  String get exitApp => 'Forlade Moonfin?';
 
   @override
   String get exitAppConfirmation => 'Er du sikker på, at du vil afslutte?';
 
   @override
-  String get exit => 'Afslut';
+  String get exit => 'Udgang';
 
   @override
-  String get noHomeRowsLoaded => 'Ingen Hjem-rækker kunne indlæses';
+  String get noHomeRowsLoaded => 'Ingen hjemmerækker kunne indlæses';
 
   @override
   String get noHomeRowsHint =>
-      'Prøv at opdatere eller reducere aktive Hjem-sektioner.';
+      'Prøv at opdatere eller reducere aktive hjemmesektioner.';
 
   @override
-  String get retryHomeRows => 'Genindlæs Hjem-rækkerne';
+  String get retryHomeRows => 'Prøv Hjem-rækkerne igen';
 
   @override
   String get guide => 'Guide';
@@ -250,13 +250,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recordings => 'Optagelser';
 
   @override
-  String get schedule => 'Planlægning';
+  String get schedule => 'Skema';
 
   @override
-  String get series => 'Serier';
+  String get series => 'Serie';
 
   @override
-  String get noItemsFound => 'Ingen elementer fundet';
+  String get noItemsFound => 'Ingen varer fundet';
 
   @override
   String get home => 'Hjem';
@@ -268,19 +268,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String get genres => 'Genrer';
 
   @override
-  String get collectionPlaceholder => 'Samlingselementer vises her';
+  String get collectionPlaceholder => 'Samlingsgenstande vises her';
 
   @override
   String get browseByLetter => 'Gennemse efter bogstav';
 
   @override
-  String get alphabeticalBrowsePlaceholder => 'Alfabetisk oversigt vises her';
+  String get alphabeticalBrowsePlaceholder => 'Alfabetisk browse vises her';
 
   @override
   String get suggestions => 'Forslag';
 
   @override
-  String get suggestionsPlaceholder => 'Foreslåede elementer vises her';
+  String get suggestionsPlaceholder => 'Foreslåede varer vises her';
 
   @override
   String get failedToLoadLibraries => 'Kunne ikke indlæse biblioteker';
@@ -327,7 +327,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count elementer';
+    return '$count Elementer';
   }
 
   @override
@@ -337,7 +337,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ended => 'Afsluttet';
 
   @override
-  String get sortAndFilter => 'Sortér og filtrér';
+  String get sortAndFilter => 'Sorter og filtrer';
 
   @override
   String get type => 'Type';
@@ -826,7 +826,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String endsAt(String time) {
-    return 'Slutter kl. $time';
+    return 'Slutter ved $time';
   }
 
   @override
@@ -876,7 +876,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cast => 'Cast';
 
   @override
-  String get trailer => 'Trailer';
+  String get trailer => 'Anhænger';
 
   @override
   String get finished => 'Færdig';
@@ -1206,10 +1206,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get stillWatching => 'Ser du stadig?';
 
   @override
-  String get unableToLoadTrailerStream => 'Kan ikke indlæse trailer.';
+  String get unableToLoadTrailerStream => 'Kan ikke indlæse trailerstream.';
 
   @override
-  String get trailerTimedOut => 'Traileren fik timeout under indlæsning.';
+  String get trailerTimedOut => 'Traileren fik timeout under lastning.';
 
   @override
   String get playbackFailedForTrailer =>
@@ -6424,6 +6424,14 @@ class AppLocalizationsDa extends AppLocalizations {
       'Ingen Jellyfin-servere rapporterer pluginnet endnu.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Registrer rækker konfigureret via ranaldsgifts \"KefinTweaks\" plugin. Brugerdefinerede sektioner, for nylig udgivet, se igen, sæsonbestemt og for nylig tilføjet i biblioteket, spejles fra KefinTweaks-konfigurationen på hver Jellyfin-server.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ingen Jellyfin-servere rapporterer KefinTweaks endnu.';
+
+  @override
   String get integrationOpenHomeSections => 'Åbn Home Sektioner';
 
   @override
@@ -6459,7 +6467,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Se alle';
@@ -7225,7 +7233,8 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsCinemaMode => 'Biograftilstand';
 
   @override
-  String get settingsCinemaModeSubtitle => 'Spil trailere før en hovedfunktion';
+  String get settingsCinemaModeSubtitle =>
+      'Spil trailere/prerolls før en hovedfunktion';
 
   @override
   String get settingsNextUpDisplayDescription =>
@@ -7420,40 +7429,6 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Slettet \"$themeName\" fra denne enhed.';
   }
@@ -7485,6 +7460,9 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Administrer downloadede plugin-temaer på denne enhed';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Sektioner på startskærmen';
@@ -7595,22 +7573,6 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -225,23 +225,23 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get exitApp => 'Forlade Moonfin?';
+  String get exitApp => 'Afslut Moonfin?';
 
   @override
   String get exitAppConfirmation => 'Er du sikker på, at du vil afslutte?';
 
   @override
-  String get exit => 'Udgang';
+  String get exit => 'Afslut';
 
   @override
-  String get noHomeRowsLoaded => 'Ingen hjemmerækker kunne indlæses';
+  String get noHomeRowsLoaded => 'Ingen Hjem-rækker kunne indlæses';
 
   @override
   String get noHomeRowsHint =>
-      'Prøv at opdatere eller reducere aktive hjemmesektioner.';
+      'Prøv at opdatere eller reducere aktive Hjem-sektioner.';
 
   @override
-  String get retryHomeRows => 'Prøv Hjem-rækkerne igen';
+  String get retryHomeRows => 'Genindlæs Hjem-rækkerne';
 
   @override
   String get guide => 'Guide';
@@ -250,13 +250,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recordings => 'Optagelser';
 
   @override
-  String get schedule => 'Skema';
+  String get schedule => 'Planlægning';
 
   @override
-  String get series => 'Serie';
+  String get series => 'Serier';
 
   @override
-  String get noItemsFound => 'Ingen varer fundet';
+  String get noItemsFound => 'Ingen elementer fundet';
 
   @override
   String get home => 'Hjem';
@@ -268,19 +268,19 @@ class AppLocalizationsDa extends AppLocalizations {
   String get genres => 'Genrer';
 
   @override
-  String get collectionPlaceholder => 'Samlingsgenstande vises her';
+  String get collectionPlaceholder => 'Samlingselementer vises her';
 
   @override
   String get browseByLetter => 'Gennemse efter bogstav';
 
   @override
-  String get alphabeticalBrowsePlaceholder => 'Alfabetisk browse vises her';
+  String get alphabeticalBrowsePlaceholder => 'Alfabetisk oversigt vises her';
 
   @override
   String get suggestions => 'Forslag';
 
   @override
-  String get suggestionsPlaceholder => 'Foreslåede varer vises her';
+  String get suggestionsPlaceholder => 'Foreslåede elementer vises her';
 
   @override
   String get failedToLoadLibraries => 'Kunne ikke indlæse biblioteker';
@@ -327,7 +327,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count Elementer';
+    return '$count elementer';
   }
 
   @override
@@ -337,7 +337,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get ended => 'Afsluttet';
 
   @override
-  String get sortAndFilter => 'Sorter og filtrer';
+  String get sortAndFilter => 'Sortér og filtrér';
 
   @override
   String get type => 'Type';
@@ -826,7 +826,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String endsAt(String time) {
-    return 'Slutter ved $time';
+    return 'Slutter kl. $time';
   }
 
   @override
@@ -876,7 +876,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get cast => 'Cast';
 
   @override
-  String get trailer => 'Anhænger';
+  String get trailer => 'Trailer';
 
   @override
   String get finished => 'Færdig';
@@ -1206,10 +1206,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get stillWatching => 'Ser du stadig?';
 
   @override
-  String get unableToLoadTrailerStream => 'Kan ikke indlæse trailerstream.';
+  String get unableToLoadTrailerStream => 'Kan ikke indlæse trailer.';
 
   @override
-  String get trailerTimedOut => 'Traileren fik timeout under lastning.';
+  String get trailerTimedOut => 'Traileren fik timeout under indlæsning.';
 
   @override
   String get playbackFailedForTrailer =>
@@ -6424,14 +6424,6 @@ class AppLocalizationsDa extends AppLocalizations {
       'Ingen Jellyfin-servere rapporterer pluginnet endnu.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Registrer rækker konfigureret via ranaldsgifts \"KefinTweaks\" plugin. Brugerdefinerede sektioner, for nylig udgivet, se igen, sæsonbestemt og for nylig tilføjet i biblioteket, spejles fra KefinTweaks-konfigurationen på hver Jellyfin-server.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ingen Jellyfin-servere rapporterer KefinTweaks endnu.';
-
-  @override
   String get integrationOpenHomeSections => 'Åbn Home Sektioner';
 
   @override
@@ -6467,7 +6459,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Se alle';
@@ -7233,8 +7225,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsCinemaMode => 'Biograftilstand';
 
   @override
-  String get settingsCinemaModeSubtitle =>
-      'Spil trailere/prerolls før en hovedfunktion';
+  String get settingsCinemaModeSubtitle => 'Spil trailere før en hovedfunktion';
 
   @override
   String get settingsNextUpDisplayDescription =>
@@ -7429,6 +7420,40 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Slettet \"$themeName\" fra denne enhed.';
   }
@@ -7460,9 +7485,6 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Administrer downloadede plugin-temaer på denne enhed';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Sektioner på startskærmen';
@@ -7573,6 +7595,22 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7683,6 +7683,14 @@ class AppLocalizationsDa extends AppLocalizations {
       'Vis Next Up-overlejringen i stedet for knappen Spring Outro over.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Spillerruting';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7684,7 +7684,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6476,6 +6476,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bisher haben keine Jellyfin-Server das Plugin gemeldet.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Erkennen Sie Zeilen, die über das „KefinTweaks“-Plugin von ranaldsgift konfiguriert wurden. Benutzerdefinierte Abschnitte, kürzlich veröffentlichte, erneut ansehen, saisonale und kürzlich zur Bibliothek hinzugefügte Abschnitte werden aus der KefinTweaks-Konfiguration auf jedem Jellyfin-Server gespiegelt.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Bisher melden keine Jellyfin-Server KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Öffnen Sie die Home-Bereiche';
 
   @override
@@ -6511,7 +6519,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Alle anzeigen';
@@ -7487,40 +7495,6 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return '„$themeName“ wurde von diesem Gerät gelöscht.';
   }
@@ -7552,6 +7526,9 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Verwalten Sie heruntergeladene Plugin-Themes auf diesem Gerät';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Abschnitte des Startbildschirms';
@@ -7664,22 +7641,6 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7752,6 +7752,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Zeigen Sie das Next Up-Overlay anstelle der Schaltfläche „Outro überspringen“ an.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Spielerrouting';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6476,14 +6476,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bisher haben keine Jellyfin-Server das Plugin gemeldet.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Erkennen Sie Zeilen, die über das „KefinTweaks“-Plugin von ranaldsgift konfiguriert wurden. Benutzerdefinierte Abschnitte, kürzlich veröffentlichte, erneut ansehen, saisonale und kürzlich zur Bibliothek hinzugefügte Abschnitte werden aus der KefinTweaks-Konfiguration auf jedem Jellyfin-Server gespiegelt.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Bisher melden keine Jellyfin-Server KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Öffnen Sie die Home-Bereiche';
 
   @override
@@ -6519,7 +6511,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Alle anzeigen';
@@ -7495,6 +7487,40 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return '„$themeName“ wurde von diesem Gerät gelöscht.';
   }
@@ -7526,9 +7552,6 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Verwalten Sie heruntergeladene Plugin-Themes auf diesem Gerät';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Abschnitte des Startbildschirms';
@@ -7641,6 +7664,22 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7753,7 +7753,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1728,7 +1728,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Seer';
 
   @override
   String get seerrAccountType => 'Τύπος λογαριασμού Seer';
@@ -6520,6 +6520,14 @@ class AppLocalizationsEl extends AppLocalizations {
       'Δεν υπάρχουν ακόμη διακομιστές Jellyfin που να αναφέρουν την προσθήκη.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Εντοπίστε σειρές που έχουν διαμορφωθεί μέσω της προσθήκης \"KefinTweaks\" του ranaldsgift. Οι προσαρμοσμένες ενότητες, που κυκλοφόρησαν πρόσφατα, παρακολουθήστε ξανά, εποχιακά και προστέθηκαν πρόσφατα στη βιβλιοθήκη αντικατοπτρίζονται από τη διαμόρφωση KefinTweaks σε κάθε διακομιστή Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Δεν υπάρχουν ακόμη διακομιστές Jellyfin που να αναφέρουν το KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Ανοίξτε τις Αρχικές Ενότητες';
 
   @override
@@ -6556,7 +6564,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Δείτε όλα';
@@ -7536,40 +7544,6 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Διαγράφηκε το \"$themeName\" από αυτήν τη συσκευή.';
   }
@@ -7601,6 +7575,9 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Διαχειριστείτε τα ληφθέντα θέματα προσθηκών σε αυτήν τη συσκευή';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Ενότητες αρχικής οθόνης';
@@ -7713,22 +7690,6 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1728,7 +1728,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seer';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Τύπος λογαριασμού Seer';
@@ -6520,14 +6520,6 @@ class AppLocalizationsEl extends AppLocalizations {
       'Δεν υπάρχουν ακόμη διακομιστές Jellyfin που να αναφέρουν την προσθήκη.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Εντοπίστε σειρές που έχουν διαμορφωθεί μέσω της προσθήκης \"KefinTweaks\" του ranaldsgift. Οι προσαρμοσμένες ενότητες, που κυκλοφόρησαν πρόσφατα, παρακολουθήστε ξανά, εποχιακά και προστέθηκαν πρόσφατα στη βιβλιοθήκη αντικατοπτρίζονται από τη διαμόρφωση KefinTweaks σε κάθε διακομιστή Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Δεν υπάρχουν ακόμη διακομιστές Jellyfin που να αναφέρουν το KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Ανοίξτε τις Αρχικές Ενότητες';
 
   @override
@@ -6564,7 +6556,7 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Δείτε όλα';
@@ -7544,6 +7536,40 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Διαγράφηκε το \"$themeName\" από αυτήν τη συσκευή.';
   }
@@ -7575,9 +7601,6 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Διαχειριστείτε τα ληφθέντα θέματα προσθηκών σε αυτήν τη συσκευή';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Ενότητες αρχικής οθόνης';
@@ -7690,6 +7713,22 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7802,6 +7802,14 @@ class AppLocalizationsEl extends AppLocalizations {
       'Εμφάνιση της επικάλυψης Next Up αντί για το κουμπί Skip Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Δρομολόγηση παίκτη';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7803,7 +7803,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6380,6 +6380,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'No Jellyfin servers reporting the plugin yet.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detect rows configured via ranaldsgift\'s \"KefinTweaks\" plugin. Custom sections, recently released, watch again, seasonal, and recently added in library are mirrored from the KefinTweaks configuration on each Jellyfin server.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'No Jellyfin servers reporting KefinTweaks yet.';
+
+  @override
   String get integrationOpenHomeSections => 'Open Home Sections';
 
   @override
@@ -7366,40 +7374,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7430,6 +7404,9 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7541,22 +7518,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -14493,6 +14454,14 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
       'No Jellyfin servers reporting the plugin yet.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detect rows configured via ranaldsgift\'s \"KefinTweaks\" plugin. Custom sections, recently released, watch again, seasonal, and recently added in library are mirrored from the KefinTweaks configuration on each Jellyfin server.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'No Jellyfin servers reporting KefinTweaks yet.';
+
+  @override
   String get integrationOpenHomeSections => 'Open Home Sections';
 
   @override
@@ -14528,7 +14497,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'See All';
@@ -15479,6 +15448,9 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7629,6 +7629,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6380,14 +6380,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'No Jellyfin servers reporting the plugin yet.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detect rows configured via ranaldsgift\'s \"KefinTweaks\" plugin. Custom sections, recently released, watch again, seasonal, and recently added in library are mirrored from the KefinTweaks configuration on each Jellyfin server.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'No Jellyfin servers reporting KefinTweaks yet.';
-
-  @override
   String get integrationOpenHomeSections => 'Open Home Sections';
 
   @override
@@ -7374,6 +7366,40 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7404,9 +7430,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7518,6 +7541,22 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -14454,14 +14493,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
       'No Jellyfin servers reporting the plugin yet.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detect rows configured via ranaldsgift\'s \"KefinTweaks\" plugin. Custom sections, recently released, watch again, seasonal, and recently added in library are mirrored from the KefinTweaks configuration on each Jellyfin server.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'No Jellyfin servers reporting KefinTweaks yet.';
-
-  @override
   String get integrationOpenHomeSections => 'Open Home Sections';
 
   @override
@@ -14497,7 +14528,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'See All';
@@ -15448,9 +15479,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7630,7 +7630,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -6414,6 +6414,14 @@ class AppLocalizationsEo extends AppLocalizations {
       'Ankoraŭ neniuj Jellyfin-serviloj raportantaj la kromaĵon.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detektu vicojn agorditajn per la kromaĵo \"KefinTweaks\" de ranaldsgift. Propraj sekcioj, lastatempe liberigitaj, rigardataj denove, laŭsezonaj, kaj lastatempe aldonitaj en biblioteko estas spegulitaj de la KefinTweaks-agordo sur ĉiu Jellyfin-servilo.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ankoraŭ neniuj Jellyfin-serviloj raportantaj KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Malfermu Hejmajn Sekciojn';
 
   @override
@@ -6449,7 +6457,7 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Vidu Ĉion';
@@ -7410,40 +7418,6 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Forigita \"$themeName\" de ĉi tiu aparato.';
   }
@@ -7475,6 +7449,9 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Administru elŝutitajn kromtemojn sur ĉi tiu aparato';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Ĉefekranaj Sekcioj';
@@ -7587,22 +7564,6 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -6414,14 +6414,6 @@ class AppLocalizationsEo extends AppLocalizations {
       'Ankoraŭ neniuj Jellyfin-serviloj raportantaj la kromaĵon.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detektu vicojn agorditajn per la kromaĵo \"KefinTweaks\" de ranaldsgift. Propraj sekcioj, lastatempe liberigitaj, rigardataj denove, laŭsezonaj, kaj lastatempe aldonitaj en biblioteko estas spegulitaj de la KefinTweaks-agordo sur ĉiu Jellyfin-servilo.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ankoraŭ neniuj Jellyfin-serviloj raportantaj KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Malfermu Hejmajn Sekciojn';
 
   @override
@@ -6457,7 +6449,7 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Vidu Ĉion';
@@ -7418,6 +7410,40 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Forigita \"$themeName\" de ĉi tiu aparato.';
   }
@@ -7449,9 +7475,6 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Administru elŝutitajn kromtemojn sur ĉi tiu aparato';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Ĉefekranaj Sekcioj';
@@ -7564,6 +7587,22 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -7675,6 +7675,14 @@ class AppLocalizationsEo extends AppLocalizations {
       'Montru la kovraĵon Sekva Supre anstataŭ la butonon Saltu Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Ludanta Vokado';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -7676,7 +7676,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1718,7 +1718,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Vidente';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -6487,6 +6487,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -6522,7 +6530,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -7496,40 +7504,6 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Se eliminó \"$themeName\" de este dispositivo.';
   }
@@ -7561,6 +7535,9 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -7673,22 +7650,6 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -10076,7 +10037,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Vidente';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -14759,6 +14720,14 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -14794,7 +14763,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -15771,6 +15740,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -18087,7 +18059,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Vidente';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -22770,6 +22742,14 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -22805,7 +22785,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -23782,6 +23762,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -26098,7 +26081,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Vidente';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -30781,6 +30764,14 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -30816,7 +30807,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -31793,6 +31784,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -34109,7 +34103,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Vidente';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -38792,6 +38786,14 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -38827,7 +38829,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -39804,6 +39806,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7762,7 +7762,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1718,7 +1718,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Vidente';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -6487,14 +6487,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -6530,7 +6522,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -7504,6 +7496,40 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Se eliminó \"$themeName\" de este dispositivo.';
   }
@@ -7535,9 +7561,6 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -7650,6 +7673,22 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -10037,7 +10076,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Vidente';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -14720,14 +14759,6 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -14763,7 +14794,7 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -15740,9 +15771,6 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -18059,7 +18087,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Vidente';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -22742,14 +22770,6 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -22785,7 +22805,7 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -23762,9 +23782,6 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -26081,7 +26098,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Vidente';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -30764,14 +30781,6 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -30807,7 +30816,7 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -31784,9 +31793,6 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';
@@ -34103,7 +34109,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
-  String get seerr => 'Vidente';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Tipo de cuenta vidente';
@@ -38786,14 +38792,6 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
       'Aún no hay servidores Jellyfin que informen sobre el complemento.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecta filas configuradas mediante el complemento \"KefinTweaks\" de ranaldsgift. Las secciones personalizadas, publicadas recientemente, ver de nuevo, de temporada y agregadas recientemente en la biblioteca se reflejan desde la configuración de KefinTweaks en cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ningún servidor Jellyfin informa sobre KefinTweaks todavía.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir secciones de inicio';
 
   @override
@@ -38829,7 +38827,7 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver todo';
@@ -39806,9 +39804,6 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   @override
   String get savedThemesManageSubtitle =>
       'Administrar temas de complementos descargados en este dispositivo';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secciones de la pantalla de inicio';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7761,6 +7761,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Muestra la superposición Siguiente en lugar del botón Omitir salida.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Enrutamiento del jugador';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1711,7 +1711,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Nägija';
 
   @override
   String get seerrAccountType => 'Nägija konto tüüp';
@@ -6436,6 +6436,14 @@ class AppLocalizationsEt extends AppLocalizations {
       'Ükski Jellyfini server pole pistikprogrammist veel teatanud.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Tuvastage read, mis on konfigureeritud ranaldsgifti pistikprogrammi \"KefinTweaks\" kaudu. Hiljuti välja antud, uuesti vaadatavad, hooajalised ja hiljuti teeki lisatud kohandatud jaotised peegelduvad iga Jellyfini serveri KefinTweaksi konfiguratsioonist.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ükski Jellyfini server ei teatanud veel KefinTweaksist.';
+
+  @override
   String get integrationOpenHomeSections => 'Avage jaotised Avaleht';
 
   @override
@@ -6471,7 +6479,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Vaata kõiki';
@@ -7435,40 +7443,6 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return '\"$themeName\" on sellest seadmest kustutatud.';
   }
@@ -7500,6 +7474,9 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Hallake selles seadmes allalaaditud pistikprogrammide teemasid';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Avakuva jaotised';
@@ -7611,22 +7588,6 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1711,7 +1711,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Nägija';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Nägija konto tüüp';
@@ -6436,14 +6436,6 @@ class AppLocalizationsEt extends AppLocalizations {
       'Ükski Jellyfini server pole pistikprogrammist veel teatanud.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Tuvastage read, mis on konfigureeritud ranaldsgifti pistikprogrammi \"KefinTweaks\" kaudu. Hiljuti välja antud, uuesti vaadatavad, hooajalised ja hiljuti teeki lisatud kohandatud jaotised peegelduvad iga Jellyfini serveri KefinTweaksi konfiguratsioonist.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ükski Jellyfini server ei teatanud veel KefinTweaksist.';
-
-  @override
   String get integrationOpenHomeSections => 'Avage jaotised Avaleht';
 
   @override
@@ -6479,7 +6471,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Vaata kõiki';
@@ -7443,6 +7435,40 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return '\"$themeName\" on sellest seadmest kustutatud.';
   }
@@ -7474,9 +7500,6 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Hallake selles seadmes allalaaditud pistikprogrammide teemasid';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Avakuva jaotised';
@@ -7588,6 +7611,22 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7700,7 +7700,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7699,6 +7699,14 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kuvage ülekate Next Up (Järgmine üles) nupu Skip Outro asemel.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Mängija marsruutimine';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1697,7 +1697,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'بیننده';
 
   @override
   String get seerrAccountType => 'نوع حساب Serr';
@@ -6395,6 +6395,14 @@ class AppLocalizationsFa extends AppLocalizations {
       'هنوز هیچ سرور Jellyfin این افزونه را گزارش نکرده است.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ردیف های پیکربندی شده از طریق پلاگین \"KefinTweaks\" ranaldsgift را شناسایی کنید. بخش‌های سفارشی، اخیراً منتشر شده، تماشای مجدد، فصلی و اخیراً اضافه شده در کتابخانه از پیکربندی KefinTweaks در هر سرور Jellyfin منعکس شده‌اند.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'هنوز هیچ سرور Jellyfin KefinTweaks را گزارش نکرده است.';
+
+  @override
   String get integrationOpenHomeSections => 'بخش های صفحه اصلی را باز کنید';
 
   @override
@@ -6430,7 +6438,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'مشاهده همه';
@@ -7383,40 +7391,6 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return '\"$themeName\" از این دستگاه حذف شد.';
   }
@@ -7447,6 +7421,9 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'مضامین بارگیری شده افزونه را در این دستگاه مدیریت کنید';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'بخش های صفحه اصلی';
@@ -7559,22 +7536,6 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1697,7 +1697,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'بیننده';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'نوع حساب Serr';
@@ -6395,14 +6395,6 @@ class AppLocalizationsFa extends AppLocalizations {
       'هنوز هیچ سرور Jellyfin این افزونه را گزارش نکرده است.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ردیف های پیکربندی شده از طریق پلاگین \"KefinTweaks\" ranaldsgift را شناسایی کنید. بخش‌های سفارشی، اخیراً منتشر شده، تماشای مجدد، فصلی و اخیراً اضافه شده در کتابخانه از پیکربندی KefinTweaks در هر سرور Jellyfin منعکس شده‌اند.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'هنوز هیچ سرور Jellyfin KefinTweaks را گزارش نکرده است.';
-
-  @override
   String get integrationOpenHomeSections => 'بخش های صفحه اصلی را باز کنید';
 
   @override
@@ -6438,7 +6430,7 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'مشاهده همه';
@@ -7391,6 +7383,40 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return '\"$themeName\" از این دستگاه حذف شد.';
   }
@@ -7421,9 +7447,6 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'مضامین بارگیری شده افزونه را در این دستگاه مدیریت کنید';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'بخش های صفحه اصلی';
@@ -7536,6 +7559,22 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -7648,6 +7648,14 @@ class AppLocalizationsFa extends AppLocalizations {
       'به جای دکمه Skip Outro، روکش Next Up را نشان دهید.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'مسیریابی بازیکن';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -7649,7 +7649,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1712,7 +1712,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Näkijä';
 
   @override
   String get seerrAccountType => 'Näkijätilin tyyppi';
@@ -6451,6 +6451,14 @@ class AppLocalizationsFi extends AppLocalizations {
       'Yksikään Jellyfin-palvelin ei ole vielä ilmoittanut laajennuksesta.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Tunnista ranaldsgiftin KefinTweaks-laajennuksen kautta määritetyt rivit. Äskettäin julkaistut mukautetut osiot, katso uudelleen, kausiluonteiset ja äskettäin kirjastoon lisätyt osiot peilataan jokaisen Jellyfin-palvelimen KefinTweaks-kokoonpanosta.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Yksikään Jellyfin-palvelin ei raportoi vielä KefinTweaksista.';
+
+  @override
   String get integrationOpenHomeSections => 'Avaa Koti-osiot';
 
   @override
@@ -6487,7 +6495,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Katso kaikki';
@@ -7448,40 +7456,6 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return '\"$themeName\" poistettiin tältä laitteelta.';
   }
@@ -7513,6 +7487,9 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Hallinnoi ladattuja laajennusteemoja tällä laitteella';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Aloitusnäytön osiot';
@@ -7623,22 +7600,6 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1712,7 +1712,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Näkijä';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Näkijätilin tyyppi';
@@ -6451,14 +6451,6 @@ class AppLocalizationsFi extends AppLocalizations {
       'Yksikään Jellyfin-palvelin ei ole vielä ilmoittanut laajennuksesta.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Tunnista ranaldsgiftin KefinTweaks-laajennuksen kautta määritetyt rivit. Äskettäin julkaistut mukautetut osiot, katso uudelleen, kausiluonteiset ja äskettäin kirjastoon lisätyt osiot peilataan jokaisen Jellyfin-palvelimen KefinTweaks-kokoonpanosta.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Yksikään Jellyfin-palvelin ei raportoi vielä KefinTweaksista.';
-
-  @override
   String get integrationOpenHomeSections => 'Avaa Koti-osiot';
 
   @override
@@ -6495,7 +6487,7 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Katso kaikki';
@@ -7456,6 +7448,40 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return '\"$themeName\" poistettiin tältä laitteelta.';
   }
@@ -7487,9 +7513,6 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Hallinnoi ladattuja laajennusteemoja tällä laitteella';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Aloitusnäytön osiot';
@@ -7600,6 +7623,22 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7712,7 +7712,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7711,6 +7711,14 @@ class AppLocalizationsFi extends AppLocalizations {
       'Näytä Next Up -peittokuva Ohita Outro -painikkeen sijaan.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Pelaajien reititys';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12,19 +12,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'PREFERENCES DU COMPTE';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Langage de l\'interface';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Langue du système';
+  String get systemLanguageDefault => 'System Default';
 
   @override
   String get signIn => 'Se connecter';
 
   @override
-  String get empty => 'Vide';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
@@ -99,7 +99,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get addServer => 'Ajouter un serveur';
 
   @override
-  String get embyConnect => 'Emby Connect';
+  String get embyConnect => 'Emby Connecter';
 
   @override
   String get removeServer => 'Supprimer le serveur';
@@ -135,7 +135,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Moonfin n\'a pas pu accéder au trousseau de votre système. La connexion peut continuer, mais le stockage sécurisé des jetons peut rester indisponible tant que le trousseau n\'est pas déverrouillé.';
 
   @override
-  String get ok => 'OK';
+  String get ok => 'D\'ACCORD';
 
   @override
   String get settingsAppearanceTheme => 'Thème de l\'application';
@@ -159,7 +159,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Le look actuel de Moonfin que vous aimez tous';
 
   @override
-  String get themeNeonPulse => 'Neon Pulse';
+  String get themeNeonPulse => 'Néon Impulsion';
 
   @override
   String get themeNeonPulseSubtitle =>
@@ -170,7 +170,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Style \"Verre liquide\" avec arrière-plan en dégradé animé, surfaces dépolies et touches de bleu Apple';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -264,7 +264,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get browseAll => 'Tout parcourir';
 
   @override
-  String get genres => 'Genres';
+  String get genres => 'Genre';
 
   @override
   String get collectionPlaceholder =>
@@ -379,7 +379,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get albums => 'Albums';
 
   @override
-  String get albumArtists => 'Artistes de l\'album';
+  String get albumArtists => 'Artistes d\'album';
 
   @override
   String get artists => 'Artistes';
@@ -413,12 +413,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String hoursAgo(int count) {
-    return 'il y a ${count}h';
+    return '${count}h il y a';
   }
 
   @override
   String daysAgo(int count) {
-    return 'il y a ${count}j';
+    return '${count}d il y a';
   }
 
   @override
@@ -438,14 +438,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get scanWithYourPhone => 'Scannez avec votre téléphone';
 
   @override
-  String get audiobookGenres => 'Genres de livres audio';
+  String get audiobookGenres => 'Genres d\'audiolivres';
 
   @override
   String get pickAudiobookGenres =>
-      'Choisissez quels genres afficher dans Découvrir pour les livres audio.';
+      'Choisissez quels genres afficher dans Découvrir les audiolivres.';
 
   @override
-  String get discoverAudiobooks => 'Découvrir des livres audio';
+  String get discoverAudiobooks => 'Découvrir des audiolivres';
 
   @override
   String get librivoxDescription =>
@@ -501,7 +501,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get bookHighlightsDescription =>
-      'Vos livres favoris, en cours de lecture ou contenant des passages surlignés.';
+      'Vos livres avec des surlignages, des favoris ou une progression de lecture.';
 
   @override
   String get handPickedFromLibrary => 'Sélectionnés dans votre bibliothèque.';
@@ -512,7 +512,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get booksWithHighlights =>
-      'Livres favoris, en cours de lecture ou contenant des passages surlignés.';
+      'Livres avec des surlignages, des favoris ou une progression de lecture.';
 
   @override
   String get jumpBackNarration =>
@@ -527,7 +527,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Accès rapide aux livres auxquels vous revenez souvent.';
 
   @override
-  String get searchAudiobooks => 'Rechercher des livres audio';
+  String get searchAudiobooks => 'Rechercher des audiolivres';
 
   @override
   String get searchYourLibrary => 'Rechercher dans votre bibliothèque';
@@ -546,7 +546,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String genresCount(int count) {
-    return '$count genres';
+    return '${count}genres';
   }
 
   @override
@@ -568,7 +568,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titres organisés pour une navigation privilégiant la lecture.';
+    return '$count titres organisés pour une navigation en lecture en premier.';
   }
 
   @override
@@ -602,7 +602,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Rien ne correspond encore à cette section. Essayez un autre onglet ou revenez une fois la synchronisation de la bibliothèque terminée.';
 
   @override
-  String get audiobooks => 'Livres audio';
+  String get audiobooks => 'Audiolivres';
 
   @override
   String noLabelFound(String label) {
@@ -668,7 +668,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get librivoxPage => 'Page LibriVox';
 
   @override
-  String get internetArchive => 'Internet Archive';
+  String get internetArchive => 'Archives Internet';
 
   @override
   String get rssFeed => 'Flux RSS';
@@ -718,9 +718,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count livres audio',
-      one: '1 livre audio',
-      zero: '0 livre audio',
+      other: '$count audiobooks',
+      one: '1 audiobook',
     );
     return '$_temp0';
   }
@@ -745,7 +744,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get save => 'Enregistrer';
 
   @override
-  String get moreLikeThis => 'Plus de ce genre';
+  String get moreLikeThis => 'Plus comme ça';
 
   @override
   String get castAndCrew => 'Casting et équipe';
@@ -828,9 +827,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Saisons',
-      one: '1 Saison',
-      zero: '0 Saison',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
@@ -842,7 +840,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String endsIn(String time) {
-    return 'Fin dans $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -899,7 +897,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get favorite => 'Favori';
 
   @override
-  String get playlist => 'Playlist';
+  String get playlist => 'Liste de lecture';
 
   @override
   String get downloaded => 'Téléchargé';
@@ -929,25 +927,27 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteItem => 'Supprimer l\'élément';
 
   @override
-  String get deletePlaylist => 'Supprimer la Playlist';
+  String get deletePlaylist => 'Supprimer la liste de lecture';
 
   @override
-  String get deletePlaylistMessage => 'Supprimer cette Playlist du serveur ?';
+  String get deletePlaylistMessage =>
+      'Supprimer cette liste de lecture du serveur ?';
 
   @override
   String get deleteItemMessage => 'Supprimer cet élément du serveur ?';
 
   @override
-  String get failedToDeletePlaylist => 'Échec de la suppression de la playlist';
+  String get failedToDeletePlaylist =>
+      'Échec de la suppression de la liste de lecture';
 
   @override
   String get failedToDeleteItem => 'Échec de la suppression de l\'élément';
 
   @override
-  String get renamePlaylist => 'Renommer la Playlist';
+  String get renamePlaylist => 'Renommer la liste de lecture';
 
   @override
-  String get playlistName => 'Nom de la Playlist';
+  String get playlistName => 'Nom de la liste de lecture';
 
   @override
   String get deleteDownloadedAlbum => 'Supprimer l\'album téléchargé';
@@ -1079,10 +1079,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get director => 'RÉALISATEUR';
 
   @override
-  String get directors => 'RÉALISATEURS';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCÉNARISTE';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'SCÉNARISTES';
@@ -1092,13 +1092,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String studioMoreCount(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '+ $count autres',
-      one: '+ 1 autre',
-    );
-    return '$_temp0';
+    return '+$count plus';
   }
 
   @override
@@ -1126,9 +1120,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count pistes',
-      one: '1 piste',
-      zero: '0 piste',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1138,9 +1131,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count chapitres',
-      one: '1 chapitre',
-      zero: '0 chapitre',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
@@ -1596,7 +1588,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get premiere => 'Première';
 
   @override
-  String get guideTimeline => 'Grille des Programmes';
+  String get guideTimeline => 'Frise du guide';
 
   @override
   String failedToLoadGuide(String error) {
@@ -1731,7 +1723,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Voyant';
 
   @override
   String get seerrAccountType => 'Type de compte Seerr';
@@ -1740,7 +1732,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get jellyfinAccount => 'Jellyfin';
 
   @override
-  String get localAccount => 'Local';
+  String get localAccount => 'Locale';
 
   @override
   String get savedMedia => 'Médias enregistrés';
@@ -1773,7 +1765,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String tracksCount(int count) {
-    return '$count pistes';
+    return '$count tracks';
   }
 
   @override
@@ -1859,9 +1851,8 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count épisodes',
-      one: '1 épisode',
-      zero: '0 épisode',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
@@ -2022,7 +2013,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get focusExpansionAnimation => 'Animation d’agrandissement du focus';
 
   @override
-  String get desktopUiScale => 'Échelle de l\'interface utilisateur';
+  String get desktopUiScale => 'Échelle de l\'interface utilisateur de bureau';
 
   @override
   String get scaleFocusedCards =>
@@ -2036,11 +2027,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher des images d’arrière-plan derrière le contenu';
 
   @override
-  String get seriesThumbnails => 'Afficher les vignettes des séries';
+  String get seriesThumbnails => 'Vignettes de séries';
 
   @override
   String get seriesThumbnailsDescription =>
-      'Pour les séries TV, utiliser le visuel principal de la série au lieu de la miniature de l\'épisode.';
+      'Épisodes uniquement : utiliser l’illustration de la série correspondant au type d’image de chaque rangée';
 
   @override
   String get homeRowInfoOverlay =>
@@ -2121,18 +2112,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get playerZoomMode => 'Mode de zoom du lecteur';
 
   @override
-  String get settingsScrollWheelAction =>
-      'Défilement avec la molette de la souris';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Choisir l\'action du défilement avec la molette de la souris durant la lecture.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Désactivé';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Défilement (avant / arrière)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
   String get scrollWheelActionVolume => 'Volume';
@@ -2250,17 +2240,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get polish => 'Polonais';
 
   @override
-  String get ac3Passthrough => 'Passthrough AC3';
+  String get ac3Passthrough => 'Pass-through AC3';
 
   @override
-  String get dtsPassthrough => 'Passthrough DTS';
+  String get dtsPassthrough => 'Passage DTS';
 
   @override
   String get trueHdSupport => 'Prise en charge de TrueHD';
 
   @override
   String get enableDtsPassthrough =>
-      'Audio Bitstream DTS vers AVR uniquement ; nécessite la piste source DTS et sa prise en charge par l\'AVR';
+      'Audio Bitstream DTS vers AVR uniquement ; nécessite la prise en charge du récepteur et la piste source DTS';
 
   @override
   String get enableTrueHdAudio =>
@@ -2271,24 +2261,23 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Choisissez comment l\'audio est décodé. AVR Passthrough envoie les flux Dolby/DTS directement à votre ampli sans traitements ; Auto ou Downmix décode localement.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
+  String get settingsAudioOutputModeAvrPassthrough => 'Passage AVR';
 
   @override
-  String get settingsAudioFallbackCodec => 'Codec audio de secours';
+  String get settingsAudioFallbackCodec => 'Codec de secours audio';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Sélectionnez le format cible pour transcoder l\'audio multicanal lorsque le flux source ne peut pas être lu directement ou transmis en passthrough.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Détection automatique\n(Recommandé)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Par défaut)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2300,7 +2289,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stéréo uniquement)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
   String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
@@ -2309,27 +2298,26 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Nombre maximum de canaux audio';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configurez le nombre maximum de canaux de votre installation audio. Les flux multicanaux dépassant cette limite feront l\'objet d\'un downmix ou d\'un transcodage.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Détection automatique\n(Réglage matériel par défaut))';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Stéréo';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
 
   @override
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonique';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2347,29 +2335,29 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioPassthroughAdvanced => 'Passthrough (avancé)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough de codecs';
+  String get settingsAudioCodecPassthrough => 'Passage de codecs';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
       'Activez uniquement les formats pris en charge par votre récepteur AVR ou HDMI.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Passthrough EAC3';
+  String get settingsAudioEac3Passthrough => 'Passage EAC3';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'Passage EAC3 JOC (Atmos)';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
+  String get settingsAudioDtsCorePassthrough => 'Passage de base DTS';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Passthrough DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'Passage DTS-HD MA';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'Passage TrueHD';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'Passage TrueHD Atmos';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2377,11 +2365,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Bitstream Dolby Atmos via EAC3 (JOC) vers un décodeur externe.';
+      'Bitstream Dolby Atmos sur EAC3 (JOC) vers un décodeur externe.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Bitstream DTS-HD MA (DTS Core inclus) vers un décodeur externe.';
+      'Bitstream DTS-HD MA (inclut le noyau DTS) vers un décodeur externe.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
@@ -2395,16 +2383,16 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aucun instantané des capacités d\'exécution n\'est encore disponible.';
 
   @override
-  String get settingsAudioRouteLabel => 'Sortie';
+  String get settingsAudioRouteLabel => 'Itinéraire';
 
   @override
-  String get settingsAudioDecodeLabel => 'Décodage';
+  String get settingsAudioDecodeLabel => 'Décoder';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Passthrough';
+  String get settingsAudioPassthroughLabel => 'Passage';
 
   @override
-  String get settingsAudioHdRoute => 'Sortie audio HD';
+  String get settingsAudioHdRoute => 'Parcours audio HD';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2419,7 +2407,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Enceintes';
+  String get settingsAudioRouteSpeaker => 'Conférencier';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2452,10 +2440,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'Passthrough audio-SPDIF';
+      'relais audio-SPDIF';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Sortie audio active';
+  String get settingsAudioDiagnosticsActiveAudioRoute =>
+      'Itinéraire audio actif';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
@@ -2530,10 +2519,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get resumeAndSkip => 'Reprendre et sauter';
 
   @override
-  String get resumeRewind => 'Retour arrière à la reprise de la lecture';
+  String get resumeRewind => 'Retour arrière à la reprise';
 
   @override
-  String get unpauseRewind => 'Retour arrière après avoir mis en pause';
+  String get unpauseRewind => 'Reprendre le rembobinage';
 
   @override
   String get fiveSeconds => '5 secondes';
@@ -2644,7 +2633,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get semiTransparentBlack => 'Noir semi-transparent';
 
   @override
-  String get global => 'Global';
+  String get global => 'Mondial';
 
   @override
   String get desktop => 'Bureau';
@@ -2684,7 +2673,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get syncing => 'Synchronisation...';
 
   @override
-  String get syncToProfile => 'Synchroniser le profil';
+  String get syncToProfile => 'Synchroniser vers le profil';
 
   @override
   String get profileSyncHidden => 'Synchronisation de profil masquée';
@@ -2799,7 +2788,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les bibliothèques dans la barre d’outils';
 
   @override
-  String get showSeerrButton => 'Afficher le bouton Seerr';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Opacité de la barre de navigation';
@@ -2854,7 +2843,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get overridePerLibrarySettings =>
-      'Écraser les paramètres par bibliothèque';
+      'Remplacer les paramètres par bibliothèque';
 
   @override
   String get applyImageTypeToAllLibraries =>
@@ -2908,7 +2897,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mediaBar => 'Barre média';
 
   @override
-  String get mediaSources => 'Média sources';
+  String get mediaSources => 'Sources médiatiques';
 
   @override
   String get behavior => 'Comportement';
@@ -2928,16 +2917,16 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get mediaBarModeDescription =>
-      'Choisissez parmi différents styles pour la barre média ou désactivez la barre média';
+      'Choisissez Moonfin, MakD ou desactivez la barre media';
 
   @override
-  String get mediaBarModeMoonfin => 'Moonfin';
+  String get mediaBarModeMoonfin => 'Aileron de lune';
 
   @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Désactivé';
+  String get mediaBarModeOff => 'Desactive';
 
   @override
   String get enableMediaBar => 'Activer la barre média';
@@ -2999,7 +2988,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Jouez un aperçu en ligne de 30 secondes sur des cartes ciblées, survolées ou enfoncées longuement';
 
   @override
-  String get previewAudio => 'Aperçu de l\'audio';
+  String get previewAudio => 'Audio de l’aperçu';
 
   @override
   String get enablePreviewAudio =>
@@ -3060,11 +3049,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Combiner les deux rangées en une seule section d’accueil';
 
   @override
-  String get fullScreenRows => 'Rangées d\'accueil étendues';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Limiter les rangées d\'accueil à une par écran';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Type d’image par rangée';
@@ -3079,7 +3067,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lastUser => 'Dernier utilisateur';
 
   @override
-  String get currentUser => 'Utilisateur actuel';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Toujours s’authentifier';
@@ -3144,7 +3132,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get libraryArt => 'Visuels de bibliothèque';
+  String get libraryArt => 'Illustrations de bibliothèque';
 
   @override
   String get logo => 'Logo';
@@ -3188,10 +3176,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher l’horloge pendant l’économiseur d’écran';
 
   @override
-  String get clockModeStatic => 'Statique';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Rebondissant';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Critiques)';
@@ -3263,7 +3251,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activer et réorganiser les sources de notes affichées dans l’app';
 
   @override
-  String get pluginLabel => 'Moonbase Plugin';
+  String get pluginLabel => 'Plugin';
 
   @override
   String get pluginDetected => 'Plugin détecté';
@@ -3335,10 +3323,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get networks => 'Chaînes';
 
   @override
-  String get seerrDiscoveryRows => 'Rangées de découverte Seerr';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
-  String get resetRowsToDefaults => 'Réinitialiser les rangées par défaut';
+  String get resetRowsToDefaults => 'Réinitialiser les lignes par défaut';
 
   @override
   String get enableSeerr => 'Activer Seerr';
@@ -3363,15 +3351,15 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Rangées de découverte';
+  String get discoverRows => 'Lignes de découverte';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Faites glisser pour réorganiser. Activez ou désactivez les rangées. L\'ordre des rangées activées se synchronise avec le plugin Moonfin.';
+      'Faites glisser pour réorganiser. Activez ou désactivez les lignes. L’ordre des lignes activées se synchronise avec le plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Faites glisser pour réorganiser. Activez ou désactivez les rangées.';
+      'Faites glisser pour réorganiser. Activez ou désactivez les lignes.';
 
   @override
   String get enabled => 'Activé';
@@ -3480,7 +3468,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get reorderToggleHomeRows =>
-      'Réorganiser et afficher/masquer les rangées d\'accueil';
+      'Réorganiser et afficher/masquer les lignes d’accueil';
 
   @override
   String get featuredContentAppearance => 'Contenu à la une, apparence';
@@ -5568,7 +5556,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminMetadataFieldOverview => 'Synopsis';
 
   @override
-  String get adminMetadataGenres => 'Genres';
+  String get adminMetadataGenres => 'Genre';
 
   @override
   String get adminMetadataTags => 'Balises';
@@ -6506,18 +6494,26 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get homeScreenSectionsIntegrationDescription =>
-      'Détectez les rangées exposées par le plugin « Home Screen Sections » d\'IAmParadox27. Les rangées peuvent être activées et réorganisées ci-dessous.';
+      'Détectez les lignes exposées par le plugin « Home Screen Sections » d\'IAmParadox27. Les lignes peuvent être activées et réorganisées ci-dessous.';
 
   @override
   String get homeScreenSectionsIntegrationNoServers =>
       'Aucun serveur Jellyfin n\'a encore signalé le plugin.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Détectez les lignes configurées via le plugin \"KefinTweaks\" de ranaldsgift. Les sections personnalisées, récemment publiées, à revoir, saisonnières et récemment ajoutées à la bibliothèque sont reflétées à partir de la configuration KefinTweaks sur chaque serveur Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Aucun serveur Jellyfin ne signale KefinTweaks pour le moment.';
+
+  @override
   String get integrationOpenHomeSections => 'Sections d\'accueil ouvertes';
 
   @override
   String get integrationOpenHomeSectionsSubtitle =>
-      'Activer, désactiver et réorganiser les rangées';
+      'Activer, désactiver et réorganiser les lignes';
 
   @override
   String get integrationInstalledButDisabled => 'Installé mais désactivé';
@@ -6548,7 +6544,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Voir tout';
@@ -6959,7 +6955,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsPersonalizationSubtitle =>
-      'Thème, navigation, rangées d\'accueil et visibilité de la bibliothèque';
+      'Thème, navigation, lignes d\'accueil et visibilité de la bibliothèque';
 
   @override
   String get settingsDynamicContent => 'Contenu dynamique';
@@ -7044,7 +7040,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Afficher le bouton Seerr dans la barre de navigation';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -7197,16 +7193,16 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ignorer les intros et les outros ?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Compte à rebours des segments';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'Barre de progression';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Minuteur';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Aucun';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Inviter l\'utilisateur';
@@ -7325,7 +7321,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsNextUpDisplayDescription =>
-      'Extended affiche une carte complète avec le visuel et la description de l\'épisode. Minimal montre une superposition de compte à rebours compacte. Désactivé masque entièrement l\'invite.';
+      'Extended affiche une carte complète avec les illustrations et la description de l\'épisode. Minimal montre une superposition de compte à rebours compacte. Désactivé masque entièrement l’invite.';
 
   @override
   String get settingsShort => 'Court';
@@ -7431,7 +7427,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String latestLibraryName(String libraryName) {
-    return '$libraryName, ajouts récents';
+    return 'Dernier $libraryName';
   }
 
   @override
@@ -7495,18 +7491,18 @@ class AppLocalizationsFr extends AppLocalizations {
       'Appliquez des conseils sur la taille de la police intégrés à la piste de sous-titres. Désactivez l\'utilisation de la taille des sous-titres dans vos préférences de style.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Afficher les détails du média';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Afficher les détails de l\'élément sélectionné en haut des pages de la bibliothèque.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
   String get useDetailedSubHeadings => 'Utiliser des sous-titres détaillés';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Afficher la sous-rangée détaillée ou minimale sur les pages de la bibliothèque.';
+      'Afficher la sous-ligne détaillée ou minimale sur les pages de la bibliothèque.';
 
   @override
   String get savedThemesDeleteDialogTitle => 'Supprimer le thème enregistré ?';
@@ -7514,40 +7510,6 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
     return 'Supprimer \"$themeName\" du cache de cet appareil ?';
-  }
-
-  @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -7584,6 +7546,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Gérer les thèmes de plugin téléchargés sur cet appareil';
 
   @override
+  String get kefinTweaksTitle => 'KefinTweaks';
+
+  @override
   String get homeScreenSectionsTitle => 'Sections de l\'écran d\'accueil';
 
   @override
@@ -7606,131 +7571,114 @@ class AppLocalizationsFr extends AppLocalizations {
   String get homeRowsStyleModern => 'Moderne';
 
   @override
-  String get homeRowsSection => 'Rangées d\'accueil';
+  String get homeRowsSection => 'Lignes d\'accueil';
 
   @override
-  String get homeRowDisplay => 'Affichage des rangées d\'accueil';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Sections des rangées d\'accueil';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Activation des rangées d\'accueil';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Activer ou désactiver les différentes catégories de rangées d\'accueil';
+      'Enable or disable different home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Activer les options suivantes pour afficher les rangées dans les sections de l\'accueil.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
-  String get rowsType => 'Type de rangée';
+  String get rowsType => 'Type de lignes';
 
   @override
   String get rowsTypeDescription =>
-      'Classic conserve le type d\'image par rangée et la superposition d\'informations. Modern utilise des rangées passant du portrait à l\'arrière-plan.';
+      'Classic conserve le type d\'image par ligne et la superposition d\'informations. Modern utilise des rangées du portrait à la toile de fond.';
 
   @override
-  String get displayFavoritesRows => 'Afficher les rangées de favoris';
+  String get displayFavoritesRows => 'Afficher les lignes de favoris';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Afficher les films, séries et autres rangées préférées dans les sections d\'accueil.';
+      'Afficher les films, séries et autres lignes préférées dans les sections d\'accueil.';
 
   @override
-  String get favoritesRowSorting => 'Tri des rangées de favoris';
+  String get favoritesRowSorting => 'Tri des lignes des favoris';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Triez les rangées de favoris par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
+      'Triez les lignes des favoris par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
 
   @override
-  String get displayCollectionsRows =>
-      'Afficher les rangées de collections dans les sections d\'accueil.';
+  String get displayCollectionsRows => 'Afficher les lignes des collections';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Afficher les rangées de collections dans les sections d\'accueil.';
+      'Afficher les lignes des collections dans les sections d\'accueil.';
 
   @override
-  String get collectionsRowSorting => 'Tri des rangées de collections';
+  String get collectionsRowSorting => 'Tri des lignes de collections';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Triez les rangées de collections par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
+      'Triez les lignes des collections par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
 
   @override
-  String get displayGenresRows => 'Afficher les rangées de genres';
+  String get displayGenresRows => 'Afficher les lignes de genres';
 
   @override
   String get displayGenresRowsSubtitle =>
-      'Afficher les rangées de genres dans les sections d\'accueil.';
+      'Afficher les lignes de genres dans les sections d\'accueil.';
 
   @override
-  String get genresRowSorting => 'Tri des rangées par genre';
+  String get genresRowSorting => 'Tri des lignes par genre';
 
   @override
   String get genresRowSortingDescription =>
-      'Triez les rangées de genres par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
+      'Triez les lignes de genres par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
 
   @override
-  String get genresRowItems => 'Éléments de rangée de genres';
+  String get genresRowItems => 'Éléments de ligne de genres';
 
   @override
   String get genresRowItemsDescription =>
-      'Afficher des films, des séries ou les deux dans les rangées Genres.';
+      'Afficher des films, des séries ou les deux dans les lignes Genres.';
 
   @override
-  String get displayPlaylistsRows => 'Afficher les rangées de playlists';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Afficher les rangées de playlists dans les sections de l\'accueil.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Tri des rangées de playlists';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Triez les rangées de playlists par date d\'ajout, date de sortie, ordre alphabétique, et plus encore.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
-
-  @override
-  String get displaySeerrRows => 'Afficher les rangées de découverte Seerr';
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
 
   @override
   String get displaySeerrRowsSubtitle =>
-      'Afficher les rangées de découverte Seerr dans les sections de l\'accueil.';
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Apparence';
 
   @override
-  String get cardSize => 'Taille des cartes des rangées d\'accueil';
+  String get cardSize => 'Taille de la carte';
 
   @override
   String get externalPlayerApp => 'Application de lecteur externe';
 
   @override
   String get externalPlayerAppDescription =>
-      'Définir un lecteur externe pour activer l\'option de lecture par appui long';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -7793,7 +7741,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Utilisez FFmpeg (audio) et libgav1 (AV1) avant les décodeurs matériels. Désactivez-le si le passage audio HDMI est interrompu.';
 
   @override
-  String get useExternalPlayer => 'Toujours utiliser un lecteur externe';
+  String get useExternalPlayer => 'Utiliser un lecteur externe';
 
   @override
   String get useExternalPlayerSubtitle =>
@@ -8266,145 +8214,145 @@ class AppLocalizationsFr extends AppLocalizations {
   String get whenFullscreen => 'En plein écran';
 
   @override
-  String get changeArtwork => 'Changer le visuel';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Manquant';
+  String get missing => 'Missing';
 
   @override
   String get transcodingLimits => 'Limites de transcodage';
 
   @override
-  String get clearAllArtworkButton => 'Effacer tous les visuels ?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Êtes-vous sûr de vouloir supprimer tous les visuels téléchargés ?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Confirmer la suppression';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Êtes-vous sûr de vouloir effacer ce $itemType ?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Envoyer ?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Résolution : ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Afficher uniquement les visuels dans la langue de l\'interface';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Confirmer la suppression';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Image envoyée avec succès !';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Échec de l\'envoi de l\'image : $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Impossible de définir l\'image : $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Impossible de supprimer l\'image : $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Impossible d\'effacer tous les visuels : $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Oui';
+  String get yes => 'Yes';
 
   @override
-  String get posterCategory => 'Affiche';
+  String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Arrière-plans';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Bannière';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Miniature';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Visuel';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Visuel du disque';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Capture d\'écran';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Jaquette';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Jaquette arrière';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Visuel du menu';
+  String get menuArtCategory => 'Menu Art';
 
   @override
-  String get confirmItemPoster => 'affiche';
+  String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'arrière-plan';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'bannière';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'miniature';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'visuel';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'visuel du disque';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'capture d\'écran';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'jaquette';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'jaquette arrière';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'visuel du menu';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Toutes';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Élevée (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Moyenne (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Basse (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
   String get sources => 'Sources';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12,19 +12,19 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'ACCOUNT PREFERENCES';
+  String get accountPreferences => 'PREFERENCES DU COMPTE';
 
   @override
-  String get interfaceLanguage => 'Interface Language';
+  String get interfaceLanguage => 'Langage de l\'interface';
 
   @override
-  String get systemLanguageDefault => 'System Default';
+  String get systemLanguageDefault => 'Langue du système';
 
   @override
   String get signIn => 'Se connecter';
 
   @override
-  String get empty => 'Empty';
+  String get empty => 'Vide';
 
   @override
   String connectingToServer(String serverName) {
@@ -99,7 +99,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get addServer => 'Ajouter un serveur';
 
   @override
-  String get embyConnect => 'Emby Connecter';
+  String get embyConnect => 'Emby Connect';
 
   @override
   String get removeServer => 'Supprimer le serveur';
@@ -135,7 +135,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Moonfin n\'a pas pu accéder au trousseau de votre système. La connexion peut continuer, mais le stockage sécurisé des jetons peut rester indisponible tant que le trousseau n\'est pas déverrouillé.';
 
   @override
-  String get ok => 'D\'ACCORD';
+  String get ok => 'OK';
 
   @override
   String get settingsAppearanceTheme => 'Thème de l\'application';
@@ -159,7 +159,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Le look actuel de Moonfin que vous aimez tous';
 
   @override
-  String get themeNeonPulse => 'Néon Impulsion';
+  String get themeNeonPulse => 'Neon Pulse';
 
   @override
   String get themeNeonPulseSubtitle =>
@@ -170,7 +170,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get themeGlassSubtitle =>
-      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
+      'Style \"Verre liquide\" avec arrière-plan en dégradé animé, surfaces dépolies et touches de bleu Apple';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -264,7 +264,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get browseAll => 'Tout parcourir';
 
   @override
-  String get genres => 'Genre';
+  String get genres => 'Genres';
 
   @override
   String get collectionPlaceholder =>
@@ -379,7 +379,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get albums => 'Albums';
 
   @override
-  String get albumArtists => 'Artistes d\'album';
+  String get albumArtists => 'Artistes de l\'album';
 
   @override
   String get artists => 'Artistes';
@@ -413,12 +413,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String hoursAgo(int count) {
-    return '${count}h il y a';
+    return 'il y a ${count}h';
   }
 
   @override
   String daysAgo(int count) {
-    return '${count}d il y a';
+    return 'il y a ${count}j';
   }
 
   @override
@@ -438,14 +438,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get scanWithYourPhone => 'Scannez avec votre téléphone';
 
   @override
-  String get audiobookGenres => 'Genres d\'audiolivres';
+  String get audiobookGenres => 'Genres de livres audio';
 
   @override
   String get pickAudiobookGenres =>
-      'Choisissez quels genres afficher dans Découvrir les audiolivres.';
+      'Choisissez quels genres afficher dans Découvrir pour les livres audio.';
 
   @override
-  String get discoverAudiobooks => 'Découvrir des audiolivres';
+  String get discoverAudiobooks => 'Découvrir des livres audio';
 
   @override
   String get librivoxDescription =>
@@ -501,7 +501,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get bookHighlightsDescription =>
-      'Vos livres avec des surlignages, des favoris ou une progression de lecture.';
+      'Vos livres favoris, en cours de lecture ou contenant des passages surlignés.';
 
   @override
   String get handPickedFromLibrary => 'Sélectionnés dans votre bibliothèque.';
@@ -512,7 +512,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get booksWithHighlights =>
-      'Livres avec des surlignages, des favoris ou une progression de lecture.';
+      'Livres favoris, en cours de lecture ou contenant des passages surlignés.';
 
   @override
   String get jumpBackNarration =>
@@ -527,7 +527,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Accès rapide aux livres auxquels vous revenez souvent.';
 
   @override
-  String get searchAudiobooks => 'Rechercher des audiolivres';
+  String get searchAudiobooks => 'Rechercher des livres audio';
 
   @override
   String get searchYourLibrary => 'Rechercher dans votre bibliothèque';
@@ -546,7 +546,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String genresCount(int count) {
-    return '${count}genres';
+    return '$count genres';
   }
 
   @override
@@ -568,7 +568,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titres organisés pour une navigation en lecture en premier.';
+    return '$count titres organisés pour une navigation privilégiant la lecture.';
   }
 
   @override
@@ -602,7 +602,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Rien ne correspond encore à cette section. Essayez un autre onglet ou revenez une fois la synchronisation de la bibliothèque terminée.';
 
   @override
-  String get audiobooks => 'Audiolivres';
+  String get audiobooks => 'Livres audio';
 
   @override
   String noLabelFound(String label) {
@@ -668,7 +668,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get librivoxPage => 'Page LibriVox';
 
   @override
-  String get internetArchive => 'Archives Internet';
+  String get internetArchive => 'Internet Archive';
 
   @override
   String get rssFeed => 'Flux RSS';
@@ -718,8 +718,9 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiobooks',
-      one: '1 audiobook',
+      other: '$count livres audio',
+      one: '1 livre audio',
+      zero: '0 livre audio',
     );
     return '$_temp0';
   }
@@ -744,7 +745,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get save => 'Enregistrer';
 
   @override
-  String get moreLikeThis => 'Plus comme ça';
+  String get moreLikeThis => 'Plus de ce genre';
 
   @override
   String get castAndCrew => 'Casting et équipe';
@@ -827,8 +828,9 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Seasons',
-      one: '1 Season',
+      other: '$count Saisons',
+      one: '1 Saison',
+      zero: '0 Saison',
     );
     return '$_temp0';
   }
@@ -840,7 +842,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String endsIn(String time) {
-    return 'Ends in $time';
+    return 'Fin dans $time';
   }
 
   @override
@@ -897,7 +899,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get favorite => 'Favori';
 
   @override
-  String get playlist => 'Liste de lecture';
+  String get playlist => 'Playlist';
 
   @override
   String get downloaded => 'Téléchargé';
@@ -927,27 +929,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get deleteItem => 'Supprimer l\'élément';
 
   @override
-  String get deletePlaylist => 'Supprimer la liste de lecture';
+  String get deletePlaylist => 'Supprimer la Playlist';
 
   @override
-  String get deletePlaylistMessage =>
-      'Supprimer cette liste de lecture du serveur ?';
+  String get deletePlaylistMessage => 'Supprimer cette Playlist du serveur ?';
 
   @override
   String get deleteItemMessage => 'Supprimer cet élément du serveur ?';
 
   @override
-  String get failedToDeletePlaylist =>
-      'Échec de la suppression de la liste de lecture';
+  String get failedToDeletePlaylist => 'Échec de la suppression de la playlist';
 
   @override
   String get failedToDeleteItem => 'Échec de la suppression de l\'élément';
 
   @override
-  String get renamePlaylist => 'Renommer la liste de lecture';
+  String get renamePlaylist => 'Renommer la Playlist';
 
   @override
-  String get playlistName => 'Nom de la liste de lecture';
+  String get playlistName => 'Nom de la Playlist';
 
   @override
   String get deleteDownloadedAlbum => 'Supprimer l\'album téléchargé';
@@ -1079,10 +1079,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get director => 'RÉALISATEUR';
 
   @override
-  String get directors => 'DIRECTORS';
+  String get directors => 'RÉALISATEURS';
 
   @override
-  String get writer => 'WRITER';
+  String get writer => 'SCÉNARISTE';
 
   @override
   String get writers => 'SCÉNARISTES';
@@ -1092,7 +1092,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String studioMoreCount(int count) {
-    return '+$count plus';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '+ $count autres',
+      one: '+ 1 autre',
+    );
+    return '$_temp0';
   }
 
   @override
@@ -1120,8 +1126,9 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count tracks',
-      one: '1 track',
+      other: '$count pistes',
+      one: '1 piste',
+      zero: '0 piste',
     );
     return '$_temp0';
   }
@@ -1131,8 +1138,9 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count chapters',
-      one: '1 chapter',
+      other: '$count chapitres',
+      one: '1 chapitre',
+      zero: '0 chapitre',
     );
     return '$_temp0';
   }
@@ -1588,7 +1596,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get premiere => 'Première';
 
   @override
-  String get guideTimeline => 'Frise du guide';
+  String get guideTimeline => 'Grille des Programmes';
 
   @override
   String failedToLoadGuide(String error) {
@@ -1723,7 +1731,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Voyant';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Type de compte Seerr';
@@ -1732,7 +1740,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get jellyfinAccount => 'Jellyfin';
 
   @override
-  String get localAccount => 'Locale';
+  String get localAccount => 'Local';
 
   @override
   String get savedMedia => 'Médias enregistrés';
@@ -1765,7 +1773,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String tracksCount(int count) {
-    return '$count tracks';
+    return '$count pistes';
   }
 
   @override
@@ -1851,8 +1859,9 @@ class AppLocalizationsFr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episodes',
-      one: '1 episode',
+      other: '$count épisodes',
+      one: '1 épisode',
+      zero: '0 épisode',
     );
     return '$_temp0';
   }
@@ -2013,7 +2022,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get focusExpansionAnimation => 'Animation d’agrandissement du focus';
 
   @override
-  String get desktopUiScale => 'Échelle de l\'interface utilisateur de bureau';
+  String get desktopUiScale => 'Échelle de l\'interface utilisateur';
 
   @override
   String get scaleFocusedCards =>
@@ -2027,11 +2036,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher des images d’arrière-plan derrière le contenu';
 
   @override
-  String get seriesThumbnails => 'Vignettes de séries';
+  String get seriesThumbnails => 'Afficher les vignettes des séries';
 
   @override
   String get seriesThumbnailsDescription =>
-      'Épisodes uniquement : utiliser l’illustration de la série correspondant au type d’image de chaque rangée';
+      'Pour les séries TV, utiliser le visuel principal de la série au lieu de la miniature de l\'épisode.';
 
   @override
   String get homeRowInfoOverlay =>
@@ -2112,17 +2121,18 @@ class AppLocalizationsFr extends AppLocalizations {
   String get playerZoomMode => 'Mode de zoom du lecteur';
 
   @override
-  String get settingsScrollWheelAction => 'Mouse scroll wheel';
+  String get settingsScrollWheelAction =>
+      'Défilement avec la molette de la souris';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Choose what scrolling the mouse wheel over the video does during playback.';
+      'Choisir l\'action du défilement avec la molette de la souris durant la lecture.';
 
   @override
-  String get scrollWheelActionOff => 'Off';
+  String get scrollWheelActionOff => 'Désactivé';
 
   @override
-  String get scrollWheelActionSeek => 'Seek (forward / back)';
+  String get scrollWheelActionSeek => 'Défilement (avant / arrière)';
 
   @override
   String get scrollWheelActionVolume => 'Volume';
@@ -2240,17 +2250,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get polish => 'Polonais';
 
   @override
-  String get ac3Passthrough => 'Pass-through AC3';
+  String get ac3Passthrough => 'Passthrough AC3';
 
   @override
-  String get dtsPassthrough => 'Passage DTS';
+  String get dtsPassthrough => 'Passthrough DTS';
 
   @override
   String get trueHdSupport => 'Prise en charge de TrueHD';
 
   @override
   String get enableDtsPassthrough =>
-      'Audio Bitstream DTS vers AVR uniquement ; nécessite la prise en charge du récepteur et la piste source DTS';
+      'Audio Bitstream DTS vers AVR uniquement ; nécessite la piste source DTS et sa prise en charge par l\'AVR';
 
   @override
   String get enableTrueHdAudio =>
@@ -2261,23 +2271,24 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
+      'Choisissez comment l\'audio est décodé. AVR Passthrough envoie les flux Dolby/DTS directement à votre ampli sans traitements ; Auto ou Downmix décode localement.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'Passage AVR';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Codec de secours audio';
+  String get settingsAudioFallbackCodec => 'Codec audio de secours';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
+      'Sélectionnez le format cible pour transcoder l\'audio multicanal lorsque le flux source ne peut pas être lu directement ou transmis en passthrough.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
+  String get settingsAudioFallbackCodecAuto =>
+      'Détection automatique\n(Recommandé)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Par défaut)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2289,7 +2300,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stéréo uniquement)';
 
   @override
   String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
@@ -2298,26 +2309,27 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Max Audio Channels';
+  String get settingsMaxAudioChannels => 'Nombre maximum de canaux audio';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
+      'Configurez le nombre maximum de canaux de votre installation audio. Les flux multicanaux dépassant cette limite feront l\'objet d\'un downmix ou d\'un transcodage.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
+  String get settingsMaxAudioChannelsAuto =>
+      'Détection automatique\n(Réglage matériel par défaut))';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
 
   @override
-  String get settingsMaxAudioChannelsStereo => '2.0 Stereo';
+  String get settingsMaxAudioChannelsStereo => '2.0 Stéréo';
 
   @override
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonique';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2335,29 +2347,29 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioPassthroughAdvanced => 'Passthrough (avancé)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passage de codecs';
+  String get settingsAudioCodecPassthrough => 'Passthrough de codecs';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
       'Activez uniquement les formats pris en charge par votre récepteur AVR ou HDMI.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'Passage EAC3';
+  String get settingsAudioEac3Passthrough => 'Passthrough EAC3';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'Passage EAC3 JOC (Atmos)';
+  String get settingsAudioEac3JocPassthrough => 'Passthrough EAC3 JOC (Atmos)';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'Passage de base DTS';
+  String get settingsAudioDtsCorePassthrough => 'Passthrough DTS Core';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'Passage DTS-HD MA';
+  String get settingsAudioDtsHdPassthrough => 'Passthrough DTS-HD MA';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'Passage TrueHD';
+  String get settingsAudioTrueHdPassthrough => 'Passthrough TrueHD';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'Passage TrueHD Atmos';
+  String get settingsAudioTrueHdAtmosPassthrough => 'Passthrough TrueHD Atmos';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
@@ -2365,11 +2377,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Bitstream Dolby Atmos sur EAC3 (JOC) vers un décodeur externe.';
+      'Bitstream Dolby Atmos via EAC3 (JOC) vers un décodeur externe.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Bitstream DTS-HD MA (inclut le noyau DTS) vers un décodeur externe.';
+      'Bitstream DTS-HD MA (DTS Core inclus) vers un décodeur externe.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
@@ -2383,16 +2395,16 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aucun instantané des capacités d\'exécution n\'est encore disponible.';
 
   @override
-  String get settingsAudioRouteLabel => 'Itinéraire';
+  String get settingsAudioRouteLabel => 'Sortie';
 
   @override
-  String get settingsAudioDecodeLabel => 'Décoder';
+  String get settingsAudioDecodeLabel => 'Décodage';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Passage';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'Parcours audio HD';
+  String get settingsAudioHdRoute => 'Sortie audio HD';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2407,7 +2419,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Conférencier';
+  String get settingsAudioRouteSpeaker => 'Enceintes';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2440,11 +2452,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'relais audio-SPDIF';
+      'Passthrough audio-SPDIF';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute =>
-      'Itinéraire audio actif';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Sortie audio active';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
@@ -2519,10 +2530,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get resumeAndSkip => 'Reprendre et sauter';
 
   @override
-  String get resumeRewind => 'Retour arrière à la reprise';
+  String get resumeRewind => 'Retour arrière à la reprise de la lecture';
 
   @override
-  String get unpauseRewind => 'Reprendre le rembobinage';
+  String get unpauseRewind => 'Retour arrière après avoir mis en pause';
 
   @override
   String get fiveSeconds => '5 secondes';
@@ -2633,7 +2644,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get semiTransparentBlack => 'Noir semi-transparent';
 
   @override
-  String get global => 'Mondial';
+  String get global => 'Global';
 
   @override
   String get desktop => 'Bureau';
@@ -2673,7 +2684,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get syncing => 'Synchronisation...';
 
   @override
-  String get syncToProfile => 'Synchroniser vers le profil';
+  String get syncToProfile => 'Synchroniser le profil';
 
   @override
   String get profileSyncHidden => 'Synchronisation de profil masquée';
@@ -2788,7 +2799,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les bibliothèques dans la barre d’outils';
 
   @override
-  String get showSeerrButton => 'Show Seerr Button';
+  String get showSeerrButton => 'Afficher le bouton Seerr';
 
   @override
   String get navbarOpacity => 'Opacité de la barre de navigation';
@@ -2843,7 +2854,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get overridePerLibrarySettings =>
-      'Remplacer les paramètres par bibliothèque';
+      'Écraser les paramètres par bibliothèque';
 
   @override
   String get applyImageTypeToAllLibraries =>
@@ -2897,7 +2908,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mediaBar => 'Barre média';
 
   @override
-  String get mediaSources => 'Sources médiatiques';
+  String get mediaSources => 'Média sources';
 
   @override
   String get behavior => 'Comportement';
@@ -2917,16 +2928,16 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get mediaBarModeDescription =>
-      'Choisissez Moonfin, MakD ou desactivez la barre media';
+      'Choisissez parmi différents styles pour la barre média ou désactivez la barre média';
 
   @override
-  String get mediaBarModeMoonfin => 'Aileron de lune';
+  String get mediaBarModeMoonfin => 'Moonfin';
 
   @override
   String get mediaBarModeMakd => 'MakD';
 
   @override
-  String get mediaBarModeOff => 'Desactive';
+  String get mediaBarModeOff => 'Désactivé';
 
   @override
   String get enableMediaBar => 'Activer la barre média';
@@ -2988,7 +2999,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Jouez un aperçu en ligne de 30 secondes sur des cartes ciblées, survolées ou enfoncées longuement';
 
   @override
-  String get previewAudio => 'Audio de l’aperçu';
+  String get previewAudio => 'Aperçu de l\'audio';
 
   @override
   String get enablePreviewAudio =>
@@ -3049,10 +3060,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Combiner les deux rangées en une seule section d’accueil';
 
   @override
-  String get fullScreenRows => 'Expanded Home Rows';
+  String get fullScreenRows => 'Rangées d\'accueil étendues';
 
   @override
-  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
+  String get fullScreenRowsDescription =>
+      'Limiter les rangées d\'accueil à une par écran';
 
   @override
   String get perRowImageType => 'Type d’image par rangée';
@@ -3067,7 +3079,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get lastUser => 'Dernier utilisateur';
 
   @override
-  String get currentUser => 'Current User';
+  String get currentUser => 'Utilisateur actuel';
 
   @override
   String get alwaysAuthenticate => 'Toujours s’authentifier';
@@ -3132,7 +3144,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get libraryArt => 'Illustrations de bibliothèque';
+  String get libraryArt => 'Visuels de bibliothèque';
 
   @override
   String get logo => 'Logo';
@@ -3176,10 +3188,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher l’horloge pendant l’économiseur d’écran';
 
   @override
-  String get clockModeStatic => 'Static';
+  String get clockModeStatic => 'Statique';
 
   @override
-  String get clockModeBouncing => 'Bouncing';
+  String get clockModeBouncing => 'Rebondissant';
 
   @override
   String get rottenTomatoesCritics => 'Rotten Tomatoes (Critiques)';
@@ -3251,7 +3263,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activer et réorganiser les sources de notes affichées dans l’app';
 
   @override
-  String get pluginLabel => 'Plugin';
+  String get pluginLabel => 'Moonbase Plugin';
 
   @override
   String get pluginDetected => 'Plugin détecté';
@@ -3323,10 +3335,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get networks => 'Chaînes';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
+  String get seerrDiscoveryRows => 'Rangées de découverte Seerr';
 
   @override
-  String get resetRowsToDefaults => 'Réinitialiser les lignes par défaut';
+  String get resetRowsToDefaults => 'Réinitialiser les rangées par défaut';
 
   @override
   String get enableSeerr => 'Activer Seerr';
@@ -3351,15 +3363,15 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Lignes de découverte';
+  String get discoverRows => 'Rangées de découverte';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Faites glisser pour réorganiser. Activez ou désactivez les lignes. L’ordre des lignes activées se synchronise avec le plugin Moonfin.';
+      'Faites glisser pour réorganiser. Activez ou désactivez les rangées. L\'ordre des rangées activées se synchronise avec le plugin Moonfin.';
 
   @override
   String get discoverRowsDescription =>
-      'Faites glisser pour réorganiser. Activez ou désactivez les lignes.';
+      'Faites glisser pour réorganiser. Activez ou désactivez les rangées.';
 
   @override
   String get enabled => 'Activé';
@@ -3468,7 +3480,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get reorderToggleHomeRows =>
-      'Réorganiser et afficher/masquer les lignes d’accueil';
+      'Réorganiser et afficher/masquer les rangées d\'accueil';
 
   @override
   String get featuredContentAppearance => 'Contenu à la une, apparence';
@@ -5556,7 +5568,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminMetadataFieldOverview => 'Synopsis';
 
   @override
-  String get adminMetadataGenres => 'Genre';
+  String get adminMetadataGenres => 'Genres';
 
   @override
   String get adminMetadataTags => 'Balises';
@@ -6494,26 +6506,18 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get homeScreenSectionsIntegrationDescription =>
-      'Détectez les lignes exposées par le plugin « Home Screen Sections » d\'IAmParadox27. Les lignes peuvent être activées et réorganisées ci-dessous.';
+      'Détectez les rangées exposées par le plugin « Home Screen Sections » d\'IAmParadox27. Les rangées peuvent être activées et réorganisées ci-dessous.';
 
   @override
   String get homeScreenSectionsIntegrationNoServers =>
       'Aucun serveur Jellyfin n\'a encore signalé le plugin.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Détectez les lignes configurées via le plugin \"KefinTweaks\" de ranaldsgift. Les sections personnalisées, récemment publiées, à revoir, saisonnières et récemment ajoutées à la bibliothèque sont reflétées à partir de la configuration KefinTweaks sur chaque serveur Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Aucun serveur Jellyfin ne signale KefinTweaks pour le moment.';
-
-  @override
   String get integrationOpenHomeSections => 'Sections d\'accueil ouvertes';
 
   @override
   String get integrationOpenHomeSectionsSubtitle =>
-      'Activer, désactiver et réorganiser les lignes';
+      'Activer, désactiver et réorganiser les rangées';
 
   @override
   String get integrationInstalledButDisabled => 'Installé mais désactivé';
@@ -6544,7 +6548,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Voir tout';
@@ -6955,7 +6959,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsPersonalizationSubtitle =>
-      'Thème, navigation, lignes d\'accueil et visibilité de la bibliothèque';
+      'Thème, navigation, rangées d\'accueil et visibilité de la bibliothèque';
 
   @override
   String get settingsDynamicContent => 'Contenu dynamique';
@@ -7040,7 +7044,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Show the Seerr button in the navigation bar';
+      'Afficher le bouton Seerr dans la barre de navigation';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -7193,16 +7197,16 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ignorer les intros et les outros ?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+  String get settingsMediaSegmentCountdown => 'Compte à rebours des segments';
 
   @override
-  String get settingsProgressBar => 'Progress Bar';
+  String get settingsProgressBar => 'Barre de progression';
 
   @override
-  String get settingsTimer => 'Timer';
+  String get settingsTimer => 'Minuteur';
 
   @override
-  String get settingsNone => 'None';
+  String get settingsNone => 'Aucun';
 
   @override
   String get settingsPromptUser => 'Inviter l\'utilisateur';
@@ -7321,7 +7325,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsNextUpDisplayDescription =>
-      'Extended affiche une carte complète avec les illustrations et la description de l\'épisode. Minimal montre une superposition de compte à rebours compacte. Désactivé masque entièrement l’invite.';
+      'Extended affiche une carte complète avec le visuel et la description de l\'épisode. Minimal montre une superposition de compte à rebours compacte. Désactivé masque entièrement l\'invite.';
 
   @override
   String get settingsShort => 'Court';
@@ -7427,7 +7431,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String latestLibraryName(String libraryName) {
-    return 'Dernier $libraryName';
+    return '$libraryName, ajouts récents';
   }
 
   @override
@@ -7491,18 +7495,18 @@ class AppLocalizationsFr extends AppLocalizations {
       'Appliquez des conseils sur la taille de la police intégrés à la piste de sous-titres. Désactivez l\'utilisation de la taille des sous-titres dans vos préférences de style.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
+  String get showMediaDetailsOnLibraryPage => 'Afficher les détails du média';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Show details of the selected item at the top of Library pages.';
+      'Afficher les détails de l\'élément sélectionné en haut des pages de la bibliothèque.';
 
   @override
   String get useDetailedSubHeadings => 'Utiliser des sous-titres détaillés';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Afficher la sous-ligne détaillée ou minimale sur les pages de la bibliothèque.';
+      'Afficher la sous-rangée détaillée ou minimale sur les pages de la bibliothèque.';
 
   @override
   String get savedThemesDeleteDialogTitle => 'Supprimer le thème enregistré ?';
@@ -7510,6 +7514,40 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
     return 'Supprimer \"$themeName\" du cache de cet appareil ?';
+  }
+
+  @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
   }
 
   @override
@@ -7546,9 +7584,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Gérer les thèmes de plugin téléchargés sur cet appareil';
 
   @override
-  String get kefinTweaksTitle => 'KefinTweaks';
-
-  @override
   String get homeScreenSectionsTitle => 'Sections de l\'écran d\'accueil';
 
   @override
@@ -7571,114 +7606,131 @@ class AppLocalizationsFr extends AppLocalizations {
   String get homeRowsStyleModern => 'Moderne';
 
   @override
-  String get homeRowsSection => 'Lignes d\'accueil';
+  String get homeRowsSection => 'Rangées d\'accueil';
 
   @override
-  String get homeRowDisplay => 'Home Row Display';
+  String get homeRowDisplay => 'Affichage des rangées d\'accueil';
 
   @override
-  String get homeRowSections => 'Home Row Sections';
+  String get homeRowSections => 'Sections des rangées d\'accueil';
 
   @override
-  String get homeRowToggles => 'Home Row Toggles';
+  String get homeRowToggles => 'Activation des rangées d\'accueil';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Enable or disable different home row categories';
+      'Activer ou désactiver les différentes catégories de rangées d\'accueil';
 
   @override
   String get homeRowTogglesDescription =>
-      'Enable the following toggles to display the rows in Home Sections.';
+      'Activer les options suivantes pour afficher les rangées dans les sections de l\'accueil.';
 
   @override
-  String get rowsType => 'Type de lignes';
+  String get rowsType => 'Type de rangée';
 
   @override
   String get rowsTypeDescription =>
-      'Classic conserve le type d\'image par ligne et la superposition d\'informations. Modern utilise des rangées du portrait à la toile de fond.';
+      'Classic conserve le type d\'image par rangée et la superposition d\'informations. Modern utilise des rangées passant du portrait à l\'arrière-plan.';
 
   @override
-  String get displayFavoritesRows => 'Afficher les lignes de favoris';
+  String get displayFavoritesRows => 'Afficher les rangées de favoris';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Afficher les films, séries et autres lignes préférées dans les sections d\'accueil.';
+      'Afficher les films, séries et autres rangées préférées dans les sections d\'accueil.';
 
   @override
-  String get favoritesRowSorting => 'Tri des lignes des favoris';
+  String get favoritesRowSorting => 'Tri des rangées de favoris';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Triez les lignes des favoris par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
+      'Triez les rangées de favoris par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
 
   @override
-  String get displayCollectionsRows => 'Afficher les lignes des collections';
+  String get displayCollectionsRows =>
+      'Afficher les rangées de collections dans les sections d\'accueil.';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Afficher les lignes des collections dans les sections d\'accueil.';
+      'Afficher les rangées de collections dans les sections d\'accueil.';
 
   @override
-  String get collectionsRowSorting => 'Tri des lignes de collections';
+  String get collectionsRowSorting => 'Tri des rangées de collections';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Triez les lignes des collections par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
+      'Triez les rangées de collections par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
 
   @override
-  String get displayGenresRows => 'Afficher les lignes de genres';
+  String get displayGenresRows => 'Afficher les rangées de genres';
 
   @override
   String get displayGenresRowsSubtitle =>
-      'Afficher les lignes de genres dans les sections d\'accueil.';
+      'Afficher les rangées de genres dans les sections d\'accueil.';
 
   @override
-  String get genresRowSorting => 'Tri des lignes par genre';
+  String get genresRowSorting => 'Tri des rangées par genre';
 
   @override
   String get genresRowSortingDescription =>
-      'Triez les lignes de genres par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
+      'Triez les rangées de genres par date d\'ajout, date de sortie, par ordre alphabétique, etc.';
 
   @override
-  String get genresRowItems => 'Éléments de ligne de genres';
+  String get genresRowItems => 'Éléments de rangée de genres';
 
   @override
   String get genresRowItemsDescription =>
-      'Afficher des films, des séries ou les deux dans les lignes Genres.';
+      'Afficher des films, des séries ou les deux dans les rangées Genres.';
 
   @override
-  String get displayPlaylistsRows => 'Display Playlist Rows';
+  String get displayPlaylistsRows => 'Afficher les rangées de playlists';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Show Playlist rows in Home Sections.';
+      'Afficher les rangées de playlists dans les sections de l\'accueil.';
 
   @override
-  String get playlistsRowSorting => 'Playlist Row Sorting';
+  String get playlistsRowSorting => 'Tri des rangées de playlists';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sort Playlist rows by date added, release date, alphabetically, and more.';
+      'Triez les rangées de playlists par date d\'ajout, date de sortie, ordre alphabétique, et plus encore.';
 
   @override
-  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
+
+  @override
+  String get displaySeerrRows => 'Afficher les rangées de découverte Seerr';
 
   @override
   String get displaySeerrRowsSubtitle =>
-      'Show Seerr discovery rows in Home Sections.';
+      'Afficher les rangées de découverte Seerr dans les sections de l\'accueil.';
 
   @override
   String get appearance => 'Apparence';
 
   @override
-  String get cardSize => 'Taille de la carte';
+  String get cardSize => 'Taille des cartes des rangées d\'accueil';
 
   @override
   String get externalPlayerApp => 'Application de lecteur externe';
 
   @override
   String get externalPlayerAppDescription =>
-      'Set external player to enable long-press play option';
+      'Définir un lecteur externe pour activer l\'option de lecture par appui long';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
@@ -7741,7 +7793,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Utilisez FFmpeg (audio) et libgav1 (AV1) avant les décodeurs matériels. Désactivez-le si le passage audio HDMI est interrompu.';
 
   @override
-  String get useExternalPlayer => 'Utiliser un lecteur externe';
+  String get useExternalPlayer => 'Toujours utiliser un lecteur externe';
 
   @override
   String get useExternalPlayerSubtitle =>
@@ -8214,145 +8266,145 @@ class AppLocalizationsFr extends AppLocalizations {
   String get whenFullscreen => 'En plein écran';
 
   @override
-  String get changeArtwork => 'Change Artwork';
+  String get changeArtwork => 'Changer le visuel';
 
   @override
-  String get missing => 'Missing';
+  String get missing => 'Manquant';
 
   @override
   String get transcodingLimits => 'Limites de transcodage';
 
   @override
-  String get clearAllArtworkButton => 'Clear all artwork?';
+  String get clearAllArtworkButton => 'Effacer tous les visuels ?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Are you sure you want to clear all downloaded artwork?';
+      'Êtes-vous sûr de vouloir supprimer tous les visuels téléchargés ?';
 
   @override
-  String get confirmClear => 'Confirm Clear';
+  String get confirmClear => 'Confirmer la suppression';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Are you sure you would like to clear this $itemType?';
+    return 'Êtes-vous sûr de vouloir effacer ce $itemType ?';
   }
 
   @override
-  String get uploadButton => 'Upload?';
+  String get uploadButton => 'Envoyer ?';
 
   @override
-  String get resolutionLabel => 'Resolution: ';
+  String get resolutionLabel => 'Résolution : ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Only show artwork in interface language';
+      'Afficher uniquement les visuels dans la langue de l\'interface';
 
   @override
-  String get confirmClearAll => 'Confirm Clear All';
+  String get confirmClearAll => 'Confirmer la suppression';
 
   @override
-  String get imageUploadSuccess => 'Image uploaded successfully!';
+  String get imageUploadSuccess => 'Image envoyée avec succès !';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Failed to upload image: $error';
+    return 'Échec de l\'envoi de l\'image : $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Failed to set image: $error';
+    return 'Impossible de définir l\'image : $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Failed to delete image: $error';
+    return 'Impossible de supprimer l\'image : $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Failed to clear all artwork: $error';
+    return 'Impossible d\'effacer tous les visuels : $error';
   }
 
   @override
-  String get yes => 'Yes';
+  String get yes => 'Oui';
 
   @override
-  String get posterCategory => 'Poster';
+  String get posterCategory => 'Affiche';
 
   @override
-  String get backdropsCategory => 'Backdrops';
+  String get backdropsCategory => 'Arrière-plans';
 
   @override
-  String get bannerCategory => 'Banner';
+  String get bannerCategory => 'Bannière';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Thumbnail';
+  String get thumbnailCategory => 'Miniature';
 
   @override
-  String get artCategory => 'Art';
+  String get artCategory => 'Visuel';
 
   @override
-  String get discArtCategory => 'Disc Art';
+  String get discArtCategory => 'Visuel du disque';
 
   @override
-  String get screenshotCategory => 'Screenshot';
+  String get screenshotCategory => 'Capture d\'écran';
 
   @override
-  String get boxCoverCategory => 'Box Cover';
+  String get boxCoverCategory => 'Jaquette';
 
   @override
-  String get boxRearCoverCategory => 'Box Rear Cover';
+  String get boxRearCoverCategory => 'Jaquette arrière';
 
   @override
-  String get menuArtCategory => 'Menu Art';
+  String get menuArtCategory => 'Visuel du menu';
 
   @override
-  String get confirmItemPoster => 'poster';
+  String get confirmItemPoster => 'affiche';
 
   @override
-  String get confirmItemBackdrop => 'backdrop';
+  String get confirmItemBackdrop => 'arrière-plan';
 
   @override
-  String get confirmItemBanner => 'banner';
+  String get confirmItemBanner => 'bannière';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'thumbnail';
+  String get confirmItemThumbnail => 'miniature';
 
   @override
-  String get confirmItemArt => 'art';
+  String get confirmItemArt => 'visuel';
 
   @override
-  String get confirmItemDiscArt => 'disc art';
+  String get confirmItemDiscArt => 'visuel du disque';
 
   @override
-  String get confirmItemScreenshot => 'screenshot';
+  String get confirmItemScreenshot => 'capture d\'écran';
 
   @override
-  String get confirmItemBoxCover => 'box cover';
+  String get confirmItemBoxCover => 'jaquette';
 
   @override
-  String get confirmItemBoxRearCover => 'box rear cover';
+  String get confirmItemBoxRearCover => 'jaquette arrière';
 
   @override
-  String get confirmItemMenuArt => 'menu art';
+  String get confirmItemMenuArt => 'visuel du menu';
 
   @override
-  String get resolutionAll => 'All';
+  String get resolutionAll => 'Toutes';
 
   @override
-  String get resolutionHigh => 'High (1080p+)';
+  String get resolutionHigh => 'Élevée (1080p+)';
 
   @override
-  String get resolutionMedium => 'Medium (720p)';
+  String get resolutionMedium => 'Moyenne (720p)';
 
   @override
-  String get resolutionLow => 'Low (<720p)';
+  String get resolutionLow => 'Basse (<720p)';
 
   @override
   String get sources => 'Sources';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7783,6 +7783,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher la superposition Next Up au lieu du bouton Ignorer Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Routage des joueurs';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7784,7 +7784,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1729,7 +1729,7 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Vidente';
 
   @override
   String get seerrAccountType => 'Tipo de conta Seerr';
@@ -6511,6 +6511,14 @@ class AppLocalizationsGl extends AppLocalizations {
       'Aínda non hai servidores Jellyfin que informen do complemento.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecta filas configuradas mediante o complemento \"KefinTweaks\" de ranaldsgift. As seccións personalizadas, publicadas recentemente, ver de novo, estacionais e engadidas recentemente na biblioteca reflícanse desde a configuración de KefinTweaks en cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Aínda non hai servidores Jellyfin que informen de KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir seccións de inicio';
 
   @override
@@ -6546,7 +6554,7 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver Todo';
@@ -7521,40 +7529,6 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7585,6 +7559,9 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7696,22 +7673,6 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -7784,6 +7784,14 @@ class AppLocalizationsGl extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1729,7 +1729,7 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Vidente';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Tipo de conta Seerr';
@@ -6511,14 +6511,6 @@ class AppLocalizationsGl extends AppLocalizations {
       'Aínda non hai servidores Jellyfin que informen do complemento.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecta filas configuradas mediante o complemento \"KefinTweaks\" de ranaldsgift. As seccións personalizadas, publicadas recentemente, ver de novo, estacionais e engadidas recentemente na biblioteca reflícanse desde a configuración de KefinTweaks en cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Aínda non hai servidores Jellyfin que informen de KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir seccións de inicio';
 
   @override
@@ -6554,7 +6546,7 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver Todo';
@@ -7529,6 +7521,40 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7559,9 +7585,6 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7673,6 +7696,22 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -7785,7 +7785,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1688,7 +1688,7 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'רואה';
 
   @override
   String get seerrAccountType => 'סוג חשבון רואה';
@@ -6346,6 +6346,14 @@ class AppLocalizationsHe extends AppLocalizations {
       'עדיין אין שרתי Jellyfin שדיווחו על התוסף.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'זיהוי שורות שהוגדרו באמצעות התוסף \"KefinTweaks\" של ranaldsgift. קטעים מותאמים אישית, שפורסמו לאחרונה, צפו שוב, עונתיים ונוספו לאחרונה בספרייה, משתקפים מתצורת KefinTweaks בכל שרת Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'עדיין אין שרתי Jellyfin שמדווחים על KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'פתח את מדור הבית';
 
   @override
@@ -6381,7 +6389,7 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'ראה הכל';
@@ -7320,40 +7328,6 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7384,6 +7358,9 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7495,22 +7472,6 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -7583,6 +7583,14 @@ class AppLocalizationsHe extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -7584,7 +7584,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1688,7 +1688,7 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'רואה';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'סוג חשבון רואה';
@@ -6346,14 +6346,6 @@ class AppLocalizationsHe extends AppLocalizations {
       'עדיין אין שרתי Jellyfin שדיווחו על התוסף.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'זיהוי שורות שהוגדרו באמצעות התוסף \"KefinTweaks\" של ranaldsgift. קטעים מותאמים אישית, שפורסמו לאחרונה, צפו שוב, עונתיים ונוספו לאחרונה בספרייה, משתקפים מתצורת KefinTweaks בכל שרת Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'עדיין אין שרתי Jellyfin שמדווחים על KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'פתח את מדור הבית';
 
   @override
@@ -6389,7 +6381,7 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'ראה הכל';
@@ -7328,6 +7320,40 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7358,9 +7384,6 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7472,6 +7495,22 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1702,7 +1702,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'द्रष्टा';
 
   @override
   String get seerrAccountType => 'द्रष्टा खाता प्रकार';
@@ -6412,6 +6412,14 @@ class AppLocalizationsHi extends AppLocalizations {
       'अभी तक कोई Jellyfin सर्वर प्लगइन की रिपोर्ट नहीं कर रहा है।';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ranaldsgift के \"KefinTweaks\" प्लगइन के माध्यम से कॉन्फ़िगर की गई पंक्तियों का पता लगाएं। कस्टम अनुभाग, हाल ही में जारी, फिर से देखें, मौसमी, और हाल ही में लाइब्रेरी में जोड़े गए प्रत्येक Jellyfin सर्वर पर KefinTweaks कॉन्फ़िगरेशन से प्रतिबिंबित होते हैं।';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'अभी तक कोई Jellyfin सर्वर KefinTweaks की रिपोर्ट नहीं कर रहा है।';
+
+  @override
   String get integrationOpenHomeSections => 'होम अनुभाग खोलें';
 
   @override
@@ -6447,7 +6455,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'सभी देखें';
@@ -7402,40 +7410,6 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7466,6 +7440,9 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7577,22 +7554,6 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -7665,6 +7665,14 @@ class AppLocalizationsHi extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1702,7 +1702,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'द्रष्टा';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'द्रष्टा खाता प्रकार';
@@ -6412,14 +6412,6 @@ class AppLocalizationsHi extends AppLocalizations {
       'अभी तक कोई Jellyfin सर्वर प्लगइन की रिपोर्ट नहीं कर रहा है।';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ranaldsgift के \"KefinTweaks\" प्लगइन के माध्यम से कॉन्फ़िगर की गई पंक्तियों का पता लगाएं। कस्टम अनुभाग, हाल ही में जारी, फिर से देखें, मौसमी, और हाल ही में लाइब्रेरी में जोड़े गए प्रत्येक Jellyfin सर्वर पर KefinTweaks कॉन्फ़िगरेशन से प्रतिबिंबित होते हैं।';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'अभी तक कोई Jellyfin सर्वर KefinTweaks की रिपोर्ट नहीं कर रहा है।';
-
-  @override
   String get integrationOpenHomeSections => 'होम अनुभाग खोलें';
 
   @override
@@ -6455,7 +6447,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'सभी देखें';
@@ -7410,6 +7402,40 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7440,9 +7466,6 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7554,6 +7577,22 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -7666,7 +7666,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -6443,6 +6443,14 @@ class AppLocalizationsHr extends AppLocalizations {
       'Još nijedan Jellyfin poslužitelj nije prijavio dodatak.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Otkrij retke konfigurirane putem dodatka \"KefinTweaks\" tvrtke ranaldsgift. Prilagođeni odjeljci, nedavno objavljeni, ponovno gledajte, sezonski i nedavno dodani u biblioteku odražavaju se iz KefinTweaks konfiguracije na svakom poslužitelju Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Još nijedan Jellyfin poslužitelj ne prijavljuje KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Otvorite početne odjeljke';
 
   @override
@@ -6478,7 +6486,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Vidi sve';
@@ -7446,40 +7454,6 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7510,6 +7484,9 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7621,22 +7598,6 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7710,7 +7710,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -6443,14 +6443,6 @@ class AppLocalizationsHr extends AppLocalizations {
       'Još nijedan Jellyfin poslužitelj nije prijavio dodatak.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Otkrij retke konfigurirane putem dodatka \"KefinTweaks\" tvrtke ranaldsgift. Prilagođeni odjeljci, nedavno objavljeni, ponovno gledajte, sezonski i nedavno dodani u biblioteku odražavaju se iz KefinTweaks konfiguracije na svakom poslužitelju Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Još nijedan Jellyfin poslužitelj ne prijavljuje KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Otvorite početne odjeljke';
 
   @override
@@ -6486,7 +6478,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Vidi sve';
@@ -7454,6 +7446,40 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7484,9 +7510,6 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7598,6 +7621,22 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7709,6 +7709,14 @@ class AppLocalizationsHr extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1714,7 +1714,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Látnok';
 
   @override
   String get seerrAccountType => 'Látó fiók típusa';
@@ -6482,6 +6482,14 @@ class AppLocalizationsHu extends AppLocalizations {
       'Még nincs Jellyfin szerver, amely jelentené a beépülő modult.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'A ranaldsgift „KefinTweaks” bővítményével konfigurált sorok észlelése. A közelmúltban megjelent, újból megtekinthető, szezonális és nemrégiben a könyvtárba felvett egyéni szakaszok tükröződnek a KefinTweaks konfigurációjában minden Jellyfin szerveren.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Még nincs olyan Jellyfin szerver, amely jelentené a KefinTweaks-et.';
+
+  @override
   String get integrationOpenHomeSections => 'Nyissa meg a Kezdőlap szakaszokat';
 
   @override
@@ -6517,7 +6525,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Összes megtekintése';
@@ -7489,40 +7497,6 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7553,6 +7527,9 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7664,22 +7641,6 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7752,6 +7752,14 @@ class AppLocalizationsHu extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1714,7 +1714,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Látnok';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Látó fiók típusa';
@@ -6482,14 +6482,6 @@ class AppLocalizationsHu extends AppLocalizations {
       'Még nincs Jellyfin szerver, amely jelentené a beépülő modult.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'A ranaldsgift „KefinTweaks” bővítményével konfigurált sorok észlelése. A közelmúltban megjelent, újból megtekinthető, szezonális és nemrégiben a könyvtárba felvett egyéni szakaszok tükröződnek a KefinTweaks konfigurációjában minden Jellyfin szerveren.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Még nincs olyan Jellyfin szerver, amely jelentené a KefinTweaks-et.';
-
-  @override
   String get integrationOpenHomeSections => 'Nyissa meg a Kezdőlap szakaszokat';
 
   @override
@@ -6525,7 +6517,7 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Összes megtekintése';
@@ -7497,6 +7489,40 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7527,9 +7553,6 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7641,6 +7664,22 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7753,7 +7753,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1710,7 +1710,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Melihat';
 
   @override
   String get seerrAccountType => 'Jenis Akun Seerr';
@@ -6440,6 +6440,14 @@ class AppLocalizationsId extends AppLocalizations {
       'Belum ada server Jellyfin yang melaporkan plugin tersebut.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Deteksi baris yang dikonfigurasi melalui plugin \"KefinTweaks\" ranaldsgift. Bagian khusus, yang baru dirilis, tonton lagi, musiman, dan baru ditambahkan di perpustakaan dicerminkan dari konfigurasi KefinTweaks di setiap server Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Belum ada server Jellyfin yang melaporkan KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Buka Bagian Rumah';
 
   @override
@@ -6475,7 +6483,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Lihat Semua';
@@ -7434,40 +7442,6 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7498,6 +7472,9 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7609,22 +7586,6 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -7697,6 +7697,14 @@ class AppLocalizationsId extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1710,7 +1710,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Melihat';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Jenis Akun Seerr';
@@ -6440,14 +6440,6 @@ class AppLocalizationsId extends AppLocalizations {
       'Belum ada server Jellyfin yang melaporkan plugin tersebut.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Deteksi baris yang dikonfigurasi melalui plugin \"KefinTweaks\" ranaldsgift. Bagian khusus, yang baru dirilis, tonton lagi, musiman, dan baru ditambahkan di perpustakaan dicerminkan dari konfigurasi KefinTweaks di setiap server Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Belum ada server Jellyfin yang melaporkan KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Buka Bagian Rumah';
 
   @override
@@ -6483,7 +6475,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Lihat Semua';
@@ -7442,6 +7434,40 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7472,9 +7498,6 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7586,6 +7609,22 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -7698,7 +7698,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6460,6 +6460,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nessun server Jellyfin segnala ancora il plug-in.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Rileva le righe configurate tramite il plugin \"KefinTweaks\" di ranaldsgift. Le sezioni personalizzate, rilasciate di recente, guarda di nuovo, stagionali e aggiunte di recente nella libreria vengono rispecchiate dalla configurazione KefinTweaks su ciascun server Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Nessun server Jellyfin segnala ancora KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Apri le sezioni Home';
 
   @override
@@ -6495,7 +6503,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Vedi Tutto';
@@ -7465,40 +7473,6 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7529,6 +7503,9 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7640,22 +7617,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6460,14 +6460,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nessun server Jellyfin segnala ancora il plug-in.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Rileva le righe configurate tramite il plugin \"KefinTweaks\" di ranaldsgift. Le sezioni personalizzate, rilasciate di recente, guarda di nuovo, stagionali e aggiunte di recente nella libreria vengono rispecchiate dalla configurazione KefinTweaks su ciascun server Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Nessun server Jellyfin segnala ancora KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Apri le sezioni Home';
 
   @override
@@ -6503,7 +6495,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Vedi Tutto';
@@ -7473,6 +7465,40 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7503,9 +7529,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7617,6 +7640,22 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7729,7 +7729,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7728,6 +7728,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1672,7 +1672,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'シーア';
 
   @override
   String get seerrAccountType => 'シーアアカウントの種類';
@@ -6280,6 +6280,14 @@ class AppLocalizationsJa extends AppLocalizations {
       'プラグインを報告している Jellyfin サーバーはまだありません。';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ranaldsgift の「KefinTweaks」プラグインを介して構成された行を検出します。カスタム セクション、最近リリースされたセクション、再度監視されたセクション、季節限定セクション、最近ライブラリに追加されたセクションは、各 Jellyfin サーバー上の KefinTweaks 構成からミラーリングされます。';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaks を報告する Jellyfin サーバーはまだありません。';
+
+  @override
   String get integrationOpenHomeSections => 'ホームセクションを開く';
 
   @override
@@ -6314,7 +6322,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'すべて見る';
@@ -7228,40 +7236,6 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7292,6 +7266,9 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7403,22 +7380,6 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7491,6 +7491,14 @@ class AppLocalizationsJa extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7492,7 +7492,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1672,7 +1672,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'シーア';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'シーアアカウントの種類';
@@ -6280,14 +6280,6 @@ class AppLocalizationsJa extends AppLocalizations {
       'プラグインを報告している Jellyfin サーバーはまだありません。';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ranaldsgift の「KefinTweaks」プラグインを介して構成された行を検出します。カスタム セクション、最近リリースされたセクション、再度監視されたセクション、季節限定セクション、最近ライブラリに追加されたセクションは、各 Jellyfin サーバー上の KefinTweaks 構成からミラーリングされます。';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaks を報告する Jellyfin サーバーはまだありません。';
-
-  @override
   String get integrationOpenHomeSections => 'ホームセクションを開く';
 
   @override
@@ -6322,7 +6314,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'すべて見る';
@@ -7236,6 +7228,40 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7266,9 +7292,6 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7380,6 +7403,22 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1710,7 +1710,7 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Көріпкел';
 
   @override
   String get seerrAccountType => 'Seerr тіркелгі түрі';
@@ -6459,6 +6459,14 @@ class AppLocalizationsKk extends AppLocalizations {
       'Плагин туралы әлі ешқандай Jellyfin серверлері есеп бермейді.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Ranaldsgift \"KefinTweaks\" плагині арқылы конфигурацияланған жолдарды анықтау. Жақында шығарылған, қайта қарау, маусымдық және кітапханаға жақында қосылған теңшелетін бөлімдер әрбір Jellyfin серверіндегі KefinTweaks конфигурациясынан бейнеленген.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaks туралы хабарлайтын Jellyfin серверлері әлі жоқ.';
+
+  @override
   String get integrationOpenHomeSections => 'Негізгі бөлімдерді ашыңыз';
 
   @override
@@ -6494,7 +6502,7 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Барлығын көру';
@@ -7457,40 +7465,6 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7521,6 +7495,9 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7632,22 +7609,6 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1710,7 +1710,7 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Көріпкел';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Seerr тіркелгі түрі';
@@ -6459,14 +6459,6 @@ class AppLocalizationsKk extends AppLocalizations {
       'Плагин туралы әлі ешқандай Jellyfin серверлері есеп бермейді.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Ranaldsgift \"KefinTweaks\" плагині арқылы конфигурацияланған жолдарды анықтау. Жақында шығарылған, қайта қарау, маусымдық және кітапханаға жақында қосылған теңшелетін бөлімдер әрбір Jellyfin серверіндегі KefinTweaks конфигурациясынан бейнеленген.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaks туралы хабарлайтын Jellyfin серверлері әлі жоқ.';
-
-  @override
   String get integrationOpenHomeSections => 'Негізгі бөлімдерді ашыңыз';
 
   @override
@@ -6502,7 +6494,7 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Барлығын көру';
@@ -7465,6 +7457,40 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7495,9 +7521,6 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7609,6 +7632,22 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -7721,7 +7721,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -7720,6 +7720,14 @@ class AppLocalizationsKk extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1715,7 +1715,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'ಸೀರ್';
 
   @override
   String get seerrAccountType => 'ಸೀರ್ ಖಾತೆಯ ಪ್ರಕಾರ';
@@ -6470,6 +6470,14 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಯಾವುದೇ Jellyfin ಸರ್ವರ್‌ಗಳು ಇನ್ನೂ ಪ್ಲಗಿನ್ ಅನ್ನು ವರದಿ ಮಾಡುತ್ತಿಲ್ಲ.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ranaldsgift ನ \"KefinTweaks\" ಪ್ಲಗಿನ್ ಮೂಲಕ ಕಾನ್ಫಿಗರ್ ಮಾಡಲಾದ ಸಾಲುಗಳನ್ನು ಪತ್ತೆ ಮಾಡಿ. ಕಸ್ಟಮ್ ವಿಭಾಗಗಳು, ಇತ್ತೀಚೆಗೆ ಬಿಡುಗಡೆ ಮಾಡಲಾಗಿದೆ, ಮತ್ತೊಮ್ಮೆ ವೀಕ್ಷಿಸಿ, ಕಾಲೋಚಿತ, ಮತ್ತು ಇತ್ತೀಚೆಗೆ ಲೈಬ್ರರಿಯಲ್ಲಿ ಸೇರಿಸಲಾಗಿದೆ ಪ್ರತಿ Jellyfin ಸರ್ವರ್‌ನಲ್ಲಿನ KefinTweaks ಕಾನ್ಫಿಗರೇಶನ್‌ನಿಂದ ಪ್ರತಿಬಿಂಬಿಸಲಾಗಿದೆ.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'ಇನ್ನೂ ಯಾವುದೇ Jellyfin ಸರ್ವರ್‌ಗಳು KefinTweaks ಅನ್ನು ವರದಿ ಮಾಡುತ್ತಿಲ್ಲ.';
+
+  @override
   String get integrationOpenHomeSections => 'ಹೋಮ್ ವಿಭಾಗಗಳನ್ನು ತೆರೆಯಿರಿ';
 
   @override
@@ -6506,7 +6514,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'ಎಲ್ಲವನ್ನೂ ನೋಡಿ';
@@ -7473,40 +7481,6 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7537,6 +7511,9 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7648,22 +7625,6 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -7736,6 +7736,14 @@ class AppLocalizationsKn extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1715,7 +1715,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'ಸೀರ್';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'ಸೀರ್ ಖಾತೆಯ ಪ್ರಕಾರ';
@@ -6470,14 +6470,6 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಯಾವುದೇ Jellyfin ಸರ್ವರ್‌ಗಳು ಇನ್ನೂ ಪ್ಲಗಿನ್ ಅನ್ನು ವರದಿ ಮಾಡುತ್ತಿಲ್ಲ.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ranaldsgift ನ \"KefinTweaks\" ಪ್ಲಗಿನ್ ಮೂಲಕ ಕಾನ್ಫಿಗರ್ ಮಾಡಲಾದ ಸಾಲುಗಳನ್ನು ಪತ್ತೆ ಮಾಡಿ. ಕಸ್ಟಮ್ ವಿಭಾಗಗಳು, ಇತ್ತೀಚೆಗೆ ಬಿಡುಗಡೆ ಮಾಡಲಾಗಿದೆ, ಮತ್ತೊಮ್ಮೆ ವೀಕ್ಷಿಸಿ, ಕಾಲೋಚಿತ, ಮತ್ತು ಇತ್ತೀಚೆಗೆ ಲೈಬ್ರರಿಯಲ್ಲಿ ಸೇರಿಸಲಾಗಿದೆ ಪ್ರತಿ Jellyfin ಸರ್ವರ್‌ನಲ್ಲಿನ KefinTweaks ಕಾನ್ಫಿಗರೇಶನ್‌ನಿಂದ ಪ್ರತಿಬಿಂಬಿಸಲಾಗಿದೆ.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'ಇನ್ನೂ ಯಾವುದೇ Jellyfin ಸರ್ವರ್‌ಗಳು KefinTweaks ಅನ್ನು ವರದಿ ಮಾಡುತ್ತಿಲ್ಲ.';
-
-  @override
   String get integrationOpenHomeSections => 'ಹೋಮ್ ವಿಭಾಗಗಳನ್ನು ತೆರೆಯಿರಿ';
 
   @override
@@ -6514,7 +6506,7 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'ಎಲ್ಲವನ್ನೂ ನೋಡಿ';
@@ -7481,6 +7473,40 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7511,9 +7537,6 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7625,6 +7648,22 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -7737,7 +7737,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1670,7 +1670,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => '시르';
 
   @override
   String get seerrAccountType => 'Seerr 계정 유형';
@@ -6272,6 +6272,14 @@ class AppLocalizationsKo extends AppLocalizations {
       '아직 플러그인을 보고하는 Jellyfin 서버가 없습니다.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ranaldsgift의 \"KefinTweaks\" 플러그인을 통해 구성된 행을 감지합니다. 최근 출시된 사용자 정의 섹션, 다시 보기, 시즌별, 최근 라이브러리에 추가된 섹션은 각 Jellyfin 서버의 KefinTweaks 구성에서 미러링됩니다.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      '아직 KefinTweaks를 보고하는 Jellyfin 서버가 없습니다.';
+
+  @override
   String get integrationOpenHomeSections => '홈 섹션 열기';
 
   @override
@@ -6306,7 +6314,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => '모두 보기';
@@ -7223,40 +7231,6 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7287,6 +7261,9 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7398,22 +7375,6 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -7486,6 +7486,14 @@ class AppLocalizationsKo extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -7487,7 +7487,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1670,7 +1670,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get seerr => '시르';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Seerr 계정 유형';
@@ -6272,14 +6272,6 @@ class AppLocalizationsKo extends AppLocalizations {
       '아직 플러그인을 보고하는 Jellyfin 서버가 없습니다.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ranaldsgift의 \"KefinTweaks\" 플러그인을 통해 구성된 행을 감지합니다. 최근 출시된 사용자 정의 섹션, 다시 보기, 시즌별, 최근 라이브러리에 추가된 섹션은 각 Jellyfin 서버의 KefinTweaks 구성에서 미러링됩니다.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      '아직 KefinTweaks를 보고하는 Jellyfin 서버가 없습니다.';
-
-  @override
   String get integrationOpenHomeSections => '홈 섹션 열기';
 
   @override
@@ -6314,7 +6306,7 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => '모두 보기';
@@ -7231,6 +7223,40 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7261,9 +7287,6 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7375,6 +7398,22 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1703,7 +1703,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Regėtojas';
 
   @override
   String get seerrAccountType => 'Serr paskyros tipas';
@@ -6445,6 +6445,14 @@ class AppLocalizationsLt extends AppLocalizations {
       'Dar nė vienas Jellyfin serveris nepraneša apie papildinį.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Aptikti eilutes, sukonfigūruotas naudojant „ranaldsgift“ papildinį „KefinTweaks“. Pasirinktiniai skyriai, neseniai išleisti, žiūrėti dar kartą, sezoniniai ir neseniai įtraukti į biblioteką, atspindi KefinTweaks konfigūraciją kiekviename Jellyfin serveryje.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Dar nėra „Jellyfin“ serverių, pranešančių apie „KefinTweaks“.';
+
+  @override
   String get integrationOpenHomeSections => 'Atidarykite pagrindinius skyrius';
 
   @override
@@ -6480,7 +6488,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Žiūrėti viską';
@@ -7451,40 +7459,6 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Ištrinta „$themeName“ iš šio įrenginio.';
   }
@@ -7515,6 +7489,9 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Tvarkykite atsisiųstų papildinių temas šiame įrenginyje';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Pagrindinio ekrano skyriai';
@@ -7627,22 +7604,6 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7716,7 +7716,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1703,7 +1703,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Regėtojas';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Serr paskyros tipas';
@@ -6445,14 +6445,6 @@ class AppLocalizationsLt extends AppLocalizations {
       'Dar nė vienas Jellyfin serveris nepraneša apie papildinį.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Aptikti eilutes, sukonfigūruotas naudojant „ranaldsgift“ papildinį „KefinTweaks“. Pasirinktiniai skyriai, neseniai išleisti, žiūrėti dar kartą, sezoniniai ir neseniai įtraukti į biblioteką, atspindi KefinTweaks konfigūraciją kiekviename Jellyfin serveryje.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Dar nėra „Jellyfin“ serverių, pranešančių apie „KefinTweaks“.';
-
-  @override
   String get integrationOpenHomeSections => 'Atidarykite pagrindinius skyrius';
 
   @override
@@ -6488,7 +6480,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Žiūrėti viską';
@@ -7459,6 +7451,40 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Ištrinta „$themeName“ iš šio įrenginio.';
   }
@@ -7489,9 +7515,6 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Tvarkykite atsisiųstų papildinių temas šiame įrenginyje';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Pagrindinio ekrano skyriai';
@@ -7604,6 +7627,22 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7715,6 +7715,14 @@ class AppLocalizationsLt extends AppLocalizations {
       'Vietoj mygtuko Skip Outro rodyti perdangą Next Up.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Žaidėjų maršrutas';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1714,7 +1714,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Redzējs';
 
   @override
   String get seerrAccountType => 'Serr konta veids';
@@ -6457,6 +6457,14 @@ class AppLocalizationsLv extends AppLocalizations {
       'Pagaidām neviens Jellyfin serveris neziņo par spraudni.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Noteikt rindas, kas konfigurētas, izmantojot ranaldsgift spraudni \"KefinTweaks\". Pielāgotas sadaļas, kas nesen izlaistas, skatīties vēlreiz, sezonālas un nesen pievienotas bibliotēkā, tiek atspoguļotas no KefinTweaks konfigurācijas katrā Jellyfin serverī.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Pagaidām neviens Jellyfin serveris neziņo par KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Atveriet sākuma sadaļas';
 
   @override
@@ -6492,7 +6500,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Skatīt visu';
@@ -7459,40 +7467,6 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Izdzēsts \"$themeName\" no šīs ierīces.';
   }
@@ -7524,6 +7498,9 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Pārvaldiet šajā ierīcē lejupielādētos spraudņu motīvus';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Sākuma ekrāna sadaļas';
@@ -7635,22 +7612,6 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1714,7 +1714,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Redzējs';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Serr konta veids';
@@ -6457,14 +6457,6 @@ class AppLocalizationsLv extends AppLocalizations {
       'Pagaidām neviens Jellyfin serveris neziņo par spraudni.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Noteikt rindas, kas konfigurētas, izmantojot ranaldsgift spraudni \"KefinTweaks\". Pielāgotas sadaļas, kas nesen izlaistas, skatīties vēlreiz, sezonālas un nesen pievienotas bibliotēkā, tiek atspoguļotas no KefinTweaks konfigurācijas katrā Jellyfin serverī.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Pagaidām neviens Jellyfin serveris neziņo par KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Atveriet sākuma sadaļas';
 
   @override
@@ -6500,7 +6492,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Skatīt visu';
@@ -7467,6 +7459,40 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Izdzēsts \"$themeName\" no šīs ierīces.';
   }
@@ -7498,9 +7524,6 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Pārvaldiet šajā ierīcē lejupielādētos spraudņu motīvus';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Sākuma ekrāna sadaļas';
@@ -7612,6 +7635,22 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7724,6 +7724,14 @@ class AppLocalizationsLv extends AppLocalizations {
       'Rādīt pārklājumu Next Up, nevis pogu Izlaist Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Spēlētāja maršrutēšana';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7725,7 +7725,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1716,7 +1716,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Гледач';
 
   @override
   String get seerrAccountType => 'Вид на сметка на Seer';
@@ -6470,6 +6470,14 @@ class AppLocalizationsMk extends AppLocalizations {
       'Сè уште нема Jellyfin сервери кои го пријавуваат приклучокот.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Откријте редови конфигурирани преку приклучокот „KefinTweaks“ на ranaldsgift. Прилагодените делови, неодамна објавени, повторно гледање, сезонски и неодамна додадени во библиотеката се пресликани од конфигурацијата KefinTweaks на секој Jellyfin сервер.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Сè уште нема Jellyfin сервери кои известуваат за KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Отворете ги почетните делови';
 
   @override
@@ -6505,7 +6513,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Види ги сите';
@@ -7475,40 +7483,6 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7539,6 +7513,9 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7650,22 +7627,6 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -7739,7 +7739,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1716,7 +1716,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Гледач';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Вид на сметка на Seer';
@@ -6470,14 +6470,6 @@ class AppLocalizationsMk extends AppLocalizations {
       'Сè уште нема Jellyfin сервери кои го пријавуваат приклучокот.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Откријте редови конфигурирани преку приклучокот „KefinTweaks“ на ranaldsgift. Прилагодените делови, неодамна објавени, повторно гледање, сезонски и неодамна додадени во библиотеката се пресликани од конфигурацијата KefinTweaks на секој Jellyfin сервер.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Сè уште нема Jellyfin сервери кои известуваат за KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Отворете ги почетните делови';
 
   @override
@@ -6513,7 +6505,7 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Види ги сите';
@@ -7483,6 +7475,40 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7513,9 +7539,6 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7627,6 +7650,22 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -7738,6 +7738,14 @@ class AppLocalizationsMk extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1717,7 +1717,7 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'സീർ';
 
   @override
   String get seerrAccountType => 'സീർ അക്കൗണ്ട് തരം';
@@ -6502,6 +6502,14 @@ class AppLocalizationsMl extends AppLocalizations {
       'Jellyfin സെർവറുകളൊന്നും ഇതുവരെ പ്ലഗിൻ റിപ്പോർട്ട് ചെയ്യുന്നില്ല.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Ranaldsgift-ൻ്റെ \"KefinTweaks\" പ്ലഗിൻ വഴി കോൺഫിഗർ ചെയ്ത വരികൾ കണ്ടെത്തുക. ഇഷ്‌ടാനുസൃത വിഭാഗങ്ങൾ, അടുത്തിടെ പുറത്തിറക്കിയ, വീണ്ടും കാണുക, സീസണൽ, അടുത്തിടെ ലൈബ്രറിയിൽ ചേർത്തത് എന്നിവ ഓരോ Jellyfin സെർവറിലുമുള്ള KefinTweaks കോൺഫിഗറേഷനിൽ നിന്ന് പ്രതിഫലിപ്പിക്കുന്നു.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaks ഇതുവരെ Jellyfin സെർവറുകൾ റിപ്പോർട്ട് ചെയ്യുന്നില്ല.';
+
+  @override
   String get integrationOpenHomeSections => 'ഹോം സെക്ഷനുകൾ തുറക്കുക';
 
   @override
@@ -6538,7 +6546,7 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'എല്ലാം കാണുക';
@@ -7516,40 +7524,6 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'ഈ ഉപകരണത്തിൽ നിന്ന് \"$themeName\" ഇല്ലാതാക്കി.';
   }
@@ -7581,6 +7555,9 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'ഈ ഉപകരണത്തിൽ ഡൗൺലോഡ് ചെയ്‌ത പ്ലഗിൻ തീമുകൾ നിയന്ത്രിക്കുക';
+
+  @override
+  String get kefinTweaksTitle => 'കെഫിൻ ട്വീക്സ്';
 
   @override
   String get homeScreenSectionsTitle => 'ഹോം സ്‌ക്രീൻ വിഭാഗങ്ങൾ';
@@ -7693,22 +7670,6 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1717,7 +1717,7 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'സീർ';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'സീർ അക്കൗണ്ട് തരം';
@@ -6502,14 +6502,6 @@ class AppLocalizationsMl extends AppLocalizations {
       'Jellyfin സെർവറുകളൊന്നും ഇതുവരെ പ്ലഗിൻ റിപ്പോർട്ട് ചെയ്യുന്നില്ല.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Ranaldsgift-ൻ്റെ \"KefinTweaks\" പ്ലഗിൻ വഴി കോൺഫിഗർ ചെയ്ത വരികൾ കണ്ടെത്തുക. ഇഷ്‌ടാനുസൃത വിഭാഗങ്ങൾ, അടുത്തിടെ പുറത്തിറക്കിയ, വീണ്ടും കാണുക, സീസണൽ, അടുത്തിടെ ലൈബ്രറിയിൽ ചേർത്തത് എന്നിവ ഓരോ Jellyfin സെർവറിലുമുള്ള KefinTweaks കോൺഫിഗറേഷനിൽ നിന്ന് പ്രതിഫലിപ്പിക്കുന്നു.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaks ഇതുവരെ Jellyfin സെർവറുകൾ റിപ്പോർട്ട് ചെയ്യുന്നില്ല.';
-
-  @override
   String get integrationOpenHomeSections => 'ഹോം സെക്ഷനുകൾ തുറക്കുക';
 
   @override
@@ -6546,7 +6538,7 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'എല്ലാം കാണുക';
@@ -7524,6 +7516,40 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'ഈ ഉപകരണത്തിൽ നിന്ന് \"$themeName\" ഇല്ലാതാക്കി.';
   }
@@ -7555,9 +7581,6 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'ഈ ഉപകരണത്തിൽ ഡൗൺലോഡ് ചെയ്‌ത പ്ലഗിൻ തീമുകൾ നിയന്ത്രിക്കുക';
-
-  @override
-  String get kefinTweaksTitle => 'കെഫിൻ ട്വീക്സ്';
 
   @override
   String get homeScreenSectionsTitle => 'ഹോം സ്‌ക്രീൻ വിഭാഗങ്ങൾ';
@@ -7670,6 +7693,22 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -7782,6 +7782,14 @@ class AppLocalizationsMl extends AppLocalizations {
       'സ്കിപ്പ് ഔട്ട്‌റോ ബട്ടണിന് പകരം അടുത്ത അപ്പ് ഓവർലേ കാണിക്കുക.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'പ്ലെയർ റൂട്ടിംഗ്';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -7783,7 +7783,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1704,7 +1704,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Үзмэрч';
 
   @override
   String get seerrAccountType => 'Үзмэрч дансны төрөл';
@@ -6449,6 +6449,14 @@ class AppLocalizationsMn extends AppLocalizations {
       'Одоогоор залгаасын талаар мэдээлсэн Jellyfin сервер алга.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Ranaldsgift-ийн \"KefinTweaks\" залгаасаар тохируулсан мөрүүдийг илрүүлэх. Саяхан гарсан, дахин үзэх, улирлын чанартай, номын санд саяхан нэмсэн захиалгат хэсгүүдийг Jellyfin сервер бүр дээрх KefinTweaks тохиргооноос тусгадаг.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaks-г мэдээлсэн Jellyfin сервер одоогоор алга.';
+
+  @override
   String get integrationOpenHomeSections => 'Нүүр хуудасны хэсгийг нээнэ үү';
 
   @override
@@ -6485,7 +6493,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Бүгдийг харах';
@@ -7451,40 +7459,6 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Энэ төхөөрөмжөөс \"$themeName\"-г устгасан.';
   }
@@ -7515,6 +7489,9 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Татаж авсан залгаасын загваруудыг энэ төхөөрөмж дээр удирдаарай';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Үндсэн дэлгэцийн хэсгүүд';
@@ -7627,22 +7604,6 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -7717,7 +7717,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -7716,6 +7716,14 @@ class AppLocalizationsMn extends AppLocalizations {
       'Skip Outro товчлуурын оронд Next Up давхаргыг харуул.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Тоглогчийн чиглүүлэлт';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1704,7 +1704,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Үзмэрч';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Үзмэрч дансны төрөл';
@@ -6449,14 +6449,6 @@ class AppLocalizationsMn extends AppLocalizations {
       'Одоогоор залгаасын талаар мэдээлсэн Jellyfin сервер алга.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Ranaldsgift-ийн \"KefinTweaks\" залгаасаар тохируулсан мөрүүдийг илрүүлэх. Саяхан гарсан, дахин үзэх, улирлын чанартай, номын санд саяхан нэмсэн захиалгат хэсгүүдийг Jellyfin сервер бүр дээрх KefinTweaks тохиргооноос тусгадаг.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaks-г мэдээлсэн Jellyfin сервер одоогоор алга.';
-
-  @override
   String get integrationOpenHomeSections => 'Нүүр хуудасны хэсгийг нээнэ үү';
 
   @override
@@ -6493,7 +6485,7 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Бүгдийг харах';
@@ -7459,6 +7451,40 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Энэ төхөөрөмжөөс \"$themeName\"-г устгасан.';
   }
@@ -7489,9 +7515,6 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Татаж авсан залгаасын загваруудыг энэ төхөөрөмж дээр удирдаарай';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Үндсэн дэлгэцийн хэсгүүд';
@@ -7604,6 +7627,22 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -6426,6 +6426,14 @@ class AppLocalizationsNb extends AppLocalizations {
       'Ingen Jellyfin-servere rapporterer plugin-modulen ennå.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Oppdag rader konfigurert via ranaldsgifts \"KefinTweaks\"-plugin. Egendefinerte seksjoner, nylig utgitt, se igjen, sesongbaserte og nylig lagt til i biblioteket, speiles fra KefinTweaks-konfigurasjonen på hver Jellyfin-server.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ingen Jellyfin-servere rapporterer KefinTweaks ennå.';
+
+  @override
   String get integrationOpenHomeSections => 'Åpne Hjem-seksjoner';
 
   @override
@@ -6461,7 +6469,7 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Se alle';
@@ -7425,40 +7433,6 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7489,6 +7463,9 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7600,22 +7577,6 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7689,7 +7689,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -6426,14 +6426,6 @@ class AppLocalizationsNb extends AppLocalizations {
       'Ingen Jellyfin-servere rapporterer plugin-modulen ennå.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Oppdag rader konfigurert via ranaldsgifts \"KefinTweaks\"-plugin. Egendefinerte seksjoner, nylig utgitt, se igjen, sesongbaserte og nylig lagt til i biblioteket, speiles fra KefinTweaks-konfigurasjonen på hver Jellyfin-server.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ingen Jellyfin-servere rapporterer KefinTweaks ennå.';
-
-  @override
   String get integrationOpenHomeSections => 'Åpne Hjem-seksjoner';
 
   @override
@@ -6469,7 +6461,7 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Se alle';
@@ -7433,6 +7425,40 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7463,9 +7489,6 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7577,6 +7600,22 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7688,6 +7688,14 @@ class AppLocalizationsNb extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6454,6 +6454,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Er zijn nog geen Jellyfin-servers die de plug-in melden.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecteer rijen die zijn geconfigureerd via de plug-in \"KefinTweaks\" van ranaldsgift. Aangepaste secties, onlangs uitgebracht, opnieuw bekijken, seizoensgebonden en onlangs toegevoegd aan de bibliotheek, worden gespiegeld vanuit de KefinTweaks-configuratie op elke Jellyfin-server.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Er zijn nog geen Jellyfin-servers die KefinTweaks rapporteren.';
+
+  @override
   String get integrationOpenHomeSections => 'Open Home-secties';
 
   @override
@@ -6490,7 +6498,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Bekijk alles';
@@ -7456,40 +7464,6 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7520,6 +7494,9 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7631,22 +7608,6 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7719,6 +7719,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7720,7 +7720,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6454,14 +6454,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Er zijn nog geen Jellyfin-servers die de plug-in melden.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecteer rijen die zijn geconfigureerd via de plug-in \"KefinTweaks\" van ranaldsgift. Aangepaste secties, onlangs uitgebracht, opnieuw bekijken, seizoensgebonden en onlangs toegevoegd aan de bibliotheek, worden gespiegeld vanuit de KefinTweaks-configuratie op elke Jellyfin-server.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Er zijn nog geen Jellyfin-servers die KefinTweaks rapporteren.';
-
-  @override
   String get integrationOpenHomeSections => 'Open Home-secties';
 
   @override
@@ -6498,7 +6490,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Bekijk alles';
@@ -7464,6 +7456,40 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7494,9 +7520,6 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7608,6 +7631,22 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1705,7 +1705,7 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'ਸੀਰ';
 
   @override
   String get seerrAccountType => 'Seerr ਖਾਤਾ ਕਿਸਮ';
@@ -6418,6 +6418,14 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਕੋਈ Jellyfin ਸਰਵਰ ਅਜੇ ਪਲੱਗਇਨ ਦੀ ਰਿਪੋਰਟ ਕਰ ਰਹੇ ਹਨ।';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ranaldsgift ਦੇ \"KefinTweaks\" ਪਲੱਗਇਨ ਰਾਹੀਂ ਸੰਰਚਿਤ ਕੀਤੀਆਂ ਕਤਾਰਾਂ ਦਾ ਪਤਾ ਲਗਾਓ। ਕਸਟਮ ਸੈਕਸ਼ਨ, ਹਾਲ ਹੀ ਵਿੱਚ ਜਾਰੀ ਕੀਤੇ ਗਏ, ਦੁਬਾਰਾ ਦੇਖੋ, ਮੌਸਮੀ, ਅਤੇ ਹਾਲ ਹੀ ਵਿੱਚ ਲਾਇਬ੍ਰੇਰੀ ਵਿੱਚ ਸ਼ਾਮਲ ਕੀਤੇ ਗਏ, ਹਰੇਕ Jellyfin ਸਰਵਰ \'ਤੇ KefinTweaks ਸੰਰਚਨਾ ਤੋਂ ਪ੍ਰਤੀਬਿੰਬ ਕੀਤੇ ਗਏ ਹਨ।';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'ਅਜੇ ਤੱਕ ਕੋਈ Jellyfin ਸਰਵਰ KefinTweaks ਦੀ ਰਿਪੋਰਟ ਨਹੀਂ ਕਰ ਰਹੇ ਹਨ।';
+
+  @override
   String get integrationOpenHomeSections => 'ਹੋਮ ਸੈਕਸ਼ਨ ਖੋਲ੍ਹੋ';
 
   @override
@@ -6453,7 +6461,7 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'ਸਭ ਦੇਖੋ';
@@ -7405,40 +7413,6 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7469,6 +7443,9 @@ class AppLocalizationsPa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7580,22 +7557,6 @@ class AppLocalizationsPa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -7668,6 +7668,14 @@ class AppLocalizationsPa extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1705,7 +1705,7 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'ਸੀਰ';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Seerr ਖਾਤਾ ਕਿਸਮ';
@@ -6418,14 +6418,6 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਕੋਈ Jellyfin ਸਰਵਰ ਅਜੇ ਪਲੱਗਇਨ ਦੀ ਰਿਪੋਰਟ ਕਰ ਰਹੇ ਹਨ।';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ranaldsgift ਦੇ \"KefinTweaks\" ਪਲੱਗਇਨ ਰਾਹੀਂ ਸੰਰਚਿਤ ਕੀਤੀਆਂ ਕਤਾਰਾਂ ਦਾ ਪਤਾ ਲਗਾਓ। ਕਸਟਮ ਸੈਕਸ਼ਨ, ਹਾਲ ਹੀ ਵਿੱਚ ਜਾਰੀ ਕੀਤੇ ਗਏ, ਦੁਬਾਰਾ ਦੇਖੋ, ਮੌਸਮੀ, ਅਤੇ ਹਾਲ ਹੀ ਵਿੱਚ ਲਾਇਬ੍ਰੇਰੀ ਵਿੱਚ ਸ਼ਾਮਲ ਕੀਤੇ ਗਏ, ਹਰੇਕ Jellyfin ਸਰਵਰ \'ਤੇ KefinTweaks ਸੰਰਚਨਾ ਤੋਂ ਪ੍ਰਤੀਬਿੰਬ ਕੀਤੇ ਗਏ ਹਨ।';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'ਅਜੇ ਤੱਕ ਕੋਈ Jellyfin ਸਰਵਰ KefinTweaks ਦੀ ਰਿਪੋਰਟ ਨਹੀਂ ਕਰ ਰਹੇ ਹਨ।';
-
-  @override
   String get integrationOpenHomeSections => 'ਹੋਮ ਸੈਕਸ਼ਨ ਖੋਲ੍ਹੋ';
 
   @override
@@ -6461,7 +6453,7 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'ਸਭ ਦੇਖੋ';
@@ -7413,6 +7405,40 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7443,9 +7469,6 @@ class AppLocalizationsPa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7557,6 +7580,22 @@ class AppLocalizationsPa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -7669,7 +7669,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -6461,6 +6461,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'Żaden serwer Jellyfin nie zgłosił jeszcze wtyczki.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Wykryj wiersze skonfigurowane za pomocą wtyczki „KefinTweaks” ranaldsgift. Sekcje niestandardowe, niedawno wydane, obejrzyj ponownie, sezonowe i niedawno dodane do biblioteki są odzwierciedlane z konfiguracji KefinTweaks na każdym serwerze Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Żaden serwer Jellyfin nie zgłosił jeszcze KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Otwórz sekcje główne';
 
   @override
@@ -6496,7 +6504,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Zobacz wszystko';
@@ -7467,40 +7475,6 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7531,6 +7505,9 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7642,22 +7619,6 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7730,6 +7730,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7731,7 +7731,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -6461,14 +6461,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'Żaden serwer Jellyfin nie zgłosił jeszcze wtyczki.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Wykryj wiersze skonfigurowane za pomocą wtyczki „KefinTweaks” ranaldsgift. Sekcje niestandardowe, niedawno wydane, obejrzyj ponownie, sezonowe i niedawno dodane do biblioteki są odzwierciedlane z konfiguracji KefinTweaks na każdym serwerze Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Żaden serwer Jellyfin nie zgłosił jeszcze KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Otwórz sekcje główne';
 
   @override
@@ -6504,7 +6496,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Zobacz wszystko';
@@ -7475,6 +7467,40 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7505,9 +7531,6 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7619,6 +7642,22 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1711,7 +1711,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Vidente';
 
   @override
   String get seerrAccountType => 'Tipo de conta Seerr';
@@ -6472,6 +6472,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Nenhum servidor Jellyfin reportando o plugin ainda.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecte linhas configuradas por meio do plugin \"KefinTweaks\" do ranaldsgift. Seções personalizadas, lançadas recentemente, assistidas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Nenhum servidor Jellyfin reportando KefinTweaks ainda.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir seções iniciais';
 
   @override
@@ -6507,7 +6515,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver Tudo';
@@ -7477,40 +7485,6 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Excluído \"$themeName\" deste dispositivo.';
   }
@@ -7542,6 +7516,9 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Gerenciar temas de plug-ins baixados neste dispositivo';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Seções da tela inicial';
@@ -7654,22 +7631,6 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -14702,6 +14663,14 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Nenhum servidor Jellyfin reportando o plugin ainda.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detecte linhas configuradas por meio do plugin \"KefinTweaks\" do ranaldsgift. Seções personalizadas, lançadas recentemente, assistidas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Nenhum servidor Jellyfin reportando KefinTweaks ainda.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir seções iniciais';
 
   @override
@@ -14737,7 +14706,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver tudo';
@@ -15704,6 +15673,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -19269,7 +19241,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get mergeContinueWatchingAndNextUp =>
-      'Combinar «Continuar a Ver» e «Próximo»';
+      'Mesclar Continuar a Ver e Próximo';
 
   @override
   String get combineBothRows =>
@@ -22711,6 +22683,14 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Nenhum servidor Jellyfin a reportar o plugin ainda.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Deteta linhas configuradas através do plugin \"KefinTweaks\" do ranaldsgift. Secções personalizadas, lançadas recentemente, vistas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Nenhum servidor Jellyfin a reportar KefinTweaks ainda.';
+
+  @override
   String get integrationOpenHomeSections => 'Abrir secções iniciais';
 
   @override
@@ -22746,7 +22726,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Ver tudo';
@@ -23742,6 +23722,9 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get savedThemesManageSubtitle =>
       'Gerir temas de plugins baixados neste dispositivo';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secções do ecrã inicial';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7742,6 +7742,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostre a sobreposição Next Up em vez do botão Pular Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Roteamento de Jogador';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7743,7 +7743,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1711,7 +1711,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Vidente';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Tipo de conta Seerr';
@@ -6472,14 +6472,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Nenhum servidor Jellyfin reportando o plugin ainda.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecte linhas configuradas por meio do plugin \"KefinTweaks\" do ranaldsgift. Seções personalizadas, lançadas recentemente, assistidas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Nenhum servidor Jellyfin reportando KefinTweaks ainda.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir seções iniciais';
 
   @override
@@ -6515,7 +6507,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver Tudo';
@@ -7485,6 +7477,40 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Excluído \"$themeName\" deste dispositivo.';
   }
@@ -7516,9 +7542,6 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Gerenciar temas de plug-ins baixados neste dispositivo';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Seções da tela inicial';
@@ -7631,6 +7654,22 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -14663,14 +14702,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Nenhum servidor Jellyfin reportando o plugin ainda.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detecte linhas configuradas por meio do plugin \"KefinTweaks\" do ranaldsgift. Seções personalizadas, lançadas recentemente, assistidas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Nenhum servidor Jellyfin reportando KefinTweaks ainda.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir seções iniciais';
 
   @override
@@ -14706,7 +14737,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver tudo';
@@ -15673,9 +15704,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -19241,7 +19269,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get mergeContinueWatchingAndNextUp =>
-      'Mesclar Continuar a Ver e Próximo';
+      'Combinar «Continuar a Ver» e «Próximo»';
 
   @override
   String get combineBothRows =>
@@ -22683,14 +22711,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
       'Nenhum servidor Jellyfin a reportar o plugin ainda.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Deteta linhas configuradas através do plugin \"KefinTweaks\" do ranaldsgift. Secções personalizadas, lançadas recentemente, vistas novamente, sazonais e adicionadas recentemente na biblioteca são espelhadas da configuração KefinTweaks em cada servidor Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Nenhum servidor Jellyfin a reportar KefinTweaks ainda.';
-
-  @override
   String get integrationOpenHomeSections => 'Abrir secções iniciais';
 
   @override
@@ -22726,7 +22746,7 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Ver tudo';
@@ -23722,9 +23742,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get savedThemesManageSubtitle =>
       'Gerir temas de plugins baixados neste dispositivo';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secções do ecrã inicial';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6466,6 +6466,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'Niciun server Jellyfin nu raportează încă pluginul.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Detectați rândurile configurate prin pluginul „KefinTweaks” de la ranaldsgift. Secțiunile personalizate, lansate recent, vizionați din nou, sezoniere și adăugate recent în bibliotecă sunt reflectate din configurația KefinTweaks pe fiecare server Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Încă niciun server Jellyfin nu raportează KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Deschideți secțiunile de pornire';
 
   @override
@@ -6501,7 +6509,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Vezi toate';
@@ -7469,40 +7477,6 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return '„$themeName” a fost șters de pe acest dispozitiv.';
   }
@@ -7534,6 +7508,9 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Gestionați temele de plugin descărcate pe acest dispozitiv';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secțiunile ecranului de pornire';
@@ -7645,22 +7622,6 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7733,6 +7733,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6466,14 +6466,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'Niciun server Jellyfin nu raportează încă pluginul.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Detectați rândurile configurate prin pluginul „KefinTweaks” de la ranaldsgift. Secțiunile personalizate, lansate recent, vizionați din nou, sezoniere și adăugate recent în bibliotecă sunt reflectate din configurația KefinTweaks pe fiecare server Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Încă niciun server Jellyfin nu raportează KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Deschideți secțiunile de pornire';
 
   @override
@@ -6509,7 +6501,7 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Vezi toate';
@@ -7477,6 +7469,40 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return '„$themeName” a fost șters de pe acest dispozitiv.';
   }
@@ -7508,9 +7534,6 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Gestionați temele de plugin descărcate pe acest dispozitiv';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Secțiunile ecranului de pornire';
@@ -7622,6 +7645,22 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7734,7 +7734,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1713,7 +1713,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Сирр';
 
   @override
   String get seerrAccountType => 'Тип учетной записи Seerr';
@@ -6469,6 +6469,14 @@ class AppLocalizationsRu extends AppLocalizations {
       'Ни один сервер Jellyfin пока не сообщил о плагине.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Обнаружение строк, настроенных с помощью плагина KefinTweaks компании ranaldsgift. Пользовательские разделы, недавно выпущенные, просмотренные снова, сезонные и недавно добавленные в библиотеку зеркально отражаются из конфигурации KefinTweaks на каждом сервере Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ни один сервер Jellyfin пока не сообщает о KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Открытые домашние разделы';
 
   @override
@@ -6504,7 +6512,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Посмотреть все';
@@ -7476,40 +7484,6 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7540,6 +7514,9 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7651,22 +7628,6 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -7740,7 +7740,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1713,7 +1713,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Сирр';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Тип учетной записи Seerr';
@@ -6469,14 +6469,6 @@ class AppLocalizationsRu extends AppLocalizations {
       'Ни один сервер Jellyfin пока не сообщил о плагине.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Обнаружение строк, настроенных с помощью плагина KefinTweaks компании ranaldsgift. Пользовательские разделы, недавно выпущенные, просмотренные снова, сезонные и недавно добавленные в библиотеку зеркально отражаются из конфигурации KefinTweaks на каждом сервере Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ни один сервер Jellyfin пока не сообщает о KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Открытые домашние разделы';
 
   @override
@@ -6512,7 +6504,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Посмотреть все';
@@ -7484,6 +7476,40 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7514,9 +7540,6 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7628,6 +7651,22 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -7739,6 +7739,14 @@ class AppLocalizationsRu extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1701,7 +1701,7 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'සීර්';
 
   @override
   String get seerrAccountType => 'Seerr ගිණුම් වර්ගය';
@@ -6421,6 +6421,14 @@ class AppLocalizationsSi extends AppLocalizations {
       'Jellyfin සේවාදායකයන් තවමත් ප්ලගිනය වාර්තා නොකරයි.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Ranaldsgift හි \"KefinTweaks\" ප්ලගිනය හරහා වින්‍යාස කර ඇති පේළි හඳුනා ගන්න. අභිරුචි කොටස්, මෑතකදී නිකුත් කරන ලද, නැවත නරඹන්න, සෘතුමය සහ මෑතකදී එකතු කරන ලද පුස්තකාලයේ එක් එක් Jellyfin සේවාදායකයේ KefinTweaks වින්‍යාසයෙන් පිළිබිඹු වේ.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaks තවමත් Jellyfin සේවාදායකයක් වාර්තා නොකරයි.';
+
+  @override
   String get integrationOpenHomeSections => 'මුල් පිටුව කොටස් විවෘත කරන්න';
 
   @override
@@ -6457,7 +6465,7 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'සියල්ල බලන්න';
@@ -7413,40 +7421,6 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7477,6 +7451,9 @@ class AppLocalizationsSi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7588,22 +7565,6 @@ class AppLocalizationsSi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -7676,6 +7676,14 @@ class AppLocalizationsSi extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1701,7 +1701,7 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'සීර්';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Seerr ගිණුම් වර්ගය';
@@ -6421,14 +6421,6 @@ class AppLocalizationsSi extends AppLocalizations {
       'Jellyfin සේවාදායකයන් තවමත් ප්ලගිනය වාර්තා නොකරයි.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Ranaldsgift හි \"KefinTweaks\" ප්ලගිනය හරහා වින්‍යාස කර ඇති පේළි හඳුනා ගන්න. අභිරුචි කොටස්, මෑතකදී නිකුත් කරන ලද, නැවත නරඹන්න, සෘතුමය සහ මෑතකදී එකතු කරන ලද පුස්තකාලයේ එක් එක් Jellyfin සේවාදායකයේ KefinTweaks වින්‍යාසයෙන් පිළිබිඹු වේ.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaks තවමත් Jellyfin සේවාදායකයක් වාර්තා නොකරයි.';
-
-  @override
   String get integrationOpenHomeSections => 'මුල් පිටුව කොටස් විවෘත කරන්න';
 
   @override
@@ -6465,7 +6457,7 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'සියල්ල බලන්න';
@@ -7421,6 +7413,40 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7451,9 +7477,6 @@ class AppLocalizationsSi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7565,6 +7588,22 @@ class AppLocalizationsSi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -7677,7 +7677,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1712,7 +1712,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Serr';
 
   @override
   String get seerrAccountType => 'Typ účtu Seerr';
@@ -6454,6 +6454,14 @@ class AppLocalizationsSk extends AppLocalizations {
       'Doplnok zatiaľ nenahlásili žiadne servery Jellyfin.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Zistiť riadky nakonfigurované prostredníctvom doplnku „KefinTweaks“ ranaldsgift. Vlastné sekcie, nedávno vydané, pozerané znova, sezónne a nedávno pridané do knižnice, sa zrkadlia z konfigurácie KefinTweaks na každom serveri Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Zatiaľ žiadne servery Jellyfin nehlásia KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Otvorte sekcie Domov';
 
   @override
@@ -6489,7 +6497,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Zobraziť všetko';
@@ -7457,40 +7465,6 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7521,6 +7495,9 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7632,22 +7609,6 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1712,7 +1712,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Serr';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Typ účtu Seerr';
@@ -6454,14 +6454,6 @@ class AppLocalizationsSk extends AppLocalizations {
       'Doplnok zatiaľ nenahlásili žiadne servery Jellyfin.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Zistiť riadky nakonfigurované prostredníctvom doplnku „KefinTweaks“ ranaldsgift. Vlastné sekcie, nedávno vydané, pozerané znova, sezónne a nedávno pridané do knižnice, sa zrkadlia z konfigurácie KefinTweaks na každom serveri Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Zatiaľ žiadne servery Jellyfin nehlásia KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Otvorte sekcie Domov';
 
   @override
@@ -6497,7 +6489,7 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Zobraziť všetko';
@@ -7465,6 +7457,40 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7495,9 +7521,6 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7609,6 +7632,22 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7720,6 +7720,14 @@ class AppLocalizationsSk extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7721,7 +7721,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -6452,6 +6452,14 @@ class AppLocalizationsSl extends AppLocalizations {
       'Noben strežnik Jellyfin še ne poroča o vtičniku.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Zaznaj vrstice, konfigurirane prek vtičnika \"KefinTweaks\" podjetja ranaldsgift. Odseki po meri, nedavno izdani, ponovni ogled, sezonski in nedavno dodani v knjižnico se zrcalijo iz konfiguracije KefinTweaks na vsakem strežniku Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Noben strežnik Jellyfin še ne poroča o KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Odprite domače razdelke';
 
   @override
@@ -6487,7 +6495,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Poglej vse';
@@ -7454,40 +7462,6 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7518,6 +7492,9 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7629,22 +7606,6 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7718,7 +7718,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -6452,14 +6452,6 @@ class AppLocalizationsSl extends AppLocalizations {
       'Noben strežnik Jellyfin še ne poroča o vtičniku.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Zaznaj vrstice, konfigurirane prek vtičnika \"KefinTweaks\" podjetja ranaldsgift. Odseki po meri, nedavno izdani, ponovni ogled, sezonski in nedavno dodani v knjižnico se zrcalijo iz konfiguracije KefinTweaks na vsakem strežniku Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Noben strežnik Jellyfin še ne poroča o KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Odprite domače razdelke';
 
   @override
@@ -6495,7 +6487,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Poglej vse';
@@ -7462,6 +7454,40 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7492,9 +7518,6 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7606,6 +7629,22 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7717,6 +7717,14 @@ class AppLocalizationsSl extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1719,7 +1719,7 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Shikuesi';
 
   @override
   String get seerrAccountType => 'Lloji i llogarisë Seer';
@@ -6482,6 +6482,14 @@ class AppLocalizationsSq extends AppLocalizations {
       'Nuk ka ende serverë Jellyfin që raportojnë shtesën.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Zbuloni rreshtat e konfiguruar nëpërmjet shtojcës \"KefinTweaks\" të ranaldsgift. Seksionet e personalizuara, të lëshuara së fundmi, shikimi përsëri, sezonal dhe të shtuar së fundi në bibliotekë pasqyrohen nga konfigurimi i KefinTweaks në çdo server Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Ende nuk ka serverë Jellyfin që raportojnë KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Hapni seksionet kryesore';
 
   @override
@@ -6517,7 +6525,7 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Shih të gjitha';
@@ -7485,40 +7493,6 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7549,6 +7523,9 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7660,22 +7637,6 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1719,7 +1719,7 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Shikuesi';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Lloji i llogarisë Seer';
@@ -6482,14 +6482,6 @@ class AppLocalizationsSq extends AppLocalizations {
       'Nuk ka ende serverë Jellyfin që raportojnë shtesën.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Zbuloni rreshtat e konfiguruar nëpërmjet shtojcës \"KefinTweaks\" të ranaldsgift. Seksionet e personalizuara, të lëshuara së fundmi, shikimi përsëri, sezonal dhe të shtuar së fundi në bibliotekë pasqyrohen nga konfigurimi i KefinTweaks në çdo server Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Ende nuk ka serverë Jellyfin që raportojnë KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Hapni seksionet kryesore';
 
   @override
@@ -6525,7 +6517,7 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Shih të gjitha';
@@ -7493,6 +7485,40 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7523,9 +7549,6 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7637,6 +7660,22 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -7748,6 +7748,14 @@ class AppLocalizationsSq extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -7749,7 +7749,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1711,7 +1711,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Сеерр';
 
   @override
   String get seerrAccountType => 'Сеерр Тип налога';
@@ -6447,6 +6447,14 @@ class AppLocalizationsSr extends AppLocalizations {
       'Још нема __АРБ_ТЕРМ_0__ сервера који пријављују додатак.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Откријте редове конфигурисане преко раналдсгифтовог додатка „КефинТвеакс“. Прилагођени одељци, недавно објављени, поново гледајте, сезонски и недавно додати у библиотеку, пресликавају се из КефинТвеакс конфигурације на сваком __АРБ_ТЕРМ_0__ серверу.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Још нема __АРБ_ТЕРМ_0__ сервера који пријављују КефинТвеакс.';
+
+  @override
   String get integrationOpenHomeSections => 'Отворите Хоме Сецтионс';
 
   @override
@@ -6482,7 +6490,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Види све';
@@ -7450,40 +7458,6 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7514,6 +7488,9 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7625,22 +7602,6 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -7714,7 +7714,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -7713,6 +7713,14 @@ class AppLocalizationsSr extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1711,7 +1711,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Сеерр';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Сеерр Тип налога';
@@ -6447,14 +6447,6 @@ class AppLocalizationsSr extends AppLocalizations {
       'Још нема __АРБ_ТЕРМ_0__ сервера који пријављују додатак.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Откријте редове конфигурисане преко раналдсгифтовог додатка „КефинТвеакс“. Прилагођени одељци, недавно објављени, поново гледајте, сезонски и недавно додати у библиотеку, пресликавају се из КефинТвеакс конфигурације на сваком __АРБ_ТЕРМ_0__ серверу.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Још нема __АРБ_ТЕРМ_0__ сервера који пријављују КефинТвеакс.';
-
-  @override
   String get integrationOpenHomeSections => 'Отворите Хоме Сецтионс';
 
   @override
@@ -6490,7 +6482,7 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Види све';
@@ -7458,6 +7450,40 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7488,9 +7514,6 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7602,6 +7625,22 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6436,6 +6436,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'Inga Jellyfin-servrar rapporterar plugin-programmet ännu.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Upptäck rader konfigurerade via ranaldsgifts \"KefinTweaks\"-plugin. Anpassade avsnitt, nyligen släppta, titta igen, säsongsbetonade och nyligen tillagda i biblioteket speglas från KefinTweaks-konfigurationen på varje Jellyfin-server.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Inga Jellyfin-servrar som rapporterar KefinTweaks än.';
+
+  @override
   String get integrationOpenHomeSections => 'Öppna Home Sektioner';
 
   @override
@@ -6471,7 +6479,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Se alla';
@@ -7436,40 +7444,6 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7500,6 +7474,9 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7611,22 +7588,6 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6436,14 +6436,6 @@ class AppLocalizationsSv extends AppLocalizations {
       'Inga Jellyfin-servrar rapporterar plugin-programmet ännu.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Upptäck rader konfigurerade via ranaldsgifts \"KefinTweaks\"-plugin. Anpassade avsnitt, nyligen släppta, titta igen, säsongsbetonade och nyligen tillagda i biblioteket speglas från KefinTweaks-konfigurationen på varje Jellyfin-server.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Inga Jellyfin-servrar som rapporterar KefinTweaks än.';
-
-  @override
   String get integrationOpenHomeSections => 'Öppna Home Sektioner';
 
   @override
@@ -6479,7 +6471,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Se alla';
@@ -7444,6 +7436,40 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7474,9 +7500,6 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7588,6 +7611,22 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7700,7 +7700,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7699,6 +7699,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1720,7 +1720,7 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Mwonaji';
 
   @override
   String get seerrAccountType => 'Aina ya Akaunti ya Mtazamaji';
@@ -6472,6 +6472,14 @@ class AppLocalizationsSw extends AppLocalizations {
       'Bado hakuna seva za Jellyfin zinazoripoti programu-jalizi.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Tambua safu mlalo zilizosanidiwa kupitia programu-jalizi ya \"KefinTweaks\" ya ranaldsgift. Sehemu maalum, iliyotolewa hivi majuzi, tazama tena, msimu, na iliyoongezwa hivi majuzi kwenye maktaba huakisiwa kutoka kwa usanidi wa KefinTweaks kwenye kila seva ya Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Bado hakuna seva za Jellyfin zinazoripoti KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Fungua Sehemu za Nyumbani';
 
   @override
@@ -6507,7 +6515,7 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Tazama Yote';
@@ -7477,40 +7485,6 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7541,6 +7515,9 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7652,22 +7629,6 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -7740,6 +7740,14 @@ class AppLocalizationsSw extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1720,7 +1720,7 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Mwonaji';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Aina ya Akaunti ya Mtazamaji';
@@ -6472,14 +6472,6 @@ class AppLocalizationsSw extends AppLocalizations {
       'Bado hakuna seva za Jellyfin zinazoripoti programu-jalizi.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Tambua safu mlalo zilizosanidiwa kupitia programu-jalizi ya \"KefinTweaks\" ya ranaldsgift. Sehemu maalum, iliyotolewa hivi majuzi, tazama tena, msimu, na iliyoongezwa hivi majuzi kwenye maktaba huakisiwa kutoka kwa usanidi wa KefinTweaks kwenye kila seva ya Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Bado hakuna seva za Jellyfin zinazoripoti KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Fungua Sehemu za Nyumbani';
 
   @override
@@ -6515,7 +6507,7 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Tazama Yote';
@@ -7485,6 +7477,40 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7515,9 +7541,6 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7629,6 +7652,22 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -7741,7 +7741,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1717,7 +1717,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'சீர்';
 
   @override
   String get seerrAccountType => 'சீர் கணக்கு வகை';
@@ -6476,6 +6476,14 @@ class AppLocalizationsTa extends AppLocalizations {
       'Jellyfin சேவையகங்கள் இன்னும் செருகுநிரலைப் புகாரளிக்கவில்லை.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ranaldsgift இன் \"KefinTweaks\" செருகுநிரல் வழியாக கட்டமைக்கப்பட்ட வரிசைகளைக் கண்டறியவும். ஒவ்வொரு Jellyfin சர்வரிலும் உள்ள KefinTweaks உள்ளமைவில் இருந்து சமீபத்தில் வெளியிடப்பட்ட தனிப்பயன் பிரிவுகள், மீண்டும் பார்க்கவும், பருவகாலம் மற்றும் சமீபத்தில் நூலகத்தில் சேர்க்கப்பட்டவை.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'இதுவரை எந்த Jellyfin சேவையகங்களும் KefinTweaks ஐப் புகாரளிக்கவில்லை.';
+
+  @override
   String get integrationOpenHomeSections => 'முகப்புப் பிரிவுகளைத் திற';
 
   @override
@@ -6512,7 +6520,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'அனைத்தையும் பார்க்கவும்';
@@ -7480,40 +7488,6 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7544,6 +7518,9 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7655,22 +7632,6 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -7744,7 +7744,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1717,7 +1717,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'சீர்';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'சீர் கணக்கு வகை';
@@ -6476,14 +6476,6 @@ class AppLocalizationsTa extends AppLocalizations {
       'Jellyfin சேவையகங்கள் இன்னும் செருகுநிரலைப் புகாரளிக்கவில்லை.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ranaldsgift இன் \"KefinTweaks\" செருகுநிரல் வழியாக கட்டமைக்கப்பட்ட வரிசைகளைக் கண்டறியவும். ஒவ்வொரு Jellyfin சர்வரிலும் உள்ள KefinTweaks உள்ளமைவில் இருந்து சமீபத்தில் வெளியிடப்பட்ட தனிப்பயன் பிரிவுகள், மீண்டும் பார்க்கவும், பருவகாலம் மற்றும் சமீபத்தில் நூலகத்தில் சேர்க்கப்பட்டவை.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'இதுவரை எந்த Jellyfin சேவையகங்களும் KefinTweaks ஐப் புகாரளிக்கவில்லை.';
-
-  @override
   String get integrationOpenHomeSections => 'முகப்புப் பிரிவுகளைத் திற';
 
   @override
@@ -6520,7 +6512,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'அனைத்தையும் பார்க்கவும்';
@@ -7488,6 +7480,40 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7518,9 +7544,6 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7632,6 +7655,22 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -7743,6 +7743,14 @@ class AppLocalizationsTa extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1714,7 +1714,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'సీర్';
 
   @override
   String get seerrAccountType => 'సీర్ ఖాతా రకం';
@@ -6463,6 +6463,14 @@ class AppLocalizationsTe extends AppLocalizations {
       'ఇంకా Jellyfin సర్వర్‌లు ప్లగిన్‌ను నివేదించలేదు.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Ranaldsgift యొక్క \"KefinTweaks\" ప్లగ్ఇన్ ద్వారా కాన్ఫిగర్ చేయబడిన అడ్డు వరుసలను గుర్తించండి. ప్రతి Jellyfin సర్వర్‌లోని కెఫిన్‌ట్వీక్స్ కాన్ఫిగరేషన్ నుండి ఇటీవల విడుదల చేసిన అనుకూల విభాగాలు, మళ్లీ చూడండి, కాలానుగుణమైనవి మరియు ఇటీవల లైబ్రరీలో జోడించబడ్డాయి.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaksని ఇంకా Jellyfin సర్వర్‌లు నివేదించలేదు.';
+
+  @override
   String get integrationOpenHomeSections => 'హోమ్ విభాగాలను తెరవండి';
 
   @override
@@ -6499,7 +6507,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'అన్నీ చూడండి';
@@ -7471,40 +7479,6 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'ఈ పరికరం నుండి \"$themeName\" తొలగించబడింది.';
   }
@@ -7536,6 +7510,9 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'ఈ పరికరంలో డౌన్‌లోడ్ చేయబడిన ప్లగిన్ థీమ్‌లను నిర్వహించండి';
+
+  @override
+  String get kefinTweaksTitle => 'కెఫిన్‌ట్వీక్స్';
 
   @override
   String get homeScreenSectionsTitle => 'హోమ్ స్క్రీన్ విభాగాలు';
@@ -7648,22 +7625,6 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -7738,7 +7738,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1714,7 +1714,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'సీర్';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'సీర్ ఖాతా రకం';
@@ -6463,14 +6463,6 @@ class AppLocalizationsTe extends AppLocalizations {
       'ఇంకా Jellyfin సర్వర్‌లు ప్లగిన్‌ను నివేదించలేదు.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Ranaldsgift యొక్క \"KefinTweaks\" ప్లగ్ఇన్ ద్వారా కాన్ఫిగర్ చేయబడిన అడ్డు వరుసలను గుర్తించండి. ప్రతి Jellyfin సర్వర్‌లోని కెఫిన్‌ట్వీక్స్ కాన్ఫిగరేషన్ నుండి ఇటీవల విడుదల చేసిన అనుకూల విభాగాలు, మళ్లీ చూడండి, కాలానుగుణమైనవి మరియు ఇటీవల లైబ్రరీలో జోడించబడ్డాయి.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaksని ఇంకా Jellyfin సర్వర్‌లు నివేదించలేదు.';
-
-  @override
   String get integrationOpenHomeSections => 'హోమ్ విభాగాలను తెరవండి';
 
   @override
@@ -6507,7 +6499,7 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'అన్నీ చూడండి';
@@ -7479,6 +7471,40 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'ఈ పరికరం నుండి \"$themeName\" తొలగించబడింది.';
   }
@@ -7510,9 +7536,6 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'ఈ పరికరంలో డౌన్‌లోడ్ చేయబడిన ప్లగిన్ థీమ్‌లను నిర్వహించండి';
-
-  @override
-  String get kefinTweaksTitle => 'కెఫిన్‌ట్వీక్స్';
 
   @override
   String get homeScreenSectionsTitle => 'హోమ్ స్క్రీన్ విభాగాలు';
@@ -7625,6 +7648,22 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -7737,6 +7737,14 @@ class AppLocalizationsTe extends AppLocalizations {
       'స్కిప్ అవుట్‌రో బటన్‌కు బదులుగా తదుపరి పైకి అతివ్యాప్తిని చూపండి.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'ప్లేయర్ రూటింగ్';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1693,7 +1693,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'เซียร์';
 
   @override
   String get seerrAccountType => 'ประเภทบัญชี Seerr';
@@ -6392,6 +6392,14 @@ class AppLocalizationsTh extends AppLocalizations {
       'ยังไม่มีเซิร์ฟเวอร์ Jellyfin รายงานปลั๊กอิน';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'ตรวจหาแถวที่กำหนดค่าผ่านปลั๊กอิน \"KefinTweaks\" ของ ranaldsgift ส่วนที่กำหนดเอง เพิ่งเปิดตัว ดูอีกครั้ง ตามฤดูกาล และเพิ่มล่าสุดในไลบรารีจะถูกมิเรอร์จากการกำหนดค่า KefinTweaks บนเซิร์ฟเวอร์ Jellyfin แต่ละตัว';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'ยังไม่มีเซิร์ฟเวอร์ Jellyfin ที่รายงาน KefinTweaks';
+
+  @override
   String get integrationOpenHomeSections => 'เปิดส่วนหน้าแรก';
 
   @override
@@ -6427,7 +6435,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'ดูทั้งหมด';
@@ -7372,40 +7380,6 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'ลบ \"$themeName\" ออกจากอุปกรณ์นี้แล้ว';
   }
@@ -7436,6 +7410,9 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'จัดการธีมปลั๊กอินที่ดาวน์โหลดบนอุปกรณ์นี้';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'ส่วนหน้าจอหลัก';
@@ -7546,22 +7523,6 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -7635,7 +7635,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -7634,6 +7634,14 @@ class AppLocalizationsTh extends AppLocalizations {
       'แสดงโอเวอร์เลย์ถัดไปแทนปุ่มข้าม';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'เส้นทางผู้เล่น';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1693,7 +1693,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'เซียร์';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'ประเภทบัญชี Seerr';
@@ -6392,14 +6392,6 @@ class AppLocalizationsTh extends AppLocalizations {
       'ยังไม่มีเซิร์ฟเวอร์ Jellyfin รายงานปลั๊กอิน';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'ตรวจหาแถวที่กำหนดค่าผ่านปลั๊กอิน \"KefinTweaks\" ของ ranaldsgift ส่วนที่กำหนดเอง เพิ่งเปิดตัว ดูอีกครั้ง ตามฤดูกาล และเพิ่มล่าสุดในไลบรารีจะถูกมิเรอร์จากการกำหนดค่า KefinTweaks บนเซิร์ฟเวอร์ Jellyfin แต่ละตัว';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'ยังไม่มีเซิร์ฟเวอร์ Jellyfin ที่รายงาน KefinTweaks';
-
-  @override
   String get integrationOpenHomeSections => 'เปิดส่วนหน้าแรก';
 
   @override
@@ -6435,7 +6427,7 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'ดูทั้งหมด';
@@ -7380,6 +7372,40 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'ลบ \"$themeName\" ออกจากอุปกรณ์นี้แล้ว';
   }
@@ -7410,9 +7436,6 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'จัดการธีมปลั๊กอินที่ดาวน์โหลดบนอุปกรณ์นี้';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'ส่วนหน้าจอหลัก';
@@ -7523,6 +7546,22 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -6499,6 +6499,14 @@ class AppLocalizationsTl extends AppLocalizations {
       'Wala pang mga server ng Jellyfin na nag-uulat ng plugin.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'I-detect ang mga row na na-configure sa pamamagitan ng \"KefinTweaks\" na plugin ng ranaldsgift. Ang mga custom na seksyon, kamakailang inilabas, manood muli, pana-panahon, at kamakailang idinagdag sa library ay sinasalamin mula sa configuration ng KefinTweaks sa bawat server ng Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Wala pang mga server ng Jellyfin na nag-uulat ng KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Buksan ang Mga Seksyon ng Tahanan';
 
   @override
@@ -6535,7 +6543,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Tingnan Lahat';
@@ -7505,40 +7513,6 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7569,6 +7543,9 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7680,22 +7657,6 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -7769,7 +7769,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -7768,6 +7768,14 @@ class AppLocalizationsTl extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -6499,14 +6499,6 @@ class AppLocalizationsTl extends AppLocalizations {
       'Wala pang mga server ng Jellyfin na nag-uulat ng plugin.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'I-detect ang mga row na na-configure sa pamamagitan ng \"KefinTweaks\" na plugin ng ranaldsgift. Ang mga custom na seksyon, kamakailang inilabas, manood muli, pana-panahon, at kamakailang idinagdag sa library ay sinasalamin mula sa configuration ng KefinTweaks sa bawat server ng Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Wala pang mga server ng Jellyfin na nag-uulat ng KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Buksan ang Mga Seksyon ng Tahanan';
 
   @override
@@ -6543,7 +6535,7 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Tingnan Lahat';
@@ -7513,6 +7505,40 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7543,9 +7569,6 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7657,6 +7680,22 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -166,11 +166,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Macenta parıltılı, camgöbeği metinli ve daha güçlü krom kontrastlı Synthwave stili';
 
   @override
-  String get themeGlass => 'Cam';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Akan gradyan arka plan, buzlu yüzeyler ve Apple mavisi vurgulu sıvı-cam tasarımı';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -1071,10 +1071,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get director => 'YÖNETMEN';
 
   @override
-  String get directors => 'YÖNETMENLER';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'YAZAR';
+  String get writer => 'WRITER';
 
   @override
   String get writers => 'YAZARLAR';
@@ -1332,7 +1332,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get playbackInformation => 'Oynatma Bilgileri';
 
   @override
-  String get playback => 'Oynatma';
+  String get playback => 'Playback';
 
   @override
   String get playMethod => 'Oynatma Yöntemi';
@@ -1991,7 +1991,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get focusExpansionAnimation => 'Odak Genişletme Animasyonu';
 
   @override
-  String get desktopUiScale => 'Arayüz Ölçeklendirme';
+  String get desktopUiScale => 'Masaüstü Kullanıcı Arayüzü Ölçeği';
 
   @override
   String get scaleFocusedCards =>
@@ -2236,24 +2236,23 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Ses çözme yöntemini seçin. AVR Doğrudan Geçiş (Passthrough), ham Dolby/DTS akışlarını alıcınıza gönderir; Otomatik veya Downmix ise sesi cihazınızda çözer.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough =>
-      'AVR Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Yedek Ses Kodeki';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Kaynak akış doğrudan oynatılamadığında veya doğrudan geçiş (passthrough) yapılamadığında, çok kanallı sesin dönüştürüleceği hedef formatı seçin.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Otomatik Algıla\n(Önerilen)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Varsayılan)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2262,27 +2261,26 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Kayıpsız)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Sadece Stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Verimli)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Kayıpsız)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maksimum Kanal Sayısı';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Ses sisteminizin maksimum kanal sayısını yapılandırın. Bu sınırı aşan çok kanallı akışlar downmix yapılacak (azaltılacak) veya dönüştürülecektir.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Otomatik Algıla\n(Donanım Varsayılanı)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2294,7 +2292,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kuadrafonik';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2309,75 +2307,67 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced =>
-      'Doğrudan Geçiş(Passthrough) (Gelişmiş)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough =>
-      'Kodek Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Yalnızca AVR veya HDMI alıcınızın desteklediği formatları etkinleştirin.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough =>
-      'EAC3 Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough =>
-      'EAC3 JOC (Atmos) Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough =>
-      'DTS Core Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough =>
-      'DTS-HD MA Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough =>
-      'TrueHD Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough =>
-      'TrueHD Atmos Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Dolby Digital Plus (EAC3) ses akışını harici dekodere ilet.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'EAC3 (JOC) üzerinden Dolby Atmos ses akışını harici dekodere ilet.';
+      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'DTS çekirdeğini içeren DTS-HD MA ses akışını harici dekodere ilet.';
+      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Atmos meta verileri içeren Dolby TrueHD ses akışını harici dekodere ilet.';
+      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Algılanan Ses Özellikleri';
+  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'Henüz çalışma zamanı yetenek profili mevcut değil.';
+      'No runtime capability snapshot available yet.';
 
   @override
-  String get settingsAudioRouteLabel => 'Ses Çıkışı';
+  String get settingsAudioRouteLabel => 'Route';
 
   @override
-  String get settingsAudioDecodeLabel => 'Kod Çözme';
+  String get settingsAudioDecodeLabel => 'Decode';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioPassthroughLabel => 'Passthrough';
 
   @override
-  String get settingsAudioHdRoute => 'HD Ses Çıkısı';
+  String get settingsAudioHdRoute => 'HD audio route';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2392,47 +2382,47 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Hoparlör';
+  String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '$count kanal PCM';
+    return '${count}ch PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Tanılama';
+  String get settingsAudioDiagnostics => 'Diagnostics';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Video Seviyesi';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Video Aralığı';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Altyazı Kodeki';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'İzin Verilen Ses Kodekleri';
+      'Allowed Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS Ses Kodekleri';
+      'HLS MPEG-TS Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 Ses Kodekleri';
+      'HLS fMP4 Audio Codecs';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif doğrudan geçiş (passthrough)';
+      'audio-spdif passthrough';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktif Ses Çıkışı';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'HD Ses Çıkışı Desteği';
+      'Route HD Audio Support';
 
   @override
   String get nightMode => 'Gece Modu';
@@ -2497,7 +2487,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return '$episodes bölüm / $hours saat sonra';
+    return 'After $episodes episodes / ${hours}h';
   }
 
   @override
@@ -2630,17 +2620,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return '$profile profil ayarları yüklendi.';
+    return 'Loaded $profile profile settings.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return '$profile profil ayarları yüklenemedi.';
+    return 'Failed to load $profile profile settings.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Yerel ayarlar $profile profiliyle senkronize edildi.';
+    return 'Synced local settings to $profile profile.';
   }
 
   @override
@@ -2657,7 +2647,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get syncing => 'Senkronize ediliyor...';
 
   @override
-  String get syncToProfile => 'Profili Senkronize Et';
+  String get syncToProfile => 'Profile Senkronizasyon';
 
   @override
   String get profileSyncHidden => 'Profil Senkronizasyonu Gizli';
@@ -2769,7 +2759,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get showLibrariesInToolbar => 'Kitaplıkları Araç Çubuğunda Göster';
 
   @override
-  String get showSeerrButton => 'Seerr Butonunu Göster';
+  String get showSeerrButton => 'Show Seerr Button';
 
   @override
   String get navbarOpacity => 'Gezinti Çubuğunun Opaklığı';
@@ -2870,7 +2860,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count öge seçildi';
+    return '$count selected';
   }
 
   @override
@@ -2893,11 +2883,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Fragmanı, medyayı ve ses önizlemelerini yapılandırın.';
 
   @override
-  String get mediaBarMode => 'Medya Çubuğu Stili';
+  String get mediaBarMode => 'Medya Cubugu Stili';
 
   @override
   String get mediaBarModeDescription =>
-      'Çeşitli medya çubuğu stilleri arasından seçim yapın veya medya çubuğunu kapatın';
+      'Moonfin, MakD arasindan secin veya medya cubugunu kapatin';
 
   @override
   String get mediaBarModeMoonfin => 'Moonfin';
@@ -3004,7 +2994,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get liveTV => 'Canlı TV';
 
   @override
-  String get homeSections => 'Ana Sayfa Bölümleri';
+  String get homeSections => 'Ana Sayfa Bölümler';
 
   @override
   String get resetToDefaults => 'Varsayılanlara sıfırla';
@@ -3021,18 +3011,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get mergeContinueWatchingAndNextUp =>
-      'İzlemeye Devam Et ve Sıradaki Bölümleri Birleştir';
+      'Birleştir İzlemeye Devam Et ve Sıradaki';
 
   @override
   String get combineBothRows =>
       'Her iki satırı tek bir ana bölümde birleştirin';
 
   @override
-  String get fullScreenRows => 'Genişletilmiş Ana Sayfa Satırları';
+  String get fullScreenRows => 'Expanded Home Rows';
 
   @override
-  String get fullScreenRowsDescription =>
-      'Ana sayfa satırlarını ekran başına 1 satırla sınırla';
+  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
 
   @override
   String get perRowImageType => 'Satır Başına Görüntü Türü';
@@ -3047,7 +3036,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get lastUser => 'Son Kullanıcı';
 
   @override
-  String get currentUser => 'Mevcut Kullanıcı';
+  String get currentUser => 'Current User';
 
   @override
   String get alwaysAuthenticate => 'Daima Kimlik Doğrula';
@@ -3154,10 +3143,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ekran koruyucu sırasında saati göster';
 
   @override
-  String get clockModeStatic => 'Statik';
+  String get clockModeStatic => 'Static';
 
   @override
-  String get clockModeBouncing => 'Zıplayan';
+  String get clockModeBouncing => 'Bouncing';
 
   @override
   String get rottenTomatoesCritics => 'Çürük Domates (Eleştirmenler)';
@@ -3231,7 +3220,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Uygulama genelinde gösterilen derecelendirme kaynaklarını etkinleştirin ve yeniden sıralayın';
 
   @override
-  String get pluginLabel => 'Moonbase Eklentisi';
+  String get pluginLabel => 'Eklenti';
 
   @override
   String get pluginDetected => 'Eklenti Algılandı';
@@ -3303,7 +3292,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get networks => 'Ağlar';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr Keşfet Satırları';
+  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override
   String get resetRowsToDefaults => 'Satırları varsayılanlara sıfırla';
@@ -3328,7 +3317,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String loggedInAs(String username) {
-    return '$username olarak oturum açıldı';
+    return 'Logged in as: $username';
   }
 
   @override
@@ -3404,7 +3393,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Güncelleme mevcut: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -3416,7 +3405,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version Mevcut';
+    return 'v$version Available';
   }
 
   @override
@@ -3503,7 +3492,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return '$name tarafından istendi';
+    return 'Requested by $name';
   }
 
   @override
@@ -3520,12 +3509,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return '\"$title\" isteği iptal edilsin mi?';
+    return 'Cancel request for \"$title\"?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return '\"$title\" için yapılan $count istek iptal edilsin mi?';
+    return 'Cancel $count requests for \"$title\"?';
   }
 
   @override
@@ -3539,12 +3528,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Bütçe: $amount \$';
+    return 'Budget: \$$amount';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Hasılat: $amount \$';
+    return 'Revenue: \$$amount';
   }
 
   @override
@@ -3554,7 +3543,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'İste $type';
+    return 'Request $type';
   }
 
   @override
@@ -3590,7 +3579,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'yaş $age';
+    return 'age $age';
   }
 
   @override
@@ -3881,22 +3870,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return '$count eklenti güncellemesi mevcut';
+    return 'Plugin updates available: $count';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Yeniden başlatılması gereken $count eklenti var';
+    return 'Plugins requiring restart: $count';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return '$count zamanlanmış görev başarısız oldu';
+    return 'Failed scheduled tasks: $count';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Son uyarı/hata kayıtları:$count';
+    return 'Recent warning/error entries: $count';
   }
 
   @override
@@ -3983,7 +3972,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Komut başarısız oldu:$error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -4044,11 +4033,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminDisconnect => 'Bağlantıyı kes';
 
   @override
-  String get adminClearDates => 'Tarihleri temizle';
+  String get adminClearDates => 'Tarihleri ​​temizle';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Etkinlik günlüğü yüklenemedi:$error';
+    return 'Failed to load activity log: $error';
   }
 
   @override
@@ -4065,7 +4054,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Cihaz güncellenemedi:$error';
+    return 'Failed to update device: $error';
   }
 
   @override
@@ -4076,7 +4065,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Cihaz silinemedi: $error';
+    return 'Failed to delete device: $error';
   }
 
   @override
@@ -4105,7 +4094,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Tarama başlatılamadı: $error';
+    return 'Failed to start scan: $error';
   }
 
   @override
@@ -4116,12 +4105,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Kitaplık adı \"$name\" olarak değiştirildi';
+    return 'Library renamed to \"$name\"';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Yeniden adlandırılamadı: $error';
+    return 'Failed to rename: $error';
   }
 
   @override
@@ -4129,17 +4118,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return '\"$name\" kitaplığı silindi';
+    return 'Library \"$name\" deleted';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Kitaplık silinemedi: $error';
+    return 'Failed to delete library: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Yol eklenemedi: $error';
+    return 'Failed to add path: $error';
   }
 
   @override
@@ -4147,12 +4136,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return '\"$path\" yolu bu kitaplıktan kaldırılsın mı?';
+    return 'Remove \"$path\" from this library?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Yol kaldırılamadı: $error';
+    return 'Failed to remove path: $error';
   }
 
   @override
@@ -4160,7 +4149,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Seçenekler kaydedilemedi: $error';
+    return 'Failed to save options: $error';
   }
 
   @override
@@ -4195,7 +4184,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Kitaplık oluşturulamadı: $error';
+    return 'Failed to create library: $error';
   }
 
   @override
@@ -4221,27 +4210,27 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return '\"$name\" kullanıcısı devre dışı bırakılsın mı? Giriş yapamayacaklar.';
+    return 'Disable $name? They will not be able to sign in.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return '\"$name\" kullanıcısı etkinleştirilsin mı? Tekrar giriş yapabilecekler.';
+    return 'Enable $name? They will be able to sign in again.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return '\"$name\" kullanıcısı devre dışı bırakıldı';
+    return 'User \"$name\" disabled';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return '\"$name\" kullanıcısı etkinleştirildi';
+    return 'User \"$name\" enabled';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Kullanıcı politikası güncellenemedi: $error';
+    return 'Failed to update user policy: $error';
   }
 
   @override
@@ -4258,7 +4247,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Kullanıcı oluşturulamadı: $error';
+    return 'Failed to create user: $error';
   }
 
   @override
@@ -4278,7 +4267,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Kaydedilemedi: $error';
+    return 'Failed to save: $error';
   }
 
   @override
@@ -4289,7 +4278,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Başarısız oldu: $error';
+    return 'Failed: $error';
   }
 
   @override
@@ -4429,22 +4418,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Sunucu yanıtı: HTTP $status';
+    return 'Server returned HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return '$name öğesini silmek istediğinizden emin misiniz?';
+    return 'Are you sure you want to delete $name?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return '\"$name\" kullanıcısı silindi';
+    return 'User \"$name\" deleted';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Kullanıcı silinemedi: $error';
+    return 'Failed to delete user: $error';
   }
 
   @override
@@ -4465,7 +4454,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Anahtar oluşturulamadı: $error';
+    return 'Failed to create key: $error';
   }
 
   @override
@@ -4476,7 +4465,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return '$name için anahtar iptal edilsin mi?';
+    return 'Revoke key for $name?';
   }
 
   @override
@@ -4484,7 +4473,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Anahtar iptal edilemedi: $error';
+    return 'Failed to revoke key: $error';
   }
 
   @override
@@ -4504,7 +4493,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Jeton: $token\\nOluşturulma tarihi: $created';
+    return 'Token: $token\\nCreated: $created';
   }
 
   @override
@@ -4515,7 +4504,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Yedek oluşturulamadı: $error';
+    return 'Failed to create backup: $error';
   }
 
   @override
@@ -4528,7 +4517,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Manifest yüklenemedi: $error';
+    return 'Failed to load manifest: $error';
   }
 
   @override
@@ -4539,7 +4528,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Yedek geri yüklenemedi: $error';
+    return 'Failed to restore backup: $error';
   }
 
   @override
@@ -4571,17 +4560,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return '$path konumuna kaydedildi';
+    return 'Saved to $path';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Dosya kaydedilemedi: $error';
+    return 'Failed to save file: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Dosya yüklenemedi: $fileName';
+    return 'Failed to load $fileName';
   }
 
   @override
@@ -4592,7 +4581,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Görevler yüklenemedi: $error';
+    return 'Failed to load tasks: $error';
   }
 
   @override
@@ -4603,17 +4592,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Görev başlatılamadı: $error';
+    return 'Failed to start task: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Görev durdurulamadı: $error';
+    return 'Failed to stop task: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Görev yüklenemedi: $error';
+    return 'Failed to load task: $error';
   }
 
   @override
@@ -4621,12 +4610,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Tetikleyici kaldırılamadı: $error';
+    return 'Failed to remove trigger: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Tetikleyici eklenemedi: $error';
+    return 'Failed to add trigger: $error';
   }
 
   @override
@@ -4652,7 +4641,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours saat';
+    return '$hours hour(s)';
   }
 
   @override
@@ -4663,7 +4652,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Eklenti durumu değiştirilemedi: $error';
+    return 'Failed to toggle plugin: $error';
   }
 
   @override
@@ -4671,27 +4660,27 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return '\"$name\" eklentisini kaldırmak istediğinize emin misiniz?';
+    return 'Are you sure you want to uninstall \"$name\"?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Eklenti kaldırılamadı: $error';
+    return 'Failed to uninstall plugin: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Paket yüklenemedi: $error';
+    return 'Failed to install package: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Güncelleme yüklenemedi: $error';
+    return 'Failed to install update: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Eklentiler yüklenemedi: $error';
+    return 'Failed to load plugins: $error';
   }
 
   @override
@@ -4707,7 +4696,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Katalog yüklenemedi: $error';
+    return 'Failed to load catalog: $error';
   }
 
   @override
@@ -4728,17 +4717,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" sunucu yeniden başlatıldıktan sonra kaldırılacak';
+    return '\"$name\" will be removed after server restart';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Kaldırılamadı: $error';
+    return 'Failed to uninstall: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return '\"$name\", v$version sürümüne güncelleniyor...';
+    return 'Updating \"$name\" to v$version...';
   }
 
   @override
@@ -4747,7 +4736,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Eklenti yüklenemedi: $error';
+    return 'Failed to load plugin: $error';
   }
 
   @override
@@ -4775,17 +4764,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return '\"$name\" ögesini kaldırmak istediğinize emin misiniz?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Depolar kaydedilemedi: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Depolar yüklenemedi: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -4802,12 +4791,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Eklenti ayarları yüklenemedi: $error';
+    return 'Unable to load plugin settings: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return '$uri açılamadı';
+    return 'Could not open $uri';
   }
 
   @override
@@ -5084,12 +5073,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Meta veriler yüklenemedi: $error';
+    return 'Failed to load metadata: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Meta veriler kaydedilemedi: $error';
+    return 'Failed to save metadata: $error';
   }
 
   @override
@@ -5109,7 +5098,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Meta veriler yenilenemedi: $error';
+    return 'Failed to refresh metadata: $error';
   }
 
   @override
@@ -5126,7 +5115,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Uzaktan arama başarısız oldu: $error';
+    return 'Remote search failed: $error';
   }
 
   @override
@@ -5140,7 +5129,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'İçerik türü güncellenemedi: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -5155,12 +5144,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType görseli güncellendi';
+    return '$imageType image updated';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Görsel indirilemedi: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -5171,12 +5160,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType görseli yüklendi';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Görsel yüklenemedi: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
@@ -5186,12 +5175,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType görseli silindi';
+    return '$imageType image deleted';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Görsel silinemedi: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
@@ -5202,14 +5191,14 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Tuner taraması başarısız oldu: $error';
+    return 'Tuner discovery failed: $error';
   }
 
   @override
-  String get adminAddTuner => 'Tuner Ekle';
+  String get adminAddTuner => 'Ayarlayıcı Ekle';
 
   @override
-  String get adminTunerType => 'Tuner Türü';
+  String get adminTunerType => 'Ayarlayıcı Türü';
 
   @override
   String get adminTunerTypeHint => 'HDHomeRun, M3U, Diğer';
@@ -5225,7 +5214,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Tuner eklenemedi: $error';
+    return 'Failed to add tuner: $error';
   }
 
   @override
@@ -5248,12 +5237,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Sağlayıcı eklenemedi: $error';
+    return 'Failed to add provider: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Tuner kaldırılamadı: $error';
+    return 'Failed to remove tuner: $error';
   }
 
   @override
@@ -5261,12 +5250,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Tuner sıfırlanamadı: $error';
+    return 'Failed to reset tuner: $error';
   }
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Sağlayıcı kaldırılamadı: $error';
+    return 'Failed to remove provider: $error';
   }
 
   @override
@@ -5289,7 +5278,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Ayarlar kaydedilemedi: $error';
+    return 'Failed to save settings: $error';
   }
 
   @override
@@ -5306,7 +5295,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Eşleştirmeler güncellenemedi: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
@@ -5331,22 +5320,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Kayıt yolu: $path';
+    return 'Recording path: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Dizi yolu: $path';
+    return 'Series path: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Kayıt öncesi süre: $minutes dk';
+    return 'Pre-padding: $minutes min';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Kayıt sonrası süre: $minutes dk';
+    return 'Post-padding: $minutes min';
   }
 
   @override
@@ -5379,7 +5368,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return '$name yedeği şimdi geri yüklensin mi?';
+    return 'Restore backup $name now?';
   }
 
   @override
@@ -5425,27 +5414,27 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '$minutes dk önce';
+    return '${minutes}m ago';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '$hours sa önce';
+    return '${hours}h ago';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '${days}g önce';
+    return '${days}d ago';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return '$fileName yüklenemedi';
+    return 'Failed to load $fileName';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count eşleşme';
+    return '$count matches';
   }
 
   @override
@@ -5556,22 +5545,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType görseli güncellendi';
+    return '$imageType image updated';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType görseli yüklendi';
+    return '$imageType image uploaded';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType görseli silindi';
+    return '$imageType image deleted';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Görsel indirilemedi: $error';
+    return 'Failed to download image: $error';
   }
 
   @override
@@ -5579,7 +5568,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Görsel yüklenemedi: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
@@ -5593,12 +5582,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Görsel silinemedi: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return '$imageType görseli seçin';
+    return 'Choose $imageType image';
   }
 
   @override
@@ -5630,7 +5619,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Güncelleme mevcut: v$version';
+    return 'Update available: v$version';
   }
 
   @override
@@ -5667,7 +5656,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" yükleniyor...';
+    return '\"$name\" is being installed...';
   }
 
   @override
@@ -5687,7 +5676,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name Ayarları';
+    return '$name Settings';
   }
 
   @override
@@ -5727,7 +5716,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Depolar yüklenemedi: $error';
+    return 'Failed to load repositories: $error';
   }
 
   @override
@@ -5735,7 +5724,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return '\"$name\" ögesini kaldırmak istediğinize emin misiniz?';
+    return 'Are you sure you want to remove \"$name\"?';
   }
 
   @override
@@ -5743,7 +5732,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Depolar kaydedilemedi: $error';
+    return 'Failed to save repositories: $error';
   }
 
   @override
@@ -6020,17 +6009,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Her gün $time';
+    return 'Daily at $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Her $day saat $time';
+    return 'Every $day at $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Her $duration';
+    return 'Every $duration';
   }
 
   @override
@@ -6068,8 +6057,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count saat',
-      one: '1 saat',
+      other: '$count hours',
+      one: '1 hour',
     );
     return '$_temp0';
   }
@@ -6097,17 +6086,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '$days g önce';
+    return '${days}d ago';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '$hours sa önce';
+    return '${hours}h ago';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '$minutes dk önce';
+    return '${minutes}m ago';
   }
 
   @override
@@ -6223,7 +6212,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'İçerik türü güncellenemedi: $error';
+    return 'Failed to update content type: $error';
   }
 
   @override
@@ -6246,12 +6235,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Eşleştirmeler güncellenemedi: $error';
+    return 'Failed to update mappings: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Süre sınırı: $duration';
+    return 'Time limit: $duration';
   }
 
   @override
@@ -6288,8 +6277,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# katılımcı',
-      one: '# katılımcı',
+      other: '# participants',
+      one: '# participant',
     );
     return '$_temp0';
   }
@@ -6382,12 +6371,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName SyncPlay grubuna katıldı';
+    return '$userName joined SyncPlay group';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName SyncPlay grubundan ayrıldı';
+    return '$userName left SyncPlay group';
   }
 
   @override
@@ -6399,7 +6388,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Oynatma durumu $groupName ile eşitleniyor';
+    return 'Syncing playback to $groupName';
   }
 
   @override
@@ -6441,6 +6430,14 @@ class AppLocalizationsTr extends AppLocalizations {
       'Henüz eklentiyi bildiren Jellyfin sunucusu yok.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Ranaldsgift\'in \"KefinTweaks\" eklentisi aracılığıyla yapılandırılan satırları tespit edin. Yakın zamanda piyasaya sürülen, tekrar izlenen, sezonluk ve kitaplığa yakın zamanda eklenen özel bölümler, her Jellyfin sunucusundaki KefinTweaks yapılandırmasından yansıtılır.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Henüz KefinTweaks\'i bildiren Jellyfin sunucusu yok.';
+
+  @override
   String get integrationOpenHomeSections => 'Ana Sayfa Bölümlerini Aç';
 
   @override
@@ -6459,8 +6456,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# bölüm',
-      one: '# bölüm',
+      other: '# sections',
+      one: '# section',
     );
     return '$_temp0';
   }
@@ -6470,14 +6467,14 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# satır keşfedildi',
-      one: '# satır keşfedildi',
+      other: '# rows discovered',
+      one: '# row discovered',
     );
     return '$_temp0';
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Tümünü Gör';
@@ -6528,12 +6525,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Yansıtma kontrolü başarısız oldu: $error';
+    return 'Cast control failed: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind Kontrolleri';
+    return '$kind Controls';
   }
 
   @override
@@ -6567,12 +6564,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return '$length haneli bir PIN girin';
+    return 'Enter a $length-digit PIN';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return '$length haneli PIN\'inizi girin';
+    return 'Enter your $length-digit PIN';
   }
 
   @override
@@ -6585,7 +6582,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get pinForgot => 'PIN\'inizi mi unuttunuz?';
 
   @override
-  String get pinClear => 'Temizle';
+  String get pinClear => 'Temizlemek';
 
   @override
   String get pinBackspace => 'Geri tuşu';
@@ -6619,7 +6616,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Hızlı Bağlantı başarısız oldu: $message';
+    return 'Quick Connect failed: $message';
   }
 
   @override
@@ -6630,7 +6627,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Komut başarısız oldu: $error';
+    return 'Command failed: $error';
   }
 
   @override
@@ -6659,7 +6656,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Yansıtma başlatılamadı: $error';
+    return 'Failed to start casting: $error';
   }
 
   @override
@@ -6704,7 +6701,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return '$name indiriliyor...';
+    return 'Downloading $name...';
   }
 
   @override
@@ -6791,7 +6788,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return '$segment geç';
+    return 'Skip $segment';
   }
 
   @override
@@ -6802,12 +6799,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'İndiriliyor: $current/$total — $fileName';
+    return 'Downloading $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return '$fileName indiriliyor';
+    return 'Downloading $fileName';
   }
 
   @override
@@ -6911,7 +6908,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsAuthenticationSection => 'DOĞRULAMA';
 
   @override
-  String get settingsSortServersBy => 'Sunucuları Şuna Göre Sırala';
+  String get settingsSortServersBy => 'Sunucuları Şuna Göre Sırala:';
 
   @override
   String get settingsLastUsed => 'Son Kullanılan';
@@ -6952,7 +6949,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsShowShuffleButtonInNavigation =>
-      'Gezinme çubuğunda karıştır düğmesini göster';
+      'Gezinme çubuğunda karışık düğmesini göster';
 
   @override
   String get settingsShowGenresButtonInNavigation =>
@@ -6968,7 +6965,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Gezinti çubuğunda Seerr butonunu göster';
+      'Show the Seerr button in the navigation bar';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -7037,7 +7034,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Geliştiriciye bir kahve ısmarla';
+      'Donate a coffee to the developer';
 
   @override
   String get settingsLegal => 'YASAL';
@@ -7054,7 +7051,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsPrivacyPolicySubtitle =>
-      'Moonfin verilerinizi nasıl işler';
+      'Moonfin verilerinizi nasıl işler?';
 
   @override
   String get settingsCheckForUpdates => 'Güncellemeleri Kontrol Et';
@@ -7071,8 +7068,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# lisans bildirimi',
-      one: '# lisans bildirimi',
+      other: '# license notices',
+      one: '# license notice',
     );
     return '$_temp0';
   }
@@ -7121,16 +7118,16 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Giriş ve Çıkışlar atlansın mı?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Medya Bölümü Geri Sayımı';
+  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override
-  String get settingsProgressBar => 'İlerleme Çubuğu';
+  String get settingsProgressBar => 'Progress Bar';
 
   @override
-  String get settingsTimer => 'Zamanlayıcı';
+  String get settingsTimer => 'Timer';
 
   @override
-  String get settingsNone => 'Hiçbiri';
+  String get settingsNone => 'None';
 
   @override
   String get settingsPromptUser => 'Kullanıcıya Sor';
@@ -7164,13 +7161,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (önerilir)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (eski nesil)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (eski)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (önerilen)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Geri dönüş';
@@ -7354,410 +7351,360 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String latestLibraryName(String libraryName) {
-    return 'Son Eklenen $libraryName';
+    return 'Latest $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Sonraki Bölümü Otomatik Oynat';
+  String get autoplayNextEpisode => 'Autoplay Next Episode';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Mevcut olduğunda sonraki bölümü otomatik oynat.';
+      'Automatically play the next episode when available.';
 
   @override
-  String get skipSilenceTitle => 'Sessizce Atla';
+  String get skipSilenceTitle => 'Skip silence';
 
   @override
   String get skipSilenceSubtitle =>
-      'Akış desteklediğinde, sessiz ses bölümlerini otomatik olarak atla.';
+      'Automatically skip silent audio segments when supported by the stream.';
 
   @override
-  String get allowExternalAudioEffectsTitle =>
-      'Harici ses efektlerine izin ver';
+  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Ekolayzer ve efekt uygulamalarının (örn. Wavelet) Media3 oynatma oturumlarına bağlanmasına izin ver.';
+      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
 
   @override
-  String get disableTunnelingTitle => 'Tünellemeyi devre dışı bırak';
+  String get disableTunnelingTitle => 'Disable tunneling';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Tünelsiz oynatmaya zorla. Tünelleme kaynaklı ses/video kopmaları yaşanan cihazlarda yararlıdır.';
+      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
 
   @override
-  String get enableTunnelingTitle => 'Tünellemeyi etkinleştir';
+  String get enableTunnelingTitle => 'Enable tunneling';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Gelişmiş. Sesi ve videoyu birbirine bağlı bir donanım yolu üzerinden iletir. Bazı cihazlarda ses/video kesintilerine neden olabileceği için varsayılan olarak kapalıdır.';
+      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
 
   @override
-  String get mapDolbyVisionP7Title =>
-      'Dolby Vision profil 7\'yi HEVC ile eşleştir';
+  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Dolby Vision profil 7 akışlarını, DV desteklemeyen cihazlarda HDR10 uyumlu HEVC olarak oynat.';
+      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Gömülü altyazı stillerini kullan';
+  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Altyazı parçasında gömülü olan renk, yazı tipi ve konumlandırmayı uygula. Kendi altyazı stili tercihlerinizi kullanmak için devre dışı bırakın.';
+      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Gömülü altyazı boyutlarını kullan';
+      'Use embedded subtitle font sizes';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Altyazı parçasında gömülü olan yazı tipi boyutu ipuçlarını uygula. Kendi stili tercihlerinizdeki altyazı boyutunu kullanmak için devre dışı bırakın.';
+      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Medya Ayrıntılarını Göster';
+  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Kütüphane sayfalarında, seçilen ögenin detaylarını üst kısımda göster.';
+      'Show details of the selected item at the top of Library pages.';
 
   @override
-  String get useDetailedSubHeadings => 'Detaylı alt başlıklar kullan';
+  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Kütüphane sayfalarında detaylı veya sade bir alt satır göster.';
+      'Show detailed or minimal subrow on Library pages.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Kaydedilen tema silinsin mi?';
+  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return '\"$themeName\" bu cihazın önbelleğinden kaldırılsın mı?';
-  }
-
-  @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
+    return 'Remove \"$themeName\" from this device cache?';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return '\"$themeName\" bu cihazdan silindi.';
+    return 'Deleted \"$themeName\" from this device.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return '\"$themeName\" silinemedi.';
+    return 'Could not delete \"$themeName\".';
   }
 
   @override
-  String get savedThemesTitle => 'Kayıtlı temalar';
+  String get savedThemesTitle => 'Saved themes';
 
   @override
   String get savedThemesDescription =>
-      'Bunlar, mevcut sunucu için Moonfin eklentisinden indirilen temalardır. Silme işlemi yalnızca bu yerel kopyayı kaldırır.';
+      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
 
   @override
-  String get savedThemesEmpty => 'Bu sunucu için kayıtlı tema bulunamadı.';
+  String get savedThemesEmpty => 'No saved themes were found for this server.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Şu an aktif';
+    return '$themeId • Currently active';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Kayıtlı temayı sil';
+  String get savedThemesDeleteTooltip => 'Delete saved theme';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Bu cihazdaki indirilen eklenti temalarını yönetin';
+      'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
 
   @override
-  String get themeEditor => 'Tema Editörü';
+  String get themeEditor => 'Theme Editor';
 
   @override
-  String get themeEditorSubtitle => 'Moonfin Tema Editörünü tarayıcınızda açın';
+  String get themeEditorSubtitle =>
+      'Open the Moonfin Theme Editor in your browser';
 
   @override
-  String get homeScreen => 'Ana Sayfa';
+  String get homeScreen => 'Home Screen';
 
   @override
-  String get bottomBar => 'Alt Bar';
+  String get bottomBar => 'Bottom Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Klasik';
+  String get homeRowsStyleClassic => 'Classic';
 
   @override
   String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Ana Sayfa Satırları';
+  String get homeRowsSection => 'Home Rows';
 
   @override
-  String get homeRowDisplay => 'Ana Sayfa Satır Gösterimi';
+  String get homeRowDisplay => 'Home Row Display';
 
   @override
-  String get homeRowSections => 'Ana Sayfa Satır Bölümleri';
+  String get homeRowSections => 'Home Row Sections';
 
   @override
-  String get homeRowToggles => 'Ana Sayfa Satır Aç/Kapat Ayarları';
+  String get homeRowToggles => 'Home Row Toggles';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Farklı ana sayfa satır kategorilerini etkinleştirin veya devre dışı bırakın';
+      'Enable or disable different home row categories';
 
   @override
   String get homeRowTogglesDescription =>
-      'Satırları Ana Sayfa Bölümleri\'nde göstermek için aşağıdaki anahtarları etkinleştirin.';
+      'Enable the following toggles to display the rows in Home Sections.';
 
   @override
-  String get rowsType => 'Satır Tipi';
+  String get rowsType => 'Rows Type';
 
   @override
   String get rowsTypeDescription =>
-      'Klasik mod, satır başına görsel türünü ve bilgi katmanını korur. Modern mod ise dikey görsellerden yatay arka planlara uzanan satırlar kullanır.';
+      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
-  String get displayFavoritesRows => 'Favoriler Satırlarını Görüntüle';
+  String get displayFavoritesRows => 'Display Favorites Rows';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Favori Filmleri, Dizileri ve diğer favori satırlarını Ana Sayfa Bölümlerinde göster.';
+      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
 
   @override
-  String get favoritesRowSorting => 'Favoriler Satırı Sıralaması';
+  String get favoritesRowSorting => 'Favorites Row Sorting';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Favori satırlarını eklenme tarihine, çıkış tarihine, alfabetik sıraya ve daha fazlasına göre sıralayın.';
+      'Sort Favorites rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayCollectionsRows => 'Koleksiyon Satırlarını Göster';
+  String get displayCollectionsRows => 'Display Collections Rows';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Koleksiyon satırlarını Ana Sayfa Bölümlerinde göster.';
+      'Show Collections rows in Home Sections.';
 
   @override
-  String get collectionsRowSorting => 'Koleksiyon Satırı Sıralaması';
+  String get collectionsRowSorting => 'Collections Row Sorting';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Koleksiyonlar satırlarını ekleme tarihine, çıkış tarihine, alfabetik sıraya ve daha fazlasına göre sıralayın.';
+      'Sort Collections rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayGenresRows => 'Tür Satırlarını Göster';
+  String get displayGenresRows => 'Display Genres Rows';
 
   @override
-  String get displayGenresRowsSubtitle =>
-      'Ana Sayfa Bölümlerinde Türler satırlarını göster.';
+  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
 
   @override
-  String get genresRowSorting => 'Türler Satırı Sıralaması';
+  String get genresRowSorting => 'Genres Row Sorting';
 
   @override
   String get genresRowSortingDescription =>
-      'Türler satırlarını ekleme tarihine, çıkış tarihine, alfabetik sıraya ve daha fazlasına göre sıralayın.';
+      'Sort Genres rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get genresRowItems => 'Türler Satırı Ögeleri';
+  String get genresRowItems => 'Genres Row Items';
 
   @override
   String get genresRowItemsDescription =>
-      'Türler satırlarında Filmleri, Dizileri veya her ikisini birden göster.';
+      'Show Movies, Series, or both in Genres rows.';
 
   @override
-  String get displayPlaylistsRows => 'Oynatma Listesi Satırlarını Göster';
+  String get displayPlaylistsRows => 'Display Playlist Rows';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Oynatma listesi satırlarını Ana Sayfa Bölümleri\'nde göster.';
+      'Show Playlist rows in Home Sections.';
 
   @override
-  String get playlistsRowSorting => 'Oynatma Listesi Satır Sıralaması';
+  String get playlistsRowSorting => 'Playlist Row Sorting';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Oynatma listesi satırlarını ekleme tarihi, yayınlanma tarihi, alfabetik ve daha fazlasına göre sıralayın.';
+      'Sort Playlist rows by date added, release date, alphabetically, and more.';
 
   @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
-
-  @override
-  String get displaySeerrRows => 'Seerr Keşif Satırlarını Göster';
+  String get displaySeerrRows => 'Display Seerr Discovery Rows';
 
   @override
   String get displaySeerrRowsSubtitle =>
-      'Seerr keşif satırlarını Ana Sayfa Bölümleri\'nde göster.';
+      'Show Seerr discovery rows in Home Sections.';
 
   @override
-  String get appearance => 'Görünüm';
+  String get appearance => 'Appearance';
 
   @override
-  String get cardSize => 'Ana Sayfa Satırı Kart Gösterim Boyutu';
+  String get cardSize => 'Card Size';
 
   @override
-  String get externalPlayerApp => 'Harici oynatıcı';
+  String get externalPlayerApp => 'External player app';
 
   @override
   String get externalPlayerAppDescription =>
-      'Üzerine uzun basarak oynatma seçeneğini etkinleştirmek için harici oynatıcıyı ayarlayın';
+      'Set external player to enable long-press play option';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Oynatma başladığında uygulama seçiciyi göster.';
+      'Show app chooser when playback starts.';
 
   @override
-  String get loadingInstalledPlayers => 'Yüklü oynatıcılar yükleniyor...';
+  String get loadingInstalledPlayers => 'Loading installed players...';
 
   @override
-  String get connection => 'Bağlantı';
+  String get connection => 'Connection';
 
   @override
-  String get audioTranscodeTarget => 'Ses Yeniden Kodlama Hedefi';
+  String get audioTranscodeTarget => 'Audio Transcode Target';
 
   @override
-  String get passthrough => 'Doğrudan Geçiş (Passthrough)';
+  String get passthrough => 'Passthrough';
 
   @override
-  String get supportedOnThisDevice => 'Bu cihazda destekleniyor';
+  String get supportedOnThisDevice => 'Supported on this device';
 
   @override
-  String get notSupportedOnThisDevice => 'Bu cihazda desteklenmiyor';
+  String get notSupportedOnThisDevice => 'Not Supported on this device';
 
   @override
-  String get settingsAudioDtsXPassthrough =>
-      'DTS:X (DTS UHD) Doğrudan Geçiş (Passthrough)';
+  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'DTS:X (DTS UHD) sesini harici kod çözücüye bitstream olarak aktar.';
+      'Bitstream DTS:X (DTS UHD) to external decoder.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD with Atmos (JOC) Doğrudan Geçiş (Passthrough)';
+      'TrueHD with Atmos (JOC) Passthrough';
 
   @override
-  String get mediaPlayerBehavior => 'Medya Oynatıcı Davranışı';
+  String get mediaPlayerBehavior => 'Media Player Behavior';
 
   @override
-  String get playbackEnhancements => 'Oynatma İyileştirmeleri';
+  String get playbackEnhancements => 'Playback Enhancements';
 
   @override
-  String get alwaysOn => 'Her zaman açık.';
+  String get alwaysOn => 'Always on.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      '\"Jeneriği Atla\" yerine \"Sıradaki Bölüm Ekranını\" yerleştir';
+      'Replace Skip Outro with Next Up Display';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      '\"Jeneriği Atla\" butonu yerine \"Sıradaki Bölüm\" ekranını göster.';
+      'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
-  String get playerRouting => 'Oynatıcı Yönlendirme';
+  String get playerRouting => 'Player Routing';
 
   @override
-  String get preferSoftwareDecoders => 'Yazılımsal kod çözücüleri tercih et';
+  String get preferSoftwareDecoders => 'Prefer software decoders';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Donanımsal kod çözücülerden önce FFmpeg (ses) ve libgav1 (AV1) kullan. HDMI ses doğrudan geçişi (passthrough) bozulursa devre dışı bırak.';
+      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
 
   @override
-  String get useExternalPlayer => 'Her zaman harici oynatıcı kullan';
+  String get useExternalPlayer => 'Use external player';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Android TV\'de video oynatmayı seçtiğiniz harici uygulamada açın.';
+      'Open video playback in your selected external app on Android TV.';
 
   @override
-  String get automaticQueuing => 'Otomatik Sıraya Ekleme';
+  String get automaticQueuing => 'Automatic Queuing';
 
   @override
-  String get preferSdhSubtitles => 'SDH altyazıları tercih et';
+  String get preferSdhSubtitles => 'Prefer SDH subtitles';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Otomatik seçim yaparken SDH/CC altyazı parçalarına öncelik ver.';
+      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
 
   @override
-  String get webDiagnostics => 'Web Tanılama';
+  String get webDiagnostics => 'Web diagnostics';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin Web Tanılama';
+  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
 
   @override
   String get webDiagnosticsIntro =>
-      'Tarayıcı bağlantı sorunlarını (CORS, karma içerik ve keşif ayarları) tanılamak için bu sayfayı kullanın.';
+      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Karma İçerik Hatası Tespit Edildi';
+      'Detected Mixed-Content Failure';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'CORS/Ön Kontrol Hatası Tespit Edildi';
+      'Detected CORS/Preflight Failure';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin, bir HTTPS sayfasının HTTP sunucu URL\'sini çağırmaya çalıştığını tespit etti. Tarayıcılar, bu isteği henüz sunucunuza ulaşmadan engeller.';
+      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin, genellikle medya sunucusundaki eksik CORS veya ön kontrol (preflight) üst bilgilerinden kaynaklanan, tarayıcı düzeyinde bir istek hatası tespit etti.';
+      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Hedef URL: $url';
+    return 'Target URL: $url';
   }
 
   @override
@@ -7766,333 +7713,329 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext =>
-      'Mevcut Çalışma Zamanı Bağlamı';
+  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
 
   @override
-  String get webDiagnosticsOrigin => 'Kaynak';
+  String get webDiagnosticsOrigin => 'Origin';
 
   @override
-  String get webDiagnosticsScheme => 'Protokol';
+  String get webDiagnosticsScheme => 'Scheme';
 
   @override
-  String get webDiagnosticsPluginMode => 'Eklenti Modu';
+  String get webDiagnosticsPluginMode => 'Plugin Mode';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC Taraması';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Zorunlu Sunucu URL\'si';
+  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Varsayılan Sunucu URL\'si';
+  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'Keşif Vekil Sunucu URL\'si';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
 
   @override
-  String get notConfigured => 'Yapılandırılmadı';
+  String get notConfigured => 'not configured';
 
   @override
-  String get webDiagnosticsMixedContent => 'Karma İçerik';
+  String get webDiagnosticsMixedContent => 'Mixed Content';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'Bu sayfa HTTPS üzerinden yüklendi, ancak yapılandırılan URL\'lerden biri veya daha fazlası HTTP. Tarayıcılar, HTTPS sayfalarının HTTP API\'lerini çağırmasını engeller.';
+      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Çözüm: Medya sunucunuzu veya vekil sunucu (proxy) uç noktanızı HTTPS üzerinden sunun ya da Moonfin\'i yalnızca güvenilir yerel ağlarda HTTP üzerinden yükleyin.';
+      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'Mevcut çalışma zamanı ayarlarında bariz bir karma içerik yapılandırması tespit edilmedi.';
+      'No obvious mixed-content configuration detected from current runtime settings.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS Kontrol Listesi';
+  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Access-Control-Allow-Origin üst bilgisinde tarayıcı kaynağına izin verin.';
+      '• Allow the browser origin in Access-Control-Allow-Origin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Access-Control-Allow-Headers üst bilgisine Authorization, X-Emby-Authorization ve X-Emby-Token değerlerini dahil edin.';
+      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Akış ve sarma işlevleri için Content-Range ve Accept-Ranges üst bilgilerini dışa aktarın (expose).';
+      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• OPTIONS ön kontrol (preflight) isteklerine 204 yanıtı döndürün.';
+      '• Return 204 to OPTIONS preflight requests.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Örnek Üst Bilgi Parçacığı (nginx tarzı)';
+      'Example Header Snippet (nginx-style)';
 
   @override
-  String get note => 'Not';
+  String get note => 'Note';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'Bu tanılama rotası web sürümleri için tasarlanmıştır. Eğer bunu başka bir platformda görüyorsanız, yapılan kontroller sizin için geçerli olmayabilir.';
+      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
 
   @override
-  String get backToServerSelect => 'Sunucu Seçimine Dön';
+  String get backToServerSelect => 'Back To Server Select';
 
   @override
-  String get signOutAllUsers => 'Tüm Kullanıcıların Oturumunu Kapat';
+  String get signOutAllUsers => 'Sign Out All Users';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Mikrofon izni kalıcı olarak reddedildi. Sistem ayarlarından izni etkinleştirin.';
+      'Microphone permission is permanently denied. Enable it in system settings.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Sesli arama için mikrofon izni gereklidir.';
+      'Microphone permission is required for voice search.';
 
   @override
-  String get voiceSearchNoMatch => 'Anlaşılamadı. Tekrar deneyin.';
+  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'Konuşma algılanmadı.';
+  String get voiceSearchNoSpeechDetected => 'No speech detected.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Mikrofon hatası.';
+  String get voiceSearchMicrophoneError => 'Microphone error.';
 
   @override
-  String get voiceSearchNeedsInternet =>
-      'Sesli arama için internet bağlantısı gereklidir.';
+  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
 
   @override
-  String get voiceSearchServiceBusy =>
-      'Sesli arama servisi meşgul. Tekrar deneyin.';
+  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Mikrofon izni kalıcı olarak reddedildi.';
+      'Microphone permission is permanently denied.';
 
   @override
-  String get microphonePermissionDenied => 'Mikrofon izni reddedildi.';
+  String get microphonePermissionDenied => 'Microphone permission is denied.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Ses tanıma özelliği bu cihazda kullanılamıyor.';
+      'Speech recognition is unavailable on this device.';
 
   @override
-  String get openIosRoutePicker => 'iOS Ses/Video Aktarımını Aç';
+  String get openIosRoutePicker => 'Open iOS route picker';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay özelliği bu cihazda kullanılamıyor.';
+      'AirPlay route picker is unavailable on this device.';
 
   @override
-  String get videos => 'Videolar';
+  String get videos => 'Videos';
 
   @override
-  String get trailers => 'Fragmanlar';
+  String get trailers => 'Trailers';
 
   @override
-  String get programs => 'Programlar';
+  String get programs => 'Programs';
 
   @override
-  String get songs => 'Şarkılar';
+  String get songs => 'Songs';
 
   @override
-  String get photoAlbums => 'Fotoğraf Albümleri';
+  String get photoAlbums => 'Photo Albums';
 
   @override
-  String get photos => 'Fotoğraflar';
+  String get photos => 'Photos';
 
   @override
-  String get people => 'Kişiler';
+  String get people => 'People';
 
   @override
-  String get recentlyReleasedEpisodes => 'Son Yayınlanan Bölümler';
+  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
 
   @override
-  String get watchAgain => 'Yeniden İzle';
+  String get watchAgain => 'Watch Again';
 
   @override
-  String get guestAppearances => 'Konuk Olduğu Bölümler';
+  String get guestAppearances => 'Guest Appearances';
 
   @override
-  String get appearancesSeerr => 'Rol Aldığı Yapımlar (Seerr)';
+  String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
-  String get watchWithGroup => 'Grupça İzle';
+  String get watchWithGroup => 'Watch with group';
 
   @override
-  String get errors => 'Hatalar';
+  String get errors => 'Errors';
 
   @override
-  String get warnings => 'Uyarılar';
+  String get warnings => 'Warnings';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Tarayıcıda Aç';
+  String get openInBrowser => 'Open in Browser';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Gömülü tarayıcı bu platformda kullanılamıyor.';
+      'Embedded browser is not available on this platform.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Sunucuyu yeniden başlatmak istediğinize emin misiniz?';
+      'Are you sure you want to restart the server?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Sunucuyu kapatmak istediğinize emin misiniz? Sunucuyu daha sonra manuel olarak yeniden başlatmanız gerekecektir.';
+      'Are you sure you want to shut down the server? You will need to restart it manually.';
 
   @override
-  String get internal => 'Dahili';
+  String get internal => 'Internal';
 
   @override
-  String get idle => 'Boşta';
+  String get idle => 'Idle';
 
   @override
-  String get os => 'İşletim Sistemi';
+  String get os => 'OS';
 
   @override
-  String get adminNoUsersFound => 'Kullanıcı Bulunamadı';
+  String get adminNoUsersFound => 'No users found';
 
   @override
-  String get adminNoUsersMatchSearch =>
-      'Aramanızla eşleşen kullanıcı bulunamadı';
+  String get adminNoUsersMatchSearch => 'No users match your search';
 
   @override
-  String get adminNoDevicesFound => 'Cihaz bulunamadı';
+  String get adminNoDevicesFound => 'No devices found';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'Mevcut filtrelere uygun cihaz bulunamadı';
+      'No devices match the current filters';
 
   @override
-  String get passwordSet => 'Şifre belirlendi';
+  String get passwordSet => 'Password set';
 
   @override
-  String get noPasswordConfigured => 'Şifre belirlenmedi';
+  String get noPasswordConfigured => 'No password configured';
 
   @override
-  String get remoteAccess => 'Uzaktan Erişim';
+  String get remoteAccess => 'Remote Access';
 
   @override
-  String get localOnly => 'Sadece Yerel Ağ';
+  String get localOnly => 'Local Only';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => 'Medya analizleri yüklenemedi';
+  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Tüm medya kütüphanelerinin ortak istatistikleri.';
+      'Combined analytics across all media libraries.';
 
   @override
-  String get analyticsTopArtists => 'En Çok Dinlenen Sanatçılar';
+  String get analyticsTopArtists => 'Top Artists';
 
   @override
-  String get analyticsTopAuthors => 'En Çok Okunan Yazarlar';
+  String get analyticsTopAuthors => 'Top Authors';
 
   @override
-  String get analyticsTopContributors => 'En Çok Katkıda Bulunanlar';
+  String get analyticsTopContributors => 'Top Contributors';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Kütüphane',
-      one: '1 Kütüphane',
+      other: '$count Libraries',
+      one: '1 Library',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'Bu seçim için henüz dizine eklenmiş medya toplamı bulunmuyor.';
+      'No indexed media totals are available for this selection yet.';
 
   @override
-  String get analyticsLibraryDetails => 'Kütüphane Detayları';
+  String get analyticsLibraryDetails => 'Library Details';
 
   @override
-  String get analyticsLibraryBreakdown => 'Kütüphane Dağılımı';
+  String get analyticsLibraryBreakdown => 'Library Breakdown';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'Kullanılabilir kütüphane yok.';
+  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
 
   @override
-  String get adminServerAdministrationTitle => 'Sunucu Yönetimi';
+  String get adminServerAdministrationTitle => 'Server Administration';
 
   @override
-  String get adminServerPathData => 'Veri';
+  String get adminServerPathData => 'Data';
 
   @override
-  String get adminServerPathImageCache => 'Görsel Önbelleği';
+  String get adminServerPathImageCache => 'Image Cache';
 
   @override
-  String get adminServerPathCache => 'Önbellek';
+  String get adminServerPathCache => 'Cache';
 
   @override
-  String get adminServerPathLogs => 'Günlükler';
+  String get adminServerPathLogs => 'Logs';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Dönüştür';
+  String get adminServerPathTranscode => 'Transcode';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'Bu sunucu tarafından hiçbir sunucu yolu döndürülmedi.';
+      'No server paths returned by this server.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '%$percent kullanıldı';
+    return '$percent% used';
   }
 
   @override
-  String get userActivity => 'Kullanıcı Hareketleri';
+  String get userActivity => 'User Activity';
 
   @override
-  String get systemEvents => 'Sistem Olayları';
+  String get systemEvents => 'System Events';
 
   @override
-  String get needsAttention => 'İşlem Gerekiyor';
+  String get needsAttention => 'Needs Attention';
 
   @override
-  String get adminDrawerSectionServer => 'Sunucu';
+  String get adminDrawerSectionServer => 'Server';
 
   @override
-  String get adminDrawerSectionPlayback => 'Oynatma';
+  String get adminDrawerSectionPlayback => 'Playback';
 
   @override
-  String get adminDrawerSectionDevices => 'Cihazlar';
+  String get adminDrawerSectionDevices => 'Devices';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Gelişmiş';
+  String get adminDrawerSectionAdvanced => 'Advanced';
 
   @override
   String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Canlı TV';
+  String get adminDrawerSectionLiveTv => 'Live TV';
 
   @override
-  String get homeVideos => 'Kişisel Videolar';
+  String get homeVideos => 'Home Videos';
 
   @override
-  String get mixedContent => 'Karma İçerik';
+  String get mixedContent => 'Mixed Content';
 
   @override
-  String get homeVideosAndPhotos => 'Kişisel Videolar & Fotoğraflar';
+  String get homeVideosAndPhotos => 'Home Videos & Photos';
 
   @override
-  String get mixedMoviesAndShows => 'Karışık Film & Diziler';
+  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -8104,223 +8047,223 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'Kayıt bulunamadı';
+  String get noRecordingsFound => 'No recordings found';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return '.$extension arşivi içinde hiç resim sayfası bulunamadı.';
+    return 'No image pages found inside .$extension archive.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Gömülü oynatıcı hatası ($code): $description';
+    return 'Embedded renderer failed ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB okuyucu hatası ($code): $description';
+    return 'EPUB renderer failed ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Okuyucu için yerel dosya bulunamadı: $uri';
+    return 'Missing local file for reader: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return '$uri adresinden kitap verileri açılırken HTTP $status hatası alındı';
+    return 'HTTP $status while opening book data from $uri';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'Okunabilir bir kitap bağlantı noktası bulunamadı';
+      'No readable book endpoint available';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Desteklenmeyen çizgi roman arşiv formatı: .$extension';
+    return 'Unsupported comic archive format: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'CBR çıkarma eklentisi bu platformda mevcut değil.';
+      'CBR extraction plugin is not available on this platform.';
 
   @override
-  String get failedToExtractCbrArchive => '.cbr arşivi çıkarılamadı.';
+  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'CB7 çıkarma işlemi bu platformda mevcut değil.';
+      'CB7 extraction is not available on this platform.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'CB7 çıkarma eklentisi bu platformda mevcut değil.';
+      'CB7 extraction plugin is not available on this platform.';
 
   @override
-  String get closeGenrePanel => 'Tür panelini kapat';
+  String get closeGenrePanel => 'Close genre panel';
 
   @override
-  String get loadingShuffle => 'Karışık liste yükleniyor...';
+  String get loadingShuffle => 'Loading shuffle...';
 
   @override
-  String get libraryShuffleLabel => 'KÜTÜPHANEYİ KARIŞTIR';
+  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
 
   @override
-  String get randomShuffleLabel => 'RASTGELE KARIŞTIR';
+  String get randomShuffleLabel => 'RANDOM SHUFFLE';
 
   @override
-  String get genresShuffleLabel => 'TÜRLERİ KARIŞTIR';
+  String get genresShuffleLabel => 'GENRES SHUFFLE';
 
   @override
-  String get autoHdrSwitching => 'Otomatik HDR Geçişi';
+  String get autoHdrSwitching => 'Auto HDR Switching';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'HDR video oynatılırken HDR\'ı otomatik olarak etkinleştirir ve çıkışta ekran modunu eski haline getirir.';
+      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
 
   @override
-  String get whenFullscreen => 'Tam ekrandayken';
+  String get whenFullscreen => 'When fullscreen';
 
   @override
-  String get changeArtwork => 'Görseli Değiştir';
+  String get changeArtwork => 'Change Artwork';
 
   @override
-  String get missing => 'Kayıp';
+  String get missing => 'Missing';
 
   @override
-  String get transcodingLimits => 'Dönüştürme Sınırları';
+  String get transcodingLimits => 'Transcoding Limits';
 
   @override
-  String get clearAllArtworkButton => 'Tüm görseller silinsin mi?';
+  String get clearAllArtworkButton => 'Clear all artwork?';
 
   @override
   String get clearAllArtworkWarning =>
-      'İndirilen tüm görselleri temizlemek istediğinize emin misiniz?';
+      'Are you sure you want to clear all downloaded artwork?';
 
   @override
-  String get confirmClear => 'Silmeyi Onayla';
+  String get confirmClear => 'Confirm Clear';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Bu nesneyi ($itemType) temizlemek istediğinize emin misiniz?';
+    return 'Are you sure you would like to clear this $itemType?';
   }
 
   @override
-  String get uploadButton => 'Yükle?';
+  String get uploadButton => 'Upload?';
 
   @override
-  String get resolutionLabel => 'Çözünürlük: ';
+  String get resolutionLabel => 'Resolution: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Görselleri yalnızca arayüz dilinde göster';
+      'Only show artwork in interface language';
 
   @override
-  String get confirmClearAll => 'Tümünü Temizlemeyi Onayla';
+  String get confirmClearAll => 'Confirm Clear All';
 
   @override
-  String get imageUploadSuccess => 'Görsel başarıyla yüklendi!';
+  String get imageUploadSuccess => 'Image uploaded successfully!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Görsel yüklenemedi: $error';
+    return 'Failed to upload image: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Görsel ayarlanamadı: $error';
+    return 'Failed to set image: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Görsel silinemedi: $error';
+    return 'Failed to delete image: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Tüm görseller temizlenemedi: $error';
+    return 'Failed to clear all artwork: $error';
   }
 
   @override
-  String get yes => 'Evet';
+  String get yes => 'Yes';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Arka Planlar';
+  String get backdropsCategory => 'Backdrops';
 
   @override
-  String get bannerCategory => 'Afiş';
+  String get bannerCategory => 'Banner';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Küçük Resim';
+  String get thumbnailCategory => 'Thumbnail';
 
   @override
-  String get artCategory => 'Görsel';
+  String get artCategory => 'Art';
 
   @override
-  String get discArtCategory => 'Disk Görseli';
+  String get discArtCategory => 'Disc Art';
 
   @override
-  String get screenshotCategory => 'Ekran Görüntüsü';
+  String get screenshotCategory => 'Screenshot';
 
   @override
-  String get boxCoverCategory => 'Kutu Kapağı';
+  String get boxCoverCategory => 'Box Cover';
 
   @override
-  String get boxRearCoverCategory => 'Kutu Arka Kapağı';
+  String get boxRearCoverCategory => 'Box Rear Cover';
 
   @override
-  String get menuArtCategory => 'Menü Görseli';
+  String get menuArtCategory => 'Menu Art';
 
   @override
   String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'arka plan';
+  String get confirmItemBackdrop => 'backdrop';
 
   @override
-  String get confirmItemBanner => 'afiş';
+  String get confirmItemBanner => 'banner';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'küçük resim';
+  String get confirmItemThumbnail => 'thumbnail';
 
   @override
-  String get confirmItemArt => 'görsel';
+  String get confirmItemArt => 'art';
 
   @override
-  String get confirmItemDiscArt => 'disk görseli';
+  String get confirmItemDiscArt => 'disc art';
 
   @override
-  String get confirmItemScreenshot => 'ekran görüntüsü';
+  String get confirmItemScreenshot => 'screenshot';
 
   @override
-  String get confirmItemBoxCover => 'kutu kapağı';
+  String get confirmItemBoxCover => 'box cover';
 
   @override
-  String get confirmItemBoxRearCover => 'kutu arka kapağı';
+  String get confirmItemBoxRearCover => 'box rear cover';
 
   @override
-  String get confirmItemMenuArt => 'menü görseli';
+  String get confirmItemMenuArt => 'menu art';
 
   @override
-  String get resolutionAll => 'Tümü';
+  String get resolutionAll => 'All';
 
   @override
-  String get resolutionHigh => 'Yüksek (1080p+)';
+  String get resolutionHigh => 'High (1080p+)';
 
   @override
-  String get resolutionMedium => 'Orta (720p)';
+  String get resolutionMedium => 'Medium (720p)';
 
   @override
-  String get resolutionLow => 'Düşük (<720p)';
+  String get resolutionLow => 'Low (<720p)';
 
   @override
-  String get sources => 'Kaynaklar';
+  String get sources => 'Sources';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -7704,7 +7704,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -7703,6 +7703,14 @@ class AppLocalizationsTr extends AppLocalizations {
       '\"Jeneriği Atla\" butonu yerine \"Sıradaki Bölüm\" ekranını göster.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Oynatıcı Yönlendirme';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -166,11 +166,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Macenta parıltılı, camgöbeği metinli ve daha güçlü krom kontrastlı Synthwave stili';
 
   @override
-  String get themeGlass => 'Glass';
+  String get themeGlass => 'Cam';
 
   @override
   String get themeGlassSubtitle =>
-      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
+      'Akan gradyan arka plan, buzlu yüzeyler ve Apple mavisi vurgulu sıvı-cam tasarımı';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -1071,10 +1071,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get director => 'YÖNETMEN';
 
   @override
-  String get directors => 'DIRECTORS';
+  String get directors => 'YÖNETMENLER';
 
   @override
-  String get writer => 'WRITER';
+  String get writer => 'YAZAR';
 
   @override
   String get writers => 'YAZARLAR';
@@ -1332,7 +1332,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get playbackInformation => 'Oynatma Bilgileri';
 
   @override
-  String get playback => 'Playback';
+  String get playback => 'Oynatma';
 
   @override
   String get playMethod => 'Oynatma Yöntemi';
@@ -1991,7 +1991,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get focusExpansionAnimation => 'Odak Genişletme Animasyonu';
 
   @override
-  String get desktopUiScale => 'Masaüstü Kullanıcı Arayüzü Ölçeği';
+  String get desktopUiScale => 'Arayüz Ölçeklendirme';
 
   @override
   String get scaleFocusedCards =>
@@ -2236,23 +2236,24 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
+      'Ses çözme yöntemini seçin. AVR Doğrudan Geçiş (Passthrough), ham Dolby/DTS akışlarını alıcınıza gönderir; Otomatik veya Downmix ise sesi cihazınızda çözer.';
 
   @override
-  String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
+  String get settingsAudioOutputModeAvrPassthrough =>
+      'AVR Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
+  String get settingsAudioFallbackCodec => 'Yedek Ses Kodeki';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
+      'Kaynak akış doğrudan oynatılamadığında veya doğrudan geçiş (passthrough) yapılamadığında, çok kanallı sesin dönüştürüleceği hedef formatı seçin.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
+  String get settingsAudioFallbackCodecAuto => 'Otomatik Algıla\n(Önerilen)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Varsayılan)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2261,26 +2262,27 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsAudioFallbackCodecEac3 => 'EAC3\n(Dolby Digital Plus)';
 
   @override
-  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
+  String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Kayıpsız)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Sadece Stereo)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Verimli)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Kayıpsız)';
 
   @override
-  String get settingsMaxAudioChannels => 'Max Audio Channels';
+  String get settingsMaxAudioChannels => 'Maksimum Kanal Sayısı';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
+      'Ses sisteminizin maksimum kanal sayısını yapılandırın. Bu sınırı aşan çok kanallı akışlar downmix yapılacak (azaltılacak) veya dönüştürülecektir.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
+  String get settingsMaxAudioChannelsAuto =>
+      'Otomatik Algıla\n(Donanım Varsayılanı)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2292,7 +2294,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsMaxAudioChannels3_0 => '3.0 / 2.1 Surround';
 
   @override
-  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Quadraphonic';
+  String get settingsMaxAudioChannels4_0 => '4.0 / 3.1 Kuadrafonik';
 
   @override
   String get settingsMaxAudioChannels5_0 => '5.0 / 4.1 Surround';
@@ -2307,67 +2309,75 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
+  String get settingsAudioPassthroughAdvanced =>
+      'Doğrudan Geçiş(Passthrough) (Gelişmiş)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
+  String get settingsAudioCodecPassthrough =>
+      'Kodek Doğrudan Geçiş (Passthrough)';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Enable only formats your AVR or HDMI sink supports.';
+      'Yalnızca AVR veya HDMI alıcınızın desteklediği formatları etkinleştirin.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
+  String get settingsAudioEac3Passthrough =>
+      'EAC3 Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
+  String get settingsAudioEac3JocPassthrough =>
+      'EAC3 JOC (Atmos) Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
+  String get settingsAudioDtsCorePassthrough =>
+      'DTS Core Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
+  String get settingsAudioDtsHdPassthrough =>
+      'DTS-HD MA Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
+  String get settingsAudioTrueHdPassthrough =>
+      'TrueHD Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
+  String get settingsAudioTrueHdAtmosPassthrough =>
+      'TrueHD Atmos Doğrudan Geçiş (Passthrough)';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
+      'Dolby Digital Plus (EAC3) ses akışını harici dekodere ilet.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
-      'Bitstream Dolby Atmos over EAC3 (JOC) to external decoder.';
+      'EAC3 (JOC) üzerinden Dolby Atmos ses akışını harici dekodere ilet.';
 
   @override
   String get settingsAudioBitstreamDtsHdToExternalDecoder =>
-      'Bitstream DTS-HD MA (includes DTS core) to external decoder.';
+      'DTS çekirdeğini içeren DTS-HD MA ses akışını harici dekodere ilet.';
 
   @override
   String get settingsAudioBitstreamTrueHdAtmosToExternalDecoder =>
-      'Bitstream Dolby TrueHD with Atmos metadata to external decoder.';
+      'Atmos meta verileri içeren Dolby TrueHD ses akışını harici dekodere ilet.';
 
   @override
-  String get settingsDetectedAudioCapabilities => 'Detected Audio Capabilities';
+  String get settingsDetectedAudioCapabilities => 'Algılanan Ses Özellikleri';
 
   @override
   String get settingsDetectedAudioCapabilitiesUnavailable =>
-      'No runtime capability snapshot available yet.';
+      'Henüz çalışma zamanı yetenek profili mevcut değil.';
 
   @override
-  String get settingsAudioRouteLabel => 'Route';
+  String get settingsAudioRouteLabel => 'Ses Çıkışı';
 
   @override
-  String get settingsAudioDecodeLabel => 'Decode';
+  String get settingsAudioDecodeLabel => 'Kod Çözme';
 
   @override
-  String get settingsAudioPassthroughLabel => 'Passthrough';
+  String get settingsAudioPassthroughLabel => 'Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get settingsAudioHdRoute => 'HD audio route';
+  String get settingsAudioHdRoute => 'HD Ses Çıkısı';
 
   @override
   String get settingsAudioRouteHdmi => 'HDMI';
@@ -2382,47 +2392,47 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsAudioRouteBluetooth => 'Bluetooth';
 
   @override
-  String get settingsAudioRouteSpeaker => 'Speaker';
+  String get settingsAudioRouteSpeaker => 'Hoparlör';
 
   @override
   String settingsAudioPcmChannels(int count) {
-    return '${count}ch PCM';
+    return '$count kanal PCM';
   }
 
   @override
-  String get settingsAudioDiagnostics => 'Diagnostics';
+  String get settingsAudioDiagnostics => 'Tanılama';
 
   @override
-  String get settingsAudioDiagnosticsVideoLevel => 'Video Level';
+  String get settingsAudioDiagnosticsVideoLevel => 'Video Seviyesi';
 
   @override
-  String get settingsAudioDiagnosticsVideoRange => 'Video Range';
+  String get settingsAudioDiagnosticsVideoRange => 'Video Aralığı';
 
   @override
-  String get settingsAudioDiagnosticsSubtitleCodec => 'Subtitle Codec';
+  String get settingsAudioDiagnosticsSubtitleCodec => 'Altyazı Kodeki';
 
   @override
   String get settingsAudioDiagnosticsAllowedAudioCodecs =>
-      'Allowed Audio Codecs';
+      'İzin Verilen Ses Kodekleri';
 
   @override
   String get settingsAudioDiagnosticsHlsMpegTsAudioCodecs =>
-      'HLS MPEG-TS Audio Codecs';
+      'HLS MPEG-TS Ses Kodekleri';
 
   @override
   String get settingsAudioDiagnosticsHlsFmp4AudioCodecs =>
-      'HLS fMP4 Audio Codecs';
+      'HLS fMP4 Ses Kodekleri';
 
   @override
   String get settingsAudioDiagnosticsAudioSpdifPassthrough =>
-      'audio-spdif passthrough';
+      'audio-spdif doğrudan geçiş (passthrough)';
 
   @override
-  String get settingsAudioDiagnosticsActiveAudioRoute => 'Active Audio Route';
+  String get settingsAudioDiagnosticsActiveAudioRoute => 'Aktif Ses Çıkışı';
 
   @override
   String get settingsAudioDiagnosticsRouteHdAudioSupport =>
-      'Route HD Audio Support';
+      'HD Ses Çıkışı Desteği';
 
   @override
   String get nightMode => 'Gece Modu';
@@ -2487,7 +2497,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String afterEpisodesAndHours(int episodes, double hours) {
-    return 'After $episodes episodes / ${hours}h';
+    return '$episodes bölüm / $hours saat sonra';
   }
 
   @override
@@ -2620,17 +2630,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String loadedProfileSettings(String profile) {
-    return 'Loaded $profile profile settings.';
+    return '$profile profil ayarları yüklendi.';
   }
 
   @override
   String failedToLoadProfileSettings(String profile) {
-    return 'Failed to load $profile profile settings.';
+    return '$profile profil ayarları yüklenemedi.';
   }
 
   @override
   String syncedSettingsToProfile(String profile) {
-    return 'Synced local settings to $profile profile.';
+    return 'Yerel ayarlar $profile profiliyle senkronize edildi.';
   }
 
   @override
@@ -2647,7 +2657,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get syncing => 'Senkronize ediliyor...';
 
   @override
-  String get syncToProfile => 'Profile Senkronizasyon';
+  String get syncToProfile => 'Profili Senkronize Et';
 
   @override
   String get profileSyncHidden => 'Profil Senkronizasyonu Gizli';
@@ -2759,7 +2769,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get showLibrariesInToolbar => 'Kitaplıkları Araç Çubuğunda Göster';
 
   @override
-  String get showSeerrButton => 'Show Seerr Button';
+  String get showSeerrButton => 'Seerr Butonunu Göster';
 
   @override
   String get navbarOpacity => 'Gezinti Çubuğunun Opaklığı';
@@ -2860,7 +2870,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String itemsSelected(int count) {
-    return '$count selected';
+    return '$count öge seçildi';
   }
 
   @override
@@ -2883,11 +2893,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Fragmanı, medyayı ve ses önizlemelerini yapılandırın.';
 
   @override
-  String get mediaBarMode => 'Medya Cubugu Stili';
+  String get mediaBarMode => 'Medya Çubuğu Stili';
 
   @override
   String get mediaBarModeDescription =>
-      'Moonfin, MakD arasindan secin veya medya cubugunu kapatin';
+      'Çeşitli medya çubuğu stilleri arasından seçim yapın veya medya çubuğunu kapatın';
 
   @override
   String get mediaBarModeMoonfin => 'Moonfin';
@@ -2994,7 +3004,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get liveTV => 'Canlı TV';
 
   @override
-  String get homeSections => 'Ana Sayfa Bölümler';
+  String get homeSections => 'Ana Sayfa Bölümleri';
 
   @override
   String get resetToDefaults => 'Varsayılanlara sıfırla';
@@ -3011,17 +3021,18 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get mergeContinueWatchingAndNextUp =>
-      'Birleştir İzlemeye Devam Et ve Sıradaki';
+      'İzlemeye Devam Et ve Sıradaki Bölümleri Birleştir';
 
   @override
   String get combineBothRows =>
       'Her iki satırı tek bir ana bölümde birleştirin';
 
   @override
-  String get fullScreenRows => 'Expanded Home Rows';
+  String get fullScreenRows => 'Genişletilmiş Ana Sayfa Satırları';
 
   @override
-  String get fullScreenRowsDescription => 'Limit home rows to 1 row per screen';
+  String get fullScreenRowsDescription =>
+      'Ana sayfa satırlarını ekran başına 1 satırla sınırla';
 
   @override
   String get perRowImageType => 'Satır Başına Görüntü Türü';
@@ -3036,7 +3047,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get lastUser => 'Son Kullanıcı';
 
   @override
-  String get currentUser => 'Current User';
+  String get currentUser => 'Mevcut Kullanıcı';
 
   @override
   String get alwaysAuthenticate => 'Daima Kimlik Doğrula';
@@ -3143,10 +3154,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ekran koruyucu sırasında saati göster';
 
   @override
-  String get clockModeStatic => 'Static';
+  String get clockModeStatic => 'Statik';
 
   @override
-  String get clockModeBouncing => 'Bouncing';
+  String get clockModeBouncing => 'Zıplayan';
 
   @override
   String get rottenTomatoesCritics => 'Çürük Domates (Eleştirmenler)';
@@ -3220,7 +3231,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Uygulama genelinde gösterilen derecelendirme kaynaklarını etkinleştirin ve yeniden sıralayın';
 
   @override
-  String get pluginLabel => 'Eklenti';
+  String get pluginLabel => 'Moonbase Eklentisi';
 
   @override
   String get pluginDetected => 'Eklenti Algılandı';
@@ -3292,7 +3303,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get networks => 'Ağlar';
 
   @override
-  String get seerrDiscoveryRows => 'Seerr Discovery Rows';
+  String get seerrDiscoveryRows => 'Seerr Keşfet Satırları';
 
   @override
   String get resetRowsToDefaults => 'Satırları varsayılanlara sıfırla';
@@ -3317,7 +3328,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String loggedInAs(String username) {
-    return 'Logged in as: $username';
+    return '$username olarak oturum açıldı';
   }
 
   @override
@@ -3393,7 +3404,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String updateAvailableVersion(String version) {
-    return 'Update available: v$version';
+    return 'Güncelleme mevcut: v$version';
   }
 
   @override
@@ -3405,7 +3416,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String updateAvailableTitle(String version) {
-    return 'v$version Available';
+    return 'v$version Mevcut';
   }
 
   @override
@@ -3492,7 +3503,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String requestedByName(String name) {
-    return 'Requested by $name';
+    return '$name tarafından istendi';
   }
 
   @override
@@ -3509,12 +3520,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String cancelRequestForTitle(String title) {
-    return 'Cancel request for \"$title\"?';
+    return '\"$title\" isteği iptal edilsin mi?';
   }
 
   @override
   String cancelCountRequestsForTitle(int count, String title) {
-    return 'Cancel $count requests for \"$title\"?';
+    return '\"$title\" için yapılan $count istek iptal edilsin mi?';
   }
 
   @override
@@ -3528,12 +3539,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String budgetAmount(String amount) {
-    return 'Budget: \$$amount';
+    return 'Bütçe: $amount \$';
   }
 
   @override
   String revenueAmount(String amount) {
-    return 'Revenue: \$$amount';
+    return 'Hasılat: $amount \$';
   }
 
   @override
@@ -3543,7 +3554,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String requestSeriesOrMovie(String type) {
-    return 'Request $type';
+    return 'İste $type';
   }
 
   @override
@@ -3579,7 +3590,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String ageValue(int age) {
-    return 'age $age';
+    return 'yaş $age';
   }
 
   @override
@@ -3870,22 +3881,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginUpdatesAvailable(int count) {
-    return 'Plugin updates available: $count';
+    return '$count eklenti güncellemesi mevcut';
   }
 
   @override
   String adminPluginsRequiringRestart(int count) {
-    return 'Plugins requiring restart: $count';
+    return 'Yeniden başlatılması gereken $count eklenti var';
   }
 
   @override
   String adminFailedScheduledTasks(int count) {
-    return 'Failed scheduled tasks: $count';
+    return '$count zamanlanmış görev başarısız oldu';
   }
 
   @override
   String adminRecentAlertEntries(int count) {
-    return 'Recent warning/error entries: $count';
+    return 'Son uyarı/hata kayıtları:$count';
   }
 
   @override
@@ -3972,7 +3983,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminCommandFailed(String error) {
-    return 'Command failed: $error';
+    return 'Komut başarısız oldu:$error';
   }
 
   @override
@@ -4033,11 +4044,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminDisconnect => 'Bağlantıyı kes';
 
   @override
-  String get adminClearDates => 'Tarihleri ​​temizle';
+  String get adminClearDates => 'Tarihleri temizle';
 
   @override
   String adminActivityLoadFailed(String error) {
-    return 'Failed to load activity log: $error';
+    return 'Etkinlik günlüğü yüklenemedi:$error';
   }
 
   @override
@@ -4054,7 +4065,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminDeviceUpdateFailed(String error) {
-    return 'Failed to update device: $error';
+    return 'Cihaz güncellenemedi:$error';
   }
 
   @override
@@ -4065,7 +4076,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminDeviceDeleteFailed(String error) {
-    return 'Failed to delete device: $error';
+    return 'Cihaz silinemedi: $error';
   }
 
   @override
@@ -4094,7 +4105,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminScanFailed(String error) {
-    return 'Failed to start scan: $error';
+    return 'Tarama başlatılamadı: $error';
   }
 
   @override
@@ -4105,12 +4116,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryRenamed(String name) {
-    return 'Library renamed to \"$name\"';
+    return 'Kitaplık adı \"$name\" olarak değiştirildi';
   }
 
   @override
   String adminRenameFailed(String error) {
-    return 'Failed to rename: $error';
+    return 'Yeniden adlandırılamadı: $error';
   }
 
   @override
@@ -4118,17 +4129,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryDeleted(String name) {
-    return 'Library \"$name\" deleted';
+    return '\"$name\" kitaplığı silindi';
   }
 
   @override
   String adminLibraryDeleteFailed(String error) {
-    return 'Failed to delete library: $error';
+    return 'Kitaplık silinemedi: $error';
   }
 
   @override
   String adminAddPathFailed(String error) {
-    return 'Failed to add path: $error';
+    return 'Yol eklenemedi: $error';
   }
 
   @override
@@ -4136,12 +4147,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRemovePathConfirm(String path) {
-    return 'Remove \"$path\" from this library?';
+    return '\"$path\" yolu bu kitaplıktan kaldırılsın mı?';
   }
 
   @override
   String adminRemovePathFailed(String error) {
-    return 'Failed to remove path: $error';
+    return 'Yol kaldırılamadı: $error';
   }
 
   @override
@@ -4149,7 +4160,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryOptionsSaveFailed(String error) {
-    return 'Failed to save options: $error';
+    return 'Seçenekler kaydedilemedi: $error';
   }
 
   @override
@@ -4184,7 +4195,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLibraryCreateFailed(String error) {
-    return 'Failed to create library: $error';
+    return 'Kitaplık oluşturulamadı: $error';
   }
 
   @override
@@ -4210,27 +4221,27 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminDisableUserConfirm(String name) {
-    return 'Disable $name? They will not be able to sign in.';
+    return '\"$name\" kullanıcısı devre dışı bırakılsın mı? Giriş yapamayacaklar.';
   }
 
   @override
   String adminEnableUserConfirm(String name) {
-    return 'Enable $name? They will be able to sign in again.';
+    return '\"$name\" kullanıcısı etkinleştirilsin mı? Tekrar giriş yapabilecekler.';
   }
 
   @override
   String adminUserDisabled(String name) {
-    return 'User \"$name\" disabled';
+    return '\"$name\" kullanıcısı devre dışı bırakıldı';
   }
 
   @override
   String adminUserEnabled(String name) {
-    return 'User \"$name\" enabled';
+    return '\"$name\" kullanıcısı etkinleştirildi';
   }
 
   @override
   String adminUserPolicyUpdateFailed(String error) {
-    return 'Failed to update user policy: $error';
+    return 'Kullanıcı politikası güncellenemedi: $error';
   }
 
   @override
@@ -4247,7 +4258,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminUserCreateFailed(String error) {
-    return 'Failed to create user: $error';
+    return 'Kullanıcı oluşturulamadı: $error';
   }
 
   @override
@@ -4267,7 +4278,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminSaveFailed(String error) {
-    return 'Failed to save: $error';
+    return 'Kaydedilemedi: $error';
   }
 
   @override
@@ -4278,7 +4289,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminFailed(String error) {
-    return 'Failed: $error';
+    return 'Başarısız oldu: $error';
   }
 
   @override
@@ -4418,22 +4429,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminServerReturnedHttp(int status) {
-    return 'Server returned HTTP $status';
+    return 'Sunucu yanıtı: HTTP $status';
   }
 
   @override
   String adminDeleteUserConfirm(String name) {
-    return 'Are you sure you want to delete $name?';
+    return '$name öğesini silmek istediğinizden emin misiniz?';
   }
 
   @override
   String adminUserDeleted(String name) {
-    return 'User \"$name\" deleted';
+    return '\"$name\" kullanıcısı silindi';
   }
 
   @override
   String adminUserDeleteFailed(String error) {
-    return 'Failed to delete user: $error';
+    return 'Kullanıcı silinemedi: $error';
   }
 
   @override
@@ -4454,7 +4465,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminApiKeyCreateFailed(String error) {
-    return 'Failed to create key: $error';
+    return 'Anahtar oluşturulamadı: $error';
   }
 
   @override
@@ -4465,7 +4476,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRevokeKeyConfirm(String name) {
-    return 'Revoke key for $name?';
+    return '$name için anahtar iptal edilsin mi?';
   }
 
   @override
@@ -4473,7 +4484,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminApiKeyRevokeFailed(String error) {
-    return 'Failed to revoke key: $error';
+    return 'Anahtar iptal edilemedi: $error';
   }
 
   @override
@@ -4493,7 +4504,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminApiKeyTokenCreated(String token, String created) {
-    return 'Token: $token\\nCreated: $created';
+    return 'Jeton: $token\\nOluşturulma tarihi: $created';
   }
 
   @override
@@ -4504,7 +4515,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminBackupCreateFailed(String error) {
-    return 'Failed to create backup: $error';
+    return 'Yedek oluşturulamadı: $error';
   }
 
   @override
@@ -4517,7 +4528,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminManifestLoadFailed(String error) {
-    return 'Failed to load manifest: $error';
+    return 'Manifest yüklenemedi: $error';
   }
 
   @override
@@ -4528,7 +4539,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRestoreFailed(String error) {
-    return 'Failed to restore backup: $error';
+    return 'Yedek geri yüklenemedi: $error';
   }
 
   @override
@@ -4560,17 +4571,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminSavedTo(String path) {
-    return 'Saved to $path';
+    return '$path konumuna kaydedildi';
   }
 
   @override
   String adminFileSaveFailed(String error) {
-    return 'Failed to save file: $error';
+    return 'Dosya kaydedilemedi: $error';
   }
 
   @override
   String adminLogFileLoadFailed(String fileName) {
-    return 'Failed to load $fileName';
+    return 'Dosya yüklenemedi: $fileName';
   }
 
   @override
@@ -4581,7 +4592,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTasksLoadFailed(String error) {
-    return 'Failed to load tasks: $error';
+    return 'Görevler yüklenemedi: $error';
   }
 
   @override
@@ -4592,17 +4603,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTaskStartFailed(String error) {
-    return 'Failed to start task: $error';
+    return 'Görev başlatılamadı: $error';
   }
 
   @override
   String adminTaskStopFailed(String error) {
-    return 'Failed to stop task: $error';
+    return 'Görev durdurulamadı: $error';
   }
 
   @override
   String adminTaskLoadFailed(String error) {
-    return 'Failed to load task: $error';
+    return 'Görev yüklenemedi: $error';
   }
 
   @override
@@ -4610,12 +4621,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTriggerRemoveFailed(String error) {
-    return 'Failed to remove trigger: $error';
+    return 'Tetikleyici kaldırılamadı: $error';
   }
 
   @override
   String adminTriggerAddFailed(String error) {
-    return 'Failed to add trigger: $error';
+    return 'Tetikleyici eklenemedi: $error';
   }
 
   @override
@@ -4641,7 +4652,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminHours(String hours) {
-    return '$hours hour(s)';
+    return '$hours saat';
   }
 
   @override
@@ -4652,7 +4663,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginToggleFailed(String error) {
-    return 'Failed to toggle plugin: $error';
+    return 'Eklenti durumu değiştirilemedi: $error';
   }
 
   @override
@@ -4660,27 +4671,27 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminUninstallPluginConfirm(String name) {
-    return 'Are you sure you want to uninstall \"$name\"?';
+    return '\"$name\" eklentisini kaldırmak istediğinize emin misiniz?';
   }
 
   @override
   String adminPluginUninstallFailed(String error) {
-    return 'Failed to uninstall plugin: $error';
+    return 'Eklenti kaldırılamadı: $error';
   }
 
   @override
   String adminPackageInstallFailed(String error) {
-    return 'Failed to install package: $error';
+    return 'Paket yüklenemedi: $error';
   }
 
   @override
   String adminPluginUpdateFailed(String error) {
-    return 'Failed to install update: $error';
+    return 'Güncelleme yüklenemedi: $error';
   }
 
   @override
   String adminPluginsLoadFailed(String error) {
-    return 'Failed to load plugins: $error';
+    return 'Eklentiler yüklenemedi: $error';
   }
 
   @override
@@ -4696,7 +4707,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminCatalogLoadFailed(String error) {
-    return 'Failed to load catalog: $error';
+    return 'Katalog yüklenemedi: $error';
   }
 
   @override
@@ -4717,17 +4728,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginRemoveAfterRestart(String name) {
-    return '\"$name\" will be removed after server restart';
+    return '\"$name\" sunucu yeniden başlatıldıktan sonra kaldırılacak';
   }
 
   @override
   String adminUninstallFailed(String error) {
-    return 'Failed to uninstall: $error';
+    return 'Kaldırılamadı: $error';
   }
 
   @override
   String adminPluginUpdating(String name, String version) {
-    return 'Updating \"$name\" to v$version...';
+    return '\"$name\", v$version sürümüne güncelleniyor...';
   }
 
   @override
@@ -4736,7 +4747,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginLoadFailed(String error) {
-    return 'Failed to load plugin: $error';
+    return 'Eklenti yüklenemedi: $error';
   }
 
   @override
@@ -4764,17 +4775,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRemoveRepositoryConfirm(String name) {
-    return 'Are you sure you want to remove \"$name\"?';
+    return '\"$name\" ögesini kaldırmak istediğinize emin misiniz?';
   }
 
   @override
   String adminRepositoriesSaveFailed(String error) {
-    return 'Failed to save repositories: $error';
+    return 'Depolar kaydedilemedi: $error';
   }
 
   @override
   String adminRepositoriesLoadFailed(String error) {
-    return 'Failed to load repositories: $error';
+    return 'Depolar yüklenemedi: $error';
   }
 
   @override
@@ -4791,12 +4802,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginSettingsLoadFailed(String error) {
-    return 'Unable to load plugin settings: $error';
+    return 'Eklenti ayarları yüklenemedi: $error';
   }
 
   @override
   String adminCouldNotOpenUrl(String uri) {
-    return 'Could not open $uri';
+    return '$uri açılamadı';
   }
 
   @override
@@ -5073,12 +5084,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataLoadFailed(String error) {
-    return 'Failed to load metadata: $error';
+    return 'Meta veriler yüklenemedi: $error';
   }
 
   @override
   String adminMetadataSaveFailed(String error) {
-    return 'Failed to save metadata: $error';
+    return 'Meta veriler kaydedilemedi: $error';
   }
 
   @override
@@ -5098,7 +5109,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataRefreshFailed(String error) {
-    return 'Failed to refresh metadata: $error';
+    return 'Meta veriler yenilenemedi: $error';
   }
 
   @override
@@ -5115,7 +5126,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRemoteSearchFailed(String error) {
-    return 'Remote search failed: $error';
+    return 'Uzaktan arama başarısız oldu: $error';
   }
 
   @override
@@ -5129,7 +5140,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminContentTypeUpdateFailed(String error) {
-    return 'Failed to update content type: $error';
+    return 'İçerik türü güncellenemedi: $error';
   }
 
   @override
@@ -5144,12 +5155,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminImageUpdated(String imageType) {
-    return '$imageType image updated';
+    return '$imageType görseli güncellendi';
   }
 
   @override
   String adminImageDownloadFailed(String error) {
-    return 'Failed to download image: $error';
+    return 'Görsel indirilemedi: $error';
   }
 
   @override
@@ -5160,12 +5171,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminImageUploaded(String imageType) {
-    return '$imageType image uploaded';
+    return '$imageType görseli yüklendi';
   }
 
   @override
   String adminImageUploadFailed(String error) {
-    return 'Failed to upload image: $error';
+    return 'Görsel yüklenemedi: $error';
   }
 
   @override
@@ -5175,12 +5186,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminImageDeleted(String imageType) {
-    return '$imageType image deleted';
+    return '$imageType görseli silindi';
   }
 
   @override
   String adminImageDeleteFailed(String error) {
-    return 'Failed to delete image: $error';
+    return 'Görsel silinemedi: $error';
   }
 
   @override
@@ -5191,14 +5202,14 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTunerDiscoveryFailed(String error) {
-    return 'Tuner discovery failed: $error';
+    return 'Tuner taraması başarısız oldu: $error';
   }
 
   @override
-  String get adminAddTuner => 'Ayarlayıcı Ekle';
+  String get adminAddTuner => 'Tuner Ekle';
 
   @override
-  String get adminTunerType => 'Ayarlayıcı Türü';
+  String get adminTunerType => 'Tuner Türü';
 
   @override
   String get adminTunerTypeHint => 'HDHomeRun, M3U, Diğer';
@@ -5214,7 +5225,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTunerAddFailed(String error) {
-    return 'Failed to add tuner: $error';
+    return 'Tuner eklenemedi: $error';
   }
 
   @override
@@ -5237,12 +5248,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminProviderAddFailed(String error) {
-    return 'Failed to add provider: $error';
+    return 'Sağlayıcı eklenemedi: $error';
   }
 
   @override
   String adminTunerRemoveFailed(String error) {
-    return 'Failed to remove tuner: $error';
+    return 'Tuner kaldırılamadı: $error';
   }
 
   @override
@@ -5250,12 +5261,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTunerResetFailed(String error) {
-    return 'Failed to reset tuner: $error';
+    return 'Tuner sıfırlanamadı: $error';
   }
 
   @override
   String adminProviderRemoveFailed(String error) {
-    return 'Failed to remove provider: $error';
+    return 'Sağlayıcı kaldırılamadı: $error';
   }
 
   @override
@@ -5278,7 +5289,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminSettingsSaveFailed(String error) {
-    return 'Failed to save settings: $error';
+    return 'Ayarlar kaydedilemedi: $error';
   }
 
   @override
@@ -5295,7 +5306,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMappingsUpdateFailed(String error) {
-    return 'Failed to update mappings: $error';
+    return 'Eşleştirmeler güncellenemedi: $error';
   }
 
   @override
@@ -5320,22 +5331,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRecordingPathDisplay(String path) {
-    return 'Recording path: $path';
+    return 'Kayıt yolu: $path';
   }
 
   @override
   String adminSeriesPathDisplay(String path) {
-    return 'Series path: $path';
+    return 'Dizi yolu: $path';
   }
 
   @override
   String adminPrePaddingDisplay(int minutes) {
-    return 'Pre-padding: $minutes min';
+    return 'Kayıt öncesi süre: $minutes dk';
   }
 
   @override
   String adminPostPaddingDisplay(int minutes) {
-    return 'Post-padding: $minutes min';
+    return 'Kayıt sonrası süre: $minutes dk';
   }
 
   @override
@@ -5368,7 +5379,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminRestoreConfirmMessage(String name) {
-    return 'Restore backup $name now?';
+    return '$name yedeği şimdi geri yüklensin mi?';
   }
 
   @override
@@ -5414,27 +5425,27 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminLogsMinutesAgo(int minutes) {
-    return '${minutes}m ago';
+    return '$minutes dk önce';
   }
 
   @override
   String adminLogsHoursAgo(int hours) {
-    return '${hours}h ago';
+    return '$hours sa önce';
   }
 
   @override
   String adminLogsDaysAgo(int days) {
-    return '${days}d ago';
+    return '${days}g önce';
   }
 
   @override
   String adminLogViewerLoadFailed(String fileName) {
-    return 'Failed to load $fileName';
+    return '$fileName yüklenemedi';
   }
 
   @override
   String adminLogViewerMatches(int count) {
-    return '$count matches';
+    return '$count eşleşme';
   }
 
   @override
@@ -5545,22 +5556,22 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataImageUpdated(String imageType) {
-    return '$imageType image updated';
+    return '$imageType görseli güncellendi';
   }
 
   @override
   String adminMetadataImageUploaded(String imageType) {
-    return '$imageType image uploaded';
+    return '$imageType görseli yüklendi';
   }
 
   @override
   String adminMetadataImageDeleted(String imageType) {
-    return '$imageType image deleted';
+    return '$imageType görseli silindi';
   }
 
   @override
   String adminMetadataImageDownloadFailed(String error) {
-    return 'Failed to download image: $error';
+    return 'Görsel indirilemedi: $error';
   }
 
   @override
@@ -5568,7 +5579,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataImageUploadFailed(String error) {
-    return 'Failed to upload image: $error';
+    return 'Görsel yüklenemedi: $error';
   }
 
   @override
@@ -5582,12 +5593,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataImageDeleteFailed(String error) {
-    return 'Failed to delete image: $error';
+    return 'Görsel silinemedi: $error';
   }
 
   @override
   String adminMetadataChooseImage(String imageType) {
-    return 'Choose $imageType image';
+    return '$imageType görseli seçin';
   }
 
   @override
@@ -5619,7 +5630,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginsUpdateAvailable(String version) {
-    return 'Update available: v$version';
+    return 'Güncelleme mevcut: v$version';
   }
 
   @override
@@ -5656,7 +5667,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginsInstalling(String name) {
-    return '\"$name\" is being installed...';
+    return '\"$name\" yükleniyor...';
   }
 
   @override
@@ -5676,7 +5687,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminPluginDetailSettingsTitle(String name) {
-    return '$name Settings';
+    return '$name Ayarları';
   }
 
   @override
@@ -5716,7 +5727,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminReposLoadFailed(String error) {
-    return 'Failed to load repositories: $error';
+    return 'Depolar yüklenemedi: $error';
   }
 
   @override
@@ -5724,7 +5735,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminReposRemoveConfirm(String name) {
-    return 'Are you sure you want to remove \"$name\"?';
+    return '\"$name\" ögesini kaldırmak istediğinize emin misiniz?';
   }
 
   @override
@@ -5732,7 +5743,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminReposSaveFailed(String error) {
-    return 'Failed to save repositories: $error';
+    return 'Depolar kaydedilemedi: $error';
   }
 
   @override
@@ -6009,17 +6020,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminTaskTriggerDaily(String time) {
-    return 'Daily at $time';
+    return 'Her gün $time';
   }
 
   @override
   String adminTaskTriggerWeekly(String day, String time) {
-    return 'Every $day at $time';
+    return 'Her $day saat $time';
   }
 
   @override
   String adminTaskTriggerInterval(String duration) {
-    return 'Every $duration';
+    return 'Her $duration';
   }
 
   @override
@@ -6057,8 +6068,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hours',
-      one: '1 hour',
+      other: '$count saat',
+      one: '1 saat',
     );
     return '$_temp0';
   }
@@ -6086,17 +6097,17 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminActivityDaysAgo(int days) {
-    return '${days}d ago';
+    return '$days g önce';
   }
 
   @override
   String adminActivityHoursAgo(int hours) {
-    return '${hours}h ago';
+    return '$hours sa önce';
   }
 
   @override
   String adminActivityMinutesAgo(int minutes) {
-    return '${minutes}m ago';
+    return '$minutes dk önce';
   }
 
   @override
@@ -6212,7 +6223,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminMetadataContentTypeFailed(String error) {
-    return 'Failed to update content type: $error';
+    return 'İçerik türü güncellenemedi: $error';
   }
 
   @override
@@ -6235,12 +6246,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String adminChannelMappingsUpdateFailed(String error) {
-    return 'Failed to update mappings: $error';
+    return 'Eşleştirmeler güncellenemedi: $error';
   }
 
   @override
   String adminTimeLimitDuration(String duration) {
-    return 'Time limit: $duration';
+    return 'Süre sınırı: $duration';
   }
 
   @override
@@ -6277,8 +6288,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# participants',
-      one: '# participant',
+      other: '# katılımcı',
+      one: '# katılımcı',
     );
     return '$_temp0';
   }
@@ -6371,12 +6382,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String syncPlayUserJoinedGroup(String userName) {
-    return '$userName joined SyncPlay group';
+    return '$userName SyncPlay grubuna katıldı';
   }
 
   @override
   String syncPlayUserLeftGroup(String userName) {
-    return '$userName left SyncPlay group';
+    return '$userName SyncPlay grubundan ayrıldı';
   }
 
   @override
@@ -6388,7 +6399,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String syncPlaySyncingPlaybackToGroup(String groupName) {
-    return 'Syncing playback to $groupName';
+    return 'Oynatma durumu $groupName ile eşitleniyor';
   }
 
   @override
@@ -6430,14 +6441,6 @@ class AppLocalizationsTr extends AppLocalizations {
       'Henüz eklentiyi bildiren Jellyfin sunucusu yok.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Ranaldsgift\'in \"KefinTweaks\" eklentisi aracılığıyla yapılandırılan satırları tespit edin. Yakın zamanda piyasaya sürülen, tekrar izlenen, sezonluk ve kitaplığa yakın zamanda eklenen özel bölümler, her Jellyfin sunucusundaki KefinTweaks yapılandırmasından yansıtılır.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Henüz KefinTweaks\'i bildiren Jellyfin sunucusu yok.';
-
-  @override
   String get integrationOpenHomeSections => 'Ana Sayfa Bölümlerini Aç';
 
   @override
@@ -6456,8 +6459,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# sections',
-      one: '# section',
+      other: '# bölüm',
+      one: '# bölüm',
     );
     return '$_temp0';
   }
@@ -6467,14 +6470,14 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# rows discovered',
-      one: '# row discovered',
+      other: '# satır keşfedildi',
+      one: '# satır keşfedildi',
     );
     return '$_temp0';
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Tümünü Gör';
@@ -6525,12 +6528,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String castControlFailed(String error) {
-    return 'Cast control failed: $error';
+    return 'Yansıtma kontrolü başarısız oldu: $error';
   }
 
   @override
   String castKindControls(String kind) {
-    return '$kind Controls';
+    return '$kind Kontrolleri';
   }
 
   @override
@@ -6564,12 +6567,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String pinEnterNDigit(int length) {
-    return 'Enter a $length-digit PIN';
+    return '$length haneli bir PIN girin';
   }
 
   @override
   String pinEnterYourNDigit(int length) {
-    return 'Enter your $length-digit PIN';
+    return '$length haneli PIN\'inizi girin';
   }
 
   @override
@@ -6582,7 +6585,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get pinForgot => 'PIN\'inizi mi unuttunuz?';
 
   @override
-  String get pinClear => 'Temizlemek';
+  String get pinClear => 'Temizle';
 
   @override
   String get pinBackspace => 'Geri tuşu';
@@ -6616,7 +6619,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String quickConnectFailedWithMessage(String message) {
-    return 'Quick Connect failed: $message';
+    return 'Hızlı Bağlantı başarısız oldu: $message';
   }
 
   @override
@@ -6627,7 +6630,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String remoteCommandFailed(String error) {
-    return 'Command failed: $error';
+    return 'Komut başarısız oldu: $error';
   }
 
   @override
@@ -6656,7 +6659,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String castingFailed(String error) {
-    return 'Failed to start casting: $error';
+    return 'Yansıtma başlatılamadı: $error';
   }
 
   @override
@@ -6701,7 +6704,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String trackActionDownloading(String name) {
-    return 'Downloading $name...';
+    return '$name indiriliyor...';
   }
 
   @override
@@ -6788,7 +6791,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String skipSegment(String segment) {
-    return 'Skip $segment';
+    return '$segment geç';
   }
 
   @override
@@ -6799,12 +6802,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String downloadingBatchProgress(int current, int total, String fileName) {
-    return 'Downloading $current/$total — $fileName';
+    return 'İndiriliyor: $current/$total — $fileName';
   }
 
   @override
   String downloadingFile(String fileName) {
-    return 'Downloading $fileName';
+    return '$fileName indiriliyor';
   }
 
   @override
@@ -6908,7 +6911,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsAuthenticationSection => 'DOĞRULAMA';
 
   @override
-  String get settingsSortServersBy => 'Sunucuları Şuna Göre Sırala:';
+  String get settingsSortServersBy => 'Sunucuları Şuna Göre Sırala';
 
   @override
   String get settingsLastUsed => 'Son Kullanılan';
@@ -6949,7 +6952,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsShowShuffleButtonInNavigation =>
-      'Gezinme çubuğunda karışık düğmesini göster';
+      'Gezinme çubuğunda karıştır düğmesini göster';
 
   @override
   String get settingsShowGenresButtonInNavigation =>
@@ -6965,7 +6968,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsShowSeerrButtonInNavigation =>
-      'Show the Seerr button in the navigation bar';
+      'Gezinti çubuğunda Seerr butonunu göster';
 
   @override
   String get settingsLibraryVisibilitySubtitle =>
@@ -7034,7 +7037,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsSupportMoonfinSubtitle =>
-      'Donate a coffee to the developer';
+      'Geliştiriciye bir kahve ısmarla';
 
   @override
   String get settingsLegal => 'YASAL';
@@ -7051,7 +7054,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsPrivacyPolicySubtitle =>
-      'Moonfin verilerinizi nasıl işler?';
+      'Moonfin verilerinizi nasıl işler';
 
   @override
   String get settingsCheckForUpdates => 'Güncellemeleri Kontrol Et';
@@ -7068,8 +7071,8 @@ class AppLocalizationsTr extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '# license notices',
-      one: '# license notice',
+      other: '# lisans bildirimi',
+      one: '# lisans bildirimi',
     );
     return '$_temp0';
   }
@@ -7118,16 +7121,16 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Giriş ve Çıkışlar atlansın mı?';
 
   @override
-  String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
+  String get settingsMediaSegmentCountdown => 'Medya Bölümü Geri Sayımı';
 
   @override
-  String get settingsProgressBar => 'Progress Bar';
+  String get settingsProgressBar => 'İlerleme Çubuğu';
 
   @override
-  String get settingsTimer => 'Timer';
+  String get settingsTimer => 'Zamanlayıcı';
 
   @override
-  String get settingsNone => 'None';
+  String get settingsNone => 'Hiçbiri';
 
   @override
   String get settingsPromptUser => 'Kullanıcıya Sor';
@@ -7161,13 +7164,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsPlaybackEngineMedia3Recommended => 'Media3 (önerilir)';
 
   @override
-  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (legacy)';
+  String get settingsPlaybackEngineMedia3Legacy => 'Media3 (eski nesil)';
 
   @override
   String get settingsPlaybackEngineMpvLegacy => 'mpv (eski)';
 
   @override
-  String get settingsPlaybackEngineMpvRecommended => 'mpv (recommended)';
+  String get settingsPlaybackEngineMpvRecommended => 'mpv (önerilen)';
 
   @override
   String get settingsDolbyVisionFallback => 'Dolby Vision Geri dönüş';
@@ -7351,360 +7354,410 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String latestLibraryName(String libraryName) {
-    return 'Latest $libraryName';
+    return 'Son Eklenen $libraryName';
   }
 
   @override
-  String get autoplayNextEpisode => 'Autoplay Next Episode';
+  String get autoplayNextEpisode => 'Sonraki Bölümü Otomatik Oynat';
 
   @override
   String get autoplayNextEpisodeSubtitle =>
-      'Automatically play the next episode when available.';
+      'Mevcut olduğunda sonraki bölümü otomatik oynat.';
 
   @override
-  String get skipSilenceTitle => 'Skip silence';
+  String get skipSilenceTitle => 'Sessizce Atla';
 
   @override
   String get skipSilenceSubtitle =>
-      'Automatically skip silent audio segments when supported by the stream.';
+      'Akış desteklediğinde, sessiz ses bölümlerini otomatik olarak atla.';
 
   @override
-  String get allowExternalAudioEffectsTitle => 'Allow external audio effects';
+  String get allowExternalAudioEffectsTitle =>
+      'Harici ses efektlerine izin ver';
 
   @override
   String get allowExternalAudioEffectsSubtitle =>
-      'Allow equalizer and effects apps (e.g. Wavelet) to attach to Media3 playback sessions.';
+      'Ekolayzer ve efekt uygulamalarının (örn. Wavelet) Media3 oynatma oturumlarına bağlanmasına izin ver.';
 
   @override
-  String get disableTunnelingTitle => 'Disable tunneling';
+  String get disableTunnelingTitle => 'Tünellemeyi devre dışı bırak';
 
   @override
   String get disableTunnelingSubtitle =>
-      'Force non-tunneled playback. Useful on devices with tunneling audio/video discontinuities.';
+      'Tünelsiz oynatmaya zorla. Tünelleme kaynaklı ses/video kopmaları yaşanan cihazlarda yararlıdır.';
 
   @override
-  String get enableTunnelingTitle => 'Enable tunneling';
+  String get enableTunnelingTitle => 'Tünellemeyi etkinleştir';
 
   @override
   String get enableTunnelingSubtitle =>
-      'Advanced. Routes audio and video through a coupled hardware path. Off by default because it causes audio/video dropouts on some devices.';
+      'Gelişmiş. Sesi ve videoyu birbirine bağlı bir donanım yolu üzerinden iletir. Bazı cihazlarda ses/video kesintilerine neden olabileceği için varsayılan olarak kapalıdır.';
 
   @override
-  String get mapDolbyVisionP7Title => 'Map Dolby Vision profile 7 to HEVC';
+  String get mapDolbyVisionP7Title =>
+      'Dolby Vision profil 7\'yi HEVC ile eşleştir';
 
   @override
   String get mapDolbyVisionP7Subtitle =>
-      'Play Dolby Vision profile 7 streams as HDR10-compatible HEVC on non-DV devices.';
+      'Dolby Vision profil 7 akışlarını, DV desteklemeyen cihazlarda HDR10 uyumlu HEVC olarak oynat.';
 
   @override
-  String get subtitlesUseEmbeddedStyles => 'Use embedded subtitle styles';
+  String get subtitlesUseEmbeddedStyles => 'Gömülü altyazı stillerini kullan';
 
   @override
   String get subtitlesUseEmbeddedStylesSubtitle =>
-      'Apply colours, fonts, and positioning embedded in the subtitle track. Disable to use your caption style preferences instead.';
+      'Altyazı parçasında gömülü olan renk, yazı tipi ve konumlandırmayı uygula. Kendi altyazı stili tercihlerinizi kullanmak için devre dışı bırakın.';
 
   @override
   String get subtitlesUseEmbeddedFontSizes =>
-      'Use embedded subtitle font sizes';
+      'Gömülü altyazı boyutlarını kullan';
 
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
-      'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
+      'Altyazı parçasında gömülü olan yazı tipi boyutu ipuçlarını uygula. Kendi stili tercihlerinizdeki altyazı boyutunu kullanmak için devre dışı bırakın.';
 
   @override
-  String get showMediaDetailsOnLibraryPage => 'Show Media Details';
+  String get showMediaDetailsOnLibraryPage => 'Medya Ayrıntılarını Göster';
 
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
-      'Show details of the selected item at the top of Library pages.';
+      'Kütüphane sayfalarında, seçilen ögenin detaylarını üst kısımda göster.';
 
   @override
-  String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
+  String get useDetailedSubHeadings => 'Detaylı alt başlıklar kullan';
 
   @override
   String get useDetailedSubHeadingsDescription =>
-      'Show detailed or minimal subrow on Library pages.';
+      'Kütüphane sayfalarında detaylı veya sade bir alt satır göster.';
 
   @override
-  String get savedThemesDeleteDialogTitle => 'Delete saved theme?';
+  String get savedThemesDeleteDialogTitle => 'Kaydedilen tema silinsin mi?';
 
   @override
   String savedThemesDeleteDialogMessage(String themeName) {
-    return 'Remove \"$themeName\" from this device cache?';
+    return '\"$themeName\" bu cihazın önbelleğinden kaldırılsın mı?';
+  }
+
+  @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
   }
 
   @override
   String savedThemesDeletedMessage(String themeName) {
-    return 'Deleted \"$themeName\" from this device.';
+    return '\"$themeName\" bu cihazdan silindi.';
   }
 
   @override
   String savedThemesDeleteFailedMessage(String themeName) {
-    return 'Could not delete \"$themeName\".';
+    return '\"$themeName\" silinemedi.';
   }
 
   @override
-  String get savedThemesTitle => 'Saved themes';
+  String get savedThemesTitle => 'Kayıtlı temalar';
 
   @override
   String get savedThemesDescription =>
-      'These are themes downloaded from the Moonfin plugin for the current server. Deleting removes only this local copy.';
+      'Bunlar, mevcut sunucu için Moonfin eklentisinden indirilen temalardır. Silme işlemi yalnızca bu yerel kopyayı kaldırır.';
 
   @override
-  String get savedThemesEmpty => 'No saved themes were found for this server.';
+  String get savedThemesEmpty => 'Bu sunucu için kayıtlı tema bulunamadı.';
 
   @override
   String savedThemesCurrentThemeId(String themeId) {
-    return '$themeId • Currently active';
+    return '$themeId • Şu an aktif';
   }
 
   @override
-  String get savedThemesDeleteTooltip => 'Delete saved theme';
+  String get savedThemesDeleteTooltip => 'Kayıtlı temayı sil';
 
   @override
   String get savedThemesManageSubtitle =>
-      'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
+      'Bu cihazdaki indirilen eklenti temalarını yönetin';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
 
   @override
-  String get themeEditor => 'Theme Editor';
+  String get themeEditor => 'Tema Editörü';
 
   @override
-  String get themeEditorSubtitle =>
-      'Open the Moonfin Theme Editor in your browser';
+  String get themeEditorSubtitle => 'Moonfin Tema Editörünü tarayıcınızda açın';
 
   @override
-  String get homeScreen => 'Home Screen';
+  String get homeScreen => 'Ana Sayfa';
 
   @override
-  String get bottomBar => 'Bottom Bar';
+  String get bottomBar => 'Alt Bar';
 
   @override
-  String get homeRowsStyleClassic => 'Classic';
+  String get homeRowsStyleClassic => 'Klasik';
 
   @override
   String get homeRowsStyleModern => 'Modern';
 
   @override
-  String get homeRowsSection => 'Home Rows';
+  String get homeRowsSection => 'Ana Sayfa Satırları';
 
   @override
-  String get homeRowDisplay => 'Home Row Display';
+  String get homeRowDisplay => 'Ana Sayfa Satır Gösterimi';
 
   @override
-  String get homeRowSections => 'Home Row Sections';
+  String get homeRowSections => 'Ana Sayfa Satır Bölümleri';
 
   @override
-  String get homeRowToggles => 'Home Row Toggles';
+  String get homeRowToggles => 'Ana Sayfa Satır Aç/Kapat Ayarları';
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Enable or disable different home row categories';
+      'Farklı ana sayfa satır kategorilerini etkinleştirin veya devre dışı bırakın';
 
   @override
   String get homeRowTogglesDescription =>
-      'Enable the following toggles to display the rows in Home Sections.';
+      'Satırları Ana Sayfa Bölümleri\'nde göstermek için aşağıdaki anahtarları etkinleştirin.';
 
   @override
-  String get rowsType => 'Rows Type';
+  String get rowsType => 'Satır Tipi';
 
   @override
   String get rowsTypeDescription =>
-      'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
+      'Klasik mod, satır başına görsel türünü ve bilgi katmanını korur. Modern mod ise dikey görsellerden yatay arka planlara uzanan satırlar kullanır.';
 
   @override
-  String get displayFavoritesRows => 'Display Favorites Rows';
+  String get displayFavoritesRows => 'Favoriler Satırlarını Görüntüle';
 
   @override
   String get displayFavoritesRowsSubtitle =>
-      'Show Favorite Movies, Series, and other favorite rows in Home Sections.';
+      'Favori Filmleri, Dizileri ve diğer favori satırlarını Ana Sayfa Bölümlerinde göster.';
 
   @override
-  String get favoritesRowSorting => 'Favorites Row Sorting';
+  String get favoritesRowSorting => 'Favoriler Satırı Sıralaması';
 
   @override
   String get favoritesRowSortingDescription =>
-      'Sort Favorites rows by date added, release date, alphabetically, and more.';
+      'Favori satırlarını eklenme tarihine, çıkış tarihine, alfabetik sıraya ve daha fazlasına göre sıralayın.';
 
   @override
-  String get displayCollectionsRows => 'Display Collections Rows';
+  String get displayCollectionsRows => 'Koleksiyon Satırlarını Göster';
 
   @override
   String get displayCollectionsRowsSubtitle =>
-      'Show Collections rows in Home Sections.';
+      'Koleksiyon satırlarını Ana Sayfa Bölümlerinde göster.';
 
   @override
-  String get collectionsRowSorting => 'Collections Row Sorting';
+  String get collectionsRowSorting => 'Koleksiyon Satırı Sıralaması';
 
   @override
   String get collectionsRowSortingDescription =>
-      'Sort Collections rows by date added, release date, alphabetically, and more.';
+      'Koleksiyonlar satırlarını ekleme tarihine, çıkış tarihine, alfabetik sıraya ve daha fazlasına göre sıralayın.';
 
   @override
-  String get displayGenresRows => 'Display Genres Rows';
+  String get displayGenresRows => 'Tür Satırlarını Göster';
 
   @override
-  String get displayGenresRowsSubtitle => 'Show Genres rows in Home Sections.';
+  String get displayGenresRowsSubtitle =>
+      'Ana Sayfa Bölümlerinde Türler satırlarını göster.';
 
   @override
-  String get genresRowSorting => 'Genres Row Sorting';
+  String get genresRowSorting => 'Türler Satırı Sıralaması';
 
   @override
   String get genresRowSortingDescription =>
-      'Sort Genres rows by date added, release date, alphabetically, and more.';
+      'Türler satırlarını ekleme tarihine, çıkış tarihine, alfabetik sıraya ve daha fazlasına göre sıralayın.';
 
   @override
-  String get genresRowItems => 'Genres Row Items';
+  String get genresRowItems => 'Türler Satırı Ögeleri';
 
   @override
   String get genresRowItemsDescription =>
-      'Show Movies, Series, or both in Genres rows.';
+      'Türler satırlarında Filmleri, Dizileri veya her ikisini birden göster.';
 
   @override
-  String get displayPlaylistsRows => 'Display Playlist Rows';
+  String get displayPlaylistsRows => 'Oynatma Listesi Satırlarını Göster';
 
   @override
   String get displayPlaylistsRowsSubtitle =>
-      'Show Playlist rows in Home Sections.';
+      'Oynatma listesi satırlarını Ana Sayfa Bölümleri\'nde göster.';
 
   @override
-  String get playlistsRowSorting => 'Playlist Row Sorting';
+  String get playlistsRowSorting => 'Oynatma Listesi Satır Sıralaması';
 
   @override
   String get playlistsRowSortingDescription =>
-      'Sort Playlist rows by date added, release date, alphabetically, and more.';
+      'Oynatma listesi satırlarını ekleme tarihi, yayınlanma tarihi, alfabetik ve daha fazlasına göre sıralayın.';
 
   @override
-  String get displaySeerrRows => 'Display Seerr Discovery Rows';
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
+
+  @override
+  String get displaySeerrRows => 'Seerr Keşif Satırlarını Göster';
 
   @override
   String get displaySeerrRowsSubtitle =>
-      'Show Seerr discovery rows in Home Sections.';
+      'Seerr keşif satırlarını Ana Sayfa Bölümleri\'nde göster.';
 
   @override
-  String get appearance => 'Appearance';
+  String get appearance => 'Görünüm';
 
   @override
-  String get cardSize => 'Card Size';
+  String get cardSize => 'Ana Sayfa Satırı Kart Gösterim Boyutu';
 
   @override
-  String get externalPlayerApp => 'External player app';
+  String get externalPlayerApp => 'Harici oynatıcı';
 
   @override
   String get externalPlayerAppDescription =>
-      'Set external player to enable long-press play option';
+      'Üzerine uzun basarak oynatma seçeneğini etkinleştirmek için harici oynatıcıyı ayarlayın';
 
   @override
   String get externalPlayerAskEachTimeSubtitle =>
-      'Show app chooser when playback starts.';
+      'Oynatma başladığında uygulama seçiciyi göster.';
 
   @override
-  String get loadingInstalledPlayers => 'Loading installed players...';
+  String get loadingInstalledPlayers => 'Yüklü oynatıcılar yükleniyor...';
 
   @override
-  String get connection => 'Connection';
+  String get connection => 'Bağlantı';
 
   @override
-  String get audioTranscodeTarget => 'Audio Transcode Target';
+  String get audioTranscodeTarget => 'Ses Yeniden Kodlama Hedefi';
 
   @override
-  String get passthrough => 'Passthrough';
+  String get passthrough => 'Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get supportedOnThisDevice => 'Supported on this device';
+  String get supportedOnThisDevice => 'Bu cihazda destekleniyor';
 
   @override
-  String get notSupportedOnThisDevice => 'Not Supported on this device';
+  String get notSupportedOnThisDevice => 'Bu cihazda desteklenmiyor';
 
   @override
-  String get settingsAudioDtsXPassthrough => 'DTS:X (DTS UHD) Passthrough';
+  String get settingsAudioDtsXPassthrough =>
+      'DTS:X (DTS UHD) Doğrudan Geçiş (Passthrough)';
 
   @override
   String get settingsAudioBitstreamDtsXToExternalDecoder =>
-      'Bitstream DTS:X (DTS UHD) to external decoder.';
+      'DTS:X (DTS UHD) sesini harici kod çözücüye bitstream olarak aktar.';
 
   @override
   String get settingsAudioTrueHdJocPassthrough =>
-      'TrueHD with Atmos (JOC) Passthrough';
+      'TrueHD with Atmos (JOC) Doğrudan Geçiş (Passthrough)';
 
   @override
-  String get mediaPlayerBehavior => 'Media Player Behavior';
+  String get mediaPlayerBehavior => 'Medya Oynatıcı Davranışı';
 
   @override
-  String get playbackEnhancements => 'Playback Enhancements';
+  String get playbackEnhancements => 'Oynatma İyileştirmeleri';
 
   @override
-  String get alwaysOn => 'Always on.';
+  String get alwaysOn => 'Her zaman açık.';
 
   @override
   String get replaceSkipOutroWithNextUpDisplay =>
-      'Replace Skip Outro with Next Up Display';
+      '\"Jeneriği Atla\" yerine \"Sıradaki Bölüm Ekranını\" yerleştir';
 
   @override
   String get replaceSkipOutroWithNextUpDisplaySubtitle =>
-      'Show the Next Up overlay instead of the Skip Outro button.';
+      '\"Jeneriği Atla\" butonu yerine \"Sıradaki Bölüm\" ekranını göster.';
 
   @override
-  String get playerRouting => 'Player Routing';
+  String get playerRouting => 'Oynatıcı Yönlendirme';
 
   @override
-  String get preferSoftwareDecoders => 'Prefer software decoders';
+  String get preferSoftwareDecoders => 'Yazılımsal kod çözücüleri tercih et';
 
   @override
   String get preferSoftwareDecodersSubtitle =>
-      'Use FFmpeg (audio) and libgav1 (AV1) before hardware decoders. Disable if HDMI audio passthrough breaks.';
+      'Donanımsal kod çözücülerden önce FFmpeg (ses) ve libgav1 (AV1) kullan. HDMI ses doğrudan geçişi (passthrough) bozulursa devre dışı bırak.';
 
   @override
-  String get useExternalPlayer => 'Use external player';
+  String get useExternalPlayer => 'Her zaman harici oynatıcı kullan';
 
   @override
   String get useExternalPlayerSubtitle =>
-      'Open video playback in your selected external app on Android TV.';
+      'Android TV\'de video oynatmayı seçtiğiniz harici uygulamada açın.';
 
   @override
-  String get automaticQueuing => 'Automatic Queuing';
+  String get automaticQueuing => 'Otomatik Sıraya Ekleme';
 
   @override
-  String get preferSdhSubtitles => 'Prefer SDH subtitles';
+  String get preferSdhSubtitles => 'SDH altyazıları tercih et';
 
   @override
   String get preferSdhSubtitlesSubtitle =>
-      'Prioritize SDH/CC subtitle tracks when auto-selecting.';
+      'Otomatik seçim yaparken SDH/CC altyazı parçalarına öncelik ver.';
 
   @override
-  String get webDiagnostics => 'Web diagnostics';
+  String get webDiagnostics => 'Web Tanılama';
 
   @override
-  String get webDiagnosticsTitle => 'Moonfin Web Diagnostics';
+  String get webDiagnosticsTitle => 'Moonfin Web Tanılama';
 
   @override
   String get webDiagnosticsIntro =>
-      'Use this page to diagnose browser connectivity issues (CORS, mixed content, and discovery settings).';
+      'Tarayıcı bağlantı sorunlarını (CORS, karma içerik ve keşif ayarları) tanılamak için bu sayfayı kullanın.';
 
   @override
   String get webDiagnosticsDetectedMixedContentFailure =>
-      'Detected Mixed-Content Failure';
+      'Karma İçerik Hatası Tespit Edildi';
 
   @override
   String get webDiagnosticsDetectedCorsPreflightFailure =>
-      'Detected CORS/Preflight Failure';
+      'CORS/Ön Kontrol Hatası Tespit Edildi';
 
   @override
   String get webDiagnosticsMixedContentFailureBody =>
-      'Moonfin detected an HTTPS page trying to call an HTTP server URL. Browsers block this request before it reaches your server.';
+      'Moonfin, bir HTTPS sayfasının HTTP sunucu URL\'sini çağırmaya çalıştığını tespit etti. Tarayıcılar, bu isteği henüz sunucunuza ulaşmadan engeller.';
 
   @override
   String get webDiagnosticsCorsFailureBody =>
-      'Moonfin detected a browser-level request failure that is commonly caused by missing CORS or preflight headers on the media server.';
+      'Moonfin, genellikle medya sunucusundaki eksik CORS veya ön kontrol (preflight) üst bilgilerinden kaynaklanan, tarayıcı düzeyinde bir istek hatası tespit etti.';
 
   @override
   String webDiagnosticsTargetUrl(String url) {
-    return 'Target URL: $url';
+    return 'Hedef URL: $url';
   }
 
   @override
@@ -7713,329 +7766,333 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get webDiagnosticsCurrentRuntimeContext => 'Current Runtime Context';
+  String get webDiagnosticsCurrentRuntimeContext =>
+      'Mevcut Çalışma Zamanı Bağlamı';
 
   @override
-  String get webDiagnosticsOrigin => 'Origin';
+  String get webDiagnosticsOrigin => 'Kaynak';
 
   @override
-  String get webDiagnosticsScheme => 'Scheme';
+  String get webDiagnosticsScheme => 'Protokol';
 
   @override
-  String get webDiagnosticsPluginMode => 'Plugin Mode';
+  String get webDiagnosticsPluginMode => 'Eklenti Modu';
 
   @override
-  String get webDiagnosticsWebRtcScan => 'WebRTC Scan';
+  String get webDiagnosticsWebRtcScan => 'WebRTC Taraması';
 
   @override
-  String get webDiagnosticsForcedServerUrl => 'Forced Server URL';
+  String get webDiagnosticsForcedServerUrl => 'Zorunlu Sunucu URL\'si';
 
   @override
-  String get webDiagnosticsDefaultServerUrl => 'Default Server URL';
+  String get webDiagnosticsDefaultServerUrl => 'Varsayılan Sunucu URL\'si';
 
   @override
-  String get webDiagnosticsDiscoveryProxyUrl => 'Discovery Proxy URL';
+  String get webDiagnosticsDiscoveryProxyUrl => 'Keşif Vekil Sunucu URL\'si';
 
   @override
-  String get notConfigured => 'not configured';
+  String get notConfigured => 'Yapılandırılmadı';
 
   @override
-  String get webDiagnosticsMixedContent => 'Mixed Content';
+  String get webDiagnosticsMixedContent => 'Karma İçerik';
 
   @override
   String get webDiagnosticsMixedContentDetected =>
-      'This page is loaded over HTTPS, but one or more configured URLs are HTTP. Browsers block HTTPS pages from calling HTTP APIs.';
+      'Bu sayfa HTTPS üzerinden yüklendi, ancak yapılandırılan URL\'lerden biri veya daha fazlası HTTP. Tarayıcılar, HTTPS sayfalarının HTTP API\'lerini çağırmasını engeller.';
 
   @override
   String get webDiagnosticsMixedContentFix =>
-      'Fix: serve your media server or proxy endpoint via HTTPS, or load Moonfin over HTTP on trusted local networks only.';
+      'Çözüm: Medya sunucunuzu veya vekil sunucu (proxy) uç noktanızı HTTPS üzerinden sunun ya da Moonfin\'i yalnızca güvenilir yerel ağlarda HTTP üzerinden yükleyin.';
 
   @override
   String get webDiagnosticsNoMixedContentDetected =>
-      'No obvious mixed-content configuration detected from current runtime settings.';
+      'Mevcut çalışma zamanı ayarlarında bariz bir karma içerik yapılandırması tespit edilmedi.';
 
   @override
-  String get webDiagnosticsCorsChecklist => 'CORS Checklist';
+  String get webDiagnosticsCorsChecklist => 'CORS Kontrol Listesi';
 
   @override
   String get webDiagnosticsCorsChecklistItem1 =>
-      '• Allow the browser origin in Access-Control-Allow-Origin.';
+      '• Access-Control-Allow-Origin üst bilgisinde tarayıcı kaynağına izin verin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem2 =>
-      '• Include Authorization, X-Emby-Authorization, and X-Emby-Token in Access-Control-Allow-Headers.';
+      '• Access-Control-Allow-Headers üst bilgisine Authorization, X-Emby-Authorization ve X-Emby-Token değerlerini dahil edin.';
 
   @override
   String get webDiagnosticsCorsChecklistItem3 =>
-      '• Expose Content-Range and Accept-Ranges for streaming and seek behavior.';
+      '• Akış ve sarma işlevleri için Content-Range ve Accept-Ranges üst bilgilerini dışa aktarın (expose).';
 
   @override
   String get webDiagnosticsCorsChecklistItem4 =>
-      '• Return 204 to OPTIONS preflight requests.';
+      '• OPTIONS ön kontrol (preflight) isteklerine 204 yanıtı döndürün.';
 
   @override
   String get webDiagnosticsHeaderSnippetTitle =>
-      'Example Header Snippet (nginx-style)';
+      'Örnek Üst Bilgi Parçacığı (nginx tarzı)';
 
   @override
-  String get note => 'Note';
+  String get note => 'Not';
 
   @override
   String get webDiagnosticsNonWebNote =>
-      'This diagnostics route is intended for web builds. If you are seeing this on another platform, these checks may not apply.';
+      'Bu tanılama rotası web sürümleri için tasarlanmıştır. Eğer bunu başka bir platformda görüyorsanız, yapılan kontroller sizin için geçerli olmayabilir.';
 
   @override
-  String get backToServerSelect => 'Back To Server Select';
+  String get backToServerSelect => 'Sunucu Seçimine Dön';
 
   @override
-  String get signOutAllUsers => 'Sign Out All Users';
+  String get signOutAllUsers => 'Tüm Kullanıcıların Oturumunu Kapat';
 
   @override
   String get voiceSearchPermissionPermanentlyDenied =>
-      'Microphone permission is permanently denied. Enable it in system settings.';
+      'Mikrofon izni kalıcı olarak reddedildi. Sistem ayarlarından izni etkinleştirin.';
 
   @override
   String get voiceSearchPermissionRequired =>
-      'Microphone permission is required for voice search.';
+      'Sesli arama için mikrofon izni gereklidir.';
 
   @override
-  String get voiceSearchNoMatch => 'Did not catch that. Try again.';
+  String get voiceSearchNoMatch => 'Anlaşılamadı. Tekrar deneyin.';
 
   @override
-  String get voiceSearchNoSpeechDetected => 'No speech detected.';
+  String get voiceSearchNoSpeechDetected => 'Konuşma algılanmadı.';
 
   @override
-  String get voiceSearchMicrophoneError => 'Microphone error.';
+  String get voiceSearchMicrophoneError => 'Mikrofon hatası.';
 
   @override
-  String get voiceSearchNeedsInternet => 'Voice search needs internet.';
+  String get voiceSearchNeedsInternet =>
+      'Sesli arama için internet bağlantısı gereklidir.';
 
   @override
-  String get voiceSearchServiceBusy => 'Voice service is busy. Try again.';
+  String get voiceSearchServiceBusy =>
+      'Sesli arama servisi meşgul. Tekrar deneyin.';
 
   @override
   String get microphonePermissionPermanentlyDenied =>
-      'Microphone permission is permanently denied.';
+      'Mikrofon izni kalıcı olarak reddedildi.';
 
   @override
-  String get microphonePermissionDenied => 'Microphone permission is denied.';
+  String get microphonePermissionDenied => 'Mikrofon izni reddedildi.';
 
   @override
   String get speechRecognitionUnavailable =>
-      'Speech recognition is unavailable on this device.';
+      'Ses tanıma özelliği bu cihazda kullanılamıyor.';
 
   @override
-  String get openIosRoutePicker => 'Open iOS route picker';
+  String get openIosRoutePicker => 'iOS Ses/Video Aktarımını Aç';
 
   @override
   String get airPlayRoutePickerUnavailable =>
-      'AirPlay route picker is unavailable on this device.';
+      'AirPlay özelliği bu cihazda kullanılamıyor.';
 
   @override
-  String get videos => 'Videos';
+  String get videos => 'Videolar';
 
   @override
-  String get trailers => 'Trailers';
+  String get trailers => 'Fragmanlar';
 
   @override
-  String get programs => 'Programs';
+  String get programs => 'Programlar';
 
   @override
-  String get songs => 'Songs';
+  String get songs => 'Şarkılar';
 
   @override
-  String get photoAlbums => 'Photo Albums';
+  String get photoAlbums => 'Fotoğraf Albümleri';
 
   @override
-  String get photos => 'Photos';
+  String get photos => 'Fotoğraflar';
 
   @override
-  String get people => 'People';
+  String get people => 'Kişiler';
 
   @override
-  String get recentlyReleasedEpisodes => 'Recently Released Episodes';
+  String get recentlyReleasedEpisodes => 'Son Yayınlanan Bölümler';
 
   @override
-  String get watchAgain => 'Watch Again';
+  String get watchAgain => 'Yeniden İzle';
 
   @override
-  String get guestAppearances => 'Guest Appearances';
+  String get guestAppearances => 'Konuk Olduğu Bölümler';
 
   @override
-  String get appearancesSeerr => 'Appearances (Seerr)';
+  String get appearancesSeerr => 'Rol Aldığı Yapımlar (Seerr)';
 
   @override
-  String get watchWithGroup => 'Watch with group';
+  String get watchWithGroup => 'Grupça İzle';
 
   @override
-  String get errors => 'Errors';
+  String get errors => 'Hatalar';
 
   @override
-  String get warnings => 'Warnings';
+  String get warnings => 'Uyarılar';
 
   @override
   String get disk => 'Disk';
 
   @override
-  String get openInBrowser => 'Open in Browser';
+  String get openInBrowser => 'Tarayıcıda Aç';
 
   @override
   String get embeddedBrowserNotAvailable =>
-      'Embedded browser is not available on this platform.';
+      'Gömülü tarayıcı bu platformda kullanılamıyor.';
 
   @override
   String get adminRestartServerConfirmation =>
-      'Are you sure you want to restart the server?';
+      'Sunucuyu yeniden başlatmak istediğinize emin misiniz?';
 
   @override
   String get adminShutdownServerConfirmation =>
-      'Are you sure you want to shut down the server? You will need to restart it manually.';
+      'Sunucuyu kapatmak istediğinize emin misiniz? Sunucuyu daha sonra manuel olarak yeniden başlatmanız gerekecektir.';
 
   @override
-  String get internal => 'Internal';
+  String get internal => 'Dahili';
 
   @override
-  String get idle => 'Idle';
+  String get idle => 'Boşta';
 
   @override
-  String get os => 'OS';
+  String get os => 'İşletim Sistemi';
 
   @override
-  String get adminNoUsersFound => 'No users found';
+  String get adminNoUsersFound => 'Kullanıcı Bulunamadı';
 
   @override
-  String get adminNoUsersMatchSearch => 'No users match your search';
+  String get adminNoUsersMatchSearch =>
+      'Aramanızla eşleşen kullanıcı bulunamadı';
 
   @override
-  String get adminNoDevicesFound => 'No devices found';
+  String get adminNoDevicesFound => 'Cihaz bulunamadı';
 
   @override
   String get adminNoDevicesMatchCurrentFilters =>
-      'No devices match the current filters';
+      'Mevcut filtrelere uygun cihaz bulunamadı';
 
   @override
-  String get passwordSet => 'Password set';
+  String get passwordSet => 'Şifre belirlendi';
 
   @override
-  String get noPasswordConfigured => 'No password configured';
+  String get noPasswordConfigured => 'Şifre belirlenmedi';
 
   @override
-  String get remoteAccess => 'Remote Access';
+  String get remoteAccess => 'Uzaktan Erişim';
 
   @override
-  String get localOnly => 'Local Only';
+  String get localOnly => 'Sadece Yerel Ağ';
 
   @override
-  String get adminMediaAnalyticsLoadFailed => 'Failed to load media analytics';
+  String get adminMediaAnalyticsLoadFailed => 'Medya analizleri yüklenemedi';
 
   @override
   String get analyticsCombinedAcrossLibraries =>
-      'Combined analytics across all media libraries.';
+      'Tüm medya kütüphanelerinin ortak istatistikleri.';
 
   @override
-  String get analyticsTopArtists => 'Top Artists';
+  String get analyticsTopArtists => 'En Çok Dinlenen Sanatçılar';
 
   @override
-  String get analyticsTopAuthors => 'Top Authors';
+  String get analyticsTopAuthors => 'En Çok Okunan Yazarlar';
 
   @override
-  String get analyticsTopContributors => 'Top Contributors';
+  String get analyticsTopContributors => 'En Çok Katkıda Bulunanlar';
 
   @override
   String analyticsLibrariesCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Libraries',
-      one: '1 Library',
+      other: '$count Kütüphane',
+      one: '1 Kütüphane',
     );
     return '$_temp0';
   }
 
   @override
   String get analyticsNoIndexedMediaTotals =>
-      'No indexed media totals are available for this selection yet.';
+      'Bu seçim için henüz dizine eklenmiş medya toplamı bulunmuyor.';
 
   @override
-  String get analyticsLibraryDetails => 'Library Details';
+  String get analyticsLibraryDetails => 'Kütüphane Detayları';
 
   @override
-  String get analyticsLibraryBreakdown => 'Library Breakdown';
+  String get analyticsLibraryBreakdown => 'Kütüphane Dağılımı';
 
   @override
-  String get analyticsNoLibrariesAvailable => 'No libraries are available.';
+  String get analyticsNoLibrariesAvailable => 'Kullanılabilir kütüphane yok.';
 
   @override
-  String get adminServerAdministrationTitle => 'Server Administration';
+  String get adminServerAdministrationTitle => 'Sunucu Yönetimi';
 
   @override
-  String get adminServerPathData => 'Data';
+  String get adminServerPathData => 'Veri';
 
   @override
-  String get adminServerPathImageCache => 'Image Cache';
+  String get adminServerPathImageCache => 'Görsel Önbelleği';
 
   @override
-  String get adminServerPathCache => 'Cache';
+  String get adminServerPathCache => 'Önbellek';
 
   @override
-  String get adminServerPathLogs => 'Logs';
+  String get adminServerPathLogs => 'Günlükler';
 
   @override
   String get adminServerPathMetadata => 'Metadata';
 
   @override
-  String get adminServerPathTranscode => 'Transcode';
+  String get adminServerPathTranscode => 'Dönüştür';
 
   @override
   String get adminServerPathWeb => 'Web';
 
   @override
   String get adminNoServerPathsReturned =>
-      'No server paths returned by this server.';
+      'Bu sunucu tarafından hiçbir sunucu yolu döndürülmedi.';
 
   @override
   String adminPercentUsed(int percent) {
-    return '$percent% used';
+    return '%$percent kullanıldı';
   }
 
   @override
-  String get userActivity => 'User Activity';
+  String get userActivity => 'Kullanıcı Hareketleri';
 
   @override
-  String get systemEvents => 'System Events';
+  String get systemEvents => 'Sistem Olayları';
 
   @override
-  String get needsAttention => 'Needs Attention';
+  String get needsAttention => 'İşlem Gerekiyor';
 
   @override
-  String get adminDrawerSectionServer => 'Server';
+  String get adminDrawerSectionServer => 'Sunucu';
 
   @override
-  String get adminDrawerSectionPlayback => 'Playback';
+  String get adminDrawerSectionPlayback => 'Oynatma';
 
   @override
-  String get adminDrawerSectionDevices => 'Devices';
+  String get adminDrawerSectionDevices => 'Cihazlar';
 
   @override
-  String get adminDrawerSectionAdvanced => 'Advanced';
+  String get adminDrawerSectionAdvanced => 'Gelişmiş';
 
   @override
   String get adminDrawerSectionPlugins => 'Plugins';
 
   @override
-  String get adminDrawerSectionLiveTv => 'Live TV';
+  String get adminDrawerSectionLiveTv => 'Canlı TV';
 
   @override
-  String get homeVideos => 'Home Videos';
+  String get homeVideos => 'Kişisel Videolar';
 
   @override
-  String get mixedContent => 'Mixed Content';
+  String get mixedContent => 'Karma İçerik';
 
   @override
-  String get homeVideosAndPhotos => 'Home Videos & Photos';
+  String get homeVideosAndPhotos => 'Kişisel Videolar & Fotoğraflar';
 
   @override
-  String get mixedMoviesAndShows => 'Mixed Movies & Shows';
+  String get mixedMoviesAndShows => 'Karışık Film & Diziler';
 
   @override
   String get intelQuickSync => 'Intel Quick Sync';
@@ -8047,223 +8104,223 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dolbyVision => 'Dolby Vision';
 
   @override
-  String get noRecordingsFound => 'No recordings found';
+  String get noRecordingsFound => 'Kayıt bulunamadı';
 
   @override
   String noImagePagesFoundInArchive(String extension) {
-    return 'No image pages found inside .$extension archive.';
+    return '.$extension arşivi içinde hiç resim sayfası bulunamadı.';
   }
 
   @override
   String embeddedRendererFailed(int code, String description) {
-    return 'Embedded renderer failed ($code): $description';
+    return 'Gömülü oynatıcı hatası ($code): $description';
   }
 
   @override
   String epubRendererFailed(int code, String description) {
-    return 'EPUB renderer failed ($code): $description';
+    return 'EPUB okuyucu hatası ($code): $description';
   }
 
   @override
   String missingLocalFileForReader(String uri) {
-    return 'Missing local file for reader: $uri';
+    return 'Okuyucu için yerel dosya bulunamadı: $uri';
   }
 
   @override
   String httpStatusWhileOpeningBookData(int status, String uri) {
-    return 'HTTP $status while opening book data from $uri';
+    return '$uri adresinden kitap verileri açılırken HTTP $status hatası alındı';
   }
 
   @override
   String get noReadableBookEndpointAvailable =>
-      'No readable book endpoint available';
+      'Okunabilir bir kitap bağlantı noktası bulunamadı';
 
   @override
   String unsupportedComicArchiveFormat(String extension) {
-    return 'Unsupported comic archive format: .$extension';
+    return 'Desteklenmeyen çizgi roman arşiv formatı: .$extension';
   }
 
   @override
   String get cbrExtractionPluginUnavailable =>
-      'CBR extraction plugin is not available on this platform.';
+      'CBR çıkarma eklentisi bu platformda mevcut değil.';
 
   @override
-  String get failedToExtractCbrArchive => 'Failed to extract .cbr archive.';
+  String get failedToExtractCbrArchive => '.cbr arşivi çıkarılamadı.';
 
   @override
   String get cb7ExtractionUnavailable =>
-      'CB7 extraction is not available on this platform.';
+      'CB7 çıkarma işlemi bu platformda mevcut değil.';
 
   @override
   String get cb7ExtractionPluginUnavailable =>
-      'CB7 extraction plugin is not available on this platform.';
+      'CB7 çıkarma eklentisi bu platformda mevcut değil.';
 
   @override
-  String get closeGenrePanel => 'Close genre panel';
+  String get closeGenrePanel => 'Tür panelini kapat';
 
   @override
-  String get loadingShuffle => 'Loading shuffle...';
+  String get loadingShuffle => 'Karışık liste yükleniyor...';
 
   @override
-  String get libraryShuffleLabel => 'LIBRARY SHUFFLE';
+  String get libraryShuffleLabel => 'KÜTÜPHANEYİ KARIŞTIR';
 
   @override
-  String get randomShuffleLabel => 'RANDOM SHUFFLE';
+  String get randomShuffleLabel => 'RASTGELE KARIŞTIR';
 
   @override
-  String get genresShuffleLabel => 'GENRES SHUFFLE';
+  String get genresShuffleLabel => 'TÜRLERİ KARIŞTIR';
 
   @override
-  String get autoHdrSwitching => 'Auto HDR Switching';
+  String get autoHdrSwitching => 'Otomatik HDR Geçişi';
 
   @override
   String get autoHdrSwitchingDescription =>
-      'Automatically enable HDR for HDR video playback and restore display mode on exit.';
+      'HDR video oynatılırken HDR\'ı otomatik olarak etkinleştirir ve çıkışta ekran modunu eski haline getirir.';
 
   @override
-  String get whenFullscreen => 'When fullscreen';
+  String get whenFullscreen => 'Tam ekrandayken';
 
   @override
-  String get changeArtwork => 'Change Artwork';
+  String get changeArtwork => 'Görseli Değiştir';
 
   @override
-  String get missing => 'Missing';
+  String get missing => 'Kayıp';
 
   @override
-  String get transcodingLimits => 'Transcoding Limits';
+  String get transcodingLimits => 'Dönüştürme Sınırları';
 
   @override
-  String get clearAllArtworkButton => 'Clear all artwork?';
+  String get clearAllArtworkButton => 'Tüm görseller silinsin mi?';
 
   @override
   String get clearAllArtworkWarning =>
-      'Are you sure you want to clear all downloaded artwork?';
+      'İndirilen tüm görselleri temizlemek istediğinize emin misiniz?';
 
   @override
-  String get confirmClear => 'Confirm Clear';
+  String get confirmClear => 'Silmeyi Onayla';
 
   @override
   String confirmClearMessage(String itemType) {
-    return 'Are you sure you would like to clear this $itemType?';
+    return 'Bu nesneyi ($itemType) temizlemek istediğinize emin misiniz?';
   }
 
   @override
-  String get uploadButton => 'Upload?';
+  String get uploadButton => 'Yükle?';
 
   @override
-  String get resolutionLabel => 'Resolution: ';
+  String get resolutionLabel => 'Çözünürlük: ';
 
   @override
   String get onlyShowInterfaceLanguage =>
-      'Only show artwork in interface language';
+      'Görselleri yalnızca arayüz dilinde göster';
 
   @override
-  String get confirmClearAll => 'Confirm Clear All';
+  String get confirmClearAll => 'Tümünü Temizlemeyi Onayla';
 
   @override
-  String get imageUploadSuccess => 'Image uploaded successfully!';
+  String get imageUploadSuccess => 'Görsel başarıyla yüklendi!';
 
   @override
   String imageUploadFailed(String error) {
-    return 'Failed to upload image: $error';
+    return 'Görsel yüklenemedi: $error';
   }
 
   @override
   String imageDownloadFailed(String error) {
-    return 'Failed to set image: $error';
+    return 'Görsel ayarlanamadı: $error';
   }
 
   @override
   String imageDeleteFailed(String error) {
-    return 'Failed to delete image: $error';
+    return 'Görsel silinemedi: $error';
   }
 
   @override
   String clearAllArtworkFailed(String error) {
-    return 'Failed to clear all artwork: $error';
+    return 'Tüm görseller temizlenemedi: $error';
   }
 
   @override
-  String get yes => 'Yes';
+  String get yes => 'Evet';
 
   @override
   String get posterCategory => 'Poster';
 
   @override
-  String get backdropsCategory => 'Backdrops';
+  String get backdropsCategory => 'Arka Planlar';
 
   @override
-  String get bannerCategory => 'Banner';
+  String get bannerCategory => 'Afiş';
 
   @override
   String get logoCategory => 'Logo';
 
   @override
-  String get thumbnailCategory => 'Thumbnail';
+  String get thumbnailCategory => 'Küçük Resim';
 
   @override
-  String get artCategory => 'Art';
+  String get artCategory => 'Görsel';
 
   @override
-  String get discArtCategory => 'Disc Art';
+  String get discArtCategory => 'Disk Görseli';
 
   @override
-  String get screenshotCategory => 'Screenshot';
+  String get screenshotCategory => 'Ekran Görüntüsü';
 
   @override
-  String get boxCoverCategory => 'Box Cover';
+  String get boxCoverCategory => 'Kutu Kapağı';
 
   @override
-  String get boxRearCoverCategory => 'Box Rear Cover';
+  String get boxRearCoverCategory => 'Kutu Arka Kapağı';
 
   @override
-  String get menuArtCategory => 'Menu Art';
+  String get menuArtCategory => 'Menü Görseli';
 
   @override
   String get confirmItemPoster => 'poster';
 
   @override
-  String get confirmItemBackdrop => 'backdrop';
+  String get confirmItemBackdrop => 'arka plan';
 
   @override
-  String get confirmItemBanner => 'banner';
+  String get confirmItemBanner => 'afiş';
 
   @override
   String get confirmItemLogo => 'logo';
 
   @override
-  String get confirmItemThumbnail => 'thumbnail';
+  String get confirmItemThumbnail => 'küçük resim';
 
   @override
-  String get confirmItemArt => 'art';
+  String get confirmItemArt => 'görsel';
 
   @override
-  String get confirmItemDiscArt => 'disc art';
+  String get confirmItemDiscArt => 'disk görseli';
 
   @override
-  String get confirmItemScreenshot => 'screenshot';
+  String get confirmItemScreenshot => 'ekran görüntüsü';
 
   @override
-  String get confirmItemBoxCover => 'box cover';
+  String get confirmItemBoxCover => 'kutu kapağı';
 
   @override
-  String get confirmItemBoxRearCover => 'box rear cover';
+  String get confirmItemBoxRearCover => 'kutu arka kapağı';
 
   @override
-  String get confirmItemMenuArt => 'menu art';
+  String get confirmItemMenuArt => 'menü görseli';
 
   @override
-  String get resolutionAll => 'All';
+  String get resolutionAll => 'Tümü';
 
   @override
-  String get resolutionHigh => 'High (1080p+)';
+  String get resolutionHigh => 'Yüksek (1080p+)';
 
   @override
-  String get resolutionMedium => 'Medium (720p)';
+  String get resolutionMedium => 'Orta (720p)';
 
   @override
-  String get resolutionLow => 'Low (<720p)';
+  String get resolutionLow => 'Düşük (<720p)';
 
   @override
-  String get sources => 'Sources';
+  String get sources => 'Kaynaklar';
 }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -6439,6 +6439,14 @@ class AppLocalizationsUg extends AppLocalizations {
       'قىستۇرمىنى دوكلات قىلىدىغان Jellyfin مۇلازىمېتىرلىرى يوق.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Rnaldsgift نىڭ «KefinTweaks» قىستۇرمىسى ئارقىلىق سەپلەنگەن قۇرلارنى ئېنىقلاڭ. يېقىندا ئېلان قىلىنغان ، قايتا كۆرۈڭ ، پەسىللىك ۋە يېقىندا كۈتۈپخانىغا قوشۇلغان ئىختىيارى بۆلەكلەر ھەر بىر Jellyfin مۇلازىمېتىرىدىكى KefinTweaks سەپلىمىسىدىن ئەينەك قىلىنغان.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'KefinTweaks نى دوكلات قىلىدىغان Jellyfin مۇلازىمېتىرلىرى تېخى يوق.';
+
+  @override
   String get integrationOpenHomeSections => 'ئۆي بۆلەكلىرىنى ئېچىڭ';
 
   @override
@@ -6474,7 +6482,7 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'ھەممىنى كۆرۈڭ';
@@ -7432,40 +7440,6 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7496,6 +7470,9 @@ class AppLocalizationsUg extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7607,22 +7584,6 @@ class AppLocalizationsUg extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -7696,7 +7696,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -6439,14 +6439,6 @@ class AppLocalizationsUg extends AppLocalizations {
       'قىستۇرمىنى دوكلات قىلىدىغان Jellyfin مۇلازىمېتىرلىرى يوق.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Rnaldsgift نىڭ «KefinTweaks» قىستۇرمىسى ئارقىلىق سەپلەنگەن قۇرلارنى ئېنىقلاڭ. يېقىندا ئېلان قىلىنغان ، قايتا كۆرۈڭ ، پەسىللىك ۋە يېقىندا كۈتۈپخانىغا قوشۇلغان ئىختىيارى بۆلەكلەر ھەر بىر Jellyfin مۇلازىمېتىرىدىكى KefinTweaks سەپلىمىسىدىن ئەينەك قىلىنغان.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'KefinTweaks نى دوكلات قىلىدىغان Jellyfin مۇلازىمېتىرلىرى تېخى يوق.';
-
-  @override
   String get integrationOpenHomeSections => 'ئۆي بۆلەكلىرىنى ئېچىڭ';
 
   @override
@@ -6482,7 +6474,7 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'ھەممىنى كۆرۈڭ';
@@ -7440,6 +7432,40 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7470,9 +7496,6 @@ class AppLocalizationsUg extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7584,6 +7607,22 @@ class AppLocalizationsUg extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -7695,6 +7695,14 @@ class AppLocalizationsUg extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -6459,6 +6459,14 @@ class AppLocalizationsUk extends AppLocalizations {
       'Жоден сервер Jellyfin не повідомляє про плагін.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Виявляти рядки, налаштовані за допомогою плагіна \"KefinTweaks\" ranaldsgift. Користувальницькі розділи, нещодавно випущені, переглянути ще раз, сезонні та нещодавно додані в бібліотеку відображаються з конфігурації KefinTweaks на кожному сервері Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Поки немає серверів Jellyfin, які повідомляють про KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Відкрийте головні розділи';
 
   @override
@@ -6494,7 +6502,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Переглянути всі';
@@ -7468,40 +7476,6 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Видалено \"$themeName\" з цього пристрою.';
   }
@@ -7533,6 +7507,9 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Керуйте завантаженими темами плагінів на цьому пристрої';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Розділи головного екрана';
@@ -7645,22 +7622,6 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -6459,14 +6459,6 @@ class AppLocalizationsUk extends AppLocalizations {
       'Жоден сервер Jellyfin не повідомляє про плагін.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Виявляти рядки, налаштовані за допомогою плагіна \"KefinTweaks\" ranaldsgift. Користувальницькі розділи, нещодавно випущені, переглянути ще раз, сезонні та нещодавно додані в бібліотеку відображаються з конфігурації KefinTweaks на кожному сервері Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Поки немає серверів Jellyfin, які повідомляють про KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Відкрийте головні розділи';
 
   @override
@@ -6502,7 +6494,7 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Переглянути всі';
@@ -7476,6 +7468,40 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Видалено \"$themeName\" з цього пристрою.';
   }
@@ -7507,9 +7533,6 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Керуйте завантаженими темами плагінів на цьому пристрої';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Розділи головного екрана';
@@ -7622,6 +7645,22 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -7733,6 +7733,14 @@ class AppLocalizationsUk extends AppLocalizations {
       'Показати накладення Next Up замість кнопки Skip Outro.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Маршрутизація гравців';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -7734,7 +7734,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1709,7 +1709,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => 'Seer';
 
   @override
   String get seerrAccountType => 'Loại tài khoản Seerr';
@@ -6437,6 +6437,14 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chưa có máy chủ Jellyfin nào báo cáo plugin.';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      'Phát hiện các hàng được định cấu hình thông qua plugin \"KefinTweaks\" của ranaldsgift. Các phần tùy chỉnh, được phát hành gần đây, xem lại, theo mùa và được thêm gần đây vào thư viện, được phản ánh từ cấu hình KefinTweaks trên mỗi máy chủ Jellyfin.';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      'Chưa có máy chủ Jellyfin nào báo cáo KefinTweaks.';
+
+  @override
   String get integrationOpenHomeSections => 'Mở phần trang chủ';
 
   @override
@@ -6472,7 +6480,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => 'Xem Tất Cả';
@@ -7430,40 +7438,6 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Đã xóa \"$themeName\" khỏi thiết bị này.';
   }
@@ -7495,6 +7469,9 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Quản lý các chủ đề plugin đã tải xuống trên thiết bị này';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTinh chỉnh';
 
   @override
   String get homeScreenSectionsTitle => 'Phần màn hình chính';
@@ -7607,22 +7584,6 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -7696,7 +7696,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1709,7 +1709,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seer';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => 'Loại tài khoản Seerr';
@@ -6437,14 +6437,6 @@ class AppLocalizationsVi extends AppLocalizations {
       'Chưa có máy chủ Jellyfin nào báo cáo plugin.';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      'Phát hiện các hàng được định cấu hình thông qua plugin \"KefinTweaks\" của ranaldsgift. Các phần tùy chỉnh, được phát hành gần đây, xem lại, theo mùa và được thêm gần đây vào thư viện, được phản ánh từ cấu hình KefinTweaks trên mỗi máy chủ Jellyfin.';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      'Chưa có máy chủ Jellyfin nào báo cáo KefinTweaks.';
-
-  @override
   String get integrationOpenHomeSections => 'Mở phần trang chủ';
 
   @override
@@ -6480,7 +6472,7 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => 'Xem Tất Cả';
@@ -7438,6 +7430,40 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Đã xóa \"$themeName\" khỏi thiết bị này.';
   }
@@ -7469,9 +7495,6 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Quản lý các chủ đề plugin đã tải xuống trên thiết bị này';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTinh chỉnh';
 
   @override
   String get homeScreenSectionsTitle => 'Phần màn hình chính';
@@ -7584,6 +7607,22 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -7695,6 +7695,14 @@ class AppLocalizationsVi extends AppLocalizations {
       'Hiển thị lớp phủ Tiếp theo thay vì nút Bỏ qua.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Định tuyến người chơi';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1665,7 +1665,7 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => '塞爾';
 
   @override
   String get seerrAccountType => '西爾帳戶類型';
@@ -6241,6 +6241,14 @@ class AppLocalizationsYue extends AppLocalizations {
       '尚無 Jellyfin 伺服器報告該外掛程式。';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      '偵測透過 ranaldsgift 的「KefinTweaks」插件配置的行。自訂部分、最近發布的、再次觀看的、季節性的以及最近添加到庫中的內容均從每個 Jellyfin 伺服器上的 KefinTweaks 配置進行鏡像。';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      '尚無 Jellyfin 伺服器報告 KefinTweaks。';
+
+  @override
   String get integrationOpenHomeSections => '開放主頁部分';
 
   @override
@@ -6275,7 +6283,7 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => '看全部';
@@ -7180,40 +7188,6 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7244,6 +7218,9 @@ class AppLocalizationsYue extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7355,22 +7332,6 @@ class AppLocalizationsYue extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -9691,7 +9652,7 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => '塞尔';
 
   @override
   String get seerrAccountType => '西尔账户类型';
@@ -14160,6 +14121,14 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get homeScreenSectionsIntegrationNoServers => '尚无 Jellyfin 服务器报告该插件。';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      '检测通过 ranaldsgift 的“KefinTweaks”插件配置的行。自定义部分、最近发布的、再次观看的、季节性的以及最近添加到库中的内容均从每个 Jellyfin 服务器上的 KefinTweaks 配置进行镜像。';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      '尚无 Jellyfin 服务器报告 KefinTweaks。';
+
+  @override
   String get integrationOpenHomeSections => '开放主页部分';
 
   @override
@@ -14194,7 +14163,7 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => '查看全部';
@@ -15100,6 +15069,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -17349,7 +17321,7 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => '塞爾';
 
   @override
   String get seerrAccountType => '西爾帳戶類型';
@@ -21819,6 +21791,14 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
       '尚無 Jellyfin 伺服器報告該外掛程式。';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      '偵測透過 ranaldsgift 的「KefinTweaks」插件配置的行。自訂部分、最近發布的、再次觀看的、季節性的以及最近添加到庫中的內容均從每個 Jellyfin 伺服器上的 KefinTweaks 配置進行鏡像。';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      '尚無 Jellyfin 伺服器報告 KefinTweaks。';
+
+  @override
   String get integrationOpenHomeSections => '開放主頁部分';
 
   @override
@@ -21853,7 +21833,7 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => '看全部';
@@ -22758,6 +22738,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -7443,6 +7443,14 @@ class AppLocalizationsYue extends AppLocalizations {
       'Show the Next Up overlay instead of the Skip Outro button.';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => 'Player Routing';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -7444,7 +7444,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1665,7 +1665,7 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
-  String get seerr => '塞爾';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => '西爾帳戶類型';
@@ -6241,14 +6241,6 @@ class AppLocalizationsYue extends AppLocalizations {
       '尚無 Jellyfin 伺服器報告該外掛程式。';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      '偵測透過 ranaldsgift 的「KefinTweaks」插件配置的行。自訂部分、最近發布的、再次觀看的、季節性的以及最近添加到庫中的內容均從每個 Jellyfin 伺服器上的 KefinTweaks 配置進行鏡像。';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      '尚無 Jellyfin 伺服器報告 KefinTweaks。';
-
-  @override
   String get integrationOpenHomeSections => '開放主頁部分';
 
   @override
@@ -6283,7 +6275,7 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => '看全部';
@@ -7188,6 +7180,40 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return 'Deleted \"$themeName\" from this device.';
   }
@@ -7218,9 +7244,6 @@ class AppLocalizationsYue extends AppLocalizations {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -7332,6 +7355,22 @@ class AppLocalizationsYue extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -9652,7 +9691,7 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   }
 
   @override
-  String get seerr => '塞尔';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => '西尔账户类型';
@@ -14121,14 +14160,6 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get homeScreenSectionsIntegrationNoServers => '尚无 Jellyfin 服务器报告该插件。';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      '检测通过 ranaldsgift 的“KefinTweaks”插件配置的行。自定义部分、最近发布的、再次观看的、季节性的以及最近添加到库中的内容均从每个 Jellyfin 服务器上的 KefinTweaks 配置进行镜像。';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      '尚无 Jellyfin 服务器报告 KefinTweaks。';
-
-  @override
   String get integrationOpenHomeSections => '开放主页部分';
 
   @override
@@ -14163,7 +14194,7 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => '查看全部';
@@ -15069,9 +15100,6 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';
@@ -17321,7 +17349,7 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   }
 
   @override
-  String get seerr => '塞爾';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => '西爾帳戶類型';
@@ -21791,14 +21819,6 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
       '尚無 Jellyfin 伺服器報告該外掛程式。';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      '偵測透過 ranaldsgift 的「KefinTweaks」插件配置的行。自訂部分、最近發布的、再次觀看的、季節性的以及最近添加到庫中的內容均從每個 Jellyfin 伺服器上的 KefinTweaks 配置進行鏡像。';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      '尚無 Jellyfin 伺服器報告 KefinTweaks。';
-
-  @override
   String get integrationOpenHomeSections => '開放主頁部分';
 
   @override
@@ -21833,7 +21853,7 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => '看全部';
@@ -22738,9 +22758,6 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1665,7 +1665,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => '塞尔';
 
   @override
   String get seerrAccountType => '西尔账户类型';
@@ -6236,6 +6236,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get homeScreenSectionsIntegrationNoServers => '尚无 Jellyfin 服务器报告该插件。';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      '检测通过 ranaldsgift 的“KefinTweaks”插件配置的行。自定义部分、最近发布的、再次观看的、季节性的以及最近添加到库中的内容均从每个 Jellyfin 服务器上的 KefinTweaks 配置进行镜像。';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      '尚无 Jellyfin 服务器报告 KefinTweaks。';
+
+  @override
   String get integrationOpenHomeSections => '开放主页部分';
 
   @override
@@ -6270,7 +6278,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => '查看全部';
@@ -7171,40 +7179,6 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get themeStore => 'Theme Store';
-
-  @override
-  String get themeStoreSubtitle => 'Browse and save community themes';
-
-  @override
-  String get themeStoreDescription =>
-      'Save a theme to use it like your other saved themes.';
-
-  @override
-  String get themeStoreEmpty => 'No themes are available right now.';
-
-  @override
-  String get themeStoreLoadFailed =>
-      'Couldn\'t load the Theme Store. Check your connection and try again.';
-
-  @override
-  String get themeStoreSave => 'Save';
-
-  @override
-  String get themeStoreSaveAndApply => 'Save & apply';
-
-  @override
-  String get themeStoreSaved => 'Saved';
-
-  @override
-  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
-
-  @override
-  String themeStoreSavedMessage(String themeName) {
-    return 'Saved \"$themeName\".';
-  }
-
-  @override
   String savedThemesDeletedMessage(String themeName) {
     return '已从此设备中删除“$themeName”。';
   }
@@ -7233,6 +7207,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get savedThemesManageSubtitle => '管理此设备上下载的插件主题';
+
+  @override
+  String get kefinTweaksTitle => '凯芬调整';
 
   @override
   String get homeScreenSectionsTitle => '主屏幕部分';
@@ -7336,22 +7313,6 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get displayAudioRows => 'Display Audio Rows';
-
-  @override
-  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
-
-  @override
-  String get audioRowsSorting => 'Audio Rows sorting';
-
-  @override
-  String get audioRowsSortingDescription =>
-      'Sort Audio rows by date added, release date, alphabetically, and more.';
-
-  @override
-  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -9644,7 +9605,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String get seerr => 'Seerr';
+  String get seerr => '塞爾';
 
   @override
   String get seerrAccountType => '西爾帳戶類型';
@@ -14114,6 +14075,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
       '尚無 Jellyfin 伺服器報告該外掛程式。';
 
   @override
+  String get kefinTweaksIntegrationDescription =>
+      '偵測透過 ranaldsgift 的「KefinTweaks」插件配置的行。自訂部分、最近發布的、再次觀看的、季節性的以及最近添加到庫中的內容均從每個 Jellyfin 伺服器上的 KefinTweaks 配置進行鏡像。';
+
+  @override
+  String get kefinTweaksIntegrationNoServers =>
+      '尚無 Jellyfin 伺服器報告 KefinTweaks。';
+
+  @override
   String get integrationOpenHomeSections => '開放主頁部分';
 
   @override
@@ -14148,7 +14117,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String get jellyseerr => 'Seerr';
+  String get jellyseerr => 'Jellyseerr';
 
   @override
   String get seeAll => '看全部';
@@ -15053,6 +15022,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
+
+  @override
+  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7421,6 +7421,14 @@ class AppLocalizationsZh extends AppLocalizations {
       '显示“下一个”叠加层而不是“跳过尾奏”按钮。';
 
   @override
+  String get nextUpIgnoreRemainingContentDisplay =>
+      'Play Next (Ignore Remaining Content After Outro)';
+
+  @override
+  String get nextUpIgnoreRemainingContentDisplaySubtitle =>
+      'Trigger Next Up pop-up even if there\'s remaining content after outro.';
+
+  @override
   String get playerRouting => '玩家路线';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7422,7 +7422,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get nextUpIgnoreRemainingContentDisplay =>
-      'Play Next (Ignore Remaining Content After Outro)';
+      'Next Up Forced (Ignore Remaining Content After Outro)';
 
   @override
   String get nextUpIgnoreRemainingContentDisplaySubtitle =>

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1665,7 +1665,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get seerr => '塞尔';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => '西尔账户类型';
@@ -6236,14 +6236,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get homeScreenSectionsIntegrationNoServers => '尚无 Jellyfin 服务器报告该插件。';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      '检测通过 ranaldsgift 的“KefinTweaks”插件配置的行。自定义部分、最近发布的、再次观看的、季节性的以及最近添加到库中的内容均从每个 Jellyfin 服务器上的 KefinTweaks 配置进行镜像。';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      '尚无 Jellyfin 服务器报告 KefinTweaks。';
-
-  @override
   String get integrationOpenHomeSections => '开放主页部分';
 
   @override
@@ -6278,7 +6270,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => '查看全部';
@@ -7179,6 +7171,40 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get themeStore => 'Theme Store';
+
+  @override
+  String get themeStoreSubtitle => 'Browse and save community themes';
+
+  @override
+  String get themeStoreDescription =>
+      'Save a theme to use it like your other saved themes.';
+
+  @override
+  String get themeStoreEmpty => 'No themes are available right now.';
+
+  @override
+  String get themeStoreLoadFailed =>
+      'Couldn\'t load the Theme Store. Check your connection and try again.';
+
+  @override
+  String get themeStoreSave => 'Save';
+
+  @override
+  String get themeStoreSaveAndApply => 'Save & apply';
+
+  @override
+  String get themeStoreSaved => 'Saved';
+
+  @override
+  String get themeStoreInvalidMessage => 'This theme couldn\'t be loaded.';
+
+  @override
+  String themeStoreSavedMessage(String themeName) {
+    return 'Saved \"$themeName\".';
+  }
+
+  @override
   String savedThemesDeletedMessage(String themeName) {
     return '已从此设备中删除“$themeName”。';
   }
@@ -7207,9 +7233,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get savedThemesManageSubtitle => '管理此设备上下载的插件主题';
-
-  @override
-  String get kefinTweaksTitle => '凯芬调整';
 
   @override
   String get homeScreenSectionsTitle => '主屏幕部分';
@@ -7313,6 +7336,22 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get playlistsRowSortingDescription =>
       'Sort Playlist rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get displayAudioRows => 'Display Audio Rows';
+
+  @override
+  String get displayAudioRowsSubtitle => 'Show Audio rows in Home Sections.';
+
+  @override
+  String get audioRowsSorting => 'Audio Rows sorting';
+
+  @override
+  String get audioRowsSortingDescription =>
+      'Sort Audio rows by date added, release date, alphabetically, and more.';
+
+  @override
+  String get audioPlaylists => 'Audio Playlists';
 
   @override
   String get displaySeerrRows => 'Display Seerr Discovery Rows';
@@ -9605,7 +9644,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String get seerr => '塞爾';
+  String get seerr => 'Seerr';
 
   @override
   String get seerrAccountType => '西爾帳戶類型';
@@ -14075,14 +14114,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
       '尚無 Jellyfin 伺服器報告該外掛程式。';
 
   @override
-  String get kefinTweaksIntegrationDescription =>
-      '偵測透過 ranaldsgift 的「KefinTweaks」插件配置的行。自訂部分、最近發布的、再次觀看的、季節性的以及最近添加到庫中的內容均從每個 Jellyfin 伺服器上的 KefinTweaks 配置進行鏡像。';
-
-  @override
-  String get kefinTweaksIntegrationNoServers =>
-      '尚無 Jellyfin 伺服器報告 KefinTweaks。';
-
-  @override
   String get integrationOpenHomeSections => '開放主頁部分';
 
   @override
@@ -14117,7 +14148,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String get jellyseerr => 'Jellyseerr';
+  String get jellyseerr => 'Seerr';
 
   @override
   String get seeAll => '看全部';
@@ -15022,9 +15053,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String get savedThemesManageSubtitle =>
       'Manage downloaded plugin themes on this device';
-
-  @override
-  String get kefinTweaksTitle => 'KefinTweaks';
 
   @override
   String get homeScreenSectionsTitle => 'Home Screen Sections';

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1130,6 +1130,11 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final nextUpIgnoreRemainingContent = Preference(
+    key: 'next_up_ignore_remaining_content',
+    defaultValue: false,
+  );
+
   static final skipBackLength = Preference(
     key: 'skipBackLength',
     defaultValue: 10000,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3316,9 +3316,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 : PlatformDetection.useMobileUi && !_isOsdLocked
                 ? _onVerticalDragCancel
                 : null,
-            onPanDown: PlatformDetection.useDesktopUi
+            /* onPanDown: PlatformDetection.useDesktopUi
                 ? (_) => _showControls()
-                : null,
+                : null, */ // Disabled because it inteferes with onTap on desktop, controls overlay would show on mouse down and instantly hide on mouse up.
             behavior: HitTestBehavior.opaque,
             child: Listener(
               onPointerSignal: PlatformDetection.useDesktopUi
@@ -3341,6 +3341,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                   fit: StackFit.expand,
                   children: [
                     _buildVideoSurface(),
+                    if (PlatformDetection.isWeb)
+                      const Positioned.fill(
+                        child: ColoredBox(color: Colors.transparent),
+                      ), // Workaround for a Flutter web issue where the video surface can block pointer events.
                     _buildBringupOverlay(context),
                     if (_isRestoringPosition)
                       const Positioned.fill(

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -5475,18 +5475,22 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       builder: (context, snap) {
         final l10n = AppLocalizations.of(context);
         final isPlaying = _displayPlaying;
+        final hasAnyNavigation = _queue.hasPrevious || _queue.hasNext;
 
         return Row(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            if (_queue.hasPrevious)
+            if (hasAnyNavigation)
               _controlButton(
                 Icons.skip_previous_rounded,
-                onPressed: _manager.previous,
+                onPressed: _queue.hasPrevious ? _manager.previous : null,
                 size: 40,
                 extent: 72,
                 tooltip: l10n.playerTooltipPrevious,
+                iconColor: _queue.hasPrevious
+                    ? Colors.white
+                    : Colors.white38,
               ),
             _controlButton(
               seekBackIcon(_prefs.get(UserPreferences.skipBackLength)),
@@ -5521,13 +5525,16 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 shortcut: 'Right',
               ),
             ),
-            if (_queue.hasNext)
+            if (hasAnyNavigation)
               _controlButton(
                 Icons.skip_next_rounded,
-                onPressed: _manager.next,
+                onPressed: _queue.hasNext ? _manager.next : null,
                 size: 40,
                 extent: 72,
                 tooltip: l10n.next,
+                iconColor: _queue.hasNext
+                    ? Colors.white
+                    : Colors.white38,
               ),
           ],
         );
@@ -5537,7 +5544,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   Widget _controlButton(
     IconData icon, {
-    required VoidCallback onPressed,
+    VoidCallback? onPressed,
     double size = 24,
     double extent = 48,
     String? tooltip,
@@ -5550,7 +5557,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         focusNode: focusNode,
         extent: extent,
         tooltip: tooltip,
-        onPressed: () => _handleControlButtonPress(onPressed),
+        onPressed: onPressed != null
+            ? () => _handleControlButtonPress(onPressed)
+            : null,
         onRightBoundary: onRightBoundary,
         child: Icon(icon, color: iconColor, size: size),
       );
@@ -5560,7 +5569,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       height: extent,
       child: IconButton(
         focusNode: focusNode,
-        onPressed: () => _handleControlButtonPress(onPressed),
+        onPressed: onPressed != null
+            ? () => _handleControlButtonPress(onPressed)
+            : null,
         tooltip: PlatformDetection.useDesktopUi ? tooltip : null,
         icon: Icon(icon, color: iconColor, size: size),
         padding: EdgeInsets.zero,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -171,8 +171,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   MediaSegment? _skipSegment;
   Duration? _skipTo;
+  Timer? _skipSegmentHideTimer;
+  bool _skipSegmentAutoHidden = false;
   bool _showNextUp = false;
   AggregatedItem? _nextUpItem;
+  Timer? _nextUpHideTimer;
+  bool _nextUpAutoHidden = false;
   bool _nextUpDismissed = false;
   bool _isNextUpAdvancing = false;
   int _consecutiveEpisodes = 0;
@@ -940,6 +944,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _removeZoomModeToastOverlay();
     _skipForwardTimer?.cancel();
     _skipBackwardTimer?.cancel();
+    _skipSegmentHideTimer?.cancel();
+    _skipSegmentHideTimer = null;
+    _nextUpHideTimer?.cancel();
+    _nextUpHideTimer = null;
     if (_useSystemVolume) {
       _volumeListenerSub?.cancel();
       VolumeController.instance.removeListener();
@@ -2157,8 +2165,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _skipSegment = result.segment;
         _skipTo = result.skipTo;
         _controlsVisible = false;
+        _skipSegmentAutoHidden = false;
       });
       _hideTimer?.cancel();
+      _startSkipSegmentAutoHide();
       _focusTvSkipSegment();
     } else if (result.isNone && _skipSegment != null) {
       _clearSkipSegment();
@@ -2268,8 +2278,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _controlsVisible = false;
       _skipSegment = null;
       _skipTo = null;
+      _skipSegmentAutoHidden = false;
     });
+    _skipSegmentHideTimer?.cancel();
+    _skipSegmentHideTimer = null;
     _hideTimer?.cancel();
+    _startNextUpAutoHide();
     _focusTvNextUpPlay();
   }
 
@@ -2280,6 +2294,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       return;
     }
     _suppressBackNavigation(duration: const Duration(milliseconds: 500));
+    _nextUpHideTimer?.cancel();
+    _nextUpHideTimer = null;
     _isNextUpAdvancing = true;
     setState(() => _showNextUp = false);
     try {
@@ -2292,18 +2308,24 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   void _handleNextUpDismiss() {
     _suppressBackNavigation(duration: const Duration(milliseconds: 500));
+    _nextUpHideTimer?.cancel();
+    _nextUpHideTimer = null;
     _manager.suppressAutoNext = false;
     setState(() {
       _showNextUp = false;
       _nextUpDismissed = true;
+      _nextUpAutoHidden = false;
     });
   }
 
   void _handleNextUpCancel() {
     _suppressBackNavigation(duration: const Duration(milliseconds: 500));
+    _nextUpHideTimer?.cancel();
+    _nextUpHideTimer = null;
     setState(() {
       _showNextUp = false;
       _nextUpDismissed = true;
+      _nextUpAutoHidden = false;
     });
     unawaited(_exitPlayback());
   }
@@ -2397,9 +2419,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   void _clearSkipSegment() {
+    _skipSegmentHideTimer?.cancel();
+    _skipSegmentHideTimer = null;
     setState(() {
       _skipSegment = null;
       _skipTo = null;
+      _skipSegmentAutoHidden = false;
     });
   }
 
@@ -2538,11 +2563,35 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _syncPrerollOsdState();
       return;
     }
-    setState(() => _controlsVisible = true);
+    setState(() {
+      _controlsVisible = true;
+    });
     _scheduleHide();
     if (focusSeekbar) {
       _focusPreferredTvOverlayTarget();
     }
+  }
+
+  /// Lance le timer auto-hide (10s) pour SkipSegment.
+  void _startSkipSegmentAutoHide() {
+    _skipSegmentHideTimer?.cancel();
+    if (_skipSegment == null) return;
+    _skipSegmentHideTimer = Timer(const Duration(seconds: 10), () {
+      if (mounted) {
+        setState(() => _skipSegmentAutoHidden = true);
+      }
+    });
+  }
+
+  /// Lance le timer auto-hide (10s) pour NextUp.
+  void _startNextUpAutoHide() {
+    _nextUpHideTimer?.cancel();
+    if (_showNextUp == false || _nextUpItem == null) return;
+    _nextUpHideTimer = Timer(const Duration(seconds: 10), () {
+      if (mounted) {
+        setState(() => _nextUpAutoHidden = true);
+      }
+    });
   }
 
   void _toggleControls() {
@@ -3372,6 +3421,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     if (_skipSegment != null)
                       SkipSegmentOverlay(
                         segment: _skipSegment!,
+                        isHidden: _skipSegmentAutoHidden && !_controlsVisible,
                         onSkip: _skipCurrentSegment,
                         focusNode: PlatformDetection.isTV
                             ? _tvSkipSegmentFocus
@@ -3382,6 +3432,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     if (_showNextUp && _nextUpItem != null)
                       NextUpOverlay(
                         nextItem: _nextUpItem!,
+                        isHidden: _nextUpAutoHidden && !_controlsVisible,
                         imageUrl: _nextUpItem!.primaryImageTag != null
                             ? _clientForItem(
                                 _nextUpItem!,
@@ -4439,6 +4490,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final buttonIconSize = isLandscape ? 28.0 : 24.0;
     final hasPrevious = _queue.hasPrevious;
     final hasNext = _queue.hasNext;
+    final hasAnyNavigation = hasPrevious || hasNext;
 
     return FocusTraversalGroup(
       policy: ReadingOrderTraversalPolicy(),
@@ -4448,14 +4500,17 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            if (_queue.hasPrevious)
+            if (hasAnyNavigation)
               _controlButton(
                 Icons.skip_previous_rounded,
-                onPressed: _manager.previous,
+                onPressed: hasPrevious ? _manager.previous : null,
                 size: buttonIconSize,
                 extent: buttonExtent,
                 focusNode: _tvTransportFirstFocus,
                 tooltip: l10n.playerTooltipPrevious,
+                iconColor: hasPrevious
+                    ? Colors.white
+                    : Colors.white38,
               ),
             const SizedBox(width: 4),
             _controlButton(
@@ -4464,7 +4519,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                   _seekRelative(-_prefs.get(UserPreferences.skipBackLength)),
               size: buttonIconSize,
               extent: buttonExtent,
-              focusNode: hasPrevious ? null : _tvTransportFirstFocus,
+              focusNode: hasAnyNavigation ? null : _tvTransportFirstFocus,
               tooltip: _tooltipMessage(
                 l10n.playerTooltipSeekBack,
                 shortcut: 'Left',
@@ -4498,21 +4553,24 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                   _seekRelative(_prefs.get(UserPreferences.skipForwardLength)),
               size: buttonIconSize,
               extent: buttonExtent,
-              focusNode: hasNext ? null : _tvTransportLastFocus,
+              focusNode: hasAnyNavigation ? null : _tvTransportLastFocus,
               tooltip: _tooltipMessage(
                 l10n.playerTooltipSeekForward,
                 shortcut: 'Right',
               ),
             ),
             const SizedBox(width: 4),
-            if (_queue.hasNext)
+            if (hasAnyNavigation)
               _controlButton(
                 Icons.skip_next_rounded,
-                onPressed: _manager.next,
+                onPressed: hasNext ? _manager.next : null,
                 size: buttonIconSize,
                 extent: buttonExtent,
                 focusNode: _tvTransportLastFocus,
                 tooltip: l10n.next,
+                iconColor: hasNext
+                    ? Colors.white
+                    : Colors.white38,
               ),
           ],
         ),

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2634,7 +2634,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
   }
 
-  /// Lance le timer auto-hide (10s) pour SkipSegment.
+  // Launch auto-hide timer (10s) for SkipSegment.
   void _startSkipSegmentAutoHide() {
     _skipSegmentHideTimer?.cancel();
     if (_skipSegment == null) return;
@@ -2645,10 +2645,20 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     });
   }
 
-  /// Lance le timer auto-hide (10s) pour NextUp.
+  // Launch auto-hide timer (10s) for NextUp.
   void _startNextUpAutoHide() {
     _nextUpHideTimer?.cancel();
     if (_showNextUp == false || _nextUpItem == null) return;
+
+    final duration = _state.duration;
+    final position = _state.position;
+
+    if (duration > Duration.zero) {
+      final remaining = duration - position;
+      if (remaining <= const Duration(seconds: 2)) {
+        return; 
+      }
+    }
     _nextUpHideTimer = Timer(const Duration(seconds: 10), () {
       if (mounted) {
         setState(() => _nextUpAutoHidden = true);

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2126,22 +2126,43 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
   }
 
+  /// Return true if there is content after the outro segment
+  /// (segment.end significantly before the end of the video).
+  bool _hasContentAfterOutro(MediaSegment? outroSegment) {
+    if (outroSegment == null) return false;
+    final duration = _state.duration;
+    if (duration <= Duration.zero) return false;
+    
+    // Less than 10 seconds of content after the outro is considered "not enough" to block a Next Up prompt.
+    final remaining = duration - outroSegment.end;
+    return remaining > const Duration(seconds: 10);
+  }
+
   void _checkSegments(Duration position) {
     final result = _segmentService.checkPosition(position);
     final replaceSkipOutroWithNextUp = _prefs.get(
       UserPreferences.replaceSkipOutroWithNextUp,
     );
+    final nextUpIgnoreRemainingContent = _prefs.get(
+      UserPreferences.nextUpIgnoreRemainingContent,
+    );
+
+    final effectiveIgnoreContentAfterOutro = replaceSkipOutroWithNextUp && nextUpIgnoreRemainingContent;
+
     if (result.shouldSkip && result.skipTo != null) {
       final isOutro = result.segment?.type == MediaSegmentType.outro;
-      if (replaceSkipOutroWithNextUp && isOutro && _showNextUp) {
+      final hasContentAfterOutro = isOutro && _hasContentAfterOutro(result.segment);
+      final protectContentAfterOutro = hasContentAfterOutro && !effectiveIgnoreContentAfterOutro;
+
+      if (replaceSkipOutroWithNextUp && isOutro && _showNextUp && !protectContentAfterOutro) {
         return;
       }
-      if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay()) {
+      if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay() && !protectContentAfterOutro) {
         unawaited(_manager.seekTo(result.skipTo!));
         _presentNextUpOverlay();
         return;
       }
-      if (isOutro && !_hasDistinctQueueNextItem()) {
+      if (isOutro && !_hasDistinctQueueNextItem() && !protectContentAfterOutro) {
         unawaited(_exitPlayback());
         return;
       }
@@ -2157,7 +2178,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
     if (result.shouldAsk && result.isNew && result.segment != null) {
       final isOutro = result.segment!.type == MediaSegmentType.outro;
-      if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay()) {
+      final effectiveIgnoreContentAfterOutro = replaceSkipOutroWithNextUp && nextUpIgnoreRemainingContent;
+      final hasContentAfterOutro = isOutro && _hasContentAfterOutro(result.segment);
+      final protectContentAfterOutro = hasContentAfterOutro && !effectiveIgnoreContentAfterOutro;
+      if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay() && !protectContentAfterOutro) {
         _presentNextUpOverlay();
         return;
       }
@@ -2297,10 +2321,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _nextUpHideTimer?.cancel();
     _nextUpHideTimer = null;
     _isNextUpAdvancing = true;
+    
+    final previousItem = _queue.currentItem;
+
     setState(() => _showNextUp = false);
     try {
       await _checkStillWatching();
       await _manager.next();
+      unawaited(_markItemAsPlayed(previousItem));
     } finally {
       _isNextUpAdvancing = false;
     }
@@ -2360,37 +2388,65 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
   }
 
+  // Mark item as "played", used when skipping an outro segment with replaceSkipOutroWithNextUp enabled to ensure the item is marked as played in the server's library.
+  Future<void> _markItemAsPlayed(dynamic item) async {
+    if (item == null) return;
+    final itemId = _itemIdForQueueItem(item);
+    if (itemId != null && itemId.isNotEmpty) {
+      try {
+        final raw = _rawDataForQueueItem(item);
+        if (raw != null) {
+          final existingUserData = raw['UserData'];
+          final userData = existingUserData is Map<String, dynamic>
+              ? existingUserData
+              : (existingUserData is Map
+                  ? existingUserData.cast<String, dynamic>()
+                  : <String, dynamic>{});
+          userData['Played'] = true;
+          userData.remove('PlaybackPositionTicks');
+          raw['UserData'] = userData;
+        }
+        
+        final mutations = ItemMutationRepository(_clientForQueueItem(item));
+        await mutations.setPlayed(itemId, isPlayed: true);
+      } catch (_) {}
+    }
+  }
+
   void _skipCurrentSegment() {
     final replaceSkipOutroWithNextUp = _prefs.get(
       UserPreferences.replaceSkipOutroWithNextUp,
     );
-    final isOutro =
-        _skipSegment?.type == MediaSegmentType.outro ||
-        _segmentService.activeSegment?.type == MediaSegmentType.outro;
+    final nextUpIgnoreRemainingContent = _prefs.get(
+      UserPreferences.nextUpIgnoreRemainingContent,
+    );
+
+    final activeOutroSegment = _skipSegment?.type == MediaSegmentType.outro
+        ? _skipSegment
+        : (_segmentService.activeSegment?.type == MediaSegmentType.outro
+            ? _segmentService.activeSegment
+            : null);
+    final isOutro = activeOutroSegment != null;
+
+    final effectiveIgnoreContentAfterOutro = replaceSkipOutroWithNextUp && nextUpIgnoreRemainingContent;
+    final hasContentAfterOutro = _hasContentAfterOutro(activeOutroSegment);
+    final protectContentAfterOutro = hasContentAfterOutro && !effectiveIgnoreContentAfterOutro;
+    bool shouldMarkPlayed = false;
     if (isOutro) {
-      final item = _queue.currentItem;
-      final itemId = _itemIdForQueueItem(item);
-      if (itemId != null && itemId.isNotEmpty) {
-        try {
-          final mutations = ItemMutationRepository(_clientForQueueItem(item));
-          unawaited(
-            mutations.setPlayed(itemId, isPlayed: true).catchError((_) {}),
-          );
-          final raw = _rawDataForQueueItem(item);
-          if (raw != null) {
-            final existingUserData = raw['UserData'];
-            final userData = existingUserData is Map<String, dynamic>
-                ? existingUserData
-                : (existingUserData is Map
-                      ? existingUserData.cast<String, dynamic>()
-                      : <String, dynamic>{});
-            userData['Played'] = true;
-            raw['UserData'] = userData;
-          }
-        } catch (_) {}
+
+      if (_skipTo != null && _state.duration > Duration.zero) {
+        final percentage = _skipTo!.inMilliseconds / _state.duration.inMilliseconds;
+        if (percentage >= 0.90) {
+          shouldMarkPlayed = true;
+        }
+      } else if (_skipTo == null) {
+        shouldMarkPlayed = true;
       }
     }
-    if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay()) {
+
+    final currentItem = _queue.currentItem;
+
+    if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay() && !protectContentAfterOutro) {
       final skipTo = _skipTo;
       if (skipTo != null) {
         unawaited(_manager.seekTo(skipTo));
@@ -2398,13 +2454,19 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _presentNextUpOverlay();
       return;
     }
-    if (isOutro && !_hasDistinctQueueNextItem()) {
+    if (isOutro && !_hasDistinctQueueNextItem() && !protectContentAfterOutro) {
+      if (shouldMarkPlayed) {
+        unawaited(_manager.stop().then((_) => _markItemAsPlayed(currentItem)));
+      }
       unawaited(_exitPlayback());
       return;
     }
 
     if (_skipTo != null) {
       _manager.seekTo(_skipTo!);
+    }
+    if (shouldMarkPlayed) {
+      unawaited(_markItemAsPlayed(currentItem));
     }
     setState(() {
       _skipSegment = null;

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -2880,6 +2880,7 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
     final showNextUpOptions = nextUpBehavior != NextUpBehavior.disabled;
     final showReplaceSkipOutroWithNextUp =
         showNextUpOptions && mediaSegmentActions == _promptSkipSegments;
+    final isReplaceSkipOutroEnabled = _prefs.get(UserPreferences.replaceSkipOutroWithNextUp);
 
     return Scaffold(
       appBar: buildSettingsAppBar(
@@ -2957,6 +2958,13 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
               title: l10n.replaceSkipOutroWithNextUpDisplay,
               subtitle: l10n.replaceSkipOutroWithNextUpDisplaySubtitle,
               icon: Icons.skip_next,
+            ),
+          if (showReplaceSkipOutroWithNextUp && isReplaceSkipOutroEnabled)
+            SwitchPreferenceTile(
+              preference: UserPreferences.nextUpIgnoreRemainingContent,
+              title: l10n.nextUpIgnoreRemainingContentDisplay,
+              subtitle: l10n.nextUpIgnoreRemainingContentDisplaySubtitle,
+              icon: Icons.play_arrow,
             ),
           EnumPreferenceTile<StillWatchingBehavior>(
             preference: UserPreferences.stillWatchingBehavior,

--- a/lib/ui/widgets/playback/next_up_overlay.dart
+++ b/lib/ui/widgets/playback/next_up_overlay.dart
@@ -10,6 +10,7 @@ import '../../../data/models/aggregated_item.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../util/platform_detection.dart';
 
 class NextUpOverlay extends StatefulWidget {
   final AggregatedItem nextItem;
@@ -20,6 +21,7 @@ class NextUpOverlay extends StatefulWidget {
   final VoidCallback? onTimeout;
   final FocusNode? focusNode;
   final FocusNode? dismissFocusNode;
+  final bool isHidden;
 
   const NextUpOverlay({
     super.key,
@@ -31,6 +33,7 @@ class NextUpOverlay extends StatefulWidget {
     this.onTimeout,
     this.focusNode,
     this.dismissFocusNode,
+    this.isHidden = false,
   });
 
   @override
@@ -83,174 +86,181 @@ class _NextUpOverlayState extends State<NextUpOverlay>
     final showTimer = mediaSegmentCountdown == MediaSegmentCountdown.timer ||
         mediaSegmentCountdown == MediaSegmentCountdown.both;
 
+    final isTV = PlatformDetection.isTV;
+    final isDesktop = PlatformDetection.useDesktopUi;
+    final bottomOffset = isTV ? 190.0 : (isDesktop ? 140.0 : 100.0);
+
     return Positioned(
       right: 24,
-      bottom: 120,
-      child: Container(
-        width: 340,
-        decoration: BoxDecoration(
-          color: AppColorScheme.surface.withValues(alpha: 0.95),
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: const [
-            BoxShadow(
-              color: Colors.black54,
-              blurRadius: 20,
-              offset: Offset(0, 4),
-            ),
-          ],
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            if (widget.imageUrl != null)
-              SizedBox(
-                height: 120,
-                child: CachedNetworkImage(
-                  imageUrl: widget.imageUrl!,
-                  fit: BoxFit.cover,
-                  errorWidget: (_, _, _) =>
-                      Container(color: AppColorScheme.surfaceVariant),
-                ),
+      bottom: bottomOffset,
+      child: Offstage(
+        offstage: widget.isHidden,
+        child: Container(
+          width: 340,
+          decoration: BoxDecoration(
+            color: AppColorScheme.surface.withValues(alpha: 0.95),
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: const [
+              BoxShadow(
+                color: Colors.black54,
+                blurRadius: 20,
+                offset: Offset(0, 4),
               ),
-            Padding(
-              padding: const EdgeInsets.all(12),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        l10n.upNext,
-                        style: const TextStyle(
-                          color: Colors.white54,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      if (showTimer && widget.timeoutMs > 0)
-                        AnimatedBuilder(
-                          animation: _countdownController,
-                          builder: (context, _) {
-                            final remainingMs = widget.timeoutMs * (1.0 - _countdownController.value);
-                            final remainingSeconds = (remainingMs / 1000).ceil();
-                            final int minutes = remainingSeconds ~/ 60;
-                            final int secs = remainingSeconds % 60;
-                            final timerText = remainingSeconds >= 60
-                                ? '$minutes:${secs.toString().padLeft(2, '0')}'
-                                : ':${secs.toString().padLeft(2, '0')}';
-                            return Text(
-                              l10n.endsIn(timerText),
-                              style: const TextStyle(
-                                color: Colors.white54,
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            );
-                          },
-                        ),
-                    ],
+            ],
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (widget.imageUrl != null)
+                SizedBox(
+                  height: 120,
+                  child: CachedNetworkImage(
+                    imageUrl: widget.imageUrl!,
+                    fit: BoxFit.cover,
+                    errorWidget: (_, _, _) =>
+                        Container(color: AppColorScheme.surfaceVariant),
                   ),
-                  const SizedBox(height: 4),
-                  Text(
-                    [epInfo, item.name]
-                        .where((s) => s != null && s.isNotEmpty)
-                        .join(' — '),
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 15,
-                      fontWeight: FontWeight.w600,
+                ),
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          l10n.upNext,
+                          style: const TextStyle(
+                            color: Colors.white54,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (showTimer && widget.timeoutMs > 0)
+                          AnimatedBuilder(
+                            animation: _countdownController,
+                            builder: (context, _) {
+                              final remainingMs = widget.timeoutMs * (1.0 - _countdownController.value);
+                              final remainingSeconds = (remainingMs / 1000).ceil();
+                              final int minutes = remainingSeconds ~/ 60;
+                              final int secs = remainingSeconds % 60;
+                              final timerText = remainingSeconds >= 60
+                                  ? '$minutes:${secs.toString().padLeft(2, '0')}'
+                                  : ':${secs.toString().padLeft(2, '0')}';
+                              return Text(
+                                l10n.endsIn(timerText),
+                                style: const TextStyle(
+                                  color: Colors.white54,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              );
+                            },
+                          ),
+                      ],
                     ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 12),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: Focus(
-                          focusNode: widget.focusNode,
+                    const SizedBox(height: 4),
+                    Text(
+                      [epInfo, item.name]
+                          .where((s) => s != null && s.isNotEmpty)
+                          .join(' — '),
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Focus(
+                            focusNode: widget.focusNode,
+                            onFocusChange: (focused) {
+                              if (_playFocused != focused) {
+                                setState(() => _playFocused = focused);
+                              }
+                            },
+                            onKeyEvent: (_, event) {
+                              if (event is KeyDownEvent &&
+                                  (event.logicalKey == LogicalKeyboardKey.select ||
+                                      event.logicalKey == LogicalKeyboardKey.enter)) {
+                                widget.onPlayNext();
+                                return KeyEventResult.handled;
+                              }
+                              return KeyEventResult.ignored;
+                            },
+                            child: ElevatedButton(
+                              autofocus: widget.focusNode == null,
+                              onPressed: widget.onPlayNext,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: tvFocusMode
+                                    ? (_playFocused
+                                        ? AppColorScheme.accent
+                                        : AppColorScheme.surfaceVariant.withValues(alpha: 0.9))
+                                    : AppColorScheme.accent,
+                                foregroundColor: Colors.white,
+                                padding: const EdgeInsets.symmetric(vertical: 10),
+                              ),
+                              child: Text(l10n.playNext),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Focus(
+                          focusNode: widget.dismissFocusNode,
                           onFocusChange: (focused) {
-                            if (_playFocused != focused) {
-                              setState(() => _playFocused = focused);
+                            if (_dismissFocused != focused) {
+                              setState(() => _dismissFocused = focused);
                             }
                           },
                           onKeyEvent: (_, event) {
                             if (event is KeyDownEvent &&
                                 (event.logicalKey == LogicalKeyboardKey.select ||
                                     event.logicalKey == LogicalKeyboardKey.enter)) {
-                              widget.onPlayNext();
+                              widget.onDismiss();
                               return KeyEventResult.handled;
                             }
                             return KeyEventResult.ignored;
                           },
-                          child: ElevatedButton(
-                            autofocus: widget.focusNode == null,
-                            onPressed: widget.onPlayNext,
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: tvFocusMode
-                                  ? (_playFocused
-                                      ? AppColorScheme.accent
-                                      : AppColorScheme.surfaceVariant.withValues(alpha: 0.9))
-                                  : AppColorScheme.accent,
+                          child: OutlinedButton(
+                            onPressed: widget.onDismiss,
+                            style: OutlinedButton.styleFrom(
                               foregroundColor: Colors.white,
+                              backgroundColor: _dismissFocused
+                                  ? AppColorScheme.accent.withValues(alpha: 0.24)
+                                  : Colors.transparent,
+                              side: _dismissFocused
+                                  ? ThemeRegistry.active.borders.focusBorder
+                                  : ThemeRegistry.active.borders.chipBorder,
                               padding: const EdgeInsets.symmetric(vertical: 10),
                             ),
-                            child: Text(l10n.playNext),
+                            child: Text(l10n.close),
                           ),
                         ),
-                      ),
-                      const SizedBox(width: 8),
-                      Focus(
-                        focusNode: widget.dismissFocusNode,
-                        onFocusChange: (focused) {
-                          if (_dismissFocused != focused) {
-                            setState(() => _dismissFocused = focused);
-                          }
-                        },
-                        onKeyEvent: (_, event) {
-                          if (event is KeyDownEvent &&
-                              (event.logicalKey == LogicalKeyboardKey.select ||
-                                  event.logicalKey == LogicalKeyboardKey.enter)) {
-                            widget.onDismiss();
-                            return KeyEventResult.handled;
-                          }
-                          return KeyEventResult.ignored;
-                        },
-                        child: OutlinedButton(
-                          onPressed: widget.onDismiss,
-                          style: OutlinedButton.styleFrom(
-                            foregroundColor: Colors.white,
-                            backgroundColor: _dismissFocused
-                                ? AppColorScheme.accent.withValues(alpha: 0.24)
-                                : Colors.transparent,
-                            side: _dismissFocused
-                                ? ThemeRegistry.active.borders.focusBorder
-                                : ThemeRegistry.active.borders.chipBorder,
-                            padding: const EdgeInsets.symmetric(vertical: 10),
-                          ),
-                          child: Text(l10n.close),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            if (showProgressBar && widget.timeoutMs > 0)
-              AnimatedBuilder(
-                animation: _countdownController,
-                builder: (context, _) => LinearProgressIndicator(
-                  value: 1.0 - _countdownController.value,
-                  backgroundColor: Colors.transparent,
-                  color: AppColorScheme.accent,
-                  minHeight: 6,
+                      ],
+                    ),
+                  ],
                 ),
               ),
-          ],
+              if (showProgressBar && widget.timeoutMs > 0)
+                AnimatedBuilder(
+                  animation: _countdownController,
+                  builder: (context, _) => LinearProgressIndicator(
+                    value: 1.0 - _countdownController.value,
+                    backgroundColor: Colors.transparent,
+                    color: AppColorScheme.accent,
+                    minHeight: 6,
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/widgets/playback/skip_segment_overlay.dart
+++ b/lib/ui/widgets/playback/skip_segment_overlay.dart
@@ -18,6 +18,7 @@ class SkipSegmentOverlay extends StatefulWidget {
   final VoidCallback onDismiss;
   final FocusNode? focusNode;
   final Stream<Duration>? positionStream;
+  final bool isHidden;
 
   const SkipSegmentOverlay({
     super.key,
@@ -26,6 +27,7 @@ class SkipSegmentOverlay extends StatefulWidget {
     required this.onDismiss,
     this.focusNode,
     this.positionStream,
+    this.isHidden = false,
   });
 
   @override
@@ -82,7 +84,9 @@ class _SkipSegmentOverlayState extends State<SkipSegmentOverlay> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final isTV = PlatformDetection.isTV;
     final isDesktop = PlatformDetection.useDesktopUi;
+    final bottomOffset = isTV ? 190.0 : (isDesktop ? 140.0 : 100.0);
 
     final prefs = GetIt.instance<UserPreferences>();
     final mediaSegmentCountdown = prefs.get(UserPreferences.mediaSegmentCountdown);
@@ -114,97 +118,100 @@ class _SkipSegmentOverlayState extends State<SkipSegmentOverlay> {
 
     return Positioned(
       right: 24,
-      bottom: 120,
-      child: Material(
-        color: Colors.transparent,
-        child: Focus(
-          focusNode: widget.focusNode,
-          onKeyEvent: (_, event) {
-            if (widget.focusNode == null) {
+      bottom: bottomOffset,
+      child: Offstage(
+        offstage: widget.isHidden,
+        child: Material(
+          color: Colors.transparent,
+          child: Focus(
+            focusNode: widget.focusNode,
+            onKeyEvent: (_, event) {
+              if (widget.focusNode == null) {
+                return KeyEventResult.ignored;
+              }
+              if (event is KeyDownEvent &&
+                  (event.logicalKey == LogicalKeyboardKey.select ||
+                      event.logicalKey == LogicalKeyboardKey.enter)) {
+                widget.onSkip();
+                return KeyEventResult.handled;
+              }
               return KeyEventResult.ignored;
-            }
-            if (event is KeyDownEvent &&
-                (event.logicalKey == LogicalKeyboardKey.select ||
-                    event.logicalKey == LogicalKeyboardKey.enter)) {
-              widget.onSkip();
-              return KeyEventResult.handled;
-            }
-            return KeyEventResult.ignored;
-          },
-          child: Stack(
-            children: [
-              InkWell(
-                onTap: widget.onSkip,
-                borderRadius: BorderRadius.circular(8),
-                child: Container(
-                  width: isDesktop ? 320.0 : 280.0,
-                  clipBehavior: Clip.antiAlias,
-                  decoration: FocusTheme.focusDecoration(
-                    isFocused: true,
-                    radius: 8,
-                    color: AppColorScheme.accent,
-                    backgroundColor: AppColorScheme.surface.withValues(
-                      alpha: 0.9,
-                    ),
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      Padding(
-                        padding: EdgeInsets.fromLTRB(20, 12, isDesktop ? 44 : 20, 12),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              '${l10n.skipSegment(widget.segment.type.displayName)}$timerSuffix',
-                              style: TextStyle(
-                                color: AppColorScheme.onSurface,
-                                fontSize: 15,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            const SizedBox(width: 8),
-                            Icon(
-                              Icons.skip_next_rounded,
-                              color: AppColorScheme.accent,
-                              size: 22,
-                            ),
-                          ],
-                        ),
+            },
+            child: Stack(
+              children: [
+                InkWell(
+                  onTap: widget.onSkip,
+                  borderRadius: BorderRadius.circular(8),
+                  child: Container(
+                    width: isDesktop ? 320.0 : 280.0,
+                    clipBehavior: Clip.antiAlias,
+                    decoration: FocusTheme.focusDecoration(
+                      isFocused: true,
+                      radius: 8,
+                      color: AppColorScheme.accent,
+                      backgroundColor: AppColorScheme.surface.withValues(
+                        alpha: 0.9,
                       ),
-                      if (showProgressBar)
-                        LinearProgressIndicator(
-                          value: progress,
-                          backgroundColor: Colors.transparent,
-                          color: AppColorScheme.accent,
-                          minHeight: 6,
+                    ),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Padding(
+                          padding: EdgeInsets.fromLTRB(20, 12, isDesktop ? 44 : 20, 12),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                '${l10n.skipSegment(widget.segment.type.displayName)}$timerSuffix',
+                                style: TextStyle(
+                                  color: AppColorScheme.onSurface,
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Icon(
+                                Icons.skip_next_rounded,
+                                color: AppColorScheme.accent,
+                                size: 22,
+                              ),
+                            ],
+                          ),
                         ),
-                    ],
-                  ),
-                ),
-              ),
-              if (isDesktop)
-                Positioned(
-                  top: 4,
-                  right: 4,
-                  child: IconButton(
-                    onPressed: widget.onDismiss,
-                    tooltip: l10n.close,
-                    padding: EdgeInsets.zero,
-                    visualDensity: VisualDensity.compact,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 24,
-                      height: 24,
-                    ),
-                    icon: Icon(
-                      Icons.close_rounded,
-                      size: 16,
-                      color: AppColorScheme.onSurface,
+                        if (showProgressBar)
+                          LinearProgressIndicator(
+                            value: progress,
+                            backgroundColor: Colors.transparent,
+                            color: AppColorScheme.accent,
+                            minHeight: 6,
+                          ),
+                      ],
                     ),
                   ),
                 ),
-            ],
+                if (isDesktop)
+                  Positioned(
+                    top: 4,
+                    right: 4,
+                    child: IconButton(
+                      onPressed: widget.onDismiss,
+                      tooltip: l10n.close,
+                      padding: EdgeInsets.zero,
+                      visualDensity: VisualDensity.compact,
+                      constraints: const BoxConstraints.tightFor(
+                        width: 24,
+                        height: 24,
+                      ),
+                      icon: Icon(
+                        Icons.close_rounded,
+                        size: 16,
+                        color: AppColorScheme.onSurface,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
# Pull Request

## Summary
This PR introduces several quality-of-life improvements and fixes to the Video Player. Updates include a smarter "Next Up" logic that protects post-credits scenes, auto-hiding behavior for skip widgets, and UI adjustments to ensure transport controls remain perfectly centered across all states. It also addresses a controls overlay bug specific to the web platform.

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

**UI Adjustments:**
- **Centered Transport Controls:** Introduced a `hasAnyNavigation` logic. The previous/next queue arrows are now always rendered in the layout (grayed out when unavailable). This prevents layout shifts and ensures the center transport controls (Play/Pause, Seek forward/backward) remain perfectly centered on screen.
- **Overlay Positioning:** Refined the vertical alignment of the Skip and Next Up widgets. Previously too high on mobile and too low on desktop, now optimized per platform ratio (Desktop: 140.0, Mobile: 100.0, TV: 190.0). (Not tested on every devices)

**New Features:**
- **Auto-Hide Prompts:** "Skip Intro/Outro" and "Next Up" widgets now automatically hide after 10 seconds of playback. They reappear if the user brings up the controls overlay.
- **Post-Credits Scene Protection:** The "Replace Skip Outro with Next Up" feature now checks for remaining video duration. If content exists after the outro segment, it falls back to the standard "Skip Outro" button to prevent users from missing post-credits scenes. 
- **New Setting:** Added a dependent setting ("Next Up Ignore Remaining Content") to allow users to bypass the post-credits protection and force the Next Up overlay if preferred.

**Bug Fixes:**
- **Web Interface:** Fixed an issue where clicking directly on the video player failed to dismiss the controls overlay.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [ ] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate through media with and without previous/next queue items to verify transport control centering.
2. Trigger outro segments with and without post-credits content to test the new Next Up protection logic.
3. Verify the new dependent setting toggles correctly in the settings panel.
4. Let the Skip/Next Up overlays time out (10s) and verify they reappear with the controls overlay.
5. (Web) Click on the video surface to ensure the controls overlay dismisses properly.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced