### PR TITLE
Feature/audio refactor

### DIFF
--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -25,6 +25,8 @@ import '../../preference/user_preferences.dart';
 import '../../syncplay/syncplay_manager.dart';
 import '../../util/platform_detection.dart';
 import '../../util/episode_playability.dart';
+import '../../util/audio_track_logic.dart';
+import '../../util/subtitle_track_logic.dart';
 
 final _getIt = GetIt.instance;
 
@@ -505,6 +507,59 @@ void registerPlaybackModule() {
   final audioArbiter = PlaybackArbiter();
   _getIt.registerSingleton<PlaybackArbiter>(audioArbiter);
   manager.setAudioArbiter(audioArbiter);
+  manager.audioTrackSelector = (audioStreams, explicitIndex) {
+    final preferredAudioLanguage = manager.lastExplicitAudioLanguage ??
+        (prefs.get(UserPreferences.defaultAudioLanguage) as String? ?? 'auto');
+
+    return computeEffectiveAudioIndex(
+      audioStreams: audioStreams,
+      preferredAudioLanguage: preferredAudioLanguage,
+      fallbackAudioLanguage: prefs.get(UserPreferences.fallbackAudioLanguage) as String? ?? '',
+      preferDefaultAudioTrack: prefs.get(UserPreferences.preferDefaultAudioTrack) as bool? ?? false,
+      preferAudioDescription: prefs.get(UserPreferences.preferAudioDescription) as bool? ?? false,
+      explicitAudioIndex: explicitIndex,
+    );
+  };
+
+  manager.subtitleTrackSelector = (subtitleStreams, audioStreams, explicitIndex) {
+    final effectiveAudioIndex = computeEffectiveAudioIndex(
+      audioStreams: audioStreams,
+      preferredAudioLanguage: manager.lastExplicitAudioLanguage ??
+          (prefs.get(UserPreferences.defaultAudioLanguage) as String? ?? 'auto'),
+      fallbackAudioLanguage: prefs.get(UserPreferences.fallbackAudioLanguage) as String? ?? '',
+      preferDefaultAudioTrack: prefs.get(UserPreferences.preferDefaultAudioTrack) as bool? ?? false,
+      preferAudioDescription: prefs.get(UserPreferences.preferAudioDescription) as bool? ?? false,
+      explicitAudioIndex: manager.audioSelectionExplicit ? manager.audioStreamIndex : null,
+    );
+
+    final activeAudioStream = audioStreams.firstWhere(
+      (s) => s['Index'] == effectiveAudioIndex,
+      orElse: () => const <String, dynamic>{},
+    );
+    final activeAudioLanguage = activeAudioStream.isNotEmpty ? activeAudioStream['Language'] as String? : null;
+
+    final subtitleMode = manager.lastExplicitSubtitleEnabled == false
+        ? SubtitleMode.none
+        : prefs.get(UserPreferences.subtitleMode);
+
+    final preferredLanguage = manager.lastExplicitSubtitleLanguage ??
+        (prefs.get(UserPreferences.defaultSubtitleLanguage) as String? ?? '');
+
+    return computeEffectiveSubtitleIndex(
+      subtitleStreams: subtitleStreams,
+      selectedSubtitleIndex: explicitIndex,
+      activePlaybackSubtitleIndex: null,
+      subtitleMode: subtitleMode,
+      preferredLanguage: preferredLanguage,
+      fallbackLanguage: prefs.get(UserPreferences.fallbackSubtitleLanguage) as String? ?? '',
+      preferSdh: prefs.get(UserPreferences.preferSdhSubtitles) as bool? ?? false,
+      pgsDirectPlay: prefs.get(UserPreferences.pgsDirectPlay) as bool? ?? false,
+      assDirectPlay: prefs.get(UserPreferences.assDirectPlay) as bool? ?? false,
+      preferredAudioLanguage: prefs.get(UserPreferences.defaultAudioLanguage) as String? ?? 'auto',
+      activeAudioLanguage: activeAudioLanguage,
+    );
+  };
+
   _getIt.registerSingleton<PlaybackManager>(manager);
 
   _getIt.registerLazySingleton<OfflineStreamResolver>(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3071,6 +3071,30 @@
   "@defaultAudioLanguage": {
     "description": "Setting for default audio language"
   },
+  "fallbackAudioLanguage": "Fallback Audio Language",
+  "@fallbackAudioLanguage": {
+    "description": "Setting for fallback audio language"
+  },
+  "preferDefaultAudioTrack": "Prefer Default Audio Track",
+  "@preferDefaultAudioTrack": {
+    "description": "Setting for preferring default audio track"
+  },
+  "preferDefaultAudioTrackDescription": "Prefer original audio track over localized dub.",
+  "@preferDefaultAudioTrackDescription": {
+    "description": "Description for preferring default audio track setting"
+  },
+  "preferAudioDescription": "Prefer Audio Description Tracks",
+  "@preferAudioDescription": {
+    "description": "Setting for preferring audio description tracks"
+  },
+  "preferAudioDescriptionDescription": "Prefer audio description tracks over normal tracks.",
+  "@preferAudioDescriptionDescription": {
+    "description": "Description for preferring audio description tracks setting"
+  },
+  "transcodingAudio": "Transcoding (Audio)",
+  "@transcodingAudio": {
+    "description": "Label for audio-only transcode playback method"
+  },
   "autoServerDefault": "Auto (Server Default)",
   "@autoServerDefault": {
     "description": "Option: auto server default"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3958,6 +3958,42 @@ abstract class AppLocalizations {
   /// **'Default Audio Language'**
   String get defaultAudioLanguage;
 
+  /// Setting for fallback audio language
+  ///
+  /// In en, this message translates to:
+  /// **'Fallback Audio Language'**
+  String get fallbackAudioLanguage;
+
+  /// Setting for preferring default audio track
+  ///
+  /// In en, this message translates to:
+  /// **'Prefer Default Audio Track'**
+  String get preferDefaultAudioTrack;
+
+  /// Description for preferring default audio track setting
+  ///
+  /// In en, this message translates to:
+  /// **'Prefer original audio track over localized dub.'**
+  String get preferDefaultAudioTrackDescription;
+
+  /// Setting for preferring audio description tracks
+  ///
+  /// In en, this message translates to:
+  /// **'Prefer Audio Description Tracks'**
+  String get preferAudioDescription;
+
+  /// Description for preferring audio description tracks setting
+  ///
+  /// In en, this message translates to:
+  /// **'Prefer audio description tracks over normal tracks.'**
+  String get preferAudioDescriptionDescription;
+
+  /// Label for audio-only transcode playback method
+  ///
+  /// In en, this message translates to:
+  /// **'Transcoding (Audio)'**
+  String get transcodingAudio;
+
   /// Option: auto server default
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2166,6 +2166,26 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultAudioLanguage => 'Default Audio Language';
 
   @override
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
+
+  @override
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
+
+  @override
+  String get preferDefaultAudioTrackDescription =>
+      'Prefer original audio track over localized dub.';
+
+  @override
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
+
+  @override
+  String get preferAudioDescriptionDescription =>
+      'Prefer audio description tracks over normal tracks.';
+
+  @override
+  String get transcodingAudio => 'Transcoding (Audio)';
+
+  @override
   String get autoServerDefault => 'Auto (Server Default)';
 
   @override

--- a/lib/playback/audio_capability_profile.dart
+++ b/lib/playback/audio_capability_profile.dart
@@ -1,4 +1,5 @@
 import '../preference/preference_constants.dart';
+import '../util/platform_detection.dart';
 
 enum AudioRouteType { hdmi, arc, earc, bluetooth, speaker, other }
 
@@ -8,7 +9,7 @@ class AudioCapabilityProfile {
     required this.canDecodeEac3,
     required this.canDecodeDts,
     required this.canDecodeDtsHd,
-    required this.canDecodeTrueHd,
+    required bool canDecodeTrueHd,
     required this.canDecodeFlac,
     required this.canPassthroughAc3,
     required this.canPassthroughEac3,
@@ -21,14 +22,14 @@ class AudioCapabilityProfile {
     required this.maxPcmChannels,
     required this.activeRouteType,
     required this.routeSupportsHdAudio,
-  });
+  }) : _canDecodeTrueHd = canDecodeTrueHd;
 
   const AudioCapabilityProfile.optimistic()
     : canDecodeAc3 = true,
       canDecodeEac3 = true,
       canDecodeDts = true,
       canDecodeDtsHd = true,
-      canDecodeTrueHd = true,
+      _canDecodeTrueHd = true,
       canDecodeFlac = true,
       canPassthroughAc3 = false,
       canPassthroughEac3 = false,
@@ -47,7 +48,7 @@ class AudioCapabilityProfile {
       canDecodeEac3 = true,
       canDecodeDts = true,
       canDecodeDtsHd = true,
-      canDecodeTrueHd = false,
+      _canDecodeTrueHd = false,
       canDecodeFlac = true,
       canPassthroughAc3 = false,
       canPassthroughEac3 = false,
@@ -65,7 +66,8 @@ class AudioCapabilityProfile {
   final bool canDecodeEac3;
   final bool canDecodeDts;
   final bool canDecodeDtsHd;
-  final bool canDecodeTrueHd;
+  final bool _canDecodeTrueHd;
+  bool get canDecodeTrueHd => !PlatformDetection.isAndroid && _canDecodeTrueHd;
   final bool canDecodeFlac;
 
   final bool canPassthroughAc3;

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1126,6 +1126,18 @@ class UserPreferences extends ChangeNotifier {
     key: 'pref_audio_language',
     defaultValue: 'auto',
   );
+  static final fallbackAudioLanguage = Preference<String>(
+    key: 'pref_fallback_audio_language',
+    defaultValue: '',
+  );
+  static final preferDefaultAudioTrack = Preference<bool>(
+    key: 'pref_prefer_default_audio_track',
+    defaultValue: false,
+  );
+  static final preferAudioDescription = Preference<bool>(
+    key: 'pref_prefer_audio_description',
+    defaultValue: false,
+  );
   static final defaultSubtitleLanguage = Preference(
     key: 'pref_subtitle_language',
     defaultValue: '',

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -63,6 +63,7 @@ import '../../../util/episode_playability.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/language_matching.dart';
 import '../../../util/subtitle_track_logic.dart';
+import '../../../util/audio_track_logic.dart';
 import '../../../util/platform_detection.dart';
 
 const _textShadows = [Shadow(blurRadius: 4, color: Colors.black54)];
@@ -5435,29 +5436,14 @@ class _ActionButtonsState extends State<_ActionButtons> {
     }
 
     final prefs = GetIt.instance<UserPreferences>();
-    final preferred = prefs.get(UserPreferences.defaultAudioLanguage).trim();
-    if (preferred.isEmpty) {
-      final defaultStream = audioStreams.firstWhere(
-        (s) => s['IsDefault'] == true,
-        orElse: () => <String, dynamic>{},
-      );
-      return defaultStream['Index'] as int?;
-    }
-
-    final preferredNormalized = normalizeLanguage(preferred);
-    final preferredIso3 = toIso3Language(preferredNormalized);
-
-    for (final stream in audioStreams) {
-      if (languageMatchesPreferred(
-        (stream['Language'] as String?)?.trim(),
-        preferredNormalized,
-        preferredIso3,
-      )) {
-        return stream['Index'] as int?;
-      }
-    }
-
-    return null;
+    return computeEffectiveAudioIndex(
+      audioStreams: audioStreams,
+      preferredAudioLanguage: prefs.get(UserPreferences.defaultAudioLanguage),
+      fallbackAudioLanguage: prefs.get(UserPreferences.fallbackAudioLanguage),
+      preferDefaultAudioTrack: prefs.get(UserPreferences.preferDefaultAudioTrack),
+      preferAudioDescription: prefs.get(UserPreferences.preferAudioDescription),
+      explicitAudioIndex: null,
+    );
   }
 
   int? _effectiveSubtitleStreamIndex(

--- a/lib/ui/screens/settings/panel/audio_preferences_screen.dart
+++ b/lib/ui/screens/settings/panel/audio_preferences_screen.dart
@@ -201,6 +201,35 @@ class _AudioPreferencesScreenState extends State<_AudioPreferencesScreen> {
     final isAdvanced =
         _prefs.get(UserPreferences.audioPassthroughPreset) ==
         AudioPassthroughPreset.advanced;
+
+    final iso3ToIso1 = {
+      for (final entry in kIso6391To6392.entries) entry.value: entry.key
+    };
+
+    final supportedIso3Codes = AppLocalizations.supportedLocales.map((locale) {
+      final lang1 = locale.languageCode;
+      return kIso6391To6392[lang1] ?? lang1;
+    }).toSet();
+
+    final defaultAudioLangOptions = {
+      'auto': l10n.autoServerDefault,
+    };
+    final fallbackAudioLangOptions = {
+      '': l10n.none,
+    };
+
+    for (final entry in kIso6392Languages.entries) {
+      final code = entry.key;
+      if (!supportedIso3Codes.contains(code)) {
+        continue;
+      }
+      final englishName = entry.value;
+      final iso1 = iso3ToIso1[code];
+      final displayName = (iso1 != null ? kLocaleDisplayNames[iso1] : null) ?? englishName;
+      defaultAudioLangOptions[code] = displayName;
+      fallbackAudioLangOptions[code] = displayName;
+    }
+
     return Scaffold(
       appBar: buildSettingsAppBar(context, Text(l10n.settingsAudioPreferences)),
       body: ListView(
@@ -214,11 +243,34 @@ class _AudioPreferencesScreenState extends State<_AudioPreferencesScreen> {
                 subtitle: l10n.compressDynamicRange,
                 icon: Icons.nights_stay,
               ),
+            ],
+          ),
+          const _SectionHeader('Audio Stream'),
+          adaptiveListSection(
+            children: [
               StringPickerPreferenceTile(
                 preference: UserPreferences.defaultAudioLanguage,
                 title: l10n.defaultAudioLanguage,
                 icon: Icons.language,
-                options: {'auto': l10n.autoServerDefault, ...kIso6392Languages},
+                options: defaultAudioLangOptions,
+              ),
+              StringPickerPreferenceTile(
+                preference: UserPreferences.fallbackAudioLanguage,
+                title: l10n.fallbackAudioLanguage,
+                icon: Icons.language,
+                options: fallbackAudioLangOptions,
+              ),
+              SwitchPreferenceTile(
+                preference: UserPreferences.preferDefaultAudioTrack,
+                title: l10n.preferDefaultAudioTrack,
+                subtitle: l10n.preferDefaultAudioTrackDescription,
+                icon: Icons.audiotrack,
+              ),
+              SwitchPreferenceTile(
+                preference: UserPreferences.preferAudioDescription,
+                title: l10n.preferAudioDescription,
+                subtitle: l10n.preferAudioDescriptionDescription,
+                icon: Icons.hearing,
               ),
             ],
           ),

--- a/lib/util/audio_track_logic.dart
+++ b/lib/util/audio_track_logic.dart
@@ -1,0 +1,136 @@
+import 'language_matching.dart';
+
+bool isCommentaryAudioStream(Map<String, dynamic> stream) {
+  if (stream['IsCommentary'] == true) return true;
+  final titleParts = [
+    stream['DisplayTitle'] as String?,
+    stream['Title'] as String?,
+    stream['Name'] as String?,
+  ].whereType<String>().map((s) => s.toLowerCase()).join(' ');
+  return RegExp(
+    r'\b(commentary|director\s*commentary|commentaries|directors\s*commentary)\b',
+  ).hasMatch(titleParts);
+}
+
+bool isAudioDescriptionAudioStream(Map<String, dynamic> stream) {
+  if (stream['IsAudioDescription'] == true) return true;
+  final titleParts = [
+    stream['DisplayTitle'] as String?,
+    stream['Title'] as String?,
+    stream['Name'] as String?,
+  ].whereType<String>().map((s) => s.toLowerCase()).join(' ');
+  return RegExp(
+    r'\b(audio\s+description|descriptive\s+audio|visual\s+description|descriptive|description|ad)\b',
+  ).hasMatch(titleParts);
+}
+
+bool matchLang(String? streamLanguage, String target) {
+  final targetClean = target.trim();
+  if (targetClean.isEmpty || targetClean.toLowerCase() == 'auto') return false;
+  final targetNormalized = normalizeLanguage(targetClean);
+  final targetIso3 = toIso3Language(targetNormalized);
+  return languageMatchesPreferred(streamLanguage, targetNormalized, targetIso3);
+}
+
+int? computeEffectiveAudioIndex({
+  required List<Map<String, dynamic>> audioStreams,
+  required String preferredAudioLanguage,
+  required String fallbackAudioLanguage,
+  required bool preferDefaultAudioTrack,
+  required bool preferAudioDescription,
+  int? explicitAudioIndex,
+}) {
+  final streams = audioStreams.where((s) => s['Type'] == 'Audio').toList();
+  if (streams.isEmpty) return null;
+
+  // 1. Explicit selection check
+  if (explicitAudioIndex != null) {
+    final hasExplicit = streams.any((s) => s['Index'] == explicitAudioIndex);
+    if (hasExplicit) return explicitAudioIndex;
+  }
+
+  // 2. Filter commentary tracks
+  final nonCommentary = streams.where((s) => !isCommentaryAudioStream(s)).toList();
+  var candidates = nonCommentary.isNotEmpty ? nonCommentary : streams;
+
+  // 3. Filter audio description tracks if not preferred
+  if (!preferAudioDescription) {
+    final nonAd = candidates.where((s) => !isAudioDescriptionAudioStream(s)).toList();
+    if (nonAd.isNotEmpty) {
+      candidates = nonAd;
+    }
+  }
+
+  // 4. Prefer Default Audio Track
+  if (preferDefaultAudioTrack) {
+    final defaultTracks = candidates.where((s) => s['IsDefault'] == true).toList();
+    if (defaultTracks.isNotEmpty) {
+      return _rankAudioCandidates(defaultTracks, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
+    }
+  }
+
+  // 5. Match preferred language
+  final preferredMatches = candidates.where((s) => matchLang(s['Language'], preferredAudioLanguage)).toList();
+  if (preferredMatches.isNotEmpty) {
+    return _rankAudioCandidates(preferredMatches, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
+  }
+
+  // 6. Match fallback language
+  final fallbackMatches = candidates.where((s) => matchLang(s['Language'], fallbackAudioLanguage)).toList();
+  if (fallbackMatches.isNotEmpty) {
+    return _rankAudioCandidates(fallbackMatches, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
+  }
+
+  // 7. Match English fallback
+  final englishMatches = candidates.where((s) => matchLang(s['Language'], 'eng')).toList();
+  if (englishMatches.isNotEmpty) {
+    return _rankAudioCandidates(englishMatches, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
+  }
+
+  // 8. Fall back to default track or first candidate
+  return _rankAudioCandidates(candidates, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
+}
+
+Map<String, dynamic> _rankAudioCandidates(
+  List<Map<String, dynamic>> candidates,
+  bool preferDefaultAudioTrack,
+  bool preferAudioDescription,
+) {
+  if (candidates.length <= 1) return candidates.first;
+  final list = List<Map<String, dynamic>>.from(candidates);
+  list.sort((a, b) {
+    if (preferAudioDescription) {
+      final aAd = isAudioDescriptionAudioStream(a);
+      final bAd = isAudioDescriptionAudioStream(b);
+      if (aAd != bAd) {
+        return aAd ? -1 : 1;
+      }
+    }
+    if (preferDefaultAudioTrack) {
+      final aDefault = a['IsDefault'] == true;
+      final bDefault = b['IsDefault'] == true;
+      if (aDefault != bDefault) {
+        return aDefault ? -1 : 1;
+      }
+    }
+    // Prefer higher channel count (surround sound)
+    final aChannels = a['Channels'] as int? ?? 0;
+    final bChannels = b['Channels'] as int? ?? 0;
+    if (aChannels != bChannels) {
+      return bChannels.compareTo(aChannels);
+    }
+    // If not preferDefaultAudioTrack, check IsDefault here as a tie-breaker
+    if (!preferDefaultAudioTrack) {
+      final aDefault = a['IsDefault'] == true;
+      final bDefault = b['IsDefault'] == true;
+      if (aDefault != bDefault) {
+        return aDefault ? -1 : 1;
+      }
+    }
+    // Tie-breaker: original index
+    final aIdx = a['Index'] as int? ?? 0;
+    final bIdx = b['Index'] as int? ?? 0;
+    return aIdx.compareTo(bIdx);
+  });
+  return list.first;
+}

--- a/lib/util/play_method_label.dart
+++ b/lib/util/play_method_label.dart
@@ -34,7 +34,7 @@ String playbackMethodLabel({
     return switch (playMethod) {
       StreamPlayMethod.directPlay => l10n.directPlay,
       StreamPlayMethod.directStream => l10n.directStream,
-      StreamPlayMethod.transcode when isRemux => '${l10n.directStream} (Remux)',
+      StreamPlayMethod.transcode when isRemux => l10n.transcodingAudio,
       StreamPlayMethod.transcode => l10n.transcoding,
     };
   }

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -37,6 +37,8 @@ class PlaybackManager implements AudioOwnable {
   )?
   _startupRecoveryDecider;
   void Function(PlaybackDecisionContext context)? _playbackDecisionLogger;
+  int? Function(List<Map<String, dynamic>> audioStreams, int? explicitIndex)? audioTrackSelector;
+  int? Function(List<Map<String, dynamic>> subtitleStreams, List<Map<String, dynamic>> audioStreams, int? explicitIndex)? subtitleTrackSelector;
   final QueueService queueService = QueueService();
   final PlayerState state = PlayerState();
   final Set<PlayerBackend> _retainedBackends = <PlayerBackend>{};
@@ -150,6 +152,11 @@ class PlaybackManager implements AudioOwnable {
   int? get pendingAudioStreamIndex => _pendingItemAudioStreamIndex;
   int? get pendingSubtitleStreamIndex => _pendingItemSubtitleStreamIndex;
   String? get pendingMediaSourceId => _mediaSourceId;
+  bool get audioSelectionExplicit => _audioSelectionExplicit;
+  bool get subtitleSelectionExplicit => _subtitleSelectionExplicit;
+  String? get lastExplicitAudioLanguage => _lastExplicitAudioLanguage;
+  String? get lastExplicitSubtitleLanguage => _lastExplicitSubtitleLanguage;
+  bool? get lastExplicitSubtitleEnabled => _lastExplicitSubtitleEnabled;
   bool get playbackDeferredToExternalPlayer => _deferPlaybackToExternalPlayer;
   bool consumeSkipExternalRoutingOnce() {
     final shouldSkip = _skipExternalRoutingOnce;
@@ -1068,37 +1075,67 @@ class PlaybackManager implements AudioOwnable {
 
     bool needsReResolve = false;
 
-    if (_lastExplicitAudioLanguage != null) {
-      final matchedIdx = _matchStreamIndexByLanguage(
-        resolution.mediaStreams,
-        _lastExplicitAudioLanguage,
-        'Audio',
+    final audioStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Audio').toList();
+    final subtitleStreams = resolution.mediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+
+    if (audioTrackSelector != null) {
+      final targetIdx = audioTrackSelector!(
+        audioStreams,
+        _audioSelectionExplicit ? _audioStreamIndex : null,
       );
-      if (matchedIdx != null && _audioStreamIndex != matchedIdx) {
-        _audioStreamIndex = matchedIdx;
+      if (targetIdx != null && _audioStreamIndex != targetIdx) {
+        _audioStreamIndex = targetIdx;
         if (resolution.playMethod == StreamPlayMethod.transcode) {
           needsReResolve = true;
+        }
+      }
+    } else {
+      if (_lastExplicitAudioLanguage != null) {
+        final matchedIdx = _matchStreamIndexByLanguage(
+          resolution.mediaStreams,
+          _lastExplicitAudioLanguage,
+          'Audio',
+        );
+        if (matchedIdx != null && _audioStreamIndex != matchedIdx) {
+          _audioStreamIndex = matchedIdx;
+          if (resolution.playMethod == StreamPlayMethod.transcode) {
+            needsReResolve = true;
+          }
         }
       }
     }
 
-    if (_lastExplicitSubtitleEnabled == false) {
-      if (_subtitleStreamIndex != -1) {
-        _subtitleStreamIndex = -1;
+    if (subtitleTrackSelector != null) {
+      final targetIdx = subtitleTrackSelector!(
+        subtitleStreams,
+        audioStreams,
+        _subtitleSelectionExplicit ? _subtitleStreamIndex : null,
+      );
+      if (targetIdx != null && _subtitleStreamIndex != targetIdx) {
+        _subtitleStreamIndex = targetIdx;
         if (resolution.playMethod == StreamPlayMethod.transcode) {
           needsReResolve = true;
         }
       }
-    } else if (_lastExplicitSubtitleLanguage != null) {
-      final matchedIdx = _matchStreamIndexByLanguage(
-        resolution.mediaStreams,
-        _lastExplicitSubtitleLanguage,
-        'Subtitle',
-      );
-      if (matchedIdx != null && _subtitleStreamIndex != matchedIdx) {
-        _subtitleStreamIndex = matchedIdx;
-        if (resolution.playMethod == StreamPlayMethod.transcode) {
-          needsReResolve = true;
+    } else {
+      if (_lastExplicitSubtitleEnabled == false) {
+        if (_subtitleStreamIndex != -1) {
+          _subtitleStreamIndex = -1;
+          if (resolution.playMethod == StreamPlayMethod.transcode) {
+            needsReResolve = true;
+          }
+        }
+      } else if (_lastExplicitSubtitleLanguage != null) {
+        final matchedIdx = _matchStreamIndexByLanguage(
+          resolution.mediaStreams,
+          _lastExplicitSubtitleLanguage,
+          'Subtitle',
+        );
+        if (matchedIdx != null && _subtitleStreamIndex != matchedIdx) {
+          _subtitleStreamIndex = matchedIdx;
+          if (resolution.playMethod == StreamPlayMethod.transcode) {
+            needsReResolve = true;
+          }
         }
       }
     }

--- a/test/playback/device_profile_builder_test.dart
+++ b/test/playback/device_profile_builder_test.dart
@@ -3,6 +3,7 @@ import 'package:moonfin/playback/audio_capability_profile.dart';
 import 'package:moonfin/playback/device_profile_builder.dart';
 import 'package:moonfin/playback/known_defects.dart';
 import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/util/platform_detection.dart';
 
 Set<String> _hevcUnsupportedRangeTypes(Map<String, dynamic> profile) {
   final codecProfiles = profile['CodecProfiles'] as List<dynamic>? ?? const [];
@@ -211,8 +212,13 @@ void main() {
       expect(codecs, contains('eac3'));
       expect(codecs, contains('dts'));
       expect(codecs, contains('dca'));
-      expect(codecs, contains('truehd'));
-      expect(codecs, contains('mlp'));
+      if (!PlatformDetection.isAndroid) {
+        expect(codecs, contains('truehd'));
+        expect(codecs, contains('mlp'));
+      } else {
+        expect(codecs, isNot(contains('truehd')));
+        expect(codecs, isNot(contains('mlp')));
+      }
     });
 
     test('keeps codec when local decode is available even without passthrough', () {

--- a/test/util/audio_track_logic_test.dart
+++ b/test/util/audio_track_logic_test.dart
@@ -1,0 +1,417 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/util/audio_track_logic.dart';
+
+void main() {
+  group('isCommentaryAudioStream', () {
+    test('returns true when IsCommentary is true', () {
+      expect(
+        isCommentaryAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'IsCommentary': true,
+        }),
+        isTrue,
+      );
+    });
+
+    test('returns true when DisplayTitle/Title/Name contains commentary keyword', () {
+      expect(
+        isCommentaryAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'Title': 'Director\'s Commentary',
+        }),
+        isTrue,
+      );
+      expect(
+        isCommentaryAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'DisplayTitle': 'Commentary by Director',
+        }),
+        isTrue,
+      );
+      expect(
+        isCommentaryAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'Name': 'commentary',
+        }),
+        isTrue,
+      );
+    });
+
+    test('returns false for normal stream', () {
+      expect(
+        isCommentaryAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'Title': 'Feature Audio',
+        }),
+        isFalse,
+      );
+    });
+  });
+
+  group('computeEffectiveAudioIndex', () {
+    final List<Map<String, dynamic>> testStreams = [
+      {
+        'Type': 'Audio',
+        'Index': 0,
+        'Language': 'fre',
+        'IsDefault': true,
+        'Channels': 2,
+      },
+      {
+        'Type': 'Audio',
+        'Index': 1,
+        'Language': 'eng',
+        'IsDefault': false,
+        'Channels': 6,
+      },
+      {
+        'Type': 'Audio',
+        'Index': 2,
+        'Language': 'spa',
+        'IsDefault': false,
+        'Channels': 2,
+      },
+      {
+        'Type': 'Audio',
+        'Index': 3,
+        'Language': 'eng',
+        'IsDefault': false,
+        'Title': 'Director Commentary',
+        'Channels': 2,
+      },
+    ];
+
+    test('returns explicit index if valid and exists', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: testStreams,
+        preferredAudioLanguage: 'spa',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+        explicitAudioIndex: 2,
+      );
+      expect(index, 2);
+    });
+
+    test('returns null when streams are empty', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: [],
+        preferredAudioLanguage: 'eng',
+        fallbackAudioLanguage: 'spa',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, isNull);
+    });
+
+    test('filters out commentary tracks if non-commentary exists', () {
+      // spanish preferred, but spain commentary has 'spa'.
+      final streamsWithCommentary = [
+        {
+          'Type': 'Audio',
+          'Index': 0,
+          'Language': 'spa',
+          'Title': 'Spanish Commentary',
+          'Channels': 2,
+        },
+        {
+          'Type': 'Audio',
+          'Index': 1,
+          'Language': 'spa',
+          'Title': 'Spanish Feature Audio',
+          'Channels': 2,
+        },
+      ];
+      final index = computeEffectiveAudioIndex(
+        audioStreams: streamsWithCommentary,
+        preferredAudioLanguage: 'spa',
+        fallbackAudioLanguage: 'eng',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 1);
+    });
+
+    test('returns commentary if only commentary tracks exist', () {
+      final commentaryOnly = [
+        {
+          'Type': 'Audio',
+          'Index': 0,
+          'Language': 'spa',
+          'Title': 'Commentary 1',
+          'Channels': 2,
+        },
+        {
+          'Type': 'Audio',
+          'Index': 1,
+          'Language': 'spa',
+          'Title': 'Commentary 2',
+          'Channels': 2,
+        },
+      ];
+      final index = computeEffectiveAudioIndex(
+        audioStreams: commentaryOnly,
+        preferredAudioLanguage: 'spa',
+        fallbackAudioLanguage: 'eng',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 0);
+    });
+
+    test('matches preferred language first', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: testStreams,
+        preferredAudioLanguage: 'spa',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 2); // spa is Index 2
+    });
+
+    test('matches fallback language if preferred not found', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: testStreams,
+        preferredAudioLanguage: 'jpn',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 0); // fre is Index 0
+    });
+
+    test('falls back to English if preferred and fallback not found', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: testStreams,
+        preferredAudioLanguage: 'jpn',
+        fallbackAudioLanguage: 'ger',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 1); // eng is Index 1
+    });
+
+    test('falls back to default/first track if nothing matched', () {
+      final unmatchedStreams = [
+        {
+          'Type': 'Audio',
+          'Index': 0,
+          'Language': 'jpn',
+          'IsDefault': false,
+          'Channels': 2,
+        },
+        {
+          'Type': 'Audio',
+          'Index': 1,
+          'Language': 'ger',
+          'IsDefault': true,
+          'Channels': 2,
+        },
+      ];
+      final index = computeEffectiveAudioIndex(
+        audioStreams: unmatchedStreams,
+        preferredAudioLanguage: 'fre',
+        fallbackAudioLanguage: 'spa',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 1); // default track Index 1
+    });
+
+    test('preferDefaultAudioTrack = true prioritizes IsDefault track regardless of language match', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: testStreams,
+        preferredAudioLanguage: 'spa',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: true,
+        preferAudioDescription: false,
+      );
+      expect(index, 0); // fre has IsDefault == true, SPA does not.
+    });
+
+    test('preferDefaultAudioTrack = false prioritizes language match over default track', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: testStreams,
+        preferredAudioLanguage: 'spa',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 2); // Spanish (Index 2) preferred over French default (Index 0)
+    });
+
+    test('breaks ties using higher channel count (surround sound)', () {
+      final sameLangStreams = [
+        {
+          'Type': 'Audio',
+          'Index': 0,
+          'Language': 'eng',
+          'Channels': 2,
+        },
+        {
+          'Type': 'Audio',
+          'Index': 1,
+          'Language': 'eng',
+          'Channels': 6,
+        },
+        {
+          'Type': 'Audio',
+          'Index': 2,
+          'Language': 'eng',
+          'Channels': 2,
+        },
+      ];
+      final index = computeEffectiveAudioIndex(
+        audioStreams: sameLangStreams,
+        preferredAudioLanguage: 'eng',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 1); // 6 channels is Index 1
+    });
+
+    test('breaks ties of channel count using original index order', () {
+      final sameLangSameChannel = [
+        {
+          'Type': 'Audio',
+          'Index': 2,
+          'Language': 'eng',
+          'Channels': 6,
+        },
+        {
+          'Type': 'Audio',
+          'Index': 0,
+          'Language': 'eng',
+          'Channels': 6,
+        },
+      ];
+      final index = computeEffectiveAudioIndex(
+        audioStreams: sameLangSameChannel,
+        preferredAudioLanguage: 'eng',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 0); // original index order (0 before 2)
+    });
+  });
+
+  group('isAudioDescriptionAudioStream', () {
+    test('returns true when IsAudioDescription is true', () {
+      expect(
+        isAudioDescriptionAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'IsAudioDescription': true,
+        }),
+        isTrue,
+      );
+    });
+
+    test('returns true when DisplayTitle/Title/Name contains AD keywords', () {
+      expect(
+        isAudioDescriptionAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'Title': 'Descriptive Audio',
+        }),
+        isTrue,
+      );
+      expect(
+        isAudioDescriptionAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'DisplayTitle': 'Audio Description',
+        }),
+        isTrue,
+      );
+      expect(
+        isAudioDescriptionAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'Name': 'English AD',
+        }),
+        isTrue,
+      );
+    });
+
+    test('returns false for normal stream', () {
+      expect(
+        isAudioDescriptionAudioStream({
+          'Type': 'Audio',
+          'Index': 1,
+          'Title': 'Feature Audio',
+        }),
+        isFalse,
+      );
+    });
+  });
+
+  group('computeEffectiveAudioIndex with preferAudioDescription', () {
+    final adStreams = [
+      {
+        'Type': 'Audio',
+        'Index': 0,
+        'Language': 'eng',
+        'Title': 'English Normal',
+        'Channels': 2,
+      },
+      {
+        'Type': 'Audio',
+        'Index': 1,
+        'Language': 'eng',
+        'Title': 'English Descriptive Audio',
+        'Channels': 2,
+      },
+    ];
+
+    test('preferAudioDescription = false filters out AD tracks if normal exists', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: adStreams,
+        preferredAudioLanguage: 'eng',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 0);
+    });
+
+    test('preferAudioDescription = false does not filter out AD tracks if only AD exists', () {
+      final onlyAd = [
+        {
+          'Type': 'Audio',
+          'Index': 1,
+          'Language': 'eng',
+          'Title': 'English Descriptive Audio',
+          'Channels': 2,
+        }
+      ];
+      final index = computeEffectiveAudioIndex(
+        audioStreams: onlyAd,
+        preferredAudioLanguage: 'eng',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: false,
+      );
+      expect(index, 1);
+    });
+
+    test('preferAudioDescription = true ranks AD tracks higher', () {
+      final index = computeEffectiveAudioIndex(
+        audioStreams: adStreams,
+        preferredAudioLanguage: 'eng',
+        fallbackAudioLanguage: 'fre',
+        preferDefaultAudioTrack: false,
+        preferAudioDescription: true,
+      );
+      expect(index, 1);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request: The One about Sound Logic

## Summary
Refactor the audio stream selection engine to support localized pickers, secondary fallbacks, default track overrides, and preferred Audio Description tracks. Additionally, resolve several player audio compatibility issues (TrueHD software decoding failures on Android, FireOS 8+ passthrough remux bugs, and audio-only transcoding info labels).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #574 
- Fixes #588, #621 
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Preferences & UI**:
  - Added `preferAudioDescription`, `fallbackAudioLanguage`, and `preferDefaultAudioTrack` options to UserPreferences.
  - Reorganized the settings layout under a new `"Audio Stream"` section header.
- **Audio Track Selection**:
  - Implemented `isAudioDescriptionAudioStream` and `isCommentaryAudioStream` filters.
  - Developed a prioritized ranking engine that matches preferred, fallback, and English languages, breaking ties using channel count (surround sound over stereo) and container ordering. See this mermaid chart for details:

<img width="500" alt="Untitled diagram-2026-06-25-054856" src="https://github.com/user-attachments/assets/7d6a2484-996d-4cea-a72b-e22fe58d5990" />
  
- **Player & Decoding Fixes**:
  - Disabled TrueHD Atmos software decoding capabilities on Android devices to prevent standard ExoPlayer from attempting software decode and force the server to transcode it instead.
  - Modified capabilities detection on native Kotlin and Dart sides so that the HEVC Dolby Vision HDR10+ remuxing workaround is restricted only to FireOS 7 (SDK < 30) devices. Newer FireOS 8+ devices can Direct Play these files directly.
  - Added `Transcoding (Audio)` label in play method labels when video stream is direct played but audio is transcoded instead of showing 'Remux`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. **Automated Tests**: Developed 21 test scenarios in `audio_track_logic_test.dart` and confirmed all 120 unit tests pass.
2. **Manual Verification**: Installed the built release APK on the Nvidia Shield TV and successfully verified:
  - Atmos files fallback to transcoding correctly (`Transcoding (Audio)`) instead of crashing.
  - Dolby Vision + HDR10+ files direct play on FireOS 8+ devices without remuxing issues.
  - The new "Audio Stream" settings section renders correctly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

* TrueHD with Passthrough ON:
<img width="500" alt="1-passthroughon" src="https://github.com/user-attachments/assets/83113bb2-55d9-4b04-b1b0-5619e3292ae4" />

* TrueHD with Passthrough OFF:
<img width="500" alt="2-passthroughoff" src="https://github.com/user-attachments/assets/da15a026-9081-4309-996e-a35372b641b3" />

* Dolby Vision + HDR10+ Direct Play
<img width="500" alt="Shield_Screenshot_2026-06-24_22-44-50" src="https://github.com/user-attachments/assets/dcb899bb-bfd5-4da1-a896-ac8f5b59ee08" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
