### PR TITLE
top_toolbar: adjust D-pad navigation during music playback

### DIFF
--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -401,14 +401,20 @@ class _TopToolbarState extends State<TopToolbar> {
     final primary = FocusManager.instance.primaryFocus;
     if (primary == null || !_isInsideToolbar(primary)) return false;
 
+    final insideMusicBar = _isDescendantOf(primary, _musicBarFocusNode);
+
     final nodes = _toolbarScopeNode.descendants
         .where((n) => !n.skipTraversal && _isLaidOutFocusNode(n))
-        .map((n) => (
-              node: n,
-              x: (n.context!.findRenderObject()! as RenderBox)
-                  .localToGlobal(Offset.zero)
-                  .dx,
-            ))
+        .where((n) {
+          final isMusicNode = _isDescendantOf(n, _musicBarFocusNode);
+          return insideMusicBar == isMusicNode;
+        })
+        .map((n) {
+          final box = n.context!.findRenderObject() as RenderBox?;
+          final pos = box?.localToGlobal(Offset.zero);
+          return (node: n, x: pos?.dx ?? -1.0);
+        })
+        .where((item) => item.x > 0)
         .toList()
       ..sort((a, b) => a.x.compareTo(b.x));
 
@@ -521,9 +527,19 @@ class _TopToolbarState extends State<TopToolbar> {
                 if (primary != null) {
                   final insideMusicBar = _isDescendantOf(primary, _musicBarFocusNode);
                   if (!insideMusicBar && isMusicActive) {
-                    final target = _firstFocusableDescendant(_musicBarFocusNode);
-                    if (target != null) {
-                      target.requestFocus();
+                    final musicNodes = _musicBarFocusNode.descendants
+                        .where((n) => !n.skipTraversal && _isLaidOutFocusNode(n))
+                        .map((n) {
+                          final box = n.context!.findRenderObject() as RenderBox?;
+                          final pos = box?.localToGlobal(Offset.zero);
+                          return (node: n, x: pos?.dx ?? -1.0);
+                        })
+                        .where((item) => item.x > 0)
+                        .toList()
+                      ..sort((a, b) => a.x.compareTo(b.x));
+
+                    if (musicNodes.isNotEmpty) {
+                      musicNodes.first.node.requestFocus();
                       return KeyEventResult.handled;
                     }
                   }
@@ -542,7 +558,35 @@ class _TopToolbarState extends State<TopToolbar> {
                 _restoreFocusBelowToolbar();
                 return KeyEventResult.handled;
               }
-              if (PlatformDetection.isTV &&
+              if (event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                final primary = FocusManager.instance.primaryFocus;
+                if (primary != null) {
+                  final insideMusicBar = _isDescendantOf(primary, _musicBarFocusNode);
+                  if (insideMusicBar) {
+                    if (_homeFocus.canRequestFocus) {
+                      _homeFocus.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                    FocusNode? targetNode;
+                    for (final n in _toolbarScopeNode.descendants) {
+                      if (!n.skipTraversal && _isLaidOutFocusNode(n) && !_isDescendantOf(n, _musicBarFocusNode)) {
+                        final box = n.context!.findRenderObject() as RenderBox?;
+                        final pos = box?.localToGlobal(Offset.zero);
+                        if (pos != null && pos.dx > 0) {
+                          targetNode = n;
+                          break;
+                        }
+                      }
+                    }
+                    if (targetNode != null) {
+                      targetNode.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                  }
+                }
+              }
+              if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
                   event is KeyDownEvent &&
                   (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
                       event.logicalKey == LogicalKeyboardKey.arrowRight)) {
@@ -667,7 +711,7 @@ class _TopToolbarState extends State<TopToolbar> {
           _restoreFocusBelowToolbar();
           return KeyEventResult.handled;
         }
-        if (PlatformDetection.isTV &&
+        if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
             event.logicalKey == LogicalKeyboardKey.arrowRight) {
           _homeFocus.requestFocus();
           return KeyEventResult.handled;


### PR DESCRIPTION
# Pull Request

## Summary
Adjust top toolbar D-pad navigation during active music playback. Treat the top navbar row and the music buttons row as distinct visual rows, ensuring that horizontal left/right traversal is contained within each row and that vertical up/down presses are required to switch between them.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #606  
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Modified `_moveWithinToolbar()` in `lib/ui/widgets/top_toolbar.dart` to determine whether the current focus is within the music bar.
- Filtered `_toolbarScopeNode.descendants` to restrict horizontal traversal strictly to nodes belonging to the same row (top navbar buttons or music buttons).
- Handled `LogicalKeyboardKey.arrowUp` inside the toolbar's `Focus` widget to move focus from the music bar back up to the top navbar.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Windows and Android TV
- [ ] Not tested (explain why):

### Test Steps
1. Deployed the built APK to Nvidia Shield.
2. Verified that when focused on the top navbar, left/right stays on the navbar and does not leak to the music bar.
3. Verified that pressing down from the navbar goes directly to the first button (skip_previous) in the music bar.
4. Verified that left/right stays on the music buttons (prev, play/pause, next, stop) and does not go to the navbar.
5. Verified that pressing up from the music buttons goes to the home button on the navbar.
6. Verified that pressing down from the music buttons exits the toolbar to the page content below.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
