### PR TITLE
Feature/settings cleanup

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -903,11 +903,6 @@ class PluginSyncService extends ChangeNotifier {
       );
       _applyBool(
         resolved,
-        'displaySeerrRows',
-        UserPreferences.displaySeerrRows,
-      );
-      _applyBool(
-        resolved,
         'useDetailedSubHeadings',
         UserPreferences.useDetailedSubHeadings,
       );
@@ -1515,7 +1510,6 @@ class PluginSyncService extends ChangeNotifier {
       ),
       'displayGenresRows': _prefs.get(UserPreferences.displayGenresRows),
       'fullScreenRows': _prefs.get(UserPreferences.fullScreenRows),
-      'displaySeerrRows': _prefs.get(UserPreferences.displaySeerrRows),
       'useDetailedSubHeadings': _prefs.get(
         UserPreferences.useDetailedSubHeadings,
       ),

--- a/lib/data/viewmodels/seerr_media_detail_view_model.dart
+++ b/lib/data/viewmodels/seerr_media_detail_view_model.dart
@@ -478,7 +478,7 @@ class SeerrMediaDetailViewModel extends ChangeNotifier {
       if (searchPage == null || searchPage.results.isEmpty) {
         searchPage = await _repo.search(tmdbId.toString());
       }
-      if (searchPage != null && searchPage.results.isNotEmpty) {
+      if (searchPage.results.isNotEmpty) {
         final match = searchPage.results.firstWhere(
           (item) => item.id == tmdbId,
           orElse: () => searchPage!.results.first,
@@ -511,7 +511,7 @@ class SeerrMediaDetailViewModel extends ChangeNotifier {
       if (searchPage == null || searchPage.results.isEmpty) {
         searchPage = await _repo.search(tmdbId.toString());
       }
-      if (searchPage != null && searchPage.results.isNotEmpty) {
+      if (searchPage.results.isNotEmpty) {
         final match = searchPage.results.firstWhere(
           (item) => item.id == tmdbId,
           orElse: () => searchPage!.results.first,

--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -7640,8 +7640,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -7689,8 +7689,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_be.arb
+++ b/lib/l10n/app_be.arb
@@ -7734,8 +7734,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -7747,8 +7747,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -7735,8 +7735,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -7759,8 +7759,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -7749,8 +7749,6 @@
     "playlistsRowSortingDescription": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -7776,8 +7776,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -7697,8 +7697,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -7746,8 +7746,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -7469,8 +7469,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "boxRearCoverCategory": "",
     "menuArtCategory": "",
     "yes": "",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4680,11 +4680,11 @@
   "@discoverRows": {
     "description": "Section title for discover rows"
   },
-  "discoverRowsDescriptionPlugin": "Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.",
+  "discoverRowsDescriptionPlugin": "Enable rows to see on Seerr mainpage. Drag to reorder. Custom order syncs with Moonbase.",
   "@discoverRowsDescriptionPlugin": {
     "description": "Description for discover rows with plugin"
   },
-  "discoverRowsDescription": "Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.",
+  "discoverRowsDescription": "Enable rows to see on Seerr mainpage. Drag to reorder. Custom order syncs with Moonbase.",
   "@discoverRowsDescription": {
     "description": "Description for discover rows without plugin"
   },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7325,8 +7325,6 @@
   "audioRowsSorting": "Audio Rows sorting",
   "audioRowsSortingDescription": "Sort Audio rows by date added, release date, alphabetically, and more.",
   "audioPlaylists": "Audio Playlists",
-  "displaySeerrRows": "Display Seerr Discovery Rows",
-  "displaySeerrRowsSubtitle": "Show Seerr discovery rows in Home Sections.",
   "appearance": "Appearance",
   "cardSize": "Home Row Card Display Size",
   "externalPlayerApp": "External player app",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4676,15 +4676,15 @@
       }
     }
   },
-  "discoverRows": "Discover Rows",
+  "discoverRows": "Seerr Homepage",
   "@discoverRows": {
     "description": "Section title for discover rows"
   },
-  "discoverRowsDescriptionPlugin": "Drag to reorder. Enable or disable rows. Enabled row order syncs with the Moonfin plugin.",
+  "discoverRowsDescriptionPlugin": "Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.",
   "@discoverRowsDescriptionPlugin": {
     "description": "Description for discover rows with plugin"
   },
-  "discoverRowsDescription": "Drag to reorder. Enable or disable rows.",
+  "discoverRowsDescription": "Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.",
   "@discoverRowsDescription": {
     "description": "Description for discover rows without plugin"
   },
@@ -4819,7 +4819,7 @@
   "@navbarStyleToolbarAppearance": {
     "description": "Navigation settings subtitle"
   },
-  "reorderToggleHomeRows": "Reorder and toggle home rows",
+  "reorderToggleHomeRows": "Reorder and toggle both library and external-based home rows",
   "@reorderToggleHomeRows": {
     "description": "Home sections settings subtitle"
   },
@@ -7298,7 +7298,7 @@
   "homeRowDisplay": "Home Row Display",
   "homeRowSections": "Home Row Sections",
   "homeRowToggles": "Home Row Toggles",
-  "homeRowTogglesSubtitle": "Enable or disable different home row categories",
+  "homeRowTogglesSubtitle": "Enable or disable library-based home row categories",
   "homeRowTogglesDescription": "Enable the following toggles to display the rows in Home Sections.",
   "rowsType": "Row Type",
   "rowsTypeDescription": "Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.",
@@ -7713,7 +7713,7 @@
   "@libraryWriteAccessReactiveBody": {
     "description": "Reactive error warning message when artwork update fails"
   },
-  "externalLists": "External Lists",
+  "externalLists": "External Home Row Lists",
   "enableImdb": "IMDb External Lists",
   "enableImdbDescription": "Fetch IMDb lists for display on the Home Screen.",
   "imdbTop250Movies": "IMDb Top 250 Movies",

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -7533,8 +7533,6 @@
     "audioRowsSorting": "Audio Rows sorting",
     "audioRowsSortingDescription": "Sort Audio rows by date added, release date, alphabetically, and more.",
     "audioPlaylists": "Audio Playlists",
-    "displaySeerrRows": "Display Seerr Discovery Rows",
-    "displaySeerrRowsSubtitle": "Show Seerr discovery rows in Home Sections.",
     "externalPlayerAppDescription": "Set external player to enable long-press play option",
     "changeArtwork": "Change Artwork",
     "missing": "Missing",

--- a/lib/l10n/app_eo.arb
+++ b/lib/l10n/app_eo.arb
@@ -7609,8 +7609,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -7594,8 +7594,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_es_419.arb
+++ b/lib/l10n/app_es_419.arb
@@ -7529,8 +7529,6 @@
     },
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "fallbackAudioLanguage": "",
     "@fallbackAudioLanguage": {

--- a/lib/l10n/app_es_AR.arb
+++ b/lib/l10n/app_es_AR.arb
@@ -7548,8 +7548,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "missing": "",

--- a/lib/l10n/app_es_DO.arb
+++ b/lib/l10n/app_es_DO.arb
@@ -7626,8 +7626,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_es_MX.arb
+++ b/lib/l10n/app_es_MX.arb
@@ -7608,8 +7608,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -7642,8 +7642,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "missing": "",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -7618,8 +7618,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "missing": "",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -7578,8 +7578,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -7524,8 +7524,6 @@
         "description": "Subtitle shown under Seerr discovery home rows"
     },
     "settingsShowSeerrButtonInNavigation": "Afficher le bouton Seerr dans la barre de navigation",
-    "displaySeerrRows": "Afficher les rangées de découverte Seerr",
-    "displaySeerrRowsSubtitle": "Afficher les rangées de découverte Seerr dans les sections de l'accueil.",
     "settingsProgressBar": "Barre de progression",
     "@settingsProgressBar": {
         "description": "Option label to show only progress bar on media segment countdown overlay"

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -7638,8 +7638,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -7690,8 +7690,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -7574,8 +7574,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -7652,8 +7652,6 @@
     "displayPlaylistsRowsSubtitle": "",
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",
     "missing": "",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -7647,8 +7647,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -7596,8 +7596,6 @@
     "audioRowsSorting": "Pengurutan Baris Audio",
     "audioRowsSortingDescription": "Urutkan baris Audio berdasarkan tanggal ditambahkan, tanggal rilis, alfabetis, dan lainnya.",
     "audioPlaylists": "Playlist Audio",
-    "displaySeerrRows": "Tampilkan Baris Discovery Seerr",
-    "displaySeerrRowsSubtitle": "Tampilkan baris discovery Seerr di Bagian Beranda.",
     "externalPlayerAppDescription": "Atur pemutar eksternal untuk mengaktifkan opsi putar dengan tekan lama",
     "changeArtwork": "Ubah Artwork",
     "missing": "Tidak ada",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -7670,8 +7670,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -7599,8 +7599,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_kk.arb
+++ b/lib/l10n/app_kk.arb
@@ -7600,8 +7600,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -7682,8 +7682,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -7693,8 +7693,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6247,13 +6247,13 @@ abstract class AppLocalizations {
   /// Description for discover rows with plugin
   ///
   /// In en, this message translates to:
-  /// **'Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.'**
+  /// **'Enable rows to see on Seerr mainpage. Drag to reorder. Custom order syncs with Moonbase.'**
   String get discoverRowsDescriptionPlugin;
 
   /// Description for discover rows without plugin
   ///
   /// In en, this message translates to:
-  /// **'Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.'**
+  /// **'Enable rows to see on Seerr mainpage. Drag to reorder. Custom order syncs with Moonbase.'**
   String get discoverRowsDescription;
 
   /// Status: enabled

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6241,19 +6241,19 @@ abstract class AppLocalizations {
   /// Section title for discover rows
   ///
   /// In en, this message translates to:
-  /// **'Discover Rows'**
+  /// **'Seerr Homepage'**
   String get discoverRows;
 
   /// Description for discover rows with plugin
   ///
   /// In en, this message translates to:
-  /// **'Drag to reorder. Enable or disable rows. Enabled row order syncs with the Moonfin plugin.'**
+  /// **'Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.'**
   String get discoverRowsDescriptionPlugin;
 
   /// Description for discover rows without plugin
   ///
   /// In en, this message translates to:
-  /// **'Drag to reorder. Enable or disable rows.'**
+  /// **'Enable to show rows on Seerr mainpage and drag to reorder. Selection and order syncs with Moonbase.'**
   String get discoverRowsDescription;
 
   /// Status: enabled
@@ -6433,7 +6433,7 @@ abstract class AppLocalizations {
   /// Home sections settings subtitle
   ///
   /// In en, this message translates to:
-  /// **'Reorder and toggle home rows'**
+  /// **'Reorder and toggle both library and external-based home rows'**
   String get reorderToggleHomeRows;
 
   /// Media bar settings subtitle
@@ -13555,7 +13555,7 @@ abstract class AppLocalizations {
   /// No description provided for @homeRowTogglesSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Enable or disable different home row categories'**
+  /// **'Enable or disable library-based home row categories'**
   String get homeRowTogglesSubtitle;
 
   /// No description provided for @homeRowTogglesDescription.
@@ -15025,7 +15025,7 @@ abstract class AppLocalizations {
   /// No description provided for @externalLists.
   ///
   /// In en, this message translates to:
-  /// **'External Lists'**
+  /// **'External Home Row Lists'**
   String get externalLists;
 
   /// No description provided for @enableImdb.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13714,18 +13714,6 @@ abstract class AppLocalizations {
   /// **'Audio Playlists'**
   String get audioPlaylists;
 
-  /// No description provided for @displaySeerrRows.
-  ///
-  /// In en, this message translates to:
-  /// **'Display Seerr Discovery Rows'**
-  String get displaySeerrRows;
-
-  /// No description provided for @displaySeerrRowsSubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Show Seerr discovery rows in Home Sections.'**
-  String get displaySeerrRowsSubtitle;
-
   /// No description provided for @appearance.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -7690,12 +7690,6 @@ class AppLocalizationsAf extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Voorkoms';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -7640,12 +7640,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'مظهر';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -7713,12 +7713,6 @@ class AppLocalizationsBe extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Знешні выгляд';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7756,12 +7756,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Външен вид';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -7677,12 +7677,6 @@ class AppLocalizationsBn extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'চেহারা';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -7804,12 +7804,6 @@ class AppLocalizationsCa extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Aparença';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7694,12 +7694,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Vzhled';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -7708,12 +7708,6 @@ class AppLocalizationsCy extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Ymddangosiad';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7683,12 +7683,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Udseende';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7752,12 +7752,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Aussehen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7799,12 +7799,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Εμφάνιση';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7652,13 +7652,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get audioPlaylists => 'Audio Playlists';
 
   @override
-  String get displaySeerrRows => 'Display Seerr Discovery Rows';
-
-  @override
-  String get displaySeerrRowsSubtitle =>
-      'Show Seerr discovery rows in Home Sections.';
-
-  @override
   String get appearance => 'Appearance';
 
   @override
@@ -16057,13 +16050,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get audioPlaylists => 'Audio Playlists';
-
-  @override
-  String get displaySeerrRows => 'Display Seerr Discovery Rows';
-
-  @override
-  String get displaySeerrRowsSubtitle =>
-      'Show Seerr discovery rows in Home Sections.';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -7673,12 +7673,6 @@ class AppLocalizationsEo extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Aspekto';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7759,12 +7759,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Apariencia';
 
   @override
@@ -16321,12 +16315,6 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Apariencia';
 
   @override
@@ -24843,12 +24831,6 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get audioPlaylists => '';
-
-  @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
 
   @override
   String get appearance => 'Apariencia';
@@ -33369,12 +33351,6 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Apariencia';
 
   @override
@@ -41891,12 +41867,6 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get audioPlaylists => '';
-
-  @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
 
   @override
   String get appearance => 'Apariencia';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7697,12 +7697,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Välimus';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -7645,12 +7645,6 @@ class AppLocalizationsFa extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'ظاهر';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7709,12 +7709,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Ulkonäkö';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7797,13 +7797,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get audioPlaylists => 'Playlists audio';
 
   @override
-  String get displaySeerrRows => 'Afficher les rangées de découverte Seerr';
-
-  @override
-  String get displaySeerrRowsSubtitle =>
-      'Afficher les rangées de découverte Seerr dans les sections de l\'accueil.';
-
-  @override
   String get appearance => 'Apparence';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -7782,12 +7782,6 @@ class AppLocalizationsGl extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -7581,12 +7581,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -7663,12 +7663,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7707,12 +7707,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7750,12 +7750,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -7703,13 +7703,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get audioPlaylists => 'Playlist Audio';
 
   @override
-  String get displaySeerrRows => 'Tampilkan Baris Discovery Seerr';
-
-  @override
-  String get displaySeerrRowsSubtitle =>
-      'Tampilkan baris discovery Seerr di Bagian Beranda.';
-
-  @override
   String get appearance => 'Tampilan';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7726,12 +7726,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -7489,12 +7489,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -7718,12 +7718,6 @@ class AppLocalizationsKk extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -7734,12 +7734,6 @@ class AppLocalizationsKn extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -7484,12 +7484,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7713,12 +7713,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Išvaizda';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7721,12 +7721,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Izskats';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -7736,12 +7736,6 @@ class AppLocalizationsMk extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -7779,12 +7779,6 @@ class AppLocalizationsMl extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'രൂപഭാവം';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -7713,12 +7713,6 @@ class AppLocalizationsMn extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Гадаад төрх';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7686,12 +7686,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7717,12 +7717,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -7666,12 +7666,6 @@ class AppLocalizationsPa extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7728,12 +7728,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7740,12 +7740,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Aparência';
 
   @override
@@ -16243,12 +16237,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override
@@ -24727,13 +24715,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get audioPlaylists => '';
-
-  @override
-  String get displaySeerrRows => 'Mostrar linhas de descoberta Seerr';
-
-  @override
-  String get displaySeerrRowsSubtitle =>
-      'Mostrar linhas de descoberta Seerr nas Secções Iniciais.';
 
   @override
   String get appearance => 'Aparência';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7731,12 +7731,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -7737,12 +7737,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -7674,12 +7674,6 @@ class AppLocalizationsSi extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7718,12 +7718,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7715,12 +7715,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -7746,12 +7746,6 @@ class AppLocalizationsSq extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -7711,12 +7711,6 @@ class AppLocalizationsSr extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7697,12 +7697,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -7738,12 +7738,6 @@ class AppLocalizationsSw extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -7741,12 +7741,6 @@ class AppLocalizationsTa extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -7734,12 +7734,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'స్వరూపం';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -7632,12 +7632,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'รูปร่าง';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -7766,12 +7766,6 @@ class AppLocalizationsTl extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -7715,13 +7715,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get audioPlaylists => 'Ses Oynatma Listeleri';
 
   @override
-  String get displaySeerrRows => 'Seerr Keşif Satırlarını Göster';
-
-  @override
-  String get displaySeerrRowsSubtitle =>
-      'Seerr keşif satırlarını Ana Sayfa Bölümleri\'nde göster.';
-
-  @override
   String get appearance => 'Görünüm';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -7693,12 +7693,6 @@ class AppLocalizationsUg extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -7731,12 +7731,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Зовнішній вигляд';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -7693,12 +7693,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Vẻ bề ngoài';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -7441,12 +7441,6 @@ class AppLocalizationsYue extends AppLocalizations {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override
@@ -15639,12 +15633,6 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get audioPlaylists => '';
 
   @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
-
-  @override
   String get appearance => 'Appearance';
 
   @override
@@ -23808,12 +23796,6 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get audioPlaylists => '';
-
-  @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7423,12 +7423,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get audioPlaylists => '音频播放列表';
 
   @override
-  String get displaySeerrRows => '显示 Seerr 发现栏目';
-
-  @override
-  String get displaySeerrRowsSubtitle => '在首页栏目中显示 Seerr 发现栏目。';
-
-  @override
   String get appearance => '外观';
 
   @override
@@ -15593,12 +15587,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get audioPlaylists => '';
-
-  @override
-  String get displaySeerrRows => '';
-
-  @override
-  String get displaySeerrRowsSubtitle => '';
 
   @override
   String get appearance => 'Appearance';

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -7742,8 +7742,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -7746,8 +7746,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "missing": "",

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -7745,8 +7745,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -7749,8 +7749,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "missing": "",

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -7426,7 +7426,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",
@@ -7586,7 +7585,6 @@
     "@empty": {
         "description": "Label indicating a section or category is empty"
     },
-    "displaySeerrRowsSubtitle": "",
     "themeGlass": "",
     "@themeGlass": {
         "description": "Display name for the Glass theme"

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -7623,8 +7623,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -7594,8 +7594,6 @@
     "displayAudioRows": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -7632,8 +7632,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -7623,8 +7623,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "missing": "",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -7623,8 +7623,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "accountPreferences": "",
     "@accountPreferences": {

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -7649,8 +7649,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_pt_PT.arb
+++ b/lib/l10n/app_pt_PT.arb
@@ -7218,8 +7218,6 @@
     "displayPlaylistsRowsSubtitle": "Mostrar linhas de listas de reprodução nas Secções Iniciais.",
     "playlistsRowSorting": "Classificação de linhas de listas de reprodução",
     "playlistsRowSortingDescription": "Classificar linhas de listas de reprodução por data de adição, data de lançamento, ordem alfabética e muito mais.",
-    "displaySeerrRows": "Mostrar linhas de descoberta Seerr",
-    "displaySeerrRowsSubtitle": "Mostrar linhas de descoberta Seerr nas Secções Iniciais.",
     "appearance": "Aparência",
     "cardSize": "Tamanho do cartão",
     "externalPlayerApp": "Reprodutor externo",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -7656,8 +7656,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -7710,8 +7710,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -7638,8 +7638,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -7694,8 +7694,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -7703,8 +7703,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -7656,8 +7656,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -7396,8 +7396,6 @@
     },
     "playlistsRowSorting": "",
     "displayAudioRows": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "changeArtwork": "",
     "confirmItemBackdrop": "",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -7637,8 +7637,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -7627,8 +7627,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -7622,8 +7622,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -7646,8 +7646,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -7706,8 +7706,6 @@
     "displayAudioRowsSubtitle": "",
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "missing": "",

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -7813,8 +7813,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "imageUploadFailed": "",
     "@imageUploadFailed": {
         "placeholders": {

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -7573,8 +7573,6 @@
     "displayPlaylistsRowsSubtitle": "Oynatma listesi satırlarını Ana Sayfa Bölümleri'nde göster.",
     "playlistsRowSorting": "Oynatma Listesi Satır Sıralaması",
     "playlistsRowSortingDescription": "Oynatma listesi satırlarını ekleme tarihi, yayınlanma tarihi, alfabetik ve daha fazlasına göre sıralayın.",
-    "displaySeerrRows": "Seerr Keşif Satırlarını Göster",
-    "displaySeerrRowsSubtitle": "Seerr keşif satırlarını Ana Sayfa Bölümleri'nde göster.",
     "externalPlayerAppDescription": "Üzerine uzun basarak oynatma seçeneğini etkinleştirmek için harici oynatıcıyı ayarlayın",
     "changeArtwork": "Görseli Değiştir",
     "missing": "Kayıp",

--- a/lib/l10n/app_ug.arb
+++ b/lib/l10n/app_ug.arb
@@ -7570,8 +7570,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -7661,8 +7661,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -7649,8 +7649,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_yue.arb
+++ b/lib/l10n/app_yue.arb
@@ -7713,8 +7713,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_yue_CN.arb
+++ b/lib/l10n/app_yue_CN.arb
@@ -7597,8 +7597,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_yue_HK.arb
+++ b/lib/l10n/app_yue_HK.arb
@@ -7678,8 +7678,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -7430,8 +7430,6 @@
     "audioRowsSorting": "音频行排序",
     "audioRowsSortingDescription": "按添加日期、发布日期、字母顺序等方式排序音频行。",
     "audioPlaylists": "音频播放列表",
-    "displaySeerrRows": "显示 Seerr 发现栏目",
-    "displaySeerrRowsSubtitle": "在首页栏目中显示 Seerr 发现栏目。",
     "externalPlayerAppDescription": "设置外部播放器以启用长按播放选项",
     "changeArtwork": "更换艺术图",
     "missing": "缺失",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -7651,8 +7651,6 @@
     "audioRowsSorting": "",
     "audioRowsSortingDescription": "",
     "audioPlaylists": "",
-    "displaySeerrRows": "",
-    "displaySeerrRowsSubtitle": "",
     "externalPlayerAppDescription": "",
     "crewContributionsSeerr": "",
     "changeArtwork": "",

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -9,6 +9,7 @@ import '../util/language_matching.dart';
 import '../util/platform_detection.dart';
 import 'home_section_config.dart';
 import 'preference_constants.dart';
+import 'seerr_row_config.dart';
 
 class UserPreferences extends ChangeNotifier {
   static const _lastServerIdPreferenceKey = 'pref_last_server_id';
@@ -35,6 +36,7 @@ class UserPreferences extends ChangeNotifier {
     _migrateOverlayPreferences();
     _migrateDefaultAudioLanguagePreference();
     _migrateSeerrPreferenceKeys();
+    _migrateSeerrRowsVisibility();
     _enforceMediaQueuingAlwaysOn();
     _migrateSubtitleModePreference();
     _initializeSubtitleLanguagePreferences();
@@ -50,6 +52,30 @@ class UserPreferences extends ChangeNotifier {
         _store.get(Preference(key: legacyBlockNsfw, defaultValue: false)),
       );
     }
+  }
+
+  // The global "Display Seerr Discovery Rows" toggle (default off) was removed.
+  // Seerr rows now show whenever any Seerr row category is enabled. Preserve the
+  // opt-out for anyone who had that toggle off by disabling their stored Seerr row
+  // configs, so the rows don't suddenly appear after upgrading. Gating on the
+  // legacy key's presence makes this run once and skips users who never had it.
+  void _migrateSeerrRowsVisibility() {
+    const legacyKey = 'pref_display_seerr_rows';
+    if (!_store.containsKey(legacyKey)) return;
+
+    final wasVisible = _store.getBool(legacyKey) ?? false;
+    if (!wasVisible) {
+      for (final key in _store.keys.toList()) {
+        if (!key.startsWith('seerr_rows_config_')) continue;
+        final disabled =
+            SeerrRowConfig.fromJsonString(_store.getString(key) ?? '')
+                .map((c) => c.copyWith(enabled: false))
+                .toList();
+        _store.setString(key, SeerrRowConfig.toJsonString(disabled));
+      }
+    }
+
+    _store.remove(legacyKey);
   }
 
   void _migrateSubtitleModePreference() {
@@ -667,11 +693,6 @@ class UserPreferences extends ChangeNotifier {
 
   static final displayAudioRows = Preference(
     key: 'pref_display_audio_rows',
-    defaultValue: false,
-  );
-
-  static final displaySeerrRows = Preference(
-    key: 'pref_display_seerr_rows',
     defaultValue: false,
   );
 

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -153,6 +153,11 @@ class HomeViewModel extends ChangeNotifier {
         _prefs.get(UserPreferences.imdbTopEnglishMoviesEnabled);
   }
 
+  bool _isAnySeerrSectionEnabled() {
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    return seerrPrefs.rowsConfig.any((r) => r.enabled);
+  }
+
   static bool _isTmdbSectionType(HomeSectionType type) {
     return type == HomeSectionType.tmdbPopularMovies ||
         type == HomeSectionType.tmdbTopRatedMovies ||
@@ -293,7 +298,7 @@ class HomeViewModel extends ChangeNotifier {
       );
       final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
       final showSeerrRows =
-          _prefs.get(UserPreferences.displaySeerrRows) &&
+          _isAnySeerrSectionEnabled() &&
           GetIt.instance<PluginSyncService>().seerrAvailable;
       final showImdbRows = _isAnyImdbSectionEnabled();
       final showTmdbRows = _isAnyTmdbSectionEnabled();

--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -7,7 +7,6 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../home/home_view_model.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/preference_constants.dart';
-import '../../../preference/seerr_preferences.dart';
 import '../../../preference/user_preferences.dart';
 import '../../widgets/adaptive/adaptive_list_section.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
@@ -122,12 +121,6 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
     setState(() {});
   }
 
-  void _onSeerrRowsToggleChanged() {
-    _pushPersonalizationSync();
-    if (!mounted) return;
-    setState(() {});
-  }
-
   void _onPlaylistsSortChanged() {
     _pushPersonalizationSync();
     _reloadHomeRows();
@@ -143,7 +136,6 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final seerrEnabledOnAccount = GetIt.instance<SeerrPreferences>().enabled;
 
     final showFavoritesRows = _prefs.get(UserPreferences.displayFavoritesRows);
     final showCollectionsRows = _prefs.get(
@@ -373,28 +365,6 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                     ),
                 ],
               ),
-
-              if (_syncService.seerrAvailable) ...[
-                _SectionHeader(l10n.seerr),
-                adaptiveListSection(
-                  children: [
-                    SwitchPreferenceTile(
-                      preference: UserPreferences.displaySeerrRows,
-                      title: l10n.displaySeerrRows,
-                      subtitle: seerrEnabledOnAccount
-                          ? l10n.displaySeerrRowsSubtitle
-                          : '${l10n.displaySeerrRowsSubtitle} (Requires Seerr login in Plugins)',
-                      enabled: seerrEnabledOnAccount,
-                      iconBuilder: (size, color) => Image.asset(
-                        'assets/icons/seerr.png',
-                        width: size,
-                        height: size,
-                      ),
-                      onChanged: _onSeerrRowsToggleChanged,
-                    ),
-                  ],
-                ),
-              ],
               const SizedBox(height: 32),
             ],
           ),

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -12,6 +12,7 @@ import '../../../data/services/home_screen_sections_service.dart';
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
+import '../../../preference/seerr_preferences.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/overlay_sheet.dart';
@@ -466,6 +467,11 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     }
   }
 
+  bool _isAnySeerrSectionEnabled() {
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    return seerrPrefs.rowsConfig.any((r) => r.enabled);
+  }
+
   bool _isHiddenByRowVisibilityGates(HomeSectionConfig section) {
     final showFavoritesRows = _prefs.get(UserPreferences.displayFavoritesRows);
     final showCollectionsRows = _prefs.get(
@@ -474,7 +480,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     final showGenresRows = _prefs.get(UserPreferences.displayGenresRows);
     final showPlaylistsRows = _prefs.get(UserPreferences.displayPlaylistsRows);
     final showSeerrRows =
-        _prefs.get(UserPreferences.displaySeerrRows) &&
+        _isAnySeerrSectionEnabled() &&
         GetIt.instance<PluginSyncService>().seerrAvailable;
 
     final hiddenByFavorites =

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -913,3 +913,150 @@ class _UpcomingCalendarsScreenState extends State<_UpcomingCalendarsScreen> {
     );
   }
 }
+
+class _SeerrListsScreen extends StatefulWidget {
+  const _SeerrListsScreen();
+
+  @override
+  State<_SeerrListsScreen> createState() => _SeerrListsScreenState();
+}
+
+class _SeerrListsScreenState extends State<_SeerrListsScreen> {
+  late final SeerrPreferences _seerrPrefs;
+  late List<SeerrRowConfig> _rows;
+  final _syncService = GetIt.instance<PluginSyncService>();
+  final _scope = FocusScopeNode(debugLabel: 'SeerrListsScope');
+  final _firstFocusNode = FocusNode(debugLabel: 'seerr_display_rows');
+
+  @override
+  void initState() {
+    super.initState();
+    _seerrPrefs = GetIt.instance<SeerrPreferences>();
+    _rows = List.of(_seerrPrefs.rowsConfig);
+  }
+
+  @override
+  void dispose() {
+    _scope.dispose();
+    _firstFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _pushPersonalizationSync() {
+    final client = GetIt.instance.isRegistered<MediaServerClient>()
+        ? GetIt.instance<MediaServerClient>()
+        : null;
+    if (client != null) {
+      _syncService.pushSettings(client);
+    }
+  }
+
+  void _saveRows() {
+    _seerrPrefs.setRowsConfig(_rows);
+    _pushPersonalizationSync();
+    if (mounted) setState(() {});
+  }
+
+  String _rowLabel(SeerrRowType type, AppLocalizations l10n) => switch (type) {
+    SeerrRowType.recentRequests => l10n.recentRequests,
+    SeerrRowType.recentlyAdded => l10n.recentlyAdded,
+    SeerrRowType.trending => l10n.trending,
+    SeerrRowType.popularMovies => l10n.popularMovies,
+    SeerrRowType.movieGenres => l10n.movieGenres,
+    SeerrRowType.upcomingMovies => l10n.upcomingMovies,
+    SeerrRowType.studios => l10n.studios,
+    SeerrRowType.popularSeries => l10n.popularSeries,
+    SeerrRowType.seriesGenres => l10n.seriesGenres,
+    SeerrRowType.upcomingSeries => l10n.upcomingSeries,
+    SeerrRowType.networks => l10n.networks,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return withCleanSettingsTypography(
+      context,
+      RequestInitialFocus(
+        targetNode: PlatformDetection.isTV ? _firstFocusNode : null,
+        child: Scaffold(
+          appBar: buildSettingsAppBar(
+            context,
+            const Text('Seerr Lists'),
+          ),
+          body: FocusScope(
+            node: _scope,
+            autofocus: true,
+            child: ListView(
+              children: [
+                const _SectionHeader('Seerr Home Page Rows'),
+                adaptiveListSection(
+                  children: _rows.map((row) {
+                    final rowIndex = _rows.indexOf(row);
+                    return _SeerrRowSwitchTile(
+                      focusNode: rowIndex == 0 ? _firstFocusNode : null,
+                      title: _rowLabel(row.type, l10n),
+                      value: row.enabled,
+                      onChanged: (enabled) {
+                        setState(() {
+                          _rows[rowIndex] = row.copyWith(enabled: enabled);
+                        });
+                        _saveRows();
+                      },
+                    );
+                  }).toList(),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SeerrRowSwitchTile extends StatelessWidget {
+  final String title;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final FocusNode? focusNode;
+
+  const _SeerrRowSwitchTile({
+    required this.title,
+    required this.value,
+    required this.onChanged,
+    this.focusNode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TvFocusHighlight(
+      enabled: true,
+      builder: (context, focused) {
+        final iconColor = focused
+            ? AppColors.black.withValues(alpha: 0.54)
+            : (Theme.of(context).iconTheme.color ?? AppColorScheme.onSurface);
+        final secondary = buildSettingsLeadingIconShell(
+          context,
+          icon: const Icon(Icons.list_alt),
+          focused: focused,
+          iconColor: iconColor,
+        );
+
+        return SwitchListTile.adaptive(
+          focusNode: focusNode,
+          secondary: secondary,
+          title: Text(
+            title,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: AppColorScheme.onSurface,
+            ),
+          ),
+          value: value,
+          onChanged: onChanged,
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -103,6 +103,18 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
                         subtitle: const Text('Toggle Upcoming Calendars from Radarr/Sonarr.'),
                         onTap: () => context.pushSettingsScreen(const _UpcomingCalendarsScreen()),
                       ),
+                    if (syncService.seerrAvailable)
+                      _TvSettingsListTile(
+                        leading: Image.asset(
+                          'assets/icons/seerr.png',
+                          width: 24,
+                          height: 24,
+                        ),
+                        title: const Text('Seerr Lists'),
+                        subtitle: const Text('Configure Seerr Discovery Rows'),
+                        onTap: () =>
+                            context.pushSettingsScreen(const _SeerrListsScreen()),
+                      ),
                   ],
                 ),
               ),

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -791,9 +791,8 @@ class _UpcomingCalendarsScreenState extends State<_UpcomingCalendarsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
     final prefs = GetIt.instance<UserPreferences>();
-    
+
     final radarrEnabled = prefs.get(UserPreferences.enableRadarrCalendar);
     final sonarrEnabled = prefs.get(UserPreferences.enableSonarrCalendar);
 

--- a/lib/ui/screens/settings/panel/integrations_screen.dart
+++ b/lib/ui/screens/settings/panel/integrations_screen.dart
@@ -49,7 +49,17 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
                 onTap: () =>
                     context.pushSettingsScreen(const _MetadataRatingsScreen()),
               ),
-
+              _TvSettingsListTile(
+                leading: Image.asset(
+                  'assets/icons/seerr.png',
+                  width: 24,
+                  height: 24,
+                ),
+                title: Text(l10n.seerr),
+                subtitle: Text(l10n.mediaRequestIntegration),
+                onTap: () =>
+                    context.pushSettingsScreen(const SeerrConfigScreen()),
+              ),
               _TvSettingsListTile(
                 leading: const Icon(Icons.list_alt),
                 title: Text(l10n.externalLists),

--- a/lib/ui/screens/settings/panel/integrations_screen.dart
+++ b/lib/ui/screens/settings/panel/integrations_screen.dart
@@ -49,17 +49,7 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
                 onTap: () =>
                     context.pushSettingsScreen(const _MetadataRatingsScreen()),
               ),
-              _TvSettingsListTile(
-                leading: Image.asset(
-                  'assets/icons/seerr.png',
-                  width: 24,
-                  height: 24,
-                ),
-                title: Text(l10n.seerr),
-                subtitle: Text(l10n.mediaRequestIntegration),
-                onTap: () =>
-                    context.pushSettingsScreen(const SeerrConfigScreen()),
-              ),
+
               _TvSettingsListTile(
                 leading: const Icon(Icons.list_alt),
                 title: Text(l10n.externalLists),

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -36,6 +36,7 @@ import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/seerr_preferences.dart';
+import '../../../preference/seerr_row_config.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/adaptive/adaptive_dialog.dart';
 import '../../widgets/adaptive/adaptive_list_section.dart';


### PR DESCRIPTION
# Pull Request

## Summary
Cleans up and reorganizes the layout of various home screen and integration preference menus under Settings. 


## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Home Screen Settings Subtitle: Changed description of "Home Row Toggles" to "Enable or disable library-based home row categories" to clearly distinguish them from external lists.
* Restored Main Seerr Config: Moved the main Seerr container/configuration screen link to Integrations -> Seerr (after Metadata & Ratings).
* Renamed Seerr Mainpage Discovery Settings: Renamed "Discover Rows" on the main Seerr page to "Seerr Homepage" with description "Enable rows to see on Seerr mainpage. Drag to reorder. Custom order syncs with Moonbase."
* Added Seerr Lists to External Home Row Lists: Under Integrations -> External Home Row Lists, added a dedicated "Seerr Lists" screen which contains switches for the various Seerr Discovery Row options that can be put on the home page under the section heading "Seerr Home Page Rows".
* Dynamic Home Rows Activation: Removed the initial global toggle for displaying Seerr rows. Like IMDb/TMDB, Seerr home rows are now prepared and displayed automatically as long as at least one Seerr home row category is enabled.
* Home Sections Subtitle: Updated subtitle description of "Home Sections" to "Reorder and toggle both library and external-based home rows" for completeness.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Personalization -> Home Screen and verify renamed Home Sections and Home Row Toggles subtitles.
2. Navigate to Settings -> Integrations and verify Seerr is listed as a main integration (after Metadata & Ratings). Open it and verify the renamed "Seerr Homepage" section description.
3. Open Settings -> Integrations -> External Home Row Lists and verify "Seerr Lists" tile exists.
4. Tap "Seerr Lists" and confirm it directly lists the switches for configuring individual Seerr discovery rows under the heading "Seerr Home Page Rows". Toggling at least one row displays Seerr rows on the Home screen.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

* Cleaned Home Row Sections descriptions
<img width="842" height="482" alt="2026-06-27_00-57-49_moonfin" src="https://github.com/user-attachments/assets/4e6c8f68-ea4b-4af6-a80a-27005a79d7cd" />

* New area in Integrations for External Home Row Lists
<img width="838" height="886" alt="2026-06-27_00-58-14_moonfin" src="https://github.com/user-attachments/assets/acec2874-3ec4-43f2-ab92-490bf809c9ce" />

* Revised heading and description in Seerr panel (Seerr Homepage)
<img width="837" height="1327" alt="2026-06-27_00-58-27_moonfin" src="https://github.com/user-attachments/assets/0120b8dc-09eb-4da0-8162-834137e5eab8" />

* New area: External Home Row Lists
<img width="851" height="823" alt="2026-06-27_00-58-38_moonfin" src="https://github.com/user-attachments/assets/466a7924-2e18-4a22-ab12-333f192ecc7f" />

* Moved and Simplified Seerr Home Row Options
<img width="826" height="1343" alt="2026-06-27_01-53-04_moonfin" src="https://github.com/user-attachments/assets/733a32c4-91d8-4b4f-9f98-26b7d453ed27" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
