### PR TITLE
playback: fix Next Up display settings

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3378,7 +3378,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     if (_showNextUp && _nextUpItem != null)
                       NextUpOverlay(
                         nextItem: _nextUpItem!,
-                        imageUrl: _nextUpItem!.primaryImageTag != null
+                        isMinimal: _prefs.get(UserPreferences.nextUpBehavior) == NextUpBehavior.minimal,
+                        imageUrl: _nextUpItem!.primaryImageTag != null &&
+                                _prefs.get(UserPreferences.nextUpBehavior) != NextUpBehavior.minimal
                             ? _clientForItem(
                                 _nextUpItem!,
                               ).imageApi.getPrimaryImageUrl(

--- a/lib/ui/widgets/playback/next_up_overlay.dart
+++ b/lib/ui/widgets/playback/next_up_overlay.dart
@@ -20,6 +20,7 @@ class NextUpOverlay extends StatefulWidget {
   final VoidCallback? onTimeout;
   final FocusNode? focusNode;
   final FocusNode? dismissFocusNode;
+  final bool isMinimal;
 
   const NextUpOverlay({
     super.key,
@@ -31,6 +32,7 @@ class NextUpOverlay extends StatefulWidget {
     this.onTimeout,
     this.focusNode,
     this.dismissFocusNode,
+    this.isMinimal = false,
   });
 
   @override
@@ -87,7 +89,7 @@ class _NextUpOverlayState extends State<NextUpOverlay>
       right: 24,
       bottom: 120,
       child: Container(
-        width: 340,
+        width: widget.isMinimal ? 300 : 340,
         decoration: BoxDecoration(
           color: AppColorScheme.surface.withValues(alpha: 0.95),
           borderRadius: BorderRadius.circular(12),
@@ -104,18 +106,27 @@ class _NextUpOverlayState extends State<NextUpOverlay>
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (widget.imageUrl != null)
-              SizedBox(
-                height: 120,
-                child: CachedNetworkImage(
-                  imageUrl: widget.imageUrl!,
-                  fit: BoxFit.cover,
-                  errorWidget: (_, _, _) =>
-                      Container(color: AppColorScheme.surfaceVariant),
+            if (widget.imageUrl != null && !widget.isMinimal)
+              CachedNetworkImage(
+                imageUrl: widget.imageUrl!,
+                fit: BoxFit.fitWidth,
+                placeholder: (context, url) => const AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: Center(
+                    child: SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                ),
+                errorWidget: (_, _, _) => AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: Container(color: AppColorScheme.surfaceVariant),
                 ),
               ),
             Padding(
-              padding: const EdgeInsets.all(12),
+              padding: EdgeInsets.all(widget.isMinimal ? 8 : 12),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
@@ -125,9 +136,9 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                     children: [
                       Text(
                         l10n.upNext,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: Colors.white54,
-                          fontSize: 12,
+                          fontSize: widget.isMinimal ? 11 : 12,
                           fontWeight: FontWeight.w600,
                         ),
                       ),
@@ -144,9 +155,9 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                                 : ':${secs.toString().padLeft(2, '0')}';
                             return Text(
                               l10n.endsIn(timerText),
-                              style: const TextStyle(
+                              style: TextStyle(
                                 color: Colors.white54,
-                                fontSize: 12,
+                                fontSize: widget.isMinimal ? 11 : 12,
                                 fontWeight: FontWeight.w600,
                               ),
                             );
@@ -154,20 +165,20 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                         ),
                     ],
                   ),
-                  const SizedBox(height: 4),
+                  SizedBox(height: widget.isMinimal ? 2 : 4),
                   Text(
                     [epInfo, item.name]
                         .where((s) => s != null && s.isNotEmpty)
                         .join(' — '),
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: Colors.white,
-                      fontSize: 15,
+                      fontSize: widget.isMinimal ? 13 : 15,
                       fontWeight: FontWeight.w600,
                     ),
-                    maxLines: 2,
+                    maxLines: widget.isMinimal ? 1 : 2,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(height: 12),
+                  SizedBox(height: widget.isMinimal ? 8 : 12),
                   Row(
                     children: [
                       Expanded(
@@ -197,7 +208,10 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                                       : AppColorScheme.surfaceVariant.withValues(alpha: 0.9))
                                   : AppColorScheme.accent,
                               foregroundColor: Colors.white,
-                              padding: const EdgeInsets.symmetric(vertical: 10),
+                              padding: EdgeInsets.symmetric(
+                                vertical: widget.isMinimal ? 6 : 10,
+                                horizontal: widget.isMinimal ? 8 : 16,
+                              ),
                             ),
                             child: Text(l10n.playNext),
                           ),
@@ -230,7 +244,10 @@ class _NextUpOverlayState extends State<NextUpOverlay>
                             side: _dismissFocused
                                 ? ThemeRegistry.active.borders.focusBorder
                                 : ThemeRegistry.active.borders.chipBorder,
-                            padding: const EdgeInsets.symmetric(vertical: 10),
+                            padding: EdgeInsets.symmetric(
+                              vertical: widget.isMinimal ? 6 : 10,
+                              horizontal: widget.isMinimal ? 8 : 16,
+                            ),
                           ),
                           child: Text(l10n.close),
                         ),


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the behavior of the Minimal Next Up display overlay and improves the Extended popup image crop.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #616  
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Introduced the `isMinimal` property to `NextUpOverlay` to render a tighter, compact overlay when the Next Up Display setting is set to Minimal.
- Hid the preview image, reduced text/button sizes, and tightened margins when minimal mode is active.
- Avoided generating or fetching the image URL when minimal mode is active to save resources.
- Removed the fixed 120px height constraint on the preview image in Extended mode to scale the image dynamically using `BoxFit.fitWidth` and its native aspect ratio.
- Configured error/placeholder widgets in `NextUpOverlay` to fall back to a 16:9 aspect ratio to maintain layout stability during network latency or failures.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV (Shield)
- [ ] Not tested (explain why):

### Test Steps
1. Set Next Up display to Expanded, check end of episode
2. Set Next Up display to Minimal, check end of episode

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

* EXPANDED
<img width="500" alt="Shield_Screenshot_2026-06-22_11-26-10" src="https://github.com/user-attachments/assets/0fc8e789-005b-4846-b224-a2cdeed2c33d" />

* MINIMAL
<img width="500" alt="Shield_Screenshot_2026-06-22_11-26-54" src="https://github.com/user-attachments/assets/77f5ddc2-12af-47a6-9cdf-2df0143df61c" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
