### PR TITLE
fix(settings): resolve Seerr preference lock and out-of-sync navigation states

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -48,7 +48,8 @@ class PluginSyncService extends ChangeNotifier {
   String? get seerrUrl => _seerrUrl;
   bool _seerrEnabled = false;
   bool get seerrEnabled => _seerrEnabled;
-  bool get seerrAvailable => _pluginAvailable && _seerrEnabled;
+  bool get seerrAvailable =>
+      _pluginAvailable && _seerrEnabled && _prefs.get(UserPreferences.seerrEnabled);
   bool _seerrInfoAvailable = false;
   bool get seerrInfoAvailable => _seerrInfoAvailable;
 
@@ -170,6 +171,7 @@ class PluginSyncService extends ChangeNotifier {
       _prefs.getEffectivePreference(UserPreferences.seerrEnabled),
       enabled,
     );
+    _seerrPrefs.setEnabled(enabled);
     _prefs.notifyPreferenceChanged();
   }
 
@@ -217,7 +219,11 @@ class PluginSyncService extends ChangeNotifier {
 
         final enabled = _readBool(seerrConfig, 'enabled');
         final userEnabled = _readBool(seerrConfig, 'userEnabled');
-        _seerrEnabled = (enabled ?? _seerrEnabled) && (userEnabled ?? true);
+        _seerrEnabled = enabled ?? _seerrEnabled;
+
+        if (userEnabled != null) {
+          _setLocalSeerrEnabled(userEnabled);
+        }
 
         final variant = _readString(seerrConfig, 'variant');
         if (variant != null && variant.trim().isNotEmpty) {
@@ -228,9 +234,9 @@ class PluginSyncService extends ChangeNotifier {
         if (displayName != null && displayName.trim().isNotEmpty) {
           await _seerrPrefs.setMoonfinDisplayName(displayName);
         }
+      } else {
+        _setLocalSeerrEnabled(_seerrEnabled);
       }
-
-      _setLocalSeerrEnabled(_seerrEnabled);
 
       notifyListeners();
       return _PluginAvailabilityStatus.available;
@@ -1236,6 +1242,9 @@ class PluginSyncService extends ChangeNotifier {
     final value = data[serverKey];
     if (value is bool) {
       _store.set(_prefs.getEffectivePreference(pref), value);
+      if (pref == UserPreferences.seerrEnabled) {
+        _seerrPrefs.setEnabled(value);
+      }
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Summary
Resolves a circular preference lock that breaks Seerr connectivity for settings-synced users, and fixes an out-of-sync state where the Seerr navigation button was displayed in the toolbar/sidebar while showing as disabled/off in the Integrations configuration screen.

## Related Issues
Link related issues or tickets separated by commas.

Fixes preference lock and UI display bugs in Seerr integration.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Modified plugin_sync_service.dart to parse global admin enablement (enabled) and user-level preference (userEnabled) independently from the server configuration.
* Simplified UI Gating: Kept the getter seerrEnabled representing only whether Seerr is configured and enabled globally on the server. This completely avoids modifying the UI settings files (seerr_config_screen.dart and plugin_settings_screen.dart), as they already check this property to show the switch/option.
* Combined Gating for Navigation: Redefined the navigation/toolbar visibility check seerrAvailable to require both plugin availability, admin enablement, and the user's active preference toggle: bool get seerrAvailable => _pluginAvailable && _seerrEnabled && _prefs.get(UserPreferences.seerrEnabled);
* Synchronized State: Synchronized the local SeerrPreferences.enabled state with UserPreferences.seerrEnabled during config pulls and updates to ensure navigation states are kept in sync with settings choices.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Enabled Seerr on the server plugin (Moonbase).
2. Verified that the Seerr config toggle switch is visible in the client under Settings -> Integrations -> Seerr.
3. Toggled the switch ON, logged in, and verified Seerr became active in the navigation.
4. Toggled the switch OFF, and verified Seerr icon was successfully removed from the navigation toolbar/sidebar.


## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
