### PR TITLE
Enable SurfaceView and refresh-rate switching on pre-API-30 devices

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -418,12 +418,24 @@ class Media3VideoView(
     }
 
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val useSurfaceView = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-    private var videoView: View = if (useSurfaceView) {
-        SurfaceView(context)
-    } else {
-        TextureView(context)
-    }
+    // SurfaceView is required for display refresh-rate switching (applyFrameRateSwitching is gated
+    // on SurfaceView); TextureView never receives it, so 24/25fps content judders. SurfaceView works
+    // on older Android too once it is lifted above Flutter's background on the legacy hybrid-
+    // composition path (see newVideoView). Previously gated to API 30+.
+    private val useSurfaceView = true
+    private var videoView: View = newVideoView()
+
+    private fun newVideoView(): View =
+        if (useSurfaceView) {
+            SurfaceView(context).apply {
+                // Legacy hybrid composition (older devices without Impeller) otherwise composites
+                // this platform-view SurfaceView behind Flutter and the video renders black; lift it
+                // as a media overlay so it stays visible. The Flutter controls still draw on top.
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) setZOrderMediaOverlay(true)
+            }
+        } else {
+            TextureView(context)
+        }
     private val firstFrameCover = View(context).apply {
         setBackgroundColor(Color.BLACK)
     }
@@ -1043,7 +1055,7 @@ class Media3VideoView(
             Gravity.CENTER,
         )
         containerView.removeView(videoView)
-        videoView = if (useSurfaceView) SurfaceView(context) else TextureView(context)
+        videoView = newVideoView()
         containerView.addView(videoView, 0, params)
     }
 


### PR DESCRIPTION
## Summary
SurfaceView — and the display refresh-rate switching that depends on it — was
limited to Android 12+ (API 30). On older devices the player fell back to
TextureView, which never receives the refresh-rate switch, so 24/25fps content
judders. This enables SurfaceView on all API levels and keeps the video visible
on the legacy hybrid-composition path (older devices without Impeller) by
lifting the surface as a media overlay; without that, the video renders black.

## Related Issues
- Related to # (judder on older Android TV devices)

## Type of Change
- [x] Bug fix

## Changes Made
- Use SurfaceView on all API levels (was gated to API 30+), so the refresh-rate
  switch — which is gated on SurfaceView — also runs on older devices.
- Call setZOrderMediaOverlay(true) on the SurfaceView for API < 30 so it stays
  visible under legacy hybrid composition instead of rendering black.

## Platform
- [x] Android

## Testing
- [x] Tested on physical device
- [x] Manual testing completed

### Test Steps
1. Fire TV Stick 4K (Fire OS, Android 7.1 / API 25), Media3 playback engine.
2. Play 24fps and 25fps content via DirectPlay.
3. Before: TextureView, no rate switch, visible judder on pans.
   After: SurfaceView, display switches to 23.976/24/25 Hz, smooth picture, audio correct.

## Screenshots
N/A — video surface change; the playing surface is a hardware overlay and is not
captured by screenshots.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

---
*Disclosure: developed with AI assistance (Claude).*
