### PR TITLE
feat: restrict artwork updater to admin and add safety check

### DIFF
--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -58,6 +58,7 @@ class SessionRepository {
   StreamSubscription<ServerWebSocketMessage>? _remoteCommandSubscription;
   double _lastUnmutedVolume = 100;
   bool _remoteMuted = false;
+  bool _hasCheckedWriteAccess = false;
 
   final _stateController = StreamController<SessionState>.broadcast();
 
@@ -105,6 +106,9 @@ class SessionRepository {
 
   SessionState get state => _state;
   Stream<SessionState> get stateStream => _stateController.stream;
+
+  bool get hasCheckedWriteAccess => _hasCheckedWriteAccess;
+  set hasCheckedWriteAccess(bool value) => _hasCheckedWriteAccess = value;
 
   Future<bool> restoreSession() async {
     _setState(SessionState.restoring);
@@ -308,6 +312,7 @@ class SessionRepository {
 
     _activeServerId = null;
     _activeUserId = null;
+    _hasCheckedWriteAccess = false;
     _userRepository.setCurrentUser(null);
     _setState(SessionState.ready);
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7680,5 +7680,37 @@
   "groupMultipleRoles": "Group multiple roles",
   "@groupMultipleRoles": {
     "description": "Option to group multiple roles for a person"
+  },
+  "libraryWriteAccessWarningTitle": "Library Write Access Warning",
+  "@libraryWriteAccessWarningTitle": {
+    "description": "Title for library write access warning dialog"
+  },
+  "libraryWriteAccessHowToFix": "How to fix this:",
+  "@libraryWriteAccessHowToFix": {
+    "description": "Section header for write access troubleshooting"
+  },
+  "libraryWriteAccessFixSteps": "1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable 'Save artwork into media folders' to store artwork in Jellyfin's internal database.",
+  "@libraryWriteAccessFixSteps": {
+    "description": "Troubleshooting steps for write access issues"
+  },
+  "dismiss": "Dismiss",
+  "@dismiss": {
+    "description": "Dismiss button text"
+  },
+  "libraryWriteAccessProactiveBody": "Your '{libraryName}' library is configured to save artwork directly into the media folders ('Save artwork into media folders' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n{failedPath}",
+  "@libraryWriteAccessProactiveBody": {
+    "description": "Proactive warning message about server write access",
+    "placeholders": {
+      "libraryName": {
+        "type": "String"
+      },
+      "failedPath": {
+        "type": "String"
+      }
+    }
+  },
+  "libraryWriteAccessReactiveBody": "It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders ('Save artwork into media folders' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.",
+  "@libraryWriteAccessReactiveBody": {
+    "description": "Reactive error warning message when artwork update fails"
   }
 }

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5776,7 +5776,8 @@ class _ActionButtonsState extends State<_ActionButtons> {
         !forceStartOver && (item.playbackPosition?.inMilliseconds ?? 0) > 0;
 
     final client = GetIt.instance<MediaServerClient>();
-    final canChangeArtwork = client.serverType == ServerType.jellyfin;
+    final isAdmin = GetIt.instance<UserRepository>().currentUser?.isAdministrator ?? false;
+    final canChangeArtwork = client.serverType == ServerType.jellyfin && isAdmin;
 
     final options = [
       if (canChangeArtwork)

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -479,20 +479,20 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
     final sessionRepo = GetIt.instance<SessionRepository>();
     if (sessionRepo.hasCheckedWriteAccess) return;
 
-    sessionRepo.hasCheckedWriteAccess = true;
-
     final client = GetIt.instance<MediaServerClient>();
     final token = client.accessToken;
     if (token == null) return;
 
+    final dio = Dio();
+    configureServerDio(dio);
     try {
-      final dio = Dio();
       final response = await dio.get(
         '${client.baseUrl}/Moonfin/Libraries/CheckWriteAccess',
         options: Options(headers: {
           'Authorization': 'MediaBrowser Token="$token"',
         }),
       );
+      sessionRepo.hasCheckedWriteAccess = true;
 
       final data = response.data;
       if (data is List) {

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -567,9 +567,10 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
           }
         }
       }
-      dio.close(force: true);
     } catch (e) {
       debugPrint('[Moonfin] Failed to check libraries write access: $e');
+    } finally {
+      dio.close(force: true);
     }
   }
 

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -518,51 +518,9 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
 
           if (matchingFailedReport != null && mounted) {
             final libraryName = matchingFailedReport['LibraryName'] ?? 'Library';
-            await showDialog<void>(
-              context: context,
-              barrierDismissible: false,
-              builder: (context) => AlertDialog(
-                backgroundColor: AppColorScheme.surface,
-                title: const Text("Library Write Access Warning"),
-                content: Scrollbar(
-                  child: SingleChildScrollView(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          "Your '$libraryName' library is configured to save artwork directly into the media folders ('Save artwork into media folders' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$matchingFailedPath",
-                        ),
-                        const SizedBox(height: 12),
-                        const Text(
-                          "How to fix this:",
-                          style: TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                        const SizedBox(height: 8),
-                        const Text(
-                          "1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n"
-                          "2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable 'Save artwork into media folders' to store artwork in Jellyfin's internal database.",
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                actions: [
-                  FocusableWrapper(
-                    autofocus: true,
-                    borderRadius: 8,
-                    suppressFocusGlow: true,
-                    onSelect: () => Navigator.of(context).pop(),
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      child: Text(
-                        "Dismiss",
-                        style: TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+            final l10n = AppLocalizations.of(context);
+            await _showWriteAccessWarningDialog(
+              l10n.libraryWriteAccessProactiveBody(libraryName.toString(), matchingFailedPath ?? ''),
             );
           }
         }
@@ -596,52 +554,8 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
     if (!mounted) return;
 
     if (isLocalMetadataEnabled) {
-      await showDialog<void>(
-        context: context,
-        barrierDismissible: false,
-        builder: (context) => AlertDialog(
-          backgroundColor: AppColorScheme.surface,
-          title: const Text("Library Write Access Warning"),
-          content: Scrollbar(
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    "It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders ('Save artwork into media folders' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.",
-                  ),
-                  const SizedBox(height: 12),
-                  const Text(
-                    "How to fix this:",
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  const Text(
-                    "1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n"
-                    "2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable 'Save artwork into media folders' to store artwork in Jellyfin's internal database.",
-                  ),
-                ],
-              ),
-            ),
-          ),
-          actions: [
-            FocusableWrapper(
-              autofocus: true,
-              borderRadius: 8,
-              suppressFocusGlow: true,
-              onSelect: () => Navigator.of(context).pop(),
-              child: const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Text(
-                  "Dismiss",
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                ),
-              ),
-            ),
-          ],
-        ),
-      );
+      final l10n = AppLocalizations.of(context);
+      await _showWriteAccessWarningDialog(l10n.libraryWriteAccessReactiveBody);
     } else {
       final l10n = AppLocalizations.of(context);
       final message = switch (actionName) {
@@ -655,6 +569,51 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
         SnackBar(content: Text(message)),
       );
     }
+  }
+
+  Future<void> _showWriteAccessWarningDialog(String bodyText) async {
+    final l10n = AppLocalizations.of(context);
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColorScheme.surface,
+        title: Text(l10n.libraryWriteAccessWarningTitle),
+        content: Scrollbar(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(bodyText),
+                const SizedBox(height: 12),
+                Text(
+                  l10n.libraryWriteAccessHowToFix,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8),
+                Text(l10n.libraryWriteAccessFixSteps),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          FocusableWrapper(
+            autofocus: true,
+            borderRadius: 8,
+            suppressFocusGlow: true,
+            onSelect: () => Navigator.of(context).pop(),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Text(
+                l10n.dismiss,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _fetchRemoteImages(String category) async {
@@ -692,7 +651,6 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
     String category,
     Map<String, dynamic> remoteImage,
   ) async {
-    final l10n = AppLocalizations.of(context);
     final url = remoteImage['Url'] as String?;
     if (url == null || url.isEmpty) return;
 

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -10,6 +10,9 @@ import '../../data/models/aggregated_item.dart';
 import '../../l10n/app_localizations.dart';
 import '../../util/focus/key_event_utils.dart';
 import '../../util/platform_detection.dart';
+import '../../auth/repositories/user_repository.dart';
+import '../../auth/repositories/session_repository.dart';
+import 'package:dio/dio.dart';
 import 'adaptive/adaptive_dialog.dart';
 import 'focus/focusable_wrapper.dart';
 import 'overlay_sheet.dart';
@@ -167,6 +170,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
     _refreshItemMetadata();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _focusFirstItem();
+      _checkLibrariesWriteAccess();
     });
   }
 
@@ -468,6 +472,190 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
     return '${client.baseUrl}/Items/${_item.id}/Images/$category?tag=$tag&maxWidth=300$indexParam';
   }
 
+  Future<void> _checkLibrariesWriteAccess() async {
+    final isAdmin = GetIt.instance<UserRepository>().currentUser?.isAdministrator ?? false;
+    if (!isAdmin) return;
+
+    final sessionRepo = GetIt.instance<SessionRepository>();
+    if (sessionRepo.hasCheckedWriteAccess) return;
+
+    sessionRepo.hasCheckedWriteAccess = true;
+
+    final client = GetIt.instance<MediaServerClient>();
+    final token = client.accessToken;
+    if (token == null) return;
+
+    try {
+      final dio = Dio();
+      final response = await dio.get(
+        '${client.baseUrl}/Moonfin/Libraries/CheckWriteAccess',
+        options: Options(headers: {
+          'Authorization': 'MediaBrowser Token="$token"',
+        }),
+      );
+
+      final data = response.data;
+      if (data is List) {
+        final reports = data.cast<Map<String, dynamic>>();
+        final itemPath = _item.rawData['Path'] as String?;
+        if (itemPath != null && itemPath.isNotEmpty) {
+          Map<String, dynamic>? matchingFailedReport;
+          String? matchingFailedPath;
+
+          for (final report in reports) {
+            final failedPaths = report['FailedPaths'] as List?;
+            if (failedPaths != null) {
+              for (final path in failedPaths) {
+                if (path is String && itemPath.startsWith(path)) {
+                  matchingFailedReport = report;
+                  matchingFailedPath = path;
+                  break;
+                }
+              }
+            }
+            if (matchingFailedReport != null) break;
+          }
+
+          if (matchingFailedReport != null && mounted) {
+            final libraryName = matchingFailedReport['LibraryName'] ?? 'Library';
+            await showDialog<void>(
+              context: context,
+              barrierDismissible: false,
+              builder: (context) => AlertDialog(
+                backgroundColor: AppColorScheme.surface,
+                title: const Text("Library Write Access Warning"),
+                content: Scrollbar(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          "Your '$libraryName' library is configured to save artwork directly into the media folders ('Save artwork into media folders' is enabled). However, Jellyfin has tested write access and does not have permission to write files into this directory:\n\n$matchingFailedPath",
+                        ),
+                        const SizedBox(height: 12),
+                        const Text(
+                          "How to fix this:",
+                          style: TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 8),
+                        const Text(
+                          "1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n"
+                          "2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable 'Save artwork into media folders' to store artwork in Jellyfin's internal database.",
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                actions: [
+                  FocusableWrapper(
+                    autofocus: true,
+                    borderRadius: 8,
+                    suppressFocusGlow: true,
+                    onSelect: () => Navigator.of(context).pop(),
+                    child: const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      child: Text(
+                        "Dismiss",
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+        }
+      }
+      dio.close(force: true);
+    } catch (e) {
+      debugPrint('[Moonfin] Failed to check libraries write access: $e');
+    }
+  }
+
+  Future<void> _handleActionError(dynamic error, String actionName) async {
+    bool isLocalMetadataEnabled = false;
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      final folders = await client.adminLibraryApi.getVirtualFolders();
+      final itemPath = _item.rawData['Path'] as String?;
+      if (itemPath != null && itemPath.isNotEmpty) {
+        for (final folder in folders) {
+          if (folder.locations.any((loc) => itemPath.startsWith(loc))) {
+            isLocalMetadataEnabled =
+                folder.libraryOptions?['SaveLocalMetadata'] as bool? ?? false;
+            break;
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('Failed to check virtual folders: $e');
+    }
+
+    if (!mounted) return;
+
+    if (isLocalMetadataEnabled) {
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => AlertDialog(
+          backgroundColor: AppColorScheme.surface,
+          title: const Text("Library Write Access Warning"),
+          content: Scrollbar(
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    "It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders ('Save artwork into media folders' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.",
+                  ),
+                  const SizedBox(height: 12),
+                  const Text(
+                    "How to fix this:",
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    "1. Grant write permissions to the Jellyfin service user (e.g., jellyfin or Docker PUID/PGID) for your media library folders on the server.\n\n"
+                    "2. Or, go to your Jellyfin Dashboard -> Libraries, edit this library, and disable 'Save artwork into media folders' to store artwork in Jellyfin's internal database.",
+                  ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            FocusableWrapper(
+              autofocus: true,
+              borderRadius: 8,
+              suppressFocusGlow: true,
+              onSelect: () => Navigator.of(context).pop(),
+              child: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Text(
+                  "Dismiss",
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    } else {
+      final l10n = AppLocalizations.of(context);
+      final message = switch (actionName) {
+        'download' => l10n.imageDownloadFailed(error.toString()),
+        'delete' => l10n.imageDeleteFailed(error.toString()),
+        'clear' => l10n.clearAllArtworkFailed(error.toString()),
+        'upload' => l10n.imageUploadFailed(error.toString()),
+        _ => error.toString(),
+      };
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+    }
+  }
+
   Future<void> _fetchRemoteImages(String category) async {
     if (!mounted) return;
     setState(() {
@@ -539,9 +727,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
         setState(() {
           _actionInProgress.remove(category);
         });
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.imageDownloadFailed(e.toString()))),
-        );
+        await _handleActionError(e, 'download');
       }
     }
   }
@@ -611,10 +797,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
         setState(() {
           _actionInProgress.remove(category);
         });
-        final l10n = AppLocalizations.of(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.imageDeleteFailed(e.toString()))),
-        );
+        await _handleActionError(e, 'delete');
       }
     }
   }
@@ -692,10 +875,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
         setState(() {
           _actionInProgress.clear();
         });
-        final l10n = AppLocalizations.of(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.clearAllArtworkFailed(e.toString()))),
-        );
+        await _handleActionError(e, 'clear');
       }
     }
   }
@@ -753,9 +933,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
         setState(() {
           _actionInProgress.remove(category);
         });
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.imageUploadFailed(e.toString()))),
-        );
+        await _handleActionError(e, 'upload');
       }
     }
   }

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -165,7 +165,8 @@ List<ItemContextAction> contextActionsFor(
   }
 
   final canChangeArtwork = (isMediaType || type == 'Folder' || type == 'CollectionFolder' || type == 'UserView') &&
-      client.serverType == ServerType.jellyfin;
+      client.serverType == ServerType.jellyfin &&
+      isAdminUser;
 
   if (canChangeArtwork) {
     actions.add(ItemContextAction(


### PR DESCRIPTION
# Pull Request

## Summary
Following the Principle of Least Privilege, this PR restricts artwork updates to administrator accounts and implements proactive directory write-access safety checks on launch. If images are intended to be stored alongside media and Jellyfin does not have write access to do so, provide a detailed warning with instructions on how to fix it. Note, this relies on a new Moonbase endpoint so both need to be merged for this to function correctly.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **context_action.dart**: Hide the "Change Artwork" option from context menus for non-admin accounts.
- **item_detail_screen.dart**: Hide the "Change Artwork" option from advanced details for non-admin accounts.
- **change_artwork_dialog.dart**: 
  - Add proactive write access verification on dialog launch using the server plugin's check endpoint.
  - Implemented session-level caching for the write-access warning dialog (it triggers only once per admin session).
- **session_repository.dart**: Track the session-level warning flag (`hasCheckedWriteAccess`) and reset it upon logout.
- **Localization Files**: Updated strings for the write-access warning.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a non-admin account, test for access
2. Have Jellyfin use "save media to folder" option but remove write access, see warning.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

* Admin Account:
<img width="500" alt="Shield_Screenshot_2026-06-25_07-05-20" src="https://github.com/user-attachments/assets/5f7b1816-e59d-49fc-8b74-d97a54583532" />

* Non-Admin Account:
<img width="500" alt="Shield_Screenshot_2026-06-25_07-04-44" src="https://github.com/user-attachments/assets/c7fb7f40-1dc0-4fb6-9b4b-386486ffe61a" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
