### PR TITLE
fix(nativevideo): use Canvas rendering overlay for ASS/SSA subtitles

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -944,7 +944,7 @@ class Media3VideoView(
         httpDataSourceFactory = DefaultHttpDataSource.Factory()
             .setAllowCrossProtocolRedirects(true)
         val bootDataSourceFactory = DefaultDataSource.Factory(context, httpDataSourceFactory)
-        val assHandler = AssHandler(AssRenderType.OVERLAY_OPEN_GL)
+        val assHandler = AssHandler(AssRenderType.OVERLAY_CANVAS)
         registerAssFonts(assHandler)
         val assParserFactory = AssSubtitleParserFactory(assHandler)
         val bootMediaSourceFactory = DefaultMediaSourceFactory(

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -341,6 +341,7 @@ class Media3VideoView(
     companion object {
         private const val TS_SEARCH_BYTES_LOW_RAM = TsExtractor.TS_PACKET_SIZE * 1800
         private const val TS_SEARCH_BYTES_DEFAULT = TsExtractor.DEFAULT_TIMESTAMP_SEARCH_BYTES
+        private const val EXTERNAL_SUBTITLE_ID_BASE = 10000
         private const val ASS_FALLBACK_FONT_ASSET = "fonts/NotoSans-Regular.ttf"
         private const val ASS_FALLBACK_FONT_NAME = "Noto Sans"
         private val ASS_SYSTEM_CJK_FONTS = listOf(
@@ -2320,6 +2321,8 @@ class Media3VideoView(
 
         val subtitleBuilder = MediaItem.SubtitleConfiguration.Builder(Uri.parse(url))
             .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
+            // ass-media matches selected Media3 text tracks back to libass tracks by ID.
+            .setId((EXTERNAL_SUBTITLE_ID_BASE + externalSubtitleConfigurations.size).toString())
 
         val mimeType = codecToMimeType(codec)
         if (!mimeType.isNullOrEmpty()) {


### PR DESCRIPTION
# Pull Request

## Summary
Switch the Advanced SubStation Alpha (ASS/SSA) subtitle rendering engine from OpenGL overlay to Canvas overlay to fix the rendering visibility bug on Android TV/Fire TV hardware.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #572 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `Media3VideoView.kt` to initialize `AssHandler` with `AssRenderType.OVERLAY_CANVAS` instead of `AssRenderType.OVERLAY_OPEN_GL`. This uses a standard Canvas view rather than stacking two hardware surfaces (`GLSurfaceView` over `SurfaceView`), which was failing to composite correctly on various Android TV stick GPUs.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video file with embedded or external ASS subtitles on an Android TV (e.g. Fire TV Stick 4K).
2. Verify that subtitles render correctly with full styling and positions.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
