### PR TITLE
Feature/youtube trailer fix

### DIFF
--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -1630,10 +1630,11 @@ class _MediaBarState extends State<MediaBar>
                     ),
                   ),
                   ..._buildVideoOverlays(),
-                  _GradientOverlay(
-                    color: overlayColor,
-                    opacity: overlayOpacity,
-                  ),
+                  if(!_isTrailerPlaying) // no gradient when trailer playing
+                    _GradientOverlay(
+                      color: overlayColor,
+                      opacity: overlayOpacity,
+                    ),
                   if (items.length > 1)
                     Positioned(
                       bottom: 8,
@@ -1842,7 +1843,7 @@ class _MediaBarState extends State<MediaBar>
                       ),
                     ),
                   if (!isMobile) ..._buildVideoOverlays(),
-                  if (!isMobile)
+                  if (!isMobile && !_isTrailerPlaying) // no gradient when trailer playing
                     Positioned.fill(
                       child: DecoratedBox(
                         decoration: BoxDecoration(
@@ -1865,7 +1866,7 @@ class _MediaBarState extends State<MediaBar>
                         ),
                       ),
                     ),
-                  if (!isMobile)
+                  if (!isMobile && !_isTrailerPlaying) // no gradient when trailer playing
                     Positioned.fill(
                       child: DecoratedBox(
                         decoration: BoxDecoration(

--- a/lib/ui/widgets/web_youtube_trailer_io.dart
+++ b/lib/ui/widgets/web_youtube_trailer_io.dart
@@ -269,7 +269,7 @@ class _WebYouTubeTrailerState extends State<WebYouTubeTrailer> {
           _reportEmbeddedUnavailable();
         },
       );
-      await (controller as dynamic).init() as Future<void>;
+      await ((controller as dynamic).init() as Future<void>);
       _autoplayWatchArmed = true;
       _restartAutoplayTimer();
 
@@ -708,12 +708,13 @@ class _WebYouTubeTrailerState extends State<WebYouTubeTrailer> {
           return const SizedBox.shrink();
         }
 
+        final dynamic wv = (controller as dynamic).webViewController;
+        if (wv is! WebViewController) return const SizedBox.shrink();
         return IgnorePointer(
           ignoring: widget.ignorePointer,
           child: _buildWithStartupChromeMask(
             WebViewWidget(
-              controller: (controller as dynamic).webViewController
-                  as WebViewController,
+              controller: wv,
             ),
           ),
         );


### PR DESCRIPTION
## Summary
Youtube wasn't working.  This gets it working again and hides some gradients when trailers are playing.

## Related Issues
- Related to #587 
- possibly fixes it, but I did not experience premature trailers

## Type of Change
- [X] Bug fix
- [X] UI/UX update

## Changes Made
-in web_youtube_trailer_io.dart
-modified _initializeYoutubeController to force a future<void> return type on the controller's init so await works reliably. Return value may be dropped otherwise, causing await on null.
-modified build to do safer type checking on the webViewController

-in media_bar.dart
-added checks to some gradients so they're hidden during trailer playback

## Platform
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on physical device
- [X] Manual testing completed

### Test Steps
1. build
2. try

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [ ] No new warnings introduced

While it plays now, it's extremely noisy with errors like:
FrameEvents             org.moonfin.androidtv.beta           E  updateAcquireFence: Did not find frame.

Removing all the overlays I could find, and setting overscan to 1 didn't seem to help.  I think it's just a problem with the webview in general.
