### PR TITLE
feature: Fixing Android OS Now Playing Integrations

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'package:playback_core/playback_core.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:window_manager/window_manager.dart';
 
+import 'data/models/aggregated_item.dart';
 import 'data/services/app_update_service.dart';
 import 'data/services/cast/cast_service.dart';
 import 'data/services/download_service.dart';
@@ -566,6 +567,26 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
         state == AppLifecycleState.hidden ||
         state == AppLifecycleState.detached;
     if (!isBackground) return;
+
+    if (GetIt.instance.isRegistered<PlaybackManager>()) {
+      final manager = GetIt.instance<PlaybackManager>();
+      final item = manager.queueService.currentItem;
+      bool isAudio = false;
+      if (item is AggregatedItem) {
+        isAudio = item.isAudioLike;
+      } else if (item is String) {
+        try {
+          final meta = manager.currentOfflineMetadata;
+          if (meta != null) {
+            final type = meta['Type']?.toString();
+            final mediaType = meta['MediaType']?.toString();
+            isAudio = type == 'Audio' || type == 'AudioBook' || mediaType == 'Audio';
+          }
+        } catch (_) {}
+      }
+      if (isAudio) return;
+    }
+
     if (!GetIt.instance.isRegistered<PlaybackArbiter>()) return;
     final arbiter = GetIt.instance<PlaybackArbiter>();
     if (arbiter.pipActive) return;

--- a/lib/playback/audio_handler.dart
+++ b/lib/playback/audio_handler.dart
@@ -141,10 +141,36 @@ class MoonfinAudioHandler extends BaseAudioHandler
       }
     } catch (_) {}
 
+    final String? artistName;
+    if (item.type == 'Episode') {
+      artistName = (item.seriesName != null && item.seriesName!.isNotEmpty)
+          ? item.seriesName
+          : 'TV Show';
+    } else if (item.type == 'Movie') {
+      final directors = item.people
+          .where((p) => p['Type'] == 'Director')
+          .map((p) => p['Name'] as String?)
+          .whereType<String>()
+          .toList();
+      if (directors.isNotEmpty) {
+        artistName = directors.join(', ');
+      } else {
+        final studios = item.studios
+            .map((s) => s['Name'] as String?)
+            .whereType<String>()
+            .toList();
+        artistName = studios.isNotEmpty ? studios.first : 'Movie';
+      }
+    } else {
+      artistName = item.artists.isNotEmpty
+          ? item.artists.join(', ')
+          : item.albumArtist;
+    }
+
     return MediaItem(
       id: item.id,
       title: item.name,
-      artist: item.artists.isNotEmpty ? item.artists.join(', ') : item.albumArtist,
+      artist: artistName,
       album: item.album,
       duration: item.runtime,
       artUri: artUri != null ? Uri.parse(artUri) : null,

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -973,7 +973,9 @@ class Media3VideoView(
                 }
                 it.addListener(listener)
                 it.addAnalyticsListener(analyticsListener)
-                Media3SessionController.attachPlayer(context, it)
+                if (currentMediaType != "audio") {
+                    Media3SessionController.attachPlayer(context, it)
+                }
             }
     }
 


### PR DESCRIPTION
# Pull Request

## Summary
This PR addresses notification metadata mapping on Android Mobile and background audio integration on Android TV. Specifically, it customizes notification subtitle rows to prevent showing literal "null"/"NULL" strings by using series names for episodes and directors/studios for movies. On Android TV, it enables audio playback to continue in the background and resolves a dual media session bug that caused duplicate Now Playing cards on the Android TV homescreen.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #273 
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `_mediaItemFor` in `lib/playback/audio_handler.dart` to determine the notification subtitle (`artist` metadata) dynamically:
  - TV Episodes display the Show Name (`seriesName`), falling back to `"TV Show"`.
  - Movies display the Director's name (falling back to Studio name, and finally to `"Movie"`).
- Modified `_maybePausePlaybackForBackground` in `lib/app.dart` to early-return for audio-like media items on Android TV, preventing background audio from pausing/exiting.
- Modified `createPlayer()` in native `Media3VideoView.kt` to conditionally attach the `MediaSession` only if the playing media type is not `"audio"`. This avoids publishing a duplicate media session to the Android system during audio playback.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Built and tested on Windows Desktop and Android TV (Shield)
- [ ] Not tested (explain why):

### Test Steps
1. Play a TV Episode or Movie on Android Mobile; check the media notification to verify the subtitle row displays the correct Show Name / Director Name without showing "null" or "NULL".
2. Play an audio file on Nvidia Shield; go to the homescreen to verify that audio continues to play in the background.
3. Verify that only a single Now Playing/album art card is visible on the Nvidia Shield homescreen during background audio playback.
4. Play a video file on Nvidia Shield; go to the homescreen to verify that playback pauses/exits as before.

## Screenshots (if applicable)

### ANDROID TV (note my default launcher, Projectivy, does not give media controls directly on the homescreen. Vanilla Android should show them)
<img width="500" alt="Shield_Screenshot_2026-06-22_09-52-56" src="https://github.com/user-attachments/assets/c04cc1b2-c5ee-492b-8623-0ae64e0e2861" />
<img width="500" alt="Shield_Screenshot_2026-06-22_09-53-17" src="https://github.com/user-attachments/assets/4c77fba1-5088-4e5f-9b6f-abf9999e98d0" />
<img width="500" alt="Shield_Screenshot_2026-06-22_09-53-27" src="https://github.com/user-attachments/assets/3564be9a-95a0-4c3a-88ef-9d14e228087e" />

### ANDROID MOBILE

* MUSIC
<img width="250" alt="Screenshot_20260622-070737" src="https://github.com/user-attachments/assets/bbec14e6-2620-408c-a0af-6009d2941207" />

* TV SHOW
<img width="250" alt="Screenshot_20260622-101910" src="https://github.com/user-attachments/assets/93de2746-1d54-49da-9da2-fe5e63646bbe" />

* MOVIE
<img width="250" alt="Screenshot_20260622-105559" src="https://github.com/user-attachments/assets/9bf48697-6d8b-4e61-8e2c-a5faf57419d2" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
