### PR TITLE
Fixed pagination of Favorites Horizontal scroll

### DIFF
--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -364,82 +364,94 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
             ),
             contentSpacing: 0,
             showControls: !isMobile && PlatformDetection.useDesktopUi,
-            builder: (context, scrollController) => LockedFocusRow<AggregatedItem>(
-              key: _rowKeys[type],
-              items: items,
-              hubKey: 'favorites_row_${type.name}',
-              controller: scrollController,
-              height: rowHeight,
-              itemExtent: imageH * ar,
-              itemSpacing: 12 * desktopScale,
-              padding: EdgeInsets.fromLTRB(
-                20 * desktopScale,
-                5 * desktopScale,
-                20 * desktopScale,
-                5 * desktopScale,
-              ),
-              onIndexChanged: (index, item) {
-                _onItemFocused(item);
-                if (index >= items.length - 8) {
-                  _vm.loadMoreForType(type);
+            builder: (context, scrollController) => NotificationListener<ScrollNotification>(
+              onNotification: (notification) {
+                // 1. Check if the scroll notification comes from the horizontal row
+                if (notification.metrics.axis == Axis.horizontal) {
+                  final maxScroll = notification.metrics.maxScrollExtent;
+                  final currentScroll = notification.metrics.pixels;
+                  
+                  // 2. Trigger a load when the user scrolls within 500 pixels of the edge
+                  if (maxScroll - currentScroll < 500) {
+                    _vm.loadMoreForType(type);
+                  }
                 }
+                return false; 
               },
-              onVerticalNavigation: (isUp) {
-                return _onRowVerticalNavigation(visibleTypes, type, isUp);
-              },
-              onLongPress: (index, item) => showContextMenu(
-                context,
-                item,
-                onChanged: () => setState(() {}),
-              ),
-              onTap: (index, item) => context.push(
-                Destinations.itemOrPhoto(
-                  item.id,
-                  serverId: item.serverId,
-                  type: item.type,
+              child: LockedFocusRow<AggregatedItem>(
+                key: _rowKeys[type],
+                items: items,
+                hubKey: 'favorites_row_${type.name}',
+                controller: scrollController,
+                height: rowHeight,
+                itemExtent: imageH * ar,
+                itemSpacing: 12 * desktopScale,
+                padding: EdgeInsets.fromLTRB(
+                  20 * desktopScale,
+                  5 * desktopScale,
+                  20 * desktopScale,
+                  5 * desktopScale,
                 ),
-              ),
-              itemBuilder: (context, item, index, isFocused) {
-                final width = imageH * ar;
-                return MediaCard(
-                  title: item.name,
-                  subtitle: _cardSubtitle(item),
-                  imageUrl: _imageUrl(
-                    item,
-                    maxWidth: width.toInt(),
-                    maxHeight: imageH.toInt(),
+                onIndexChanged: (index, item) {
+                  _onItemFocused(item);
+                },
+                onVerticalNavigation: (isUp) {
+                  return _onRowVerticalNavigation(visibleTypes, type, isUp);
+                },
+                onLongPress: (index, item) => showContextMenu(
+                  context,
+                  item,
+                  onChanged: () => setState(() {}),
+                ),
+                onTap: (index, item) => context.push(
+                  Destinations.itemOrPhoto(
+                    item.id,
+                    serverId: item.serverId,
+                    type: item.type,
                   ),
-                  width: width,
-                  aspectRatio: ar,
-                  isFavorite: item.isFavorite,
-                  isPlayed: item.isPlayed,
-                  unplayedCount: item.unplayedItemCount,
-                  playedPercentage: item.playedPercentage,
-                  watchedBehavior: watchedBehavior,
-                  itemType: item.type,
-                  focusColor: focusColor,
-                  cardFocusExpansion: cardFocusExpansion,
-                  suppressFocusGlow: suppressFocusGlow,
-                  externalIsFocused: isFocused,
-                  onFocus: isMobile
-                      ? null
-                      : () {
-                          _onItemFocused(item);
-                          if (isTopRow && PlatformDetection.isTV) {
-                            _snapRowsToTop();
-                          }
-                        },
-                  onHoverStart: isMobile ? null : () => _onItemFocused(item),
-                  onHoverEnd: isMobile ? null : () => _vm.setFocusedItem(null),
-                  onTap: () => context.push(
-                    Destinations.itemOrPhoto(
-                      item.id,
-                      serverId: item.serverId,
-                      type: item.type,
+                ),
+                itemBuilder: (context, item, index, isFocused) {
+                  final width = imageH * ar;
+                  return MediaCard(
+                    title: item.name,
+                    subtitle: _cardSubtitle(item),
+                    imageUrl: _imageUrl(
+                      item,
+                      maxWidth: width.toInt(),
+                      maxHeight: imageH.toInt(),
                     ),
-                  ),
-                );
-              },
+                    width: width,
+                    aspectRatio: ar,
+                    isFavorite: item.isFavorite,
+                    isPlayed: item.isPlayed,
+                    unplayedCount: item.unplayedItemCount,
+                    playedPercentage: item.playedPercentage,
+                    watchedBehavior: watchedBehavior,
+                    itemType: item.type,
+                    focusColor: focusColor,
+                    cardFocusExpansion: cardFocusExpansion,
+                    suppressFocusGlow: suppressFocusGlow,
+                    externalIsFocused: isFocused,
+                    onFocus: isMobile
+                        ? null
+                        : () {
+                            _onItemFocused(item);
+                            if (isTopRow && PlatformDetection.isTV) {
+                              _snapRowsToTop();
+                            }
+                          },
+                    onHoverStart: isMobile ? null : () => _onItemFocused(item),
+                    onHoverEnd: isMobile ? null : () => _vm.setFocusedItem(null),
+                    onTap: () => context.push(
+                      Destinations.itemOrPhoto(
+                        item.id,
+                        serverId: item.serverId,
+                        type: item.type,
+                      ),
+                    ),
+                  );
+                },
+              ), 
             ),
           ),
         ),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -565,6 +565,7 @@ class _ContentRowsState extends State<_ContentRows>
   final Map<int, GlobalKey> _rowKeys = {};
   final Map<int, GlobalKey> _rowContainerKeys = {};
   final Map<int, ScrollController> _rowHorizontalControllers = {};
+  final Set<int> _rowsWithPagingListener = {}; 
   List<HomeRow>? _cachedExtentRows;
   PosterSize? _cachedExtentPosterSize;
   double? _cachedExtentDesktopScale;
@@ -1882,10 +1883,24 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   ScrollController _rowHorizontalController(int rowIndex) {
-    return _rowHorizontalControllers.putIfAbsent(
+    final controller = _rowHorizontalControllers.putIfAbsent(
       rowIndex,
       () => ScrollController(),
     );
+    if (_rowsWithPagingListener.add(rowIndex)) {
+      controller.addListener(() => _onRowScrolled(rowIndex, controller));
+    }
+    return controller;
+  }
+
+  void _onRowScrolled(int rowIndex, ScrollController controller) {
+    if (!controller.hasClients) return;
+    const _loadMoreTriggerDistance = 600.0;
+    final remaining =
+        controller.position.maxScrollExtent - controller.offset;
+    if (remaining <= _loadMoreTriggerDistance) {
+      widget.viewModel.loadMoreForRow(rowIndex);
+    }
   }
 
   void _scrollHomeRowHorizontal(int rowIndex, double delta) {


### PR DESCRIPTION
# Pull Request

## Summary
Implements infinite scrolling pagination for favorites grouped into rows on the Home View. The previous approach relied on index tracking via item focus, which failed to page correctly on D-pad layout environments and constrained desktop/mobile interfaces, causing list rows to arbitrarily cap at the initial 30 items. 

By migrating to a pixel-exact scroll notification tracker, subsequent pages are automatically and reliably fetched from the Emby server as the user pans or navigates toward the end of a row.

## Related Issues
No open issues

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Wrapped `LockedFocusRow` within a `NotificationListener<ScrollNotification>` inside the `_buildRows()` loop[cite: 1].
- Implemented axis metric validation to detect when horizontal scrolling gets within 500 pixels of the current row's right edge.
- Connected the scroll boundary trigger to `FavoritesViewModel.loadMoreForType(type)` to request the next data window asynchronously[cite: 2].
- Removed the old index-based pagination threshold check from the `onIndexChanged` callback to prevent duplicate trigger conflicts[cite: 1].

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the Favorites Screen and ensure the view is configured to **Home View**.
2. Scroll horizontally or use D-pad navigation to move right across a populated row (e.g., Movies or Series).
3. Verify that once you approach the right margin, the UI seamlessly fetches and populates items beyond the initial 30-item constraint without losing focus state.

## Screenshots (if applicable)
*N/A*

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced