### PR TITLE
Update Windows updater logic to select correct architecture installer

### DIFF
--- a/lib/data/services/app_update_service.dart
+++ b/lib/data/services/app_update_service.dart
@@ -226,7 +226,14 @@ class AppUpdateService {
       case DistributionChannel.macosDmg:
         return _firstByExtension(assets, const ['.dmg']);
       case DistributionChannel.windows:
-        return _firstByExtension(assets, const ['.exe']);
+        final isArm64 = Platform.version.toLowerCase().contains('windows_arm64');
+        if (isArm64) {
+          return _firstWhere(assets, '.exe', requireSubstring: 'arm64') ??
+              _firstByExtension(assets, const ['.exe']);
+        } else {
+          return _firstWhere(assets, '.exe', excludeSubstring: 'arm64') ??
+              _firstByExtension(assets, const ['.exe']);
+        }
       default:
         return null;
     }


### PR DESCRIPTION
# Pull Request

## Summary
Update the Windows in-app update checker to dynamically select and download the correct processor architecture installer based on the currently running build. Fixes issue where x64 Windows machines automatically downloaded the ARM64 release executable.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.
- Modified `_selectAsset()` under `case DistributionChannel.windows` to check if `Platform.version` contains `'windows_arm64'`.
- Filter release assets for `.exe` containing `'arm64'` if the current running build is ARM64.
- Filter release assets for `.exe` excluding `'arm64'` if the current running build is not ARM64.
- Fall back to first matching `.exe` extension if filtered results are empty.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Executed simulated unit test checks evaluating asset selection logic with both ARM64 and x64 runner conditions.
2. Verified standard fallback cases (selecting the alternative installer format if only one is available in the release).
3. Ran compilation and build testing via `C:\Moonfin-Core\build-windows.ps1` successfully and tested for updates.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
