### PR TITLE
ui - Add back buttons to Person details pages that were missing them

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -310,8 +310,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     final isAlbumOrPlaylist = type == 'MusicAlbum' || type == 'Playlist';
     final showNavigationChrome =
         _viewModel.state == ItemDetailState.ready && !isAlbumOrPlaylist;
+    final showBackButton = type != 'Person';
     Widget body = NavigationLayout(
-      showBackButton: true,
+      showBackButton: showBackButton,
       showNavigationChrome: showNavigationChrome,
       child: _buildBody(context),
     );
@@ -536,7 +537,10 @@ class _DetailContentState extends State<_DetailContent> {
     final favoriteFocusNode =
         widget.initialFocusNode ?? _sectionFocusNodes['detailPersonFavorite'];
     final seerrFocusNode = _sectionFocusNodes['detailPersonSeerrButton'];
-    if (target == favoriteFocusNode || target == seerrFocusNode) {
+    final backFocusNode = _sectionFocusNodes['detailPersonBack'];
+    if (target == favoriteFocusNode ||
+        target == seerrFocusNode ||
+        target == backFocusNode) {
       return true;
     }
     return target.context
@@ -733,7 +737,8 @@ class _DetailContentState extends State<_DetailContent> {
       if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
         _resetSectionHorizontalOffset(sourceFocusNode);
         if (upTarget != null) {
-          if (upTarget == favoriteFocusNode) {
+          if (upTarget == favoriteFocusNode ||
+              upTarget == _sectionFocusNodes['detailPersonBack']) {
             _scrollMainToTop();
           }
           _requestSectionFocus(upTarget);
@@ -2115,6 +2120,7 @@ class _DetailContentState extends State<_DetailContent> {
     final musicVideos = viewModel.filmographyMusicVideos;
     final useSplit = _useDesktopDetailLayout(context);
 
+    final backFocusNode = _sectionFocusNode('detailPersonBack');
     final favoriteFocusNode =
         initialFocusNode ?? _sectionFocusNode('detailPersonFavorite');
     final bioFocusNode = _sectionFocusNode('detailPersonBio');
@@ -2168,7 +2174,7 @@ class _DetailContentState extends State<_DetailContent> {
           upTarget: null,
           onArrowUp: _tryFocusNavbar,
           onArrowDown: () {
-            _requestSectionFocus(favoriteFocusNode);
+            _requestSectionFocus(backFocusNode);
           },
           onArrowLeft: () {
             _tryFocusSidebar();
@@ -2184,15 +2190,16 @@ class _DetailContentState extends State<_DetailContent> {
               : MainAxisAlignment.center,
           children: [
             _DetailActionButton(
-              label: item.isFavorite ? l10n.favorited : l10n.favorite,
-              icon: Icons.favorite,
-              onPressed: viewModel.toggleFavorite,
-              isActive: item.isFavorite,
-              activeColor: const Color(0xFFFF4757),
-              focusNode: favoriteFocusNode,
+              label: l10n.back,
+              icon: Icons.arrow_back,
+              onPressed: () => context.popOrHome(),
+              isActive: false,
+              focusNode: backFocusNode,
               suppressAutoScrollToTop: true,
               onArrowUp: () {
-                if (hasBio && firstFocus.canRequestFocus) {
+                if (hasBio &&
+                    firstFocus.context != null &&
+                    firstFocus.canRequestFocus) {
                   _requestSectionFocus(firstFocus);
                 } else {
                   _tryFocusNavbar();
@@ -2202,6 +2209,41 @@ class _DetailContentState extends State<_DetailContent> {
                 _requestSectionFocus(
                   moviesFocusNode ??
                       seriesFocusNode ??
+                      guestAppearancesFocusNode ??
+                      musicVideosFocusNode ??
+                      seerrAppearancesFocusNode,
+                );
+              },
+              onArrowRight: () {
+                _requestSectionFocus(favoriteFocusNode);
+              },
+              onArrowLeft: () {
+                _tryFocusSidebar();
+              },
+            ),
+            const SizedBox(width: 16),
+            _DetailActionButton(
+              label: item.isFavorite ? l10n.favorited : l10n.favorite,
+              icon: Icons.favorite,
+              onPressed: viewModel.toggleFavorite,
+              isActive: item.isFavorite,
+              activeColor: const Color(0xFFFF4757),
+              focusNode: favoriteFocusNode,
+              suppressAutoScrollToTop: true,
+              onArrowUp: () {
+                if (hasBio &&
+                    firstFocus.context != null &&
+                    firstFocus.canRequestFocus) {
+                  _requestSectionFocus(firstFocus);
+                } else {
+                  _tryFocusNavbar();
+                }
+              },
+              onArrowDown: () {
+                _requestSectionFocus(
+                  moviesFocusNode ??
+                      seriesFocusNode ??
+                      guestAppearancesFocusNode ??
                       musicVideosFocusNode ??
                       seerrAppearancesFocusNode,
                 );
@@ -2212,7 +2254,7 @@ class _DetailContentState extends State<_DetailContent> {
                     }
                   : () {},
               onArrowLeft: () {
-                _tryFocusSidebar();
+                _requestSectionFocus(backFocusNode);
               },
             ),
             if (hasSeerrButton) ...[
@@ -2227,7 +2269,9 @@ class _DetailContentState extends State<_DetailContent> {
                 focusNode: seerrFocusNode,
                 suppressAutoScrollToTop: true,
                 onArrowUp: () {
-                  if (hasBio && firstFocus.canRequestFocus) {
+                  if (hasBio &&
+                      firstFocus.context != null &&
+                      firstFocus.canRequestFocus) {
                     _requestSectionFocus(firstFocus);
                   } else {
                     _tryFocusNavbar();
@@ -2237,6 +2281,7 @@ class _DetailContentState extends State<_DetailContent> {
                   _requestSectionFocus(
                     moviesFocusNode ??
                         seriesFocusNode ??
+                        guestAppearancesFocusNode ??
                         musicVideosFocusNode ??
                         seerrAppearancesFocusNode,
                   );

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -310,9 +310,8 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     final isAlbumOrPlaylist = type == 'MusicAlbum' || type == 'Playlist';
     final showNavigationChrome =
         _viewModel.state == ItemDetailState.ready && !isAlbumOrPlaylist;
-    final showBackButton = type != 'Person';
     Widget body = NavigationLayout(
-      showBackButton: showBackButton,
+      showBackButton: true,
       showNavigationChrome: showNavigationChrome,
       child: _buildBody(context),
     );
@@ -537,10 +536,7 @@ class _DetailContentState extends State<_DetailContent> {
     final favoriteFocusNode =
         widget.initialFocusNode ?? _sectionFocusNodes['detailPersonFavorite'];
     final seerrFocusNode = _sectionFocusNodes['detailPersonSeerrButton'];
-    final backFocusNode = _sectionFocusNodes['detailPersonBack'];
-    if (target == favoriteFocusNode ||
-        target == seerrFocusNode ||
-        target == backFocusNode) {
+    if (target == favoriteFocusNode || target == seerrFocusNode) {
       return true;
     }
     return target.context
@@ -737,8 +733,7 @@ class _DetailContentState extends State<_DetailContent> {
       if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
         _resetSectionHorizontalOffset(sourceFocusNode);
         if (upTarget != null) {
-          if (upTarget == favoriteFocusNode ||
-              upTarget == _sectionFocusNodes['detailPersonBack']) {
+          if (upTarget == favoriteFocusNode) {
             _scrollMainToTop();
           }
           _requestSectionFocus(upTarget);
@@ -2120,7 +2115,6 @@ class _DetailContentState extends State<_DetailContent> {
     final musicVideos = viewModel.filmographyMusicVideos;
     final useSplit = _useDesktopDetailLayout(context);
 
-    final backFocusNode = _sectionFocusNode('detailPersonBack');
     final favoriteFocusNode =
         initialFocusNode ?? _sectionFocusNode('detailPersonFavorite');
     final bioFocusNode = _sectionFocusNode('detailPersonBio');
@@ -2174,7 +2168,7 @@ class _DetailContentState extends State<_DetailContent> {
           upTarget: null,
           onArrowUp: _tryFocusNavbar,
           onArrowDown: () {
-            _requestSectionFocus(backFocusNode);
+            _requestSectionFocus(favoriteFocusNode);
           },
           onArrowLeft: () {
             _tryFocusSidebar();
@@ -2190,39 +2184,6 @@ class _DetailContentState extends State<_DetailContent> {
               : MainAxisAlignment.center,
           children: [
             _DetailActionButton(
-              label: l10n.back,
-              icon: Icons.arrow_back,
-              onPressed: () => context.popOrHome(),
-              isActive: false,
-              focusNode: backFocusNode,
-              suppressAutoScrollToTop: true,
-              onArrowUp: () {
-                if (hasBio &&
-                    firstFocus.context != null &&
-                    firstFocus.canRequestFocus) {
-                  _requestSectionFocus(firstFocus);
-                } else {
-                  _tryFocusNavbar();
-                }
-              },
-              onArrowDown: () {
-                _requestSectionFocus(
-                  moviesFocusNode ??
-                      seriesFocusNode ??
-                      guestAppearancesFocusNode ??
-                      musicVideosFocusNode ??
-                      seerrAppearancesFocusNode,
-                );
-              },
-              onArrowRight: () {
-                _requestSectionFocus(favoriteFocusNode);
-              },
-              onArrowLeft: () {
-                _tryFocusSidebar();
-              },
-            ),
-            const SizedBox(width: 16),
-            _DetailActionButton(
               label: item.isFavorite ? l10n.favorited : l10n.favorite,
               icon: Icons.favorite,
               onPressed: viewModel.toggleFavorite,
@@ -2231,9 +2192,7 @@ class _DetailContentState extends State<_DetailContent> {
               focusNode: favoriteFocusNode,
               suppressAutoScrollToTop: true,
               onArrowUp: () {
-                if (hasBio &&
-                    firstFocus.context != null &&
-                    firstFocus.canRequestFocus) {
+                if (hasBio && firstFocus.canRequestFocus) {
                   _requestSectionFocus(firstFocus);
                 } else {
                   _tryFocusNavbar();
@@ -2243,7 +2202,6 @@ class _DetailContentState extends State<_DetailContent> {
                 _requestSectionFocus(
                   moviesFocusNode ??
                       seriesFocusNode ??
-                      guestAppearancesFocusNode ??
                       musicVideosFocusNode ??
                       seerrAppearancesFocusNode,
                 );
@@ -2254,7 +2212,7 @@ class _DetailContentState extends State<_DetailContent> {
                     }
                   : () {},
               onArrowLeft: () {
-                _requestSectionFocus(backFocusNode);
+                _tryFocusSidebar();
               },
             ),
             if (hasSeerrButton) ...[
@@ -2269,9 +2227,7 @@ class _DetailContentState extends State<_DetailContent> {
                 focusNode: seerrFocusNode,
                 suppressAutoScrollToTop: true,
                 onArrowUp: () {
-                  if (hasBio &&
-                      firstFocus.context != null &&
-                      firstFocus.canRequestFocus) {
+                  if (hasBio && firstFocus.canRequestFocus) {
                     _requestSectionFocus(firstFocus);
                   } else {
                     _tryFocusNavbar();
@@ -2281,7 +2237,6 @@ class _DetailContentState extends State<_DetailContent> {
                   _requestSectionFocus(
                     moviesFocusNode ??
                         seriesFocusNode ??
-                        guestAppearancesFocusNode ??
                         musicVideosFocusNode ??
                         seerrAppearancesFocusNode,
                   );

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import '../../preference/preference_constants.dart';
 import '../../preference/user_preferences.dart';
 import '../../util/platform_detection.dart';
+import '../../util/overlay_color_palette.dart';
 import 'download_progress_bar.dart';
 import 'left_sidebar.dart';
 import 'mobile_bottom_nav_bar.dart';
@@ -154,12 +155,24 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
       skipTraversal: true,
       child: widget.child,
     );
-    return Column(
+    return Stack(
       children: [
-        Expanded(child: content),
-        const DownloadProgressBar(),
-        const BottomMusicBar(),
-        MobileBottomNavBar(activeRoute: widget.activeRoute),
+        Column(
+          children: [
+            Expanded(child: content),
+            const DownloadProgressBar(),
+            const BottomMusicBar(),
+            MobileBottomNavBar(activeRoute: widget.activeRoute),
+          ],
+        ),
+        if (widget.showBackButton)
+          Positioned(
+            top: 16,
+            left: 16,
+            child: SafeArea(
+              child: _buildFloatingBackButton(),
+            ),
+          ),
       ],
     );
   }
@@ -262,6 +275,12 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
                   bottom: 0,
                   child: sidebar,
                 ),
+                if (widget.showBackButton && !PlatformDetection.isTV)
+                  Positioned(
+                    top: 16,
+                    left: 88,
+                    child: _buildFloatingBackButton(),
+                  ),
               ],
             ),
           ),
@@ -284,6 +303,44 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
         ),
         const DownloadProgressBar(),
       ],
+    );
+  }
+
+  Widget _buildFloatingBackButton() {
+    final overlayColor = OverlayColorPalette.resolveColor(
+      _prefs.get(UserPreferences.navbarColor),
+    );
+    final opacity = _prefs.get(UserPreferences.navbarOpacity) / 100.0;
+    final backgroundColor = ThemeRegistry.active.transparentNavbarSurface
+        ? Colors.transparent
+        : overlayColor.withValues(alpha: opacity);
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => context.popOrHome(),
+        child: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.25),
+                blurRadius: 4,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: const Icon(
+            Icons.arrow_back,
+            size: 20,
+            color: Colors.white,
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
# Pull Request

## Summary
Add an inline Back button to the actions row on the Person details page (Media Info page) to allow sidebar navigation users to return to the previous page. Remove the duplicate back arrow from the top toolbar for these pages (from top bar users).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added a `_DetailActionButton` for Back navigation next to the `Favorite` button on Person details screens.
- Disabled `showBackButton` on the top navbar `NavigationLayout` specifically for `Person` pages.
- Wired up D-pad navigation targets for biography, back button, favorite button, and guest appearances.
- Checked biography focus attachment (`firstFocus.context != null`) in onArrowUp handlers to dynamically fallback to navbar/sidebar focus when biography is not focusable.
- Added `backFocusNode` to scroll-to-top vertical handler and `_shouldSkipSectionEnsureVisible` exclusions.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a media detail screen (e.g. Movie or Series details).
2. Click on a Director/Writer/Person link (e.g., Anthony Byrne or Cillian Murphy) to navigate to the Person details subpage.
3. Verify that the inline "Back" button is visible to the left of the "Favorite" button.
4. Verify that the top toolbar back button (the little arrow next to the avatar in the upper-left corner) is hidden.
5. Use D-pad navigation to verify the traversal behavior:
   - Press Down from the biography (or top navbar/sidebar if no biography is present/focusable) and verify focus lands on the "Back" button.
   - Press Right/Left to move between "Back", "Favorite", and "Seerr".
   - Press Down from the actions row and verify focus enters the first available filmography section below (including "Guest Appearances" if it is the only row present).
   - Press Up from the actions row and verify focus successfully returns to the top navbar/sidebar (bypassing the biography if it is too short to be focusable/expandable).
6. Select the "Back" button and verify it returns you to the previous media details screen.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

BEFORE
<img width="400" alt="2026-06-21_22-36-15_moonfin" src="https://github.com/user-attachments/assets/5751d7f4-84c4-4600-9a5c-dd89deaddb78" />
<img width="400" alt="2026-06-21_22-36-32_moonfin" src="https://github.com/user-attachments/assets/bd974bdc-95f2-49f3-961f-37aab0633f06" />

AFTER
<img width="400" alt="Shield_Screenshot_2026-06-21_23-15-29" src="https://github.com/user-attachments/assets/e21403ac-ae6a-478b-9388-714c0f8f1139" />
<img width="400" alt="Shield_Screenshot_2026-06-21_23-18-30" src="https://github.com/user-attachments/assets/653947a0-607f-4127-9469-e0606ad20bde" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
