### PR TITLE
fix(playback): persist offline playback position across sessions

### DIFF
--- a/lib/data/services/connectivity_service.dart
+++ b/lib/data/services/connectivity_service.dart
@@ -49,6 +49,9 @@ class ConnectivityService extends ChangeNotifier {
     if (PlatformDetection.isAppleTV) {
       _isOnline = true;
       await _checkServerReachability();
+      if (_serverReachable) {
+        _triggerSync();
+      }
       _initialCheckDone = true;
       notifyListeners();
       return;
@@ -57,6 +60,9 @@ class ConnectivityService extends ChangeNotifier {
     _isOnline = results.any((r) => r != ConnectivityResult.none);
     if (_isOnline) {
       await _checkServerReachability();
+      if (_serverReachable) {
+        _triggerSync();
+      }
     } else {
       _serverReachable = false;
     }

--- a/lib/data/services/offline_playback_tracker.dart
+++ b/lib/data/services/offline_playback_tracker.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
 
+import 'package:get_it/get_it.dart';
+import 'package:playback_core/playback_core.dart';
+
 import '../repositories/offline_repository.dart';
 
 class OfflinePlaybackTracker {
@@ -13,12 +16,18 @@ class OfflinePlaybackTracker {
 
   OfflinePlaybackTracker(this._repo);
 
-  void startTracking({
+  Future<void> startTracking({
     required String itemId,
     required Duration duration,
     required Stream<Duration> positionStream,
-  }) {
-    stopTracking();
+  }) async {
+    // Await the previous session's cleanup (including its final DB write)
+    // before setting up the new session.  Without this await, the old
+    // stopTracking() would asynchronously null-out _activeItemId AFTER
+    // we've already assigned the new one, causing every subsequent save
+    // to silently no-op.
+    await stopTracking();
+
     _activeItemId = itemId;
     _itemDuration = duration;
     _markedComplete = false;
@@ -32,18 +41,24 @@ class OfflinePlaybackTracker {
 
   Future<void> _saveProgress() async {
     if (_activeItemId == null) return;
-    if (_lastPosition <= Duration.zero) return;
+
+    final manager = GetIt.instance<PlaybackManager>();
+    final managerPos = manager.currentPlaybackPosition;
+    final bestPosition =
+        managerPos > _lastPosition ? managerPos : _lastPosition;
+
+    if (bestPosition <= Duration.zero) return;
 
     if (!_markedComplete &&
         _itemDuration > Duration.zero &&
-        _lastPosition.inMilliseconds / _itemDuration.inMilliseconds > 0.9) {
+        bestPosition.inMilliseconds / _itemDuration.inMilliseconds > 0.9) {
       _markedComplete = true;
       await _repo.updatePlaybackPosition(_activeItemId!, 0);
       return;
     }
 
     if (!_markedComplete) {
-      final ticks = _lastPosition.inMicroseconds * 10;
+      final ticks = bestPosition.inMicroseconds * 10;
       await _repo.updatePlaybackPosition(_activeItemId!, ticks);
     }
   }
@@ -51,8 +66,24 @@ class OfflinePlaybackTracker {
   Future<void> stopTracking() async {
     _progressTimer?.cancel();
     _progressTimer = null;
+
+    // Snapshot the best position BEFORE cancelling the stream subscription,
+    // so _lastPosition is as fresh as possible for the final save.
+    if (_activeItemId != null) {
+      try {
+        final manager = GetIt.instance<PlaybackManager>();
+        final pos = manager.currentPlaybackPosition;
+        if (pos > _lastPosition) {
+          _lastPosition = pos;
+        }
+      } catch (_) {
+        // GetIt may not have the manager registered yet during init.
+      }
+    }
+
     _positionSub?.cancel();
     _positionSub = null;
+
     await _saveProgress();
     _activeItemId = null;
     _lastPosition = Duration.zero;

--- a/lib/playback/offline_playback_launcher.dart
+++ b/lib/playback/offline_playback_launcher.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:playback_core/playback_core.dart';
 
 import '../data/database/offline_database.dart';
+import '../data/repositories/offline_repository.dart';
 import '../data/services/offline_playback_tracker.dart';
 import '../data/services/storage_path_service.dart';
 import '../l10n/app_localizations.dart';
@@ -35,10 +36,20 @@ Future<void> launchOfflinePlayback(
   final backend = manager.backend;
   if (backend == null) return;
 
-  final startTicks = item.playbackPositionTicks;
+  // The exit flow fires stop with unawaited, so the tracker's DB write may
+  // still be in flight.  Wait for it before reading the saved position.
+  await manager.pendingStop;
+
+  // Always read the latest position from the DB, not from the (potentially
+  // stale) UI item.  The stop callback writes the position asynchronously,
+  // so the DownloadedItem passed from the grid may not reflect it yet.
+  final repo = GetIt.instance<OfflineRepository>();
+  final freshItem = await repo.getItem(item.itemId);
+  final startTicks = freshItem?.playbackPositionTicks ?? item.playbackPositionTicks;
   final startPos = startTicks > 0
       ? Duration(microseconds: startTicks ~/ 10)
       : Duration.zero;
+
   final metadata = jsonDecode(item.metadataJson) as Map<String, dynamic>;
   final mediaType = metadata['MediaType'] as String?;
   final type = metadata['Type'] as String?;
@@ -110,7 +121,7 @@ Future<void> launchOfflinePlayback(
             codec: sub.codec,
           );
         }
-        tracker.startTracking(
+        await tracker.startTracking(
           itemId: nextResult.itemId,
           duration: nextResult.duration,
           positionStream: backend.positionStream,
@@ -127,7 +138,7 @@ Future<void> launchOfflinePlayback(
       codec: sub.codec,
     );
   }
-  tracker.startTracking(
+  await tracker.startTracking(
     itemId: result.itemId,
     duration: result.duration,
     positionStream: backend.positionStream,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2428,7 +2428,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       });
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          Navigator.of(context).pop();
+          if (context.canPop()) {
+            context.pop();
+          } else {
+            Navigator.of(context).pop();
+          }
         }
       });
     }

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -95,6 +95,16 @@ class PlaybackManager implements AudioOwnable {
   PlaybackBringupState _bringupState = const PlaybackBringupState.idle();
 
   PlayerBackend? get backend => _backend;
+  Duration get currentPlaybackPosition {
+    final backendPos = _backend?.position ?? Duration.zero;
+    return Duration(
+      microseconds: [
+        backendPos.inMicroseconds,
+        state.position.inMicroseconds,
+        _lastKnownPosition.inMicroseconds,
+      ].reduce((a, b) => a > b ? a : b),
+    );
+  }
   Stream<PlayerBackend> get backendChangedStream =>
       _backendChangedController.stream;
   PlaybackBringupState get bringupState => _bringupState;
@@ -165,6 +175,10 @@ class PlaybackManager implements AudioOwnable {
 
   int? get maxBitrateOverrideMbps => _maxBitrateOverrideMbps;
   bool get isOfflinePlayback => _isOfflinePlayback;
+
+  /// Completes when any in-flight stop operation (including the offline
+  /// tracker's DB write) finishes.  Returns `null` when no stop is pending.
+  Future<void>? get pendingStop => _stopInFlight;
   Duration consumeDeferredStartPosition() {
     final value = _deferredStartPosition;
     _deferredStartPosition = Duration.zero;
@@ -2124,6 +2138,7 @@ class PlaybackManager implements AudioOwnable {
     _onOfflineAutoNext = onAutoNext;
     _itemKnownDuration = itemDuration;
     _currentResolution = null;
+    _lastKnownPosition = startPosition;
 
     if (queueUrls.isNotEmpty) {
       queueService.setQueue(queueUrls, startIndex: startIndex);
@@ -2182,16 +2197,18 @@ class PlaybackManager implements AudioOwnable {
         return;
       }
       if (_isOfflinePlayback) {
+        if (!skipQueueChange) {
+          await _onOfflineStop?.call();
+          _onOfflineStop = null;
+          _onOfflineAutoNext = null;
+        }
         await _backend?.stop();
         _playbackStartTime = null;
         _waitingForMedia = false;
         if (!skipQueueChange) {
-          await _onOfflineStop?.call();
           _isOfflinePlayback = false;
           _forceTranscodeForQueue = false;
           _resetBackendSelectionLock();
-          _onOfflineStop = null;
-          _onOfflineAutoNext = null;
           queueService.clear();
           state.reset();
           _setBringupState(const PlaybackBringupState.idle());


### PR DESCRIPTION
# Pull Request

## Summary
Fix offline playback progress not being persisted across sessions. After seeking to a position and exiting playback, re-entering the same item would always restart from 0:00 instead of resuming from the saved position.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #376 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

OfflinePlaybackTracker.startTracking() called the async stopTracking() without await. The deferred cleanup set _activeItemId = null after the new session had already assigned its item ID, causing every subsequent periodic save and the final exit save to silently return (because _activeItemId was null). Fixes applied across 5 files:

* offline_playback_tracker.dart - Made startTracking() async and await stopTracking() to prevent the race condition. Also snapshots the manager position before cancelling the stream subscription in stopTracking(), and uses max(managerPos, streamPos) as the best position for saves.
* offline_playback_launcher.dart - Reads the start position fresh from the DB via OfflineRepository.getItem() instead of from the potentially stale DownloadedItem passed by the UI. Awaits PlaybackManager.pendingStop first so any in-flight DB write from the previous exit has committed.
* playback_manager.dart - Exposed pendingStop getter for the in-flight stop future. Added currentPlaybackPosition getter that returns the max of backend position, state position, and last known position. Moved _onOfflineStop callback to fire before backend.stop() so the tracker reads a live position. Set _lastKnownPosition in playOffline() for accurate resume.
* video_player_screen.dart - Used context.canPop() with fallback to Navigator.of(context).pop() in _exitPlayback to handle both GoRouter and Navigator contexts.
* connectivity_service.dart - Trigger offline-to-server progress sync when connectivity is restored and the server is reachable.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Built on Android Mobile and tested against Windows Desktop
- [ ] Not tested (explain why):

### Test Steps
1. Download a show/movie for offline viewing
2. Exit the app and enable airplane mode
3. Reopen the app and start offline playback
4. Seek to ~15 minutes and press back to exit playback
5. Re-enter the same item - it should resume from ~15 minutes
6. Exit the app completely, reopen, verify the position is still saved
7. Disable airplane mode - verify the progress syncs to the server

## Screenshots (if applicable)
A tale in 6 images...

1. partially played episode while online
2. airplane mode on, showing playback status retained
3. offline playback, fast forwarded to ~16 minutes in
4. leaving playback, 16 minute timestamp retrained
5. airplane mode off, 16 minute timestamp SYNCED
6. Windows Desktop showing new timestamp!

<img width="500" alt="Screenshot_20260622-184011" src="https://github.com/user-attachments/assets/a55768f8-941c-42bf-a86c-49b4f7537729" />
<img width="500" alt="Screenshot_20260622-184213" src="https://github.com/user-attachments/assets/334998ef-ddaa-486e-8f19-46df4f16efd1" />
<img width="500" alt="Screenshot_20260622-184230" src="https://github.com/user-attachments/assets/faac4622-1d03-4da8-a8cf-82c6d0848681" />
<img width="500" alt="Screenshot_20260622-184242" src="https://github.com/user-attachments/assets/35085ecf-0bcf-4199-9188-61a24c4c14fc" />
<img width="500" alt="Screenshot_20260622-184322" src="https://github.com/user-attachments/assets/43e5ae90-4683-4a8d-a328-74ee37471dca" />
<img width="500" alt="2026-06-22_18-48-38_moonfin" src="https://github.com/user-attachments/assets/60b0a268-c265-4f8e-87e2-a0e31be5c6eb" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
