### PR TITLE
Beginning of Carplay compatibility

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -28,6 +28,8 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
# Pull Request

## Summary
Exposes the existing ios mobile media player to the carplay service

Todo in later update: expose media libraries (at least music library) to the app so users can select items to play without needing to queue them on the phone

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add carplay to info.plist
- 
- 

## Platform
- [ ] Android
- [X] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): need iphone and app store registration

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
