### PR TITLE
Add setting to group library items into collections client-side

### DIFF
--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -310,12 +310,10 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     final groupCollections = _prefs.get(UserPreferences.groupItemsIntoCollections);
     if (includeItemTypes != null) {
       includeTypes = List<String>.from(includeItemTypes!);
-      if (groupCollections) {
-        if (includeTypes.contains('Movie')) {
-          collapseBoxSets = true;
-        } else if (includeTypes.contains('Series')) {
-          collapseBoxSets = true;
-        }
+      if (groupCollections &&
+          (includeTypes.contains('Movie') ||
+              includeTypes.contains('Series'))) {
+        collapseBoxSets = true;
       }
     } else {
       switch (_collectionType) {

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -89,6 +89,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   String? _errorMessage;
   String? get errorMessage => _errorMessage;
 
+  bool? _lastGroupCollectionsValue;
+
   AggregatedItem? _focusedItem;
   AggregatedItem? get focusedItem => _focusedItem;
 
@@ -170,6 +172,16 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     _letterFilter = '';
     _imageType = _prefs.get(UserPreferences.libraryImageType(_imagePrefKey));
     _posterSize = _readScopedPosterSize();
+    _lastGroupCollectionsValue = _prefs.get(UserPreferences.groupItemsIntoCollections);
+    _prefs.addListener(_onPrefsChanged);
+  }
+
+  void _onPrefsChanged() {
+    final newValue = _prefs.get(UserPreferences.groupItemsIntoCollections);
+    if (_lastGroupCollectionsValue != newValue) {
+      _lastGroupCollectionsValue = newValue;
+      load();
+    }
   }
 
   String get _prefKey => genreId ?? libraryId;
@@ -295,18 +307,37 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         includeItemTypes != null &&
         includeItemTypes!.length == 1 &&
         includeItemTypes!.first == 'MusicArtist';
+    final groupCollections = _prefs.get(UserPreferences.groupItemsIntoCollections);
     if (includeItemTypes != null) {
-      includeTypes = includeItemTypes;
+      includeTypes = List<String>.from(includeItemTypes!);
+      if (groupCollections) {
+        if (includeTypes.contains('Movie')) {
+          collapseBoxSets = true;
+        } else if (includeTypes.contains('Series')) {
+          collapseBoxSets = true;
+        }
+      }
     } else {
       switch (_collectionType) {
         case 'movies':
-          includeTypes = ['Movie'];
-          excludeTypes = ['BoxSet'];
-          collapseBoxSets = false;
+          if (groupCollections) {
+            includeTypes = ['Movie'];
+            excludeTypes = null;
+            collapseBoxSets = true;
+          } else {
+            includeTypes = ['Movie'];
+            excludeTypes = ['BoxSet'];
+            collapseBoxSets = false;
+          }
           break;
         case 'tvshows':
-          includeTypes = ['Series'];
-          collapseBoxSets = false;
+          if (groupCollections) {
+            includeTypes = ['Series'];
+            collapseBoxSets = true;
+          } else {
+            includeTypes = ['Series'];
+            collapseBoxSets = false;
+          }
           break;
         case 'playlists':
           includeTypes = ['Playlist'];
@@ -736,4 +767,10 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   }
 
   String get counterText => '${_items.length} | $_totalCount';
+
+  @override
+  void dispose() {
+    _prefs.removeListener(_onPrefsChanged);
+    super.dispose();
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3952,6 +3952,22 @@
   "@showFolderBrowsingOption": {
     "description": "Description for folder view"
   },
+  "groupItemsIntoCollections": "Group Items into Collections",
+  "@groupItemsIntoCollections": {
+    "description": "Setting for grouping items into collections"
+  },
+  "hideCollectionAssociatedItems": "Hide Collection associated library items when browsing libraries",
+  "@hideCollectionAssociatedItems": {
+    "description": "Description for grouping items into collections"
+  },
+  "groupItemsIntoCollectionsDialogTitle": "Library Grouping Notice",
+  "@groupItemsIntoCollectionsDialogTitle": {
+    "description": "Title of the alert dialog explaining server settings requirement"
+  },
+  "groupItemsIntoCollectionsDialogMessage": "To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library's Display settings on your Jellyfin or Emby server.",
+  "@groupItemsIntoCollectionsDialogMessage": {
+    "description": "Message of the alert dialog explaining server settings requirement"
+  },
   "libraryVisibility": "Library Visibility",
   "@libraryVisibility": {
     "description": "Section title for library visibility"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5212,6 +5212,30 @@ abstract class AppLocalizations {
   /// **'Show folder browsing option'**
   String get showFolderBrowsingOption;
 
+  /// Setting for grouping items into collections
+  ///
+  /// In en, this message translates to:
+  /// **'Group Items into Collections'**
+  String get groupItemsIntoCollections;
+
+  /// Description for grouping items into collections
+  ///
+  /// In en, this message translates to:
+  /// **'Hide Collection associated library items when browsing libraries'**
+  String get hideCollectionAssociatedItems;
+
+  /// Title of the alert dialog explaining server settings requirement
+  ///
+  /// In en, this message translates to:
+  /// **'Library Grouping Notice'**
+  String get groupItemsIntoCollectionsDialogTitle;
+
+  /// Message of the alert dialog explaining server settings requirement
+  ///
+  /// In en, this message translates to:
+  /// **'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.'**
+  String get groupItemsIntoCollectionsDialogMessage;
+
   /// Section title for library visibility
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -2853,6 +2853,20 @@ class AppLocalizationsAf extends AppLocalizations {
   String get showFolderBrowsingOption => 'Wys gidsblaai-opsie';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Biblioteeksigbaarheid';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2839,6 +2839,20 @@ class AppLocalizationsAr extends AppLocalizations {
   String get showFolderBrowsingOption => 'إظهار خيار تصفح المجلد';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'رؤية المكتبة';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -2853,6 +2853,20 @@ class AppLocalizationsBe extends AppLocalizations {
   String get showFolderBrowsingOption => 'Паказаць параметр прагляду тэчак';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Бачнасць бібліятэкі';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2867,6 +2867,20 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на опцията за разглеждане на папки';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Видимост на библиотеката';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -2843,6 +2843,20 @@ class AppLocalizationsBn extends AppLocalizations {
   String get showFolderBrowsingOption => 'ফোল্ডার ব্রাউজিং অপশন দেখান';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'লাইব্রেরি দৃশ্যমানতা';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -2883,6 +2883,20 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra l\'opció de navegació de carpetes';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibilitat de la biblioteca';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2850,6 +2850,20 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showFolderBrowsingOption => 'Zobrazit možnost procházení složek';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Viditelnost knihovny';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -2859,6 +2859,20 @@ class AppLocalizationsCy extends AppLocalizations {
   String get showFolderBrowsingOption => 'Dangos opsiwn pori ffolder';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Gwelededd Llyfrgell';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2849,6 +2849,20 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showFolderBrowsingOption => 'Vis mulighed for browsing af mapper';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Bibliotekets synlighed';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2867,6 +2867,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showFolderBrowsingOption => 'Ordner-Durchsuchen-Option anzeigen';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Bibliothekssichtbarkeit';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2881,6 +2881,20 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Εμφάνιση επιλογής περιήγησης φακέλου';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Βιβλιοθήκη Ορατότητα';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2837,6 +2837,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showFolderBrowsingOption => 'Show folder browsing option';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Library Visibility';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -2846,6 +2846,20 @@ class AppLocalizationsEo extends AppLocalizations {
   String get showFolderBrowsingOption => 'Montru dosierujan foliumadan opcion';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Biblioteko Videbleco';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2869,6 +2869,20 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar opción de exploración por carpetas';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibilidad de la biblioteca';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2857,6 +2857,20 @@ class AppLocalizationsEt extends AppLocalizations {
   String get showFolderBrowsingOption => 'Kuva kaustade sirvimise valik';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Raamatukogu nähtavus';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -2834,6 +2834,20 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showFolderBrowsingOption => 'نمایش گزینه مرور پوشه';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'قابلیت مشاهده کتابخانه';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2861,6 +2861,20 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showFolderBrowsingOption => 'Näytä kansion selausvaihtoehto';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Kirjaston näkyvyys';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2891,6 +2891,20 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher l’option de navigation par dossiers';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibilité de la bibliothèque';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -2884,6 +2884,20 @@ class AppLocalizationsGl extends AppLocalizations {
       'Mostrar a opción de navegación por cartafoles';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibilidade da biblioteca';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2821,6 +2821,20 @@ class AppLocalizationsHe extends AppLocalizations {
   String get showFolderBrowsingOption => 'הצג אפשרות גלישה בתיקייה';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'נראות הספרייה';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2841,6 +2841,20 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showFolderBrowsingOption => 'फ़ोल्डर ब्राउज़िंग विकल्प दिखाएँ';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'पुस्तकालय दृश्यता';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2854,6 +2854,20 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showFolderBrowsingOption => 'Prikaži opciju pregledavanja mape';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Vidljivost knjižnice';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2864,6 +2864,20 @@ class AppLocalizationsHu extends AppLocalizations {
   String get showFolderBrowsingOption => 'Mappaböngészési opció megjelenítése';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Könyvtár láthatósága';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2852,6 +2852,20 @@ class AppLocalizationsId extends AppLocalizations {
   String get showFolderBrowsingOption => 'Tampilkan opsi penelusuran folder';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibilitas Pustaka';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2864,6 +2864,20 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mostra opzione di navigazione cartelle';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibilità Libreria';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2799,6 +2799,20 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showFolderBrowsingOption => 'フォルダー参照オプションを表示する';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'ライブラリの可視性';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -2861,6 +2861,20 @@ class AppLocalizationsKk extends AppLocalizations {
   String get showFolderBrowsingOption => 'Қалтаны шолу опциясын көрсету';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Кітапхананың көрінуі';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -2863,6 +2863,20 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showFolderBrowsingOption => 'ಫೋಲ್ಡರ್ ಬ್ರೌಸಿಂಗ್ ಆಯ್ಕೆಯನ್ನು ತೋರಿಸಿ';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'ಲೈಬ್ರರಿ ಗೋಚರತೆ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2793,6 +2793,20 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showFolderBrowsingOption => '폴더 탐색 옵션 표시';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => '도서관 가시성';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2850,6 +2850,20 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showFolderBrowsingOption => 'Rodyti aplanko naršymo parinktį';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Bibliotekos matomumas';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2862,6 +2862,20 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showFolderBrowsingOption => 'Rādīt mapju pārlūkošanas opciju';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Bibliotēkas redzamība';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -2867,6 +2867,20 @@ class AppLocalizationsMk extends AppLocalizations {
       'Прикажи ја опцијата за прелистување папки';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Видливост на библиотеката';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2868,6 +2868,20 @@ class AppLocalizationsMl extends AppLocalizations {
   String get showFolderBrowsingOption => 'ഫോൾഡർ ബ്രൗസിംഗ് ഓപ്ഷൻ കാണിക്കുക';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'ലൈബ്രറി ദൃശ്യപരത';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -2852,6 +2852,20 @@ class AppLocalizationsMn extends AppLocalizations {
   String get showFolderBrowsingOption => 'Фолдер үзэх сонголтыг харуулах';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Номын сангийн харагдах байдал';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2847,6 +2847,20 @@ class AppLocalizationsNb extends AppLocalizations {
   String get showFolderBrowsingOption => 'Vis alternativ for mappelesing';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Bibliotekets synlighet';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2861,6 +2861,20 @@ class AppLocalizationsNl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Toon de mapzoekoptie';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Zichtbaarheid van de bibliotheek';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -2846,6 +2846,20 @@ class AppLocalizationsPa extends AppLocalizations {
   String get showFolderBrowsingOption => 'ਫੋਲਡਰ ਬ੍ਰਾਊਜ਼ਿੰਗ ਵਿਕਲਪ ਦਿਖਾਓ';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'ਲਾਇਬ੍ਰੇਰੀ ਦਰਿਸ਼ਗੋਚਰਤਾ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2861,6 +2861,20 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Pokaż opcję przeglądania folderów';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Widoczność biblioteki';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2863,6 +2863,20 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar opção de navegação por pastas';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibilidade da Biblioteca';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2864,6 +2864,20 @@ class AppLocalizationsRo extends AppLocalizations {
       'Afișează opțiunea de navigare în folder';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Vizibilitatea bibliotecii';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2864,6 +2864,20 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showFolderBrowsingOption => 'Показать опцию просмотра папок';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Видимость библиотеки';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -2845,6 +2845,20 @@ class AppLocalizationsSi extends AppLocalizations {
   String get showFolderBrowsingOption => 'ෆෝල්ඩර බ්‍රවුසින් විකල්පය පෙන්වන්න';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'පුස්තකාල දෘශ්‍යතාව';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2859,6 +2859,20 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zobraziť možnosť prehliadania priečinkov';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Viditeľnosť knižnice';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2860,6 +2860,20 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showFolderBrowsingOption => 'Pokaži možnost brskanja po mapah';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Vidnost knjižnice';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -2868,6 +2868,20 @@ class AppLocalizationsSq extends AppLocalizations {
       'Shfaq opsionin e shfletimit të dosjeve';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Dukshmëria e Bibliotekës';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -2857,6 +2857,20 @@ class AppLocalizationsSr extends AppLocalizations {
   String get showFolderBrowsingOption => 'Прикажи опцију прегледања фолдера';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Видљивост библиотеке';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2856,6 +2856,20 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showFolderBrowsingOption => 'Visa mappsökningsalternativ';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Bibliotekets synlighet';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -2868,6 +2868,20 @@ class AppLocalizationsSw extends AppLocalizations {
       'Onyesha chaguo la kuvinjari kwenye folda';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Mwonekano wa Maktaba';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -2868,6 +2868,20 @@ class AppLocalizationsTa extends AppLocalizations {
   String get showFolderBrowsingOption => 'கோப்புறை உலாவல் விருப்பத்தைக் காட்டு';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'நூலகத் தெரிவுநிலை';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2862,6 +2862,20 @@ class AppLocalizationsTe extends AppLocalizations {
   String get showFolderBrowsingOption => 'ఫోల్డర్ బ్రౌజింగ్ ఎంపికను చూపు';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'లైబ్రరీ దృశ్యమానత';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -2831,6 +2831,20 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showFolderBrowsingOption => 'แสดงตัวเลือกการเรียกดูโฟลเดอร์';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'การมองเห็นห้องสมุด';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -2876,6 +2876,20 @@ class AppLocalizationsTl extends AppLocalizations {
       'Ipakita ang opsyon sa pagba-browse ng folder';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Visibility ng Library';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2860,6 +2860,20 @@ class AppLocalizationsTr extends AppLocalizations {
   String get showFolderBrowsingOption => 'Klasöre göz atma seçeneğini göster';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Kütüphane Görünürlüğü';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -2853,6 +2853,20 @@ class AppLocalizationsUg extends AppLocalizations {
       'ھۆججەت قىسقۇچنى كۆرۈش تاللانمىسىنى كۆرسەت';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'كۈتۈپخانىنىڭ كۆرۈنۈشچانلىقى';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2859,6 +2859,20 @@ class AppLocalizationsUk extends AppLocalizations {
   String get showFolderBrowsingOption => 'Показати опцію перегляду папок';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Видимість бібліотеки';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2853,6 +2853,20 @@ class AppLocalizationsVi extends AppLocalizations {
   String get showFolderBrowsingOption => 'Hiển thị tùy chọn duyệt thư mục';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => 'Hiển thị thư viện';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2781,6 +2781,20 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showFolderBrowsingOption => '顯示資料夾瀏覽選項';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => '圖書館可見性';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2773,6 +2773,20 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showFolderBrowsingOption => '显示文件夹浏览选项';
 
   @override
+  String get groupItemsIntoCollections => 'Group Items into Collections';
+
+  @override
+  String get hideCollectionAssociatedItems =>
+      'Hide Collection associated library items when browsing libraries';
+
+  @override
+  String get groupItemsIntoCollectionsDialogTitle => 'Library Grouping Notice';
+
+  @override
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'To use this setting, please ensure the \"Group movies into collections\" and/or \"Group shows into collections\" Library settings are enabled under your library\'s Display settings on your Jellyfin or Emby server.';
+
+  @override
   String get libraryVisibility => '媒体库可见性';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -751,6 +751,11 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final groupItemsIntoCollections = Preference(
+    key: 'pref_group_items_into_collections',
+    defaultValue: false,
+  );
+
   static final showMediaDetailsOnLibraryPage = Preference(
     key: 'pref_show_media_details_on_library_page',
     defaultValue: true,

--- a/lib/ui/screens/settings/panel/libraries_category_screen.dart
+++ b/lib/ui/screens/settings/panel/libraries_category_screen.dart
@@ -34,6 +34,46 @@ class _LibrariesCategoryScreen extends StatelessWidget {
                 onChanged: _pushPersonalizationSync,
               ),
               SwitchPreferenceTile(
+                preference: UserPreferences.groupItemsIntoCollections,
+                title: l10n.groupItemsIntoCollections,
+                subtitle: l10n.hideCollectionAssociatedItems,
+                icon: Icons.collections_bookmark,
+                onChanged: () async {
+                  _pushPersonalizationSync();
+                  final prefs = GetIt.instance<PreferenceStore>();
+                  final isEnabled = prefs.get(UserPreferences.groupItemsIntoCollections);
+                  if (isEnabled) {
+                    final client = GetIt.instance<MediaServerClient>();
+                    if (client.serverType == ServerType.jellyfin) {
+                      try {
+                        final config = await client.adminSystemApi.getServerConfiguration();
+                        final groupMovies = config['EnableGroupingMoviesIntoCollections'] as bool? ?? false;
+                        final groupShows = config['EnableGroupingShowsIntoCollections'] as bool? ?? false;
+                        if (groupMovies && groupShows) {
+                          return;
+                        }
+                      } catch (_) {}
+                    }
+
+                    if (!context.mounted) return;
+                    showFocusRestoringDialog(
+                      context: context,
+                      builder: (dialogContext) => AlertDialog(
+                        title: Text(l10n.groupItemsIntoCollectionsDialogTitle),
+                        content: Text(l10n.groupItemsIntoCollectionsDialogMessage),
+                        actions: [
+                          TextButton(
+                            autofocus: true,
+                            onPressed: () => Navigator.pop(dialogContext),
+                            child: Text(l10n.ok),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+                },
+              ),
+              SwitchPreferenceTile(
                 preference: UserPreferences.showMediaDetailsOnLibraryPage,
                 title: l10n.showMediaDetailsOnLibraryPage,
                 subtitle: l10n.showMediaDetailsOnLibraryPageDescription,

--- a/lib/ui/screens/settings/panel/libraries_category_screen.dart
+++ b/lib/ui/screens/settings/panel/libraries_category_screen.dart
@@ -47,10 +47,15 @@ class _LibrariesCategoryScreen extends StatelessWidget {
                     try {
                       final config =
                           await client.adminSystemApi.getServerConfiguration();
-                      final groupingEnabled =
-                          config['EnableGroupingIntoCollections'] as bool? ??
-                              false;
-                      if (groupingEnabled) {
+                      final groupMovies =
+                          (config['EnableGroupingMoviesIntoCollections'] as bool?) ??
+                          (config['EnableGroupingIntoCollections'] as bool?) ??
+                          false;
+                      final groupShows =
+                          (config['EnableGroupingShowsIntoCollections'] as bool?) ??
+                          (config['EnableGroupingIntoCollections'] as bool?) ??
+                          false;
+                      if (groupMovies && groupShows) {
                         return;
                       }
                     } catch (_) {}

--- a/lib/ui/screens/settings/panel/libraries_category_screen.dart
+++ b/lib/ui/screens/settings/panel/libraries_category_screen.dart
@@ -44,16 +44,16 @@ class _LibrariesCategoryScreen extends StatelessWidget {
                   final isEnabled = prefs.get(UserPreferences.groupItemsIntoCollections);
                   if (isEnabled) {
                     final client = GetIt.instance<MediaServerClient>();
-                    if (client.serverType == ServerType.jellyfin) {
-                      try {
-                        final config = await client.adminSystemApi.getServerConfiguration();
-                        final groupMovies = config['EnableGroupingMoviesIntoCollections'] as bool? ?? false;
-                        final groupShows = config['EnableGroupingShowsIntoCollections'] as bool? ?? false;
-                        if (groupMovies && groupShows) {
-                          return;
-                        }
-                      } catch (_) {}
-                    }
+                    try {
+                      final config =
+                          await client.adminSystemApi.getServerConfiguration();
+                      final groupingEnabled =
+                          config['EnableGroupingIntoCollections'] as bool? ??
+                              false;
+                      if (groupingEnabled) {
+                        return;
+                      }
+                    } catch (_) {}
 
                     if (!context.mounted) return;
                     showFocusRestoringDialog(

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -48,42 +48,44 @@ class JellyfinItemsApi implements ItemsApi {
     String? maxOfficialRating,
     bool? hasParentalRating,
   }) async {
+    final userId = _getUserId();
+    final queryParams = {
+      'ParentId': ?parentId,
+      if (ids != null) 'Ids': ids.join(','),
+      if (includeItemTypes != null)
+        'IncludeItemTypes': includeItemTypes.join(','),
+      if (excludeItemTypes != null)
+        'ExcludeItemTypes': excludeItemTypes.join(','),
+      'SortBy': ?sortBy,
+      'SortOrder': ?sortOrder,
+      'StartIndex': ?startIndex,
+      'Limit': ?limit,
+      'Recursive': ?recursive,
+      'SearchTerm': ?searchTerm,
+      'Fields': ?fields,
+      if (personIds != null) 'PersonIds': personIds.join(','),
+      if (artistIds != null) 'ArtistIds': artistIds.join(','),
+      if (filters != null) 'Filters': filters.join(','),
+      if (seriesStatus != null) 'SeriesStatus': seriesStatus.join(','),
+      'NameStartsWith': ?nameStartsWith,
+      'NameLessThan': ?nameLessThan,
+      if (genreIds != null) 'GenreIds': genreIds.join(','),
+      if (genres != null) 'Genres': genres.join(','),
+      'IsFavorite': ?isFavorite,
+      'CollapseBoxSetItems': ?collapseBoxSetItems,
+      'EnableTotalRecordCount': ?enableTotalRecordCount,
+      'EnableImageTypes': ?enableImageTypes,
+      'ImageTypeLimit': ?imageTypeLimit,
+      if (tags != null && tags.isNotEmpty) 'Tags': tags.join('|'),
+      if (studios != null && studios.isNotEmpty) 'Studios': studios.join('|'),
+      if (minPremiereDate != null)
+        'MinPremiereDate': minPremiereDate.toUtc().toIso8601String(),
+      'MaxOfficialRating': ?maxOfficialRating,
+      'HasParentalRating': ?hasParentalRating,
+    };
     final response = await _dio.get(
-      '/Items',
-      queryParameters: {
-        'ParentId': ?parentId,
-        if (ids != null) 'Ids': ids.join(','),
-        if (includeItemTypes != null)
-          'IncludeItemTypes': includeItemTypes.join(','),
-        if (excludeItemTypes != null)
-          'ExcludeItemTypes': excludeItemTypes.join(','),
-        'SortBy': ?sortBy,
-        'SortOrder': ?sortOrder,
-        'StartIndex': ?startIndex,
-        'Limit': ?limit,
-        'Recursive': ?recursive,
-        'SearchTerm': ?searchTerm,
-        'Fields': ?fields,
-        if (personIds != null) 'PersonIds': personIds.join(','),
-        if (artistIds != null) 'ArtistIds': artistIds.join(','),
-        if (filters != null) 'Filters': filters.join(','),
-        if (seriesStatus != null) 'SeriesStatus': seriesStatus.join(','),
-        'NameStartsWith': ?nameStartsWith,
-        'NameLessThan': ?nameLessThan,
-        if (genreIds != null) 'GenreIds': genreIds.join(','),
-        if (genres != null) 'Genres': genres.join(','),
-        'IsFavorite': ?isFavorite,
-        'CollapseBoxSetItems': ?collapseBoxSetItems,
-        'EnableTotalRecordCount': ?enableTotalRecordCount,
-        'EnableImageTypes': ?enableImageTypes,
-        'ImageTypeLimit': ?imageTypeLimit,
-        if (tags != null && tags.isNotEmpty) 'Tags': tags.join('|'),
-        if (studios != null && studios.isNotEmpty) 'Studios': studios.join('|'),
-        if (minPremiereDate != null)
-          'MinPremiereDate': minPremiereDate.toUtc().toIso8601String(),
-        'MaxOfficialRating': ?maxOfficialRating,
-        'HasParentalRating': ?hasParentalRating,
-      },
+      '/Users/$userId/Items',
+      queryParameters: queryParams,
     );
     return response.data as Map<String, dynamic>;
   }


### PR DESCRIPTION
# Pull Request

## Summary
This PR adds a client-side library personalization setting: "Group Items into Collections". When enabled, it groups movies and shows that belong to collections under their respective boxsets (displayed alphabetically in the library view) and hides the individual movie or show items.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #622 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **User Preference definition**: Added `groupItemsIntoCollections` preference key in `UserPreferences`.
- **Settings Screen Integration**:
  - Added a `SwitchPreferenceTile` in the Libraries section of `SettingsSidePanel`.
  - Added localization strings in `app_en.arb`.
  - Added a popup notice when toggling the setting ON if the server-side grouping options (`EnableGroupingMoviesIntoCollections` and `EnableGroupingShowsIntoCollections`) are not active on the server.
- **API and Endpoint adjustment**: Changed the `/Items` endpoint to `/Users/$userId/Items` in `JellyfinItemsApi` to correctly support user-scoped query filtering, specifically respecting the `CollapseBoxSetItems` parameter.
- **ViewModel adjustment**:
  - Listened to preference changes in `LibraryBrowseViewModel` to trigger page reload automatically.
  - Dynamically altered queried `includeTypes`, `excludeTypes`, and `collapseBoxSets` when requesting movies or shows if the preference is enabled.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Personalization -> Libraries and toggle "Group Items into Collections" ON.
2. Verify the warning dialog displays indicating server settings requirement triggers if the server setting is OFF.
3. Turn the server settings ON and toggle "Group Items into Collections" ON.
4. Browse movies and TV shows libraries alphabetically to verify collections collapse and individual items are hidden.
5. Verify toggling setting OFF returns the display to individual items list.

## Checklist
## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

* New Setting:
<img width="500" alt="Shield_Screenshot_2026-06-24_12-18-51" src="https://github.com/user-attachments/assets/31f41c87-abde-4594-b9e8-2b5b6e450359" />

* Ungrouped Library
<img width="500" alt="Shield_Screenshot_2026-06-24_12-19-07" src="https://github.com/user-attachments/assets/973b82cb-0ac5-43b9-b5ee-2f52e52dce19" />

* Movie Collection Library
<img width="500" alt="Shield_Screenshot_2026-06-24_12-18-27" src="https://github.com/user-attachments/assets/885837c8-9717-416b-b3f7-70f83d8049b2" />

* TV Show Collection Library
<img width="500" alt="Shield_Screenshot_2026-06-24_12-34-30" src="https://github.com/user-attachments/assets/bcbe3b5a-5448-41e2-bfe0-e8ba55297278" />

* Warning Message about Server-side Toggle:
<img width="500" alt="Shield_Screenshot_2026-06-24_12-19-35" src="https://github.com/user-attachments/assets/d0090c5d-ac7f-4982-ab07-44c8fc5666aa" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
