### PR TITLE
bug - Fix Cinema Mode local intros advance when autoplay is disabled

### DIFF
--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -549,7 +549,7 @@ class PlaybackManager implements AudioOwnable {
         suppressAutoNext) {
       return;
     }
-    if (!autoAdvanceEnabled) {
+    if (!autoAdvanceEnabled && !_isPreroll(queueService.currentItem)) {
       _isAutoNexting = true;
       _mediaSourceId = null;
       _stopAndReportCurrent(skipQueueChange: true).whenComplete(() {


### PR DESCRIPTION
# Pull Request

## Summary
Ensure that local intros/prerolls in Local Intros/Cinema Mode always auto-advance to the main feature, even if the "Autoplay next episode" setting is turned off.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Playback Core (`packages/playback_core`)**: Modified `_onTrackCompleted` in `playback_manager.dart` to bypass the `!autoAdvanceEnabled` early-exit if the completed queue item is a local intro/preroll:
    ```dart
    if (!autoAdvanceEnabled && !_isPreroll(queueService.currentItem)) {
    ```
- This ensures that if the completed item is an intro, playback does not stop and exit to Media Details; instead, it calls `_autoNext()` and advances to the main movie.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. In settings, disable the "Autoplay next episode" option.
2. Enable local intros / Cinema Mode in settings.
3. Play a movie that has local intros.
4. Verify that the intro plays through and automatically transitions into the main movie.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
