### PR TITLE
Use jellyfinId from Seerr for the play button link

### DIFF
--- a/lib/data/services/seerr/seerr_api_models.dart
+++ b/lib/data/services/seerr/seerr_api_models.dart
@@ -569,6 +569,8 @@ class SeerrMediaInfo {
   final int? status;
   final int? status4k;
   final List<SeerrRequest>? requests;
+  final String? jellyfinMediaId;
+  final String? jellyfinMediaId4k;
 
   const SeerrMediaInfo({
     this.id,
@@ -577,6 +579,8 @@ class SeerrMediaInfo {
     this.status,
     this.status4k,
     this.requests,
+    this.jellyfinMediaId,
+    this.jellyfinMediaId4k,
   });
 
   factory SeerrMediaInfo.fromJson(Map<String, dynamic> json) =>

--- a/lib/data/services/seerr/seerr_api_models.g.dart
+++ b/lib/data/services/seerr/seerr_api_models.g.dart
@@ -514,6 +514,8 @@ SeerrMediaInfo _$SeerrMediaInfoFromJson(Map<String, dynamic> json) =>
       requests: (json['requests'] as List<dynamic>?)
           ?.map((e) => SeerrRequest.fromJson(e as Map<String, dynamic>))
           .toList(),
+      jellyfinMediaId: (json['jellyfinMediaId'] as String?),
+      jellyfinMediaId4k: (json['jellyfinMediaId4k'] as String?),
     );
 
 Map<String, dynamic> _$SeerrMediaInfoToJson(SeerrMediaInfo instance) =>
@@ -524,6 +526,8 @@ Map<String, dynamic> _$SeerrMediaInfoToJson(SeerrMediaInfo instance) =>
       'status': instance.status,
       'status4k': instance.status4k,
       'requests': instance.requests,
+      'jellyfinMediaId': instance.jellyfinMediaId,
+      'jellyfinMediaId4k': instance.jellyfinMediaId4k,
     };
 
 SeerrPersonDetails _$SeerrPersonDetailsFromJson(Map<String, dynamic> json) =>

--- a/lib/ui/screens/seerr/seerr_media_detail_screen.dart
+++ b/lib/ui/screens/seerr/seerr_media_detail_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
-import 'package:server_core/server_core.dart';
 
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
@@ -1397,77 +1396,17 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
   }
 
   Future<void> _playInMoonfin(SeerrMediaDetailState s) async {
+    if (!mounted) return;
     final l10n = AppLocalizations.of(context);
-    final client = GetIt.instance<MediaServerClient>();
-    final externalIds = s.externalIds;
-    final tmdbId = externalIds?.tmdbId ?? (s.tmdbId != 0 ? s.tmdbId : null);
-    final tvdbId = externalIds?.tvdbId;
-    final imdbId = externalIds?.imdbId;
-    final title = s.displayTitle;
-    final mediaType = s.isMovie ? 'Movie' : 'Series';
 
-    try {
-      final response = await client.itemsApi.getItems(
-        searchTerm: title,
-        includeItemTypes: [mediaType],
-        recursive: true,
-        limit: 50,
-        fields: 'ProviderIds',
-      );
-
-      final items =
-          (response['Items'] as List?)?.cast<Map<String, dynamic>?>() ??
-          <Map<String, dynamic>?>[];
-
-      Map<String, dynamic>? match;
-
-      if (tmdbId != null) {
-        match = items.firstWhere(
-          (item) =>
-              (item!['ProviderIds'] as Map?)?['Tmdb'] == tmdbId.toString(),
-          orElse: () => null,
-        );
-      }
-
-      if (match == null && tvdbId != null) {
-        match = items.firstWhere(
-          (item) =>
-              (item!['ProviderIds'] as Map?)?['Tvdb'] == tvdbId.toString(),
-          orElse: () => null,
-        );
-      }
-
-      if (match == null && imdbId != null) {
-        match = items.firstWhere(
-          (item) => (item!['ProviderIds'] as Map?)?['Imdb'] == imdbId,
-          orElse: () => null,
-        );
-      }
-
-      match ??= items.firstWhere(
-        (item) =>
-            (item!['Name'] as String?)?.toLowerCase() == title.toLowerCase(),
-        orElse: () => null,
-      );
-
-      if (!mounted) return;
-
-      if (match != null) {
-        final itemId = match['Id']?.toString() ?? '';
-        context.push(Destinations.item(itemId));
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(l10n.itemNotFoundInLibrary),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    } catch (_) {
-      if (!mounted) return;
+    final jellyfinId =
+        s.mediaInfo?.jellyfinMediaId ?? s.mediaInfo?.jellyfinMediaId4k;
+    if (jellyfinId != null) {
+      context.push(Destinations.item(jellyfinId));
+    } else {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(l10n.errorSearchingLibrary),
+          content: Text(l10n.itemNotFoundInLibrary),
           behavior: SnackBarBehavior.floating,
         ),
       );


### PR DESCRIPTION
# Pull Request

## Summary

This solves a bug that happens when you search for a media item in a language different from your Jellyfin library's language (if the titles do not match at all across languages). You will get a Seerr result that says the media is available but clicking on "Play in Moonfin" will pop up the "Item not found in your Moonfin library" message.

The fix seems to be just grabbing the jellyfin id that Seerr already scans and using it directly. Which could also improve performance a little bit.

## Related Issues

None yet, but I can open one if there is the change is not agreeable.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Deserialize two more keys in Seerr's MediaInfo API response
- Replacing title search in Seerr's `_playinMoonfin` functionality with just getting the ID

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built release website with `flutter build web --release` and hosted it with `python -m http.server -d build/web/`
2. Searched for `Entre fantasmas` which is partially available in my library. My library is set to English metadata so it is `Ghost whisperer` there. Click on the result that Seerr manages to find, for which it also says the series is available.
3. Clicked `Play in Moonfin`. If the `"Item not found in your Moonfin library"` popup message comes up, the test failed. If the Moonfin media page for the series comes up the test succeeded.

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
