### PR TITLE
ui/feature: Add Crew Contributions (Seerr) Row and Sorting/Filters to People Pages

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7636,5 +7636,25 @@
   "subtitleRendering": "Subtitle Rendering",
   "@subtitleRendering": {
     "description": "Header for subtitle rendering settings"
+  },
+  "displayOptions": "Display Options",
+  "@displayOptions": {
+    "description": "Title for details display options dialog"
+  },
+  "releaseDateAscending": "Release Date (Ascending)",
+  "@releaseDateAscending": {
+    "description": "Sort option for crew/cast contributions in ascending release date order"
+  },
+  "releaseDateDescending": "Release Date (Descending)",
+  "@releaseDateDescending": {
+    "description": "Sort option for crew/cast contributions in descending release date order"
+  },
+  "groupContributions": "Group Contributions",
+  "@groupContributions": {
+    "description": "Section header for grouping person contributions"
+  },
+  "groupMultipleRoles": "Group multiple roles",
+  "@groupMultipleRoles": {
+    "description": "Option to group multiple roles for a person"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7401,6 +7401,7 @@
   "watchAgain": "Watch Again",
   "guestAppearances": "Guest Appearances",
   "appearancesSeerr": "Appearances (Seerr)",
+  "crewContributionsSeerr": "Crew Contributions (Seerr)",
   "watchWithGroup": "Watch with group",
   "errors": "Errors",
   "warnings": "Warnings",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14182,6 +14182,12 @@ abstract class AppLocalizations {
   /// **'Appearances (Seerr)'**
   String get appearancesSeerr;
 
+  /// No description provided for @crewContributionsSeerr.
+  ///
+  /// In en, this message translates to:
+  /// **'Crew Contributions (Seerr)'**
+  String get crewContributionsSeerr;
+
   /// No description provided for @watchWithGroup.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -7981,6 +7981,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get appearancesSeerr => 'Voorkoms (Siener)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Kyk saam met die groep';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -7929,6 +7929,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get appearancesSeerr => 'المظاهر (العراف)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'شاهد مع المجموعة';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8008,6 +8008,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get appearancesSeerr => 'З\'яўленне (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Глядзіце з групай';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8053,6 +8053,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get appearancesSeerr => 'Изяви (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Гледайте с група';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -7968,6 +7968,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get appearancesSeerr => 'উপস্থিতি (দ্রষ্টা)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'গ্রুপের সাথে দেখুন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8092,6 +8092,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get appearancesSeerr => 'Aparicions (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Veure amb grup';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7987,6 +7987,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get appearancesSeerr => 'Vzhled (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Sledujte se skupinou';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8002,6 +8002,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get appearancesSeerr => 'Ymddangosiadau (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Gwyliwch gyda\'r grŵp';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7971,6 +7971,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get appearancesSeerr => 'Optrædener (seer)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Se med gruppen';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8043,6 +8043,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appearancesSeerr => 'Auftritte (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Mit der Gruppe ansehen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8099,6 +8099,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get appearancesSeerr => 'Εμφανίσεις (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Παρακολουθήστε με ομάδα';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7917,6 +7917,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -7965,6 +7965,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get appearancesSeerr => 'Aperoj (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Rigardu kun grupo';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8055,6 +8055,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appearancesSeerr => 'Apariciones (Vidente)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Ver con grupo';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7988,6 +7988,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get appearancesSeerr => 'Esinemised (nägija)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Vaadake koos rühmaga';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -7936,6 +7936,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get appearancesSeerr => 'ظاهر (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'با گروه تماشا کنید';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8002,6 +8002,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get appearancesSeerr => 'Ulkonäkö (näkijä)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Katso ryhmän kanssa';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8076,6 +8076,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appearancesSeerr => 'Apparitions (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Regarder en groupe';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8072,6 +8072,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -7871,6 +7871,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -7953,6 +7953,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7997,6 +7997,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8040,6 +8040,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -7978,6 +7978,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get appearancesSeerr => 'Penampilan (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Tonton bersama grup';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8016,6 +8016,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7779,6 +7779,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8008,6 +8008,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8024,6 +8024,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -7774,6 +7774,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8007,6 +8007,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get appearancesSeerr => 'Pasirodymai (Serr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Žiūrėkite su grupe';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8017,6 +8017,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get appearancesSeerr => 'Izskati (Serr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Skatieties kopā ar grupu';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8026,6 +8026,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8071,6 +8071,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get appearancesSeerr => 'രൂപഭാവങ്ങൾ (സീർ)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'ഗ്രൂപ്പിനൊപ്പം കാണുക';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8005,6 +8005,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7976,6 +7976,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8007,6 +8007,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -7956,6 +7956,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -8018,6 +8018,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8034,6 +8034,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appearancesSeerr => 'Aparições (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Assista com grupo';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8021,6 +8021,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8027,6 +8027,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -7964,6 +7964,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8008,6 +8008,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8005,6 +8005,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8036,6 +8036,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -8001,6 +8001,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7987,6 +7987,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8028,6 +8028,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8031,6 +8031,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8026,6 +8026,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get appearancesSeerr => 'ప్రదర్శనలు (సీర్)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'సమూహంతో చూడండి';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -7922,6 +7922,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get appearancesSeerr => 'การปรากฏตัว (เซียร์)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'ดูกับกลุ่ม.';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8056,6 +8056,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -7994,6 +7994,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get appearancesSeerr => 'Rol Aldığı Yapımlar (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Grupça İzle';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -7983,6 +7983,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8027,6 +8027,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get appearancesSeerr => 'Поява (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Дивіться з групою';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -7986,6 +7986,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get appearancesSeerr => 'Xuất hiện (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Xem cùng nhóm';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -7731,6 +7731,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get appearancesSeerr => 'Appearances (Seerr)';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => 'Watch with group';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7681,6 +7681,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get appearancesSeerr => '出场作品（Seerr）';
 
   @override
+  String get crewContributionsSeerr => 'Crew Contributions (Seerr)';
+
+  @override
   String get watchWithGroup => '与群组一起观看';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -243,6 +243,8 @@ class UserPreferences extends ChangeNotifier {
     'pref_audio_display_artists',
     'pref_audio_display_albums',
     'pref_audio_sort_option',
+    'pref_person_page_sort_option',
+    'pref_person_page_group_items',
   };
 
   bool _isScopedPreference<T>(Preference<T> pref) {
@@ -1695,6 +1697,16 @@ class UserPreferences extends ChangeNotifier {
   static final audioSortOption = Preference<String>(
     key: 'pref_audio_sort_option',
     defaultValue: 'name',
+  );
+
+  static final personPageSortOption = Preference<String>(
+    key: 'pref_person_page_sort_option',
+    defaultValue: 'alphabetical',
+  );
+
+  static final personPageGroupItems = Preference<bool>(
+    key: 'pref_person_page_group_items',
+    defaultValue: false,
   );
 
   String getSeriesSubtitleLanguage(String seriesId) {

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -2408,7 +2408,7 @@ class _DetailContentState extends State<_DetailContent> {
             ),
             const SizedBox(width: 16),
             _DetailActionButton(
-              label: 'Display',
+              label: l10n.display,
               icon: Icons.tune,
               onPressed: () => _showDisplaySettingsDialog(context),
               isActive: false,
@@ -12495,6 +12495,7 @@ class _PersonDisplaySettingsDialogState
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final onSurface = AppColorScheme.onSurface;
     final accent = AppColorScheme.accent;
     final dividerColor = onSurface.withValues(alpha: 0.12);
@@ -12518,7 +12519,7 @@ class _PersonDisplaySettingsDialogState
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
               child: Text(
-                'Display Options',
+                l10n.displayOptions,
                 style: TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.w600,
@@ -12530,7 +12531,7 @@ class _PersonDisplaySettingsDialogState
             Padding(
               padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
               child: Text(
-                'Sort By',
+                l10n.sortBy,
                 style: TextStyle(
                   fontSize: 13,
                   fontWeight: FontWeight.w500,
@@ -12539,21 +12540,21 @@ class _PersonDisplaySettingsDialogState
               ),
             ),
             _radioTile(
-              label: 'Alphabetical',
+              label: l10n.settingsAlphabetical,
               selected: _sortOption == 'alphabetical',
               onTap: () => _updateSort('alphabetical'),
               accent: accent,
               onSurface: onSurface,
             ),
             _radioTile(
-              label: 'Release Date (Ascending)',
+              label: l10n.releaseDateAscending,
               selected: _sortOption == 'releaseDateAsc',
               onTap: () => _updateSort('releaseDateAsc'),
               accent: accent,
               onSurface: onSurface,
             ),
             _radioTile(
-              label: 'Release Date (Descending)',
+              label: l10n.releaseDateDescending,
               selected: _sortOption == 'releaseDateDesc',
               onTap: () => _updateSort('releaseDateDesc'),
               accent: accent,
@@ -12563,7 +12564,7 @@ class _PersonDisplaySettingsDialogState
             Padding(
               padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
               child: Text(
-                'Group Contributions',
+                l10n.groupContributions,
                 style: TextStyle(
                   fontSize: 13,
                   fontWeight: FontWeight.w500,
@@ -12572,7 +12573,7 @@ class _PersonDisplaySettingsDialogState
               ),
             ),
             _checkboxTile(
-              label: 'Group multiple roles',
+              label: l10n.groupMultipleRoles,
               checked: _groupItems,
               onTap: () => _updateGroup(!_groupItems),
               accent: accent,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -47,6 +47,7 @@ import '../../widgets/track_action_dialog.dart';
 import '../../widgets/track_selector_dialog.dart';
 import '../../widgets/remote_play_to_session_dialog.dart';
 import '../../widgets/fullscreen_backdrop_switcher.dart';
+import '../../widgets/seerr_icons.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/focus/focusable_button.dart';
 import '../../widgets/focus/request_initial_focus.dart';
@@ -2442,7 +2443,7 @@ class _DetailContentState extends State<_DetailContent> {
               const SizedBox(width: 16),
               _DetailActionButton(
                 label: l10n.seerr,
-                icon: Icons.explore_outlined,
+                iconBuilder: (size, color) => SeerrIcon(size: size, color: color),
                 onPressed: () {
                   context.push(Destinations.seerrPerson(item.tmdbId!));
                 },
@@ -8329,7 +8330,8 @@ class _DeleteDownloadButtonState extends State<_DeleteDownloadButton> {
 
 class _DetailActionButton extends StatefulWidget {
   final String label;
-  final IconData icon;
+  final IconData? icon;
+  final Widget Function(double size, Color color)? iconBuilder;
   final VoidCallback onPressed;
   final VoidCallback? onLongPress;
   final VoidCallback? onFocused;
@@ -8346,7 +8348,8 @@ class _DetailActionButton extends StatefulWidget {
 
   const _DetailActionButton({
     required this.label,
-    required this.icon,
+    this.icon,
+    this.iconBuilder,
     required this.onPressed,
     this.onLongPress,
     this.onFocused,
@@ -8592,11 +8595,16 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                       isMobile ? 14 : 15 * desktopScale,
                     ),
                   ),
-                  child: AdaptiveIcon(
-                    widget.icon,
-                    color: iconColor,
-                    size: isMobile ? 22 : 27 * desktopScale,
-                  ),
+                  child: widget.iconBuilder != null
+                      ? widget.iconBuilder!(
+                          isMobile ? 22 : 27 * desktopScale,
+                          iconColor,
+                        )
+                      : AdaptiveIcon(
+                          widget.icon!,
+                          color: iconColor,
+                          size: isMobile ? 22 : 27 * desktopScale,
+                        ),
                 ),
                 SizedBox(height: isMobile ? 6 : 8 * desktopScale),
                 Text(
@@ -12476,22 +12484,17 @@ class _PersonDisplaySettingsDialogState
     super.initState();
     _sortOption = widget.prefs.get(UserPreferences.personPageSortOption);
     _groupItems = widget.prefs.get(UserPreferences.personPageGroupItems);
-    print('MOONFIN_DEBUG: initState: _sortOption=$_sortOption, _groupItems=$_groupItems');
   }
 
   @override
   void didUpdateWidget(covariant _PersonDisplaySettingsDialog oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final prevSort = _sortOption;
-    final prevGroup = _groupItems;
     _sortOption = widget.prefs.get(UserPreferences.personPageSortOption);
     _groupItems = widget.prefs.get(UserPreferences.personPageGroupItems);
-    print('MOONFIN_DEBUG: didUpdateWidget: sort $prevSort -> $_sortOption, group $prevGroup -> $_groupItems');
   }
 
   @override
   Widget build(BuildContext context) {
-    print('MOONFIN_DEBUG: build: _sortOption=$_sortOption, _groupItems=$_groupItems');
     final onSurface = AppColorScheme.onSurface;
     final accent = AppColorScheme.accent;
     final dividerColor = onSurface.withValues(alpha: 0.12);
@@ -12585,7 +12588,6 @@ class _PersonDisplaySettingsDialogState
     final now = DateTime.now();
     if (_lastTapTime != null &&
         now.difference(_lastTapTime!) < const Duration(milliseconds: 300)) {
-      print('MOONFIN_DEBUG: throttling tap');
       return true;
     }
     _lastTapTime = now;
@@ -12594,7 +12596,6 @@ class _PersonDisplaySettingsDialogState
 
   void _updateSort(String option) {
     if (_shouldThrottleTap()) return;
-    print('MOONFIN_DEBUG: _updateSort: $option');
     setState(() {
       _sortOption = option;
     });
@@ -12603,7 +12604,6 @@ class _PersonDisplaySettingsDialogState
 
   void _updateGroup(bool value) {
     if (_shouldThrottleTap()) return;
-    print('MOONFIN_DEBUG: _updateGroup: $value');
     setState(() {
       _groupItems = value;
     });

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -458,6 +458,7 @@ class _DetailContentState extends State<_DetailContent> {
   );
   String? _tvAlbumPlayFocusAppliedForItemId;
   List<SeerrDiscoverItem>? _seerrAppearances;
+  List<SeerrDiscoverItem>? _seerrCrewCredits;
 
   Future<void> _loadSeerrAppearances() async {
     final item = widget.viewModel.item;
@@ -471,6 +472,7 @@ class _DetailContentState extends State<_DetailContent> {
     if (mounted) {
       setState(() {
         _seerrAppearances = null;
+        _seerrCrewCredits = null;
       });
     }
 
@@ -480,12 +482,22 @@ class _DetailContentState extends State<_DetailContent> {
       final personId = int.tryParse(tmdbId);
       if (personId != null) {
         final credits = await repo.getPersonCombinedCredits(personId);
+        const excludedJobs = {'thanks', 'special thanks'};
         final castWithPosters =
             credits.cast.where((i) => i.posterPath != null).toList()
               ..sort((a, b) => a.displayTitle.compareTo(b.displayTitle));
+        final crewWithPosters = credits.crew
+            .where(
+              (i) =>
+                  i.posterPath != null &&
+                  !excludedJobs.contains(i.job?.toLowerCase()),
+            )
+            .toList()
+          ..sort((a, b) => a.displayTitle.compareTo(b.displayTitle));
         if (mounted) {
           setState(() {
             _seerrAppearances = castWithPosters;
+            _seerrCrewCredits = crewWithPosters;
           });
         }
       }
@@ -554,8 +566,9 @@ class _DetailContentState extends State<_DetailContent> {
     }
     final favoriteFocusNode =
         widget.initialFocusNode ?? _sectionFocusNodes['detailPersonFavorite'];
+    final displayFocusNode = _sectionFocusNodes['detailPersonDisplayButton'];
     final seerrFocusNode = _sectionFocusNodes['detailPersonSeerrButton'];
-    if (target == favoriteFocusNode || target == seerrFocusNode) {
+    if (target == favoriteFocusNode || target == displayFocusNode || target == seerrFocusNode) {
       return true;
     }
     return target.context
@@ -752,7 +765,11 @@ class _DetailContentState extends State<_DetailContent> {
       if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
         _resetSectionHorizontalOffset(sourceFocusNode);
         if (upTarget != null) {
-          if (upTarget == favoriteFocusNode) {
+          final displayFocusNode = _sectionFocusNodes['detailPersonDisplayButton'];
+          final seerrFocusNode = _sectionFocusNodes['detailPersonSeerrButton'];
+          if (upTarget == favoriteFocusNode ||
+              upTarget == displayFocusNode ||
+              upTarget == seerrFocusNode) {
             _scrollMainToTop();
           }
           _requestSectionFocus(upTarget);
@@ -780,7 +797,12 @@ class _DetailContentState extends State<_DetailContent> {
     super.initState();
     _scrollController = ScrollController();
     _contentFocusNode = FocusNode(debugLabel: 'detailContent');
+    widget.prefs.addListener(_onPrefsChanged);
     _loadSeerrAppearances();
+  }
+
+  void _onPrefsChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
@@ -825,6 +847,7 @@ class _DetailContentState extends State<_DetailContent> {
 
   @override
   void dispose() {
+    widget.prefs.removeListener(_onPrefsChanged);
     _scrollController.dispose();
     _contentFocusNode.dispose();
     for (final node in _sectionFocusNodes.values) {
@@ -2132,13 +2155,146 @@ class _DetailContentState extends State<_DetailContent> {
 
   List<Widget> _buildPersonContent(BuildContext context, AggregatedItem item) {
     final l10n = AppLocalizations.of(context);
-    final movies = viewModel.filmographyMovies;
-    final series = viewModel.filmographySeries;
-    final musicVideos = viewModel.filmographyMusicVideos;
+    final sortOpt = widget.prefs.get(UserPreferences.personPageSortOption);
+    final groupOpt = widget.prefs.get(UserPreferences.personPageGroupItems);
+
+    List<AggregatedItem> sortJellyfinItems(List<AggregatedItem> list) {
+      final sorted = List<AggregatedItem>.from(list);
+      if (sortOpt == 'alphabetical') {
+        sorted.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+      } else {
+        final asc = sortOpt == 'releaseDateAsc';
+        sorted.sort((a, b) {
+          final dateA = a.premiereDate ?? (a.productionYear != null ? DateTime(a.productionYear!) : null);
+          final dateB = b.premiereDate ?? (b.productionYear != null ? DateTime(b.productionYear!) : null);
+          if (dateA == null && dateB == null) {
+            return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+          }
+          if (dateA == null) return 1;
+          if (dateB == null) return -1;
+          final comp = dateA.compareTo(dateB);
+          return asc ? comp : -comp;
+        });
+      }
+      return sorted;
+    }
+
+    List<SeerrDiscoverItem> groupSeerrItems(List<SeerrDiscoverItem> list, bool isCrew) {
+      if (!groupOpt) return list;
+      final grouped = <int, List<SeerrDiscoverItem>>{};
+      for (final item in list) {
+        grouped.putIfAbsent(item.id, () => []).add(item);
+      }
+
+      final result = <SeerrDiscoverItem>[];
+      for (final entries in grouped.values) {
+        final first = entries.first;
+        if (entries.length == 1) {
+          result.add(first);
+          continue;
+        }
+
+        if (isCrew) {
+          final jobs = entries
+              .map((e) => e.job ?? e.department)
+              .where((j) => j != null && j.isNotEmpty)
+              .map((j) => j!)
+              .toSet();
+          final combinedJobs = jobs.join(', ');
+          result.add(SeerrDiscoverItem(
+            id: first.id,
+            mediaType: first.mediaType,
+            title: first.title,
+            name: first.name,
+            originalTitle: first.originalTitle,
+            originalName: first.originalName,
+            posterPath: first.posterPath,
+            backdropPath: first.backdropPath,
+            overview: first.overview,
+            releaseDate: first.releaseDate,
+            firstAirDate: first.firstAirDate,
+            originalLanguage: first.originalLanguage,
+            genreIds: first.genreIds,
+            voteAverage: first.voteAverage,
+            voteCount: first.voteCount,
+            popularity: first.popularity,
+            adult: first.adult,
+            mediaInfo: first.mediaInfo,
+            character: first.character,
+            job: combinedJobs.isNotEmpty ? combinedJobs : null,
+            department: first.department,
+          ));
+        } else {
+          final characters = entries
+              .map((e) => e.character)
+              .where((c) => c != null && c.isNotEmpty)
+              .map((c) => c!)
+              .toSet();
+          final combinedCharacters = characters.join(', ');
+          result.add(SeerrDiscoverItem(
+            id: first.id,
+            mediaType: first.mediaType,
+            title: first.title,
+            name: first.name,
+            originalTitle: first.originalTitle,
+            originalName: first.originalName,
+            posterPath: first.posterPath,
+            backdropPath: first.backdropPath,
+            overview: first.overview,
+            releaseDate: first.releaseDate,
+            firstAirDate: first.firstAirDate,
+            originalLanguage: first.originalLanguage,
+            genreIds: first.genreIds,
+            voteAverage: first.voteAverage,
+            voteCount: first.voteCount,
+            popularity: first.popularity,
+            adult: first.adult,
+            mediaInfo: first.mediaInfo,
+            character: combinedCharacters.isNotEmpty ? combinedCharacters : null,
+            job: first.job,
+            department: first.department,
+          ));
+        }
+      }
+      return result;
+    }
+
+    List<SeerrDiscoverItem> sortSeerrItems(List<SeerrDiscoverItem> list) {
+      final sorted = List<SeerrDiscoverItem>.from(list);
+      if (sortOpt == 'alphabetical') {
+        sorted.sort((a, b) => a.displayTitle.toLowerCase().compareTo(b.displayTitle.toLowerCase()));
+      } else {
+        final asc = sortOpt == 'releaseDateAsc';
+        sorted.sort((a, b) {
+          final dateStrA = a.releaseDate ?? a.firstAirDate;
+          final dateStrB = b.releaseDate ?? b.firstAirDate;
+          if (dateStrA == null && dateStrB == null) {
+            return a.displayTitle.toLowerCase().compareTo(b.displayTitle.toLowerCase());
+          }
+          if (dateStrA == null) return 1;
+          if (dateStrB == null) return -1;
+          final dateA = DateTime.tryParse(dateStrA);
+          final dateB = DateTime.tryParse(dateStrB);
+          if (dateA == null && dateB == null) {
+            return dateStrA.compareTo(dateStrB);
+          }
+          if (dateA == null) return 1;
+          if (dateB == null) return -1;
+          final comp = dateA.compareTo(dateB);
+          return asc ? comp : -comp;
+        });
+      }
+      return sorted;
+    }
+
+    final movies = sortJellyfinItems(viewModel.filmographyMovies);
+    final series = sortJellyfinItems(viewModel.filmographySeries);
+    final musicVideos = sortJellyfinItems(viewModel.filmographyMusicVideos);
     final useSplit = _useDesktopDetailLayout(context);
 
     final favoriteFocusNode =
         initialFocusNode ?? _sectionFocusNode('detailPersonFavorite');
+    final displayFocusNode = _sectionFocusNode('detailPersonDisplayButton');
     final bioFocusNode = _sectionFocusNode('detailPersonBio');
     final firstFocus = bioFocusNode;
     final hasBio = item.overview != null && item.overview!.isNotEmpty;
@@ -2157,12 +2313,12 @@ class _DetailContentState extends State<_DetailContent> {
     final seriesFocusNode = series.isNotEmpty
         ? _sectionFocusNode('detailPersonSeries')
         : null;
-    final guestAppearances = viewModel.filmographyEpisodes.where((episode) {
+    final guestAppearances = sortJellyfinItems(viewModel.filmographyEpisodes.where((episode) {
       final sId = episode.seriesId;
       if (sId == null || sId.isEmpty) return true;
       final isMainCastOfSeries = series.any((s) => s.id == sId);
       return !isMainCastOfSeries;
-    }).toList();
+    }).toList());
     final guestAppearancesFocusNode = guestAppearances.isNotEmpty
         ? _sectionFocusNode('detailPersonGuestAppearances')
         : null;
@@ -2170,7 +2326,20 @@ class _DetailContentState extends State<_DetailContent> {
         ? _sectionFocusNode('detailPersonMusicVideos')
         : null;
 
-    final seerrAppearances = _seerrAppearances;
+    final rawCrew = _seerrCrewCredits;
+    final seerrCrewCredits = rawCrew != null
+        ? sortSeerrItems(groupSeerrItems(rawCrew, true))
+        : null;
+    final hasSeerrCrewCredits =
+        seerrCrewCredits != null && seerrCrewCredits.isNotEmpty;
+    final seerrCrewCreditsFocusNode = hasSeerrCrewCredits
+        ? _sectionFocusNode('detailPersonSeerrCrewCredits')
+        : null;
+
+    final rawAppearances = _seerrAppearances;
+    final seerrAppearances = rawAppearances != null
+        ? sortSeerrItems(groupSeerrItems(rawAppearances, false))
+        : null;
     final hasSeerrAppearances =
         seerrAppearances != null && seerrAppearances.isNotEmpty;
     final seerrAppearancesFocusNode = hasSeerrAppearances
@@ -2225,17 +2394,49 @@ class _DetailContentState extends State<_DetailContent> {
                   moviesFocusNode ??
                       seriesFocusNode ??
                       musicVideosFocusNode ??
+                      seerrCrewCreditsFocusNode ??
                       seerrAppearancesFocusNode,
                 );
+              },
+              onArrowRight: () {
+                _requestSectionFocus(displayFocusNode);
+              },
+              onArrowLeft: () {
+                _tryFocusSidebar();
+              },
+            ),
+            const SizedBox(width: 16),
+            _DetailActionButton(
+              label: 'Display',
+              icon: Icons.tune,
+              onPressed: () => _showDisplaySettingsDialog(context),
+              isActive: false,
+              focusNode: displayFocusNode,
+              suppressAutoScrollToTop: true,
+              onArrowUp: () {
+                if (hasBio && firstFocus.canRequestFocus) {
+                  _requestSectionFocus(firstFocus);
+                } else {
+                  _tryFocusNavbar();
+                }
+              },
+              onArrowDown: () {
+                _requestSectionFocus(
+                  moviesFocusNode ??
+                      seriesFocusNode ??
+                      musicVideosFocusNode ??
+                      seerrCrewCreditsFocusNode ??
+                      seerrAppearancesFocusNode,
+                );
+              },
+              onArrowLeft: () {
+                _requestSectionFocus(favoriteFocusNode);
               },
               onArrowRight: hasSeerrButton
                   ? () {
                       _requestSectionFocus(seerrFocusNode);
                     }
                   : () {},
-              onArrowLeft: () {
-                _tryFocusSidebar();
-              },
             ),
             if (hasSeerrButton) ...[
               const SizedBox(width: 16),
@@ -2260,11 +2461,12 @@ class _DetailContentState extends State<_DetailContent> {
                     moviesFocusNode ??
                         seriesFocusNode ??
                         musicVideosFocusNode ??
+                        seerrCrewCreditsFocusNode ??
                         seerrAppearancesFocusNode,
                   );
                 },
                 onArrowLeft: () {
-                  _requestSectionFocus(favoriteFocusNode);
+                  _requestSectionFocus(displayFocusNode);
                 },
                 onArrowRight: () {},
               ),
@@ -2293,6 +2495,7 @@ class _DetailContentState extends State<_DetailContent> {
                   seriesFocusNode ??
                   guestAppearancesFocusNode ??
                   musicVideosFocusNode ??
+                  seerrCrewCreditsFocusNode ??
                   seerrAppearancesFocusNode,
               itemCount: movies.length,
             ),
@@ -2319,6 +2522,7 @@ class _DetailContentState extends State<_DetailContent> {
               downTarget:
                   guestAppearancesFocusNode ??
                   musicVideosFocusNode ??
+                  seerrCrewCreditsFocusNode ??
                   seerrAppearancesFocusNode,
               itemCount: series.length,
             ),
@@ -2342,7 +2546,7 @@ class _DetailContentState extends State<_DetailContent> {
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: guestAppearancesFocusNode,
               upTarget: seriesFocusNode ?? moviesFocusNode ?? favoriteFocusNode,
-              downTarget: musicVideosFocusNode ?? seerrAppearancesFocusNode,
+              downTarget: musicVideosFocusNode ?? seerrCrewCreditsFocusNode ?? seerrAppearancesFocusNode,
               itemCount: guestAppearances.length,
             ),
           ),
@@ -2369,8 +2573,35 @@ class _DetailContentState extends State<_DetailContent> {
                   seriesFocusNode ??
                   moviesFocusNode ??
                   favoriteFocusNode,
-              downTarget: seerrAppearancesFocusNode,
+              downTarget: seerrCrewCreditsFocusNode ?? seerrAppearancesFocusNode,
               itemCount: musicVideos.length,
+              consumeDownWhenNoTarget: !hasSeerrCrewCredits && !hasSeerrAppearances,
+            ),
+          ),
+        ),
+      ],
+      if (hasSeerrCrewCredits) ...[
+        const SizedBox(height: 32),
+        HorizontalScrollSection(
+          title: l10n.crewContributionsSeerr,
+          builder: (_, ctrl) => _SeerrCrewCreditsRow(
+            items: seerrCrewCredits,
+            prefs: prefs,
+            scrollController: _trackSectionScrollController(
+              seerrCrewCreditsFocusNode,
+              ctrl,
+            ),
+            firstFocusNode: seerrCrewCreditsFocusNode,
+            onItemKeyEvent: _buildVerticalRowHandler(
+              sourceFocusNode: seerrCrewCreditsFocusNode,
+              upTarget:
+                  musicVideosFocusNode ??
+                  guestAppearancesFocusNode ??
+                  seriesFocusNode ??
+                  moviesFocusNode ??
+                  favoriteFocusNode,
+              downTarget: seerrAppearancesFocusNode,
+              itemCount: seerrCrewCredits.length,
               consumeDownWhenNoTarget: !hasSeerrAppearances,
             ),
           ),
@@ -2391,6 +2622,7 @@ class _DetailContentState extends State<_DetailContent> {
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: seerrAppearancesFocusNode,
               upTarget:
+                  seerrCrewCreditsFocusNode ??
                   musicVideosFocusNode ??
                   guestAppearancesFocusNode ??
                   seriesFocusNode ??
@@ -2404,6 +2636,14 @@ class _DetailContentState extends State<_DetailContent> {
       ],
       const SizedBox(height: 48),
     ];
+  }
+
+  void _showDisplaySettingsDialog(BuildContext context) {
+    showFocusRestoringDialog(
+      context: context,
+      useRootNavigator: false,
+      builder: (_) => _PersonDisplaySettingsDialog(prefs: widget.prefs),
+    );
   }
 
   List<Widget> _buildArtistContent(BuildContext context, AggregatedItem item) {
@@ -8427,6 +8667,7 @@ class _CastRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         padding: const EdgeInsets.fromLTRB(4, 10, 4, 4),
         itemCount: people.length,
         separatorBuilder: (_, _) =>
@@ -8639,6 +8880,7 @@ class _SimilarRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         padding: const EdgeInsets.fromLTRB(6, 10, 6, 4),
         itemCount: items.length,
         separatorBuilder: (_, _) =>
@@ -8718,6 +8960,7 @@ class _FeaturesRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         padding: const EdgeInsets.fromLTRB(4, 4, 4, 4),
         itemCount: items.length,
         separatorBuilder: (_, _) =>
@@ -8795,6 +9038,7 @@ class _ChaptersRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         padding: const EdgeInsets.fromLTRB(4, 4, 4, 4),
         itemCount: chapters.length,
         separatorBuilder: (_, _) =>
@@ -9624,6 +9868,7 @@ class _SeasonsRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         padding: const EdgeInsets.fromLTRB(4, 4, 4, 4),
         itemCount: seasons.length,
         separatorBuilder: (_, _) =>
@@ -9747,6 +9992,7 @@ class _EpisodesRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         itemCount: episodes.length,
         separatorBuilder: (_, _) =>
             SizedBox(width: isMobile ? 8 : 12 * desktopScale),
@@ -10860,6 +11106,7 @@ class _FilmographyRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         itemCount: items.length,
         separatorBuilder: (_, _) =>
             SizedBox(width: isMobile ? 8 : 12 * desktopScale),
@@ -10966,6 +11213,7 @@ class _SeerrAppearancesRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         itemCount: items.length,
         separatorBuilder: (_, _) =>
             SizedBox(width: isMobile ? 8 : 12 * desktopScale),
@@ -10975,6 +11223,88 @@ class _SeerrAppearancesRow extends StatelessWidget {
           return MediaCard(
             title: item.displayTitle,
             subtitle: item.character,
+            imageUrl: item.posterPath != null
+                ? 'https://image.tmdb.org/t/p/w342${item.posterPath}'
+                : null,
+            width: cardWidth,
+            aspectRatio: 2 / 3,
+            focusColor: focusColor,
+            cardFocusExpansion: cardExpansion,
+            suppressFocusGlow: suppressFocusGlow,
+            seerrMediaType: item.mediaType,
+            seerrStatus: item.mediaInfo?.status,
+            autofocus: index == 0 && firstFocusNode != null,
+            focusNode: index == 0 ? firstFocusNode : null,
+            onKeyEvent: onItemKeyEvent == null
+                ? null
+                : (_, event) => onItemKeyEvent!(index, event),
+            onTap: () {
+              final mediaType = item.mediaType ?? 'movie';
+              context.push(
+                Destinations.seerrMedia(item.id.toString()),
+                extra: {'mediaType': mediaType},
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SeerrCrewCreditsRow extends StatelessWidget {
+  final List<SeerrDiscoverItem> items;
+  final UserPreferences prefs;
+  final ScrollController? scrollController;
+  final FocusNode? firstFocusNode;
+  final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
+
+  const _SeerrCrewCreditsRow({
+    required this.items,
+    required this.prefs,
+    this.scrollController,
+    this.firstFocusNode,
+    this.onItemKeyEvent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion);
+    final isMobile = _isCompact(context);
+    final desktopScale = _desktopUiScale(prefs: prefs);
+
+    final platformScale = PlatformDetection.isTV
+        ? 0.8 * desktopScale
+        : desktopScale;
+    final metadataScale = desktopScale;
+    final isRowsV2 =
+        prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2;
+    final rowScale = isRowsV2 ? 2.0 : 1.0;
+
+    final posterSize = prefs.get(UserPreferences.posterSize);
+    final cardHeight =
+        posterSize.portraitHeight.toDouble() * platformScale * rowScale;
+
+    final cardWidth = isMobile ? 120.0 : cardHeight * (2 / 3);
+    final rowHeight = isMobile ? 240.0 : cardHeight + (56 * metadataScale);
+    final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
+    final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
+
+    return SizedBox(
+      height: rowHeight,
+      child: ListView.separated(
+        controller: scrollController,
+        scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
+        itemCount: items.length,
+        separatorBuilder: (_, _) =>
+            SizedBox(width: isMobile ? 8 : 12 * desktopScale),
+        itemBuilder: (context, index) {
+          final item = items[index];
+
+          return MediaCard(
+            title: item.displayTitle,
+            subtitle: item.job ?? item.department,
             imageUrl: item.posterPath != null
                 ? 'https://image.tmdb.org/t/p/w342${item.posterPath}'
                 : null,
@@ -11440,6 +11770,7 @@ class _AlbumsRow extends StatelessWidget {
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
         itemCount: albums.length,
         separatorBuilder: (_, _) =>
             SizedBox(width: isMobile ? 8 : 12 * desktopScale),
@@ -12122,4 +12453,277 @@ class _AdvancedPlaybackOption {
     required this.icon,
     required this.onTap,
   });
+}
+
+class _PersonDisplaySettingsDialog extends StatefulWidget {
+  final UserPreferences prefs;
+
+  const _PersonDisplaySettingsDialog({required this.prefs});
+
+  @override
+  State<_PersonDisplaySettingsDialog> createState() =>
+      _PersonDisplaySettingsDialogState();
+}
+
+class _PersonDisplaySettingsDialogState
+    extends State<_PersonDisplaySettingsDialog> {
+  late String _sortOption;
+  late bool _groupItems;
+  DateTime? _lastTapTime;
+
+  @override
+  void initState() {
+    super.initState();
+    _sortOption = widget.prefs.get(UserPreferences.personPageSortOption);
+    _groupItems = widget.prefs.get(UserPreferences.personPageGroupItems);
+    print('MOONFIN_DEBUG: initState: _sortOption=$_sortOption, _groupItems=$_groupItems');
+  }
+
+  @override
+  void didUpdateWidget(covariant _PersonDisplaySettingsDialog oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final prevSort = _sortOption;
+    final prevGroup = _groupItems;
+    _sortOption = widget.prefs.get(UserPreferences.personPageSortOption);
+    _groupItems = widget.prefs.get(UserPreferences.personPageGroupItems);
+    print('MOONFIN_DEBUG: didUpdateWidget: sort $prevSort -> $_sortOption, group $prevGroup -> $_groupItems');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    print('MOONFIN_DEBUG: build: _sortOption=$_sortOption, _groupItems=$_groupItems');
+    final onSurface = AppColorScheme.onSurface;
+    final accent = AppColorScheme.accent;
+    final dividerColor = onSurface.withValues(alpha: 0.12);
+    final sectionColor = onSurface.withValues(alpha: 0.72);
+    final dialogWidth = (MediaQuery.sizeOf(context).width - 32).clamp(280.0, 380.0);
+
+    return Dialog(
+      backgroundColor: AppColorScheme.surface.withValues(alpha: 0.92),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: ThemeRegistry.active.borders.chipBorder.copyWith(
+          color: onSurface.withValues(alpha: 0.18),
+        ),
+      ),
+      child: SizedBox(
+        width: dialogWidth,
+        child: ListView(
+          shrinkWrap: true,
+          padding: const EdgeInsets.symmetric(vertical: 20),
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+              child: Text(
+                'Display Options',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w600,
+                  color: onSurface,
+                ),
+              ),
+            ),
+            Divider(color: dividerColor),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
+              child: Text(
+                'Sort By',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: sectionColor,
+                ),
+              ),
+            ),
+            _radioTile(
+              label: 'Alphabetical',
+              selected: _sortOption == 'alphabetical',
+              onTap: () => _updateSort('alphabetical'),
+              accent: accent,
+              onSurface: onSurface,
+            ),
+            _radioTile(
+              label: 'Release Date (Ascending)',
+              selected: _sortOption == 'releaseDateAsc',
+              onTap: () => _updateSort('releaseDateAsc'),
+              accent: accent,
+              onSurface: onSurface,
+            ),
+            _radioTile(
+              label: 'Release Date (Descending)',
+              selected: _sortOption == 'releaseDateDesc',
+              onTap: () => _updateSort('releaseDateDesc'),
+              accent: accent,
+              onSurface: onSurface,
+            ),
+            Divider(color: dividerColor),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
+              child: Text(
+                'Group Contributions',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: sectionColor,
+                ),
+              ),
+            ),
+            _checkboxTile(
+              label: 'Group multiple roles',
+              checked: _groupItems,
+              onTap: () => _updateGroup(!_groupItems),
+              accent: accent,
+              onSurface: onSurface,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  bool _shouldThrottleTap() {
+    final now = DateTime.now();
+    if (_lastTapTime != null &&
+        now.difference(_lastTapTime!) < const Duration(milliseconds: 300)) {
+      print('MOONFIN_DEBUG: throttling tap');
+      return true;
+    }
+    _lastTapTime = now;
+    return false;
+  }
+
+  void _updateSort(String option) {
+    if (_shouldThrottleTap()) return;
+    print('MOONFIN_DEBUG: _updateSort: $option');
+    setState(() {
+      _sortOption = option;
+    });
+    widget.prefs.set(UserPreferences.personPageSortOption, option);
+  }
+
+  void _updateGroup(bool value) {
+    if (_shouldThrottleTap()) return;
+    print('MOONFIN_DEBUG: _updateGroup: $value');
+    setState(() {
+      _groupItems = value;
+    });
+    widget.prefs.set(UserPreferences.personPageGroupItems, value);
+  }
+
+  Widget _radioTile({
+    required String label,
+    required bool selected,
+    required VoidCallback onTap,
+    Color? accent,
+    required Color onSurface,
+  }) {
+    final effectiveAccent = accent ?? AppColorScheme.accent;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        child: Row(
+          children: [
+            Container(
+              width: 18,
+              height: 18,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.fromBorderSide(
+                  ThemeRegistry.active.borders.chipBorder.copyWith(
+                    color: selected
+                        ? effectiveAccent
+                        : onSurface.withValues(alpha: 0.5),
+                    width: 2,
+                  ),
+                ),
+                color: selected ? effectiveAccent : Colors.transparent,
+              ),
+              child: selected
+                  ? Center(
+                      child: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: onSurface,
+                        ),
+                      ),
+                    )
+                  : null,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontSize: 15,
+                  color: selected
+                      ? onSurface
+                      : onSurface.withValues(alpha: 0.72),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _checkboxTile({
+    required String label,
+    required bool checked,
+    required VoidCallback onTap,
+    required Color accent,
+    required Color onSurface,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        child: Row(
+          children: [
+            Container(
+              width: 18,
+              height: 18,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(4),
+                border: Border.fromBorderSide(
+                  ThemeRegistry.active.borders.chipBorder.copyWith(
+                    color: checked ? accent : onSurface.withValues(alpha: 0.5),
+                    width: 2,
+                  ),
+                ),
+                color: checked ? accent : Colors.transparent,
+              ),
+              child: checked
+                  ? Center(
+                      child: Text(
+                        '✓',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          color: onSurface,
+                        ),
+                      ),
+                    )
+                  : null,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontSize: 15,
+                  color: checked
+                      ? onSurface
+                      : onSurface.withValues(alpha: 0.72),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
# The One about Directors/Writers/Producers

## Summary
This PR adds a "Display" settings button between the Favorite and Seerr buttons on the Person detail pages. This dialog allows users to globally sort all person filmography and contribution lists (alphabetically or by release date) and group multiple crew/cast roles on the same media item into a single aggregated card.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Added profile-scoped preferences personPageSortOption and personPageGroupItems in user_preferences.dart.
* Registered preference listeners in item_detail_screen.dart to trigger UI rebuilds on setting changes.
* Inserted the D-pad focusable Display action button on the Person detail page with correct directional graph navigation.
* Implemented sorting and grouping transforms for Jellyfin list items and Seerr discover items.
* Added clipBehavior: Clip.none to all horizontal ListView.separated row views in item_detail_screen.dart to prevent the focus border and card hover scaling animation from being cropped.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV - Shield
- [ ] Not tested (explain why):

### Test Steps
1. Navigated to a Person page.
2. Verified the Display button is focusable and opens the display settings dialog.
3. Tested alphabetical, chronological ascending/descending sorting, and grouping multiple roles. Verified changes update instantly and persist across profile.
4. Focused cards in all row sections (e.g. Crew Contributions, Appearances, Filmography).

## Screenshots (if applicable)

* Sort Options:
<img width="500" alt="Shield_Screenshot_2026-06-23_18-25-30" src="https://github.com/user-attachments/assets/f69c7bb4-ceee-4731-89d3-6172ea5f5d8a" />

* Crew Contributions (Alphabetical):
<img width="500" alt="Shield_Screenshot_2026-06-23_19-02-27" src="https://github.com/user-attachments/assets/910aae4b-705c-4afe-b141-d545e675dfd7" />

* Crew Contributions (Release Date, Descending; Grouped ON):
<img width="500" alt="Shield_Screenshot_2026-06-23_19-03-17" src="https://github.com/user-attachments/assets/72e84391-a746-4bc9-a182-8ce88da8985d" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
