### PR TITLE
bug - Fix keyboard backspace behavior on TV

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -39,6 +39,7 @@ import 'ui/widgets/overlay_sheet.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'util/focus/key_event_utils.dart';
 import 'ui/widgets/focus/request_initial_focus.dart';
+import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 
 class MoonfinApp extends StatefulWidget {
   const MoonfinApp({super.key});
@@ -462,7 +463,13 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
   bool _isEditingText() {
     final focusContext = FocusManager.instance.primaryFocus?.context;
     if (focusContext == null) return false;
-    return focusContext.findAncestorWidgetOfExactType<EditableText>() != null;
+    if (focusContext.findAncestorWidgetOfExactType<EditableText>() != null) {
+      return true;
+    }
+    if (CustomTVTextField.isKeyboardVisibleNotifier.value) {
+      return true;
+    }
+    return false;
   }
 
   bool _onHardwareKeyEvent(KeyEvent event) {

--- a/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
+++ b/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
@@ -15,6 +15,7 @@ enum TextFieldType {
 }
 
 class CustomTVTextField extends StatefulWidget {
+  static final ValueNotifier<bool> isKeyboardVisibleNotifier = ValueNotifier<bool>(false);
   final TextEditingController controller;
   final bool isFocused;
   final String hint;
@@ -244,7 +245,9 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
   }
 
   void _notifyVisibilityChanged() {
-    widget.onVisibilityChanged?.call(isKeyboardVisible);
+    final visible = isKeyboardVisible;
+    CustomTVTextField.isKeyboardVisibleNotifier.value = visible;
+    widget.onVisibilityChanged?.call(visible);
   }
 
   @override
@@ -385,6 +388,9 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
 
   @override
   void dispose() {
+    if (isKeyboardVisible) {
+      CustomTVTextField.isKeyboardVisibleNotifier.value = false;
+    }
     widget.controller.removeListener(_onTextChanged);
     _systemInputFocusNode.removeListener(_onSystemInputFocusChanged);
     _keyboardController.removeListener(_onKeyboardStateChanged);


### PR DESCRIPTION
# Pull Request

## Summary
Ensure that the Backspace key (both on the virtual in-app TV keyboard and on an external keyboard) erases characters to the left of the cursor instead of triggering global back navigation and closing the keyboard dialogue.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Custom TV Text Field (`packages/custom_tv_text_field_fork`)**:
  - Added a static `isKeyboardVisibleNotifier` to track the virtual keyboard visibility state globally.
  - Updated the notifier in `_notifyVisibilityChanged` and reset it in `dispose`.
- **App Shell (`lib`)**:
  - Updated `_isEditingText()` in `lib/app.dart` to return true if the virtual keyboard is open. This prevents the global raw hardware key listener from intercepting `backspace` key events and invoking `appRouter.pop()`.
  - The backspace key event now propagates to the focused virtual keyboard or text input to perform the character deletion.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a text field on Android TV (e.g. Search screen or the Add Server dialogue box).
2. Open the on-screen keyboard.
3. Press the Backspace key on the on-screen keyboard or on an external keyboard.
4. Verify that the character is erased and the keyboard remains open.
5. Press the Escape key on an external keyboard and verify that the keyboard closes correctly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
