### PR TITLE
fix: resolve silent TV audio on stereo configurations

### DIFF
--- a/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/AudioCapabilities.kt
@@ -238,7 +238,7 @@ object AudioCapabilities {
         val supportsDts = canPassthroughDts || canPassthroughDtsHd || canPassthroughDtsX
         val supportsTrueHd = canPassthroughTrueHd || canPassthroughTrueHdJoc
 
-        val maxPcmChannels = estimateMaxPcmChannels(routeType)
+        val maxPcmChannels = detectMaxPcmChannels(bitstreamDevices, routeType)
 
         return mapOf(
             "supportsAc3" to supportsAc3,
@@ -427,6 +427,24 @@ object AudioCapabilities {
         }
 
         return ROUTE_OTHER
+    }
+
+    private fun detectMaxPcmChannels(devices: List<AudioDeviceInfo>, routeType: String): Int {
+        var maxVal = 0
+        for (device in devices) {
+            val counts = device.channelCounts
+            if (counts != null) {
+                for (count in counts) {
+                    if (count > maxVal) {
+                        maxVal = count
+                    }
+                }
+            }
+        }
+        if (maxVal > 0) {
+            return maxVal
+        }
+        return estimateMaxPcmChannels(routeType)
     }
 
     private fun estimateMaxPcmChannels(routeType: String): Int {

--- a/lib/ui/screens/settings/panel/audio_preferences_screen.dart
+++ b/lib/ui/screens/settings/panel/audio_preferences_screen.dart
@@ -173,12 +173,12 @@ class _AudioPreferencesScreenState extends State<_AudioPreferencesScreen> {
     AudioCapabilityProbe.apply(profile);
 
     final AudioPassthroughPreset preset;
-    if (profile != null &&
+    if (profile != null && profile.maxPcmChannels <= 2) {
+      preset = AudioPassthroughPreset.stereo;
+    } else if (profile != null &&
         profile.isAvReceiverRoute &&
         profile.hasCompressedPassthroughRoute) {
       preset = AudioPassthroughPreset.surroundReceiver;
-    } else if (profile != null && profile.maxPcmChannels <= 2) {
-      preset = AudioPassthroughPreset.stereo;
     } else {
       preset = AudioPassthroughPreset.auto;
     }


### PR DESCRIPTION
# Pull Request: Playing Nice with TV Audio

## Summary
Resolve silent audio output on basic TV speakers (stereo endpoints connected directly via HDMI) by dynamically querying the hardware PCM capability and prioritizing the stereo preset recommendation when the max channel count is 2 or less.

## Related Issues
Fixes issue where direct HDMI connections to stereo TVs default to auto/surround receiver modes and output silent multichannel or unsupported bitstreams, reported on Discord.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* **Audio Capabilities (Android)**:
  - Refactored `AudioCapabilities.kt` to dynamically query active audio devices' `AudioDeviceInfo.channelCounts` instead of assuming any `ROUTE_HDMI` connection can handle up to 8 PCM channels.
  - Preserved a safe fallback to route-based channel estimation in case the hardware capability query returns null or empty.
- **Settings UI (Dart)**:
  - Updated the "Re-detect & apply recommended" preset selection in `settings_side_panel.dart` to prioritize checking if the detected PCM channels are 2 or fewer first.
  - Ensures a standard stereo TV setup is correctly recommended the `Stereo` preset, forcing client downmixing or server-side stereo transcoding and avoiding silence from raw bitstreams.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Need more basic set-up.

### Test Steps
1. Try playing media on basic TV.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
