### PR TITLE
Features/custom rows Fully Custom Row Support to Moonfin

### DIFF
--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -13,6 +13,7 @@ class ImdbExternalListItem {
   final String imdbId;
   final String title;
   final String? posterUrl;
+  final String? backdropUrl;
   final int? year;
   final String type; // 'Movie' or 'Series'
   final double? popularity;
@@ -23,6 +24,7 @@ class ImdbExternalListItem {
     required this.imdbId,
     required this.title,
     this.posterUrl,
+    this.backdropUrl,
     this.year,
     required this.type,
     this.popularity,
@@ -34,6 +36,7 @@ class ImdbExternalListItem {
         'imdbId': imdbId,
         'title': title,
         'posterUrl': posterUrl,
+        'backdropUrl': backdropUrl,
         'year': year,
         'type': type,
         'popularity': popularity,
@@ -46,6 +49,7 @@ class ImdbExternalListItem {
         imdbId: json['imdbId'] as String,
         title: json['title'] as String,
         posterUrl: json['posterUrl'] as String?,
+        backdropUrl: json['backdropUrl'] as String?,
         year: json['year'] as int?,
         type: json['type'] as String,
         popularity: (json['popularity'] as num?)?.toDouble(),
@@ -83,14 +87,16 @@ class CustomExternalListsService {
           return 'https://www.themoviedb.org/list/$id';
         }
       case 'letterboxd':
+        if (type == 'user_list') {
+          return params['url'] as String? ?? 'https://letterboxd.com/';
+        }
         final username = params['user'] as String? ?? '';
-        final name = params['name'] as String? ?? '';
         if (type == 'watchlist') {
           return 'https://letterboxd.com/$username/watchlist/';
         } else if (type == 'films') {
           return 'https://letterboxd.com/$username/films/';
         } else {
-          return 'https://letterboxd.com/$username/list/$name/';
+          return 'https://letterboxd.com/$username/rss/';
         }
       case 'mdblist':
         final username = params['username'] as String? ?? '';
@@ -175,6 +181,7 @@ class CustomExternalListsService {
         final tmdbId = providerIds['Tmdb'] as String? ?? '';
         final title = rawItem['name'] as String? ?? 'Unknown';
         final posterUrl = rawItem['posterUrl'] as String?;
+        final backdropUrl = rawItem['backdropUrl'] as String?;
         final year = rawItem['productionYear'] as int?;
         final itemType = rawItem['type'] as String? ?? 'Movie';
         final userRating = rawItem['userRating'] as String?;
@@ -184,6 +191,7 @@ class CustomExternalListsService {
             imdbId: imdbId.isNotEmpty ? imdbId : tmdbId,
             title: title,
             posterUrl: posterUrl,
+            backdropUrl: backdropUrl,
             year: year,
             type: itemType,
             userRating: userRating,
@@ -230,6 +238,14 @@ class CustomExternalListsService {
         final items = decoded
             .map((item) => ImdbExternalListItem.fromJson(item as Map<String, dynamic>))
             .toList();
+        final hasOldCache = decoded.any((item) => item is Map && !item.containsKey('backdropUrl'));
+        if (hasOldCache) {
+          debugPrint('[CustomService] Old custom row cache detected without backdropUrl, invalidating...');
+          try {
+            await file.delete();
+          } catch (_) {}
+          return [];
+        }
         return _applySorting(items, config);
       }
     } catch (e) {

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -11,6 +11,7 @@ import '../../util/platform_detection.dart';
 
 class ImdbExternalListItem {
   final String imdbId;
+  final String tmdbId;
   final String title;
   final String? posterUrl;
   final String? backdropUrl;

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -190,7 +190,8 @@ class CustomExternalListsService {
 
         if (imdbId.isNotEmpty || tmdbId.isNotEmpty) {
           items.add(ImdbExternalListItem(
-            imdbId: imdbId.isNotEmpty ? imdbId : tmdbId,
+            imdbId: imdbId,
+            tmdbId: tmdbId,
             title: title,
             posterUrl: posterUrl,
             backdropUrl: backdropUrl,

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -88,17 +88,8 @@ class CustomExternalListsService {
           return 'https://www.themoviedb.org/list/$id';
         }
       case 'letterboxd':
-        if (type == 'user_list') {
-          return params['url'] as String? ?? 'https://letterboxd.com/';
-        }
         final username = params['user'] as String? ?? '';
-        if (type == 'watchlist') {
-          return 'https://letterboxd.com/$username/watchlist/';
-        } else if (type == 'films') {
-          return 'https://letterboxd.com/$username/films/';
-        } else {
-          return 'https://letterboxd.com/$username/rss/';
-        }
+        return 'https://letterboxd.com/$username/';
       case 'mdblist':
         final username = params['username'] as String? ?? '';
         final listname = params['listname'] as String? ?? '';

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -163,7 +163,7 @@ class CustomExternalListsService {
       );
 
       if (response.statusCode != 200) {
-        throw Exception('Custom rows controller returned status ${response?.statusCode}');
+        throw Exception('Custom rows controller returned status ${response.statusCode}');
       }
 
       final data = response.data;

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -2,11 +2,57 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:server_core/server_core.dart';
 import '../../preference/home_section_config.dart';
 import '../../preference/user_preferences.dart';
 import '../../util/platform_detection.dart';
-import 'imdb_external_lists_service.dart';
+
+class ImdbExternalListItem {
+  final String imdbId;
+  final String title;
+  final String? posterUrl;
+  final int? year;
+  final String type; // 'Movie' or 'Series'
+  final double? popularity;
+  final double? rating;
+  final String? userRating;
+
+  ImdbExternalListItem({
+    required this.imdbId,
+    required this.title,
+    this.posterUrl,
+    this.year,
+    required this.type,
+    this.popularity,
+    this.rating,
+    this.userRating,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'imdbId': imdbId,
+        'title': title,
+        'posterUrl': posterUrl,
+        'year': year,
+        'type': type,
+        'popularity': popularity,
+        'rating': rating,
+        'userRating': userRating,
+      };
+
+  factory ImdbExternalListItem.fromJson(Map<String, dynamic> json) =>
+      ImdbExternalListItem(
+        imdbId: json['imdbId'] as String,
+        title: json['title'] as String,
+        posterUrl: json['posterUrl'] as String?,
+        year: json['year'] as int?,
+        type: json['type'] as String,
+        popularity: (json['popularity'] as num?)?.toDouble(),
+        rating: (json['rating'] as num?)?.toDouble(),
+        userRating: json['userRating'] as String?,
+      );
+}
 
 class CustomExternalListsService {
   final Dio _dio = Dio(BaseOptions(
@@ -15,41 +61,8 @@ class CustomExternalListsService {
   ));
 
   final UserPreferences _prefs;
-  final Map<String, String> _letterboxdCache = {};
-  bool _letterboxdCacheLoaded = false;
 
   CustomExternalListsService(this._prefs);
-
-  Future<void> _ensureLetterboxdCacheLoaded() async {
-    if (_letterboxdCacheLoaded) return;
-    try {
-      final file = await _letterboxdCacheFile();
-      if (file.existsSync()) {
-        final content = await file.readAsString();
-        final decoded = jsonDecode(content) as Map<String, dynamic>;
-        _letterboxdCache.addAll(decoded.cast<String, String>());
-      }
-    } catch (e) {
-      debugPrint('[CustomService] Failed to load Letterboxd cache: $e');
-    }
-    _letterboxdCacheLoaded = true;
-  }
-
-  Future<void> _saveLetterboxdCache() async {
-    try {
-      final file = await _letterboxdCacheFile();
-      await file.writeAsString(jsonEncode(_letterboxdCache), flush: true);
-    } catch (e) {
-      debugPrint('[CustomService] Failed to save Letterboxd cache: $e');
-    }
-  }
-
-  Future<File> _letterboxdCacheFile() async {
-    final dir = PlatformDetection.isAppleTV
-        ? await getApplicationCacheDirectory()
-        : await getApplicationSupportDirectory();
-    return File('${dir.path}/letterboxd_slug_to_tmdb.json');
-  }
 
   String constructSourceUrl(String source, String type, Map<String, dynamic> params) {
     switch (source) {
@@ -109,682 +122,83 @@ class CustomExternalListsService {
 
     if (source == null || type == null) return [];
 
-    List<ImdbExternalListItem> items = [];
-
-    try {
-      switch (source) {
-        case 'mdblist':
-          items = await _fetchMdbList(type, params);
-          break;
-        case 'imdb':
-          items = await _fetchImdb(type, params);
-          break;
-        case 'letterboxd':
-          items = await _fetchLetterboxd(type, params);
-          break;
-        case 'tmdb':
-          items = await _fetchTmdb(type, params);
-          break;
-        default:
-          debugPrint('[CustomService] Unsupported custom source: $source');
-      }
-    } catch (e) {
-      final url = constructSourceUrl(source, type, params);
-      throw Exception('Failed to fetch from custom row. Constructed URL: $url. Error: $e');
-    }
-
-    if (items.isEmpty) {
-      final url = constructSourceUrl(source, type, params);
-      throw Exception('Fetched 0 items from custom row. Constructed URL: $url. Please check your parameters.');
-    }
-
-    await saveCustomRowToCache(config, items);
-
-    return _applySorting(items, config);
-  }
-
-  // --- MDBList ---
-  Future<List<ImdbExternalListItem>> _fetchMdbList(String type, Map<String, dynamic> params) async {
-    final apiKey = _prefs.get(UserPreferences.mdblistApiKey);
-    if (apiKey.isEmpty) {
-      throw StateError('MDBList API Key is not configured');
-    }
-
-    final username = params['username'] as String?;
-    final listname = params['listname'] as String?;
-    if (username == null || username.isEmpty || listname == null || listname.isEmpty) {
+    if (source == 'imdb') {
+      debugPrint('[CustomService] IMDb custom row source is deprecated and unsupported.');
       return [];
     }
 
-    final url = 'https://api.mdblist.com/lists/$username/$listname/items';
+    final client = GetIt.instance.isRegistered<MediaServerClient>()
+        ? GetIt.instance<MediaServerClient>()
+        : null;
+    if (client == null) {
+      return loadCustomRowFromCache(config);
+    }
+
+    final baseUrl = client.baseUrl;
+    final token = client.accessToken;
+    if (token == null) {
+      return loadCustomRowFromCache(config);
+    }
+
+    final paramsJson = jsonEncode(params);
+    final url = '$baseUrl/Moonfin/CustomRows/Items';
+
     try {
       final response = await _dio.get(
         url,
         queryParameters: {
-          'apikey': apiKey,
-          'limit': 250,
+          'source': source,
+          'type': type,
+          'params': paramsJson,
         },
+        options: Options(
+          headers: {'Authorization': 'MediaBrowser Token="$token"'},
+        ),
       );
 
       if (response.statusCode != 200) {
-        throw Exception('MDBList API returned ${response.statusCode}');
+        throw Exception('Custom rows controller returned status ${response?.statusCode}');
       }
 
       final data = response.data;
-      if (data == null) return [];
-
-      final items = <ImdbExternalListItem>[];
-
-      // Parse either wrapper format {movies: [], shows: []} or flat list
-      List<dynamic> rawList = [];
-      if (data is Map<String, dynamic>) {
-        if (data['movies'] is List) rawList.addAll(data['movies'] as List);
-        if (data['shows'] is List) rawList.addAll(data['shows'] as List);
-      } else if (data is List) {
-        rawList = data;
+      if (data == null || data['success'] != true) {
+        throw Exception(data?['error'] ?? 'Unknown backend error');
       }
 
-      for (final item in rawList) {
-        final ids = item['ids'] as Map<String, dynamic>?;
-        final imdbId = (item['imdb_id'] as String?) ?? (ids?['imdb'] as String?);
-        final tmdbId = ids?['tmdb']?.toString();
-        final title = (item['title'] as String?) ?? 'Unknown';
-        final posterPath = item['poster'] as String? ?? ids?['poster'] as String?;
-        final year = item['release_year'] as int?;
-        final mediaType = (item['mediatype'] as String?)?.toLowerCase();
-        final type = (mediaType == 'show' || mediaType == 'shows' || mediaType == 'series' || mediaType == 'tv') ? 'Series' : 'Movie';
-        final rating = (item['rating'] as num?)?.toDouble() ?? (item['score'] as num?)?.toDouble();
-        final popularity = (item['popularity'] as num?)?.toDouble() ?? (item['rank'] as num?)?.toDouble();
+      final rawItems = data['items'] as List?;
+      if (rawItems == null) return [];
 
-        if (imdbId != null && imdbId.isNotEmpty) {
+      final List<ImdbExternalListItem> items = [];
+      for (final rawItem in rawItems) {
+        final providerIds = rawItem['providerIds'] as Map<String, dynamic>? ?? {};
+        final imdbId = providerIds['Imdb'] as String? ?? '';
+        final tmdbId = providerIds['Tmdb'] as String? ?? '';
+        final title = rawItem['name'] as String? ?? 'Unknown';
+        final posterUrl = rawItem['posterUrl'] as String?;
+        final year = rawItem['productionYear'] as int?;
+        final itemType = rawItem['type'] as String? ?? 'Movie';
+        final userRating = rawItem['userRating'] as String?;
+
+        if (imdbId.isNotEmpty || tmdbId.isNotEmpty) {
           items.add(ImdbExternalListItem(
-            imdbId: imdbId,
-            title: title,
-            posterUrl: posterPath,
-            year: year,
-            type: type,
-            popularity: popularity,
-            rating: rating,
-          ));
-        } else if (tmdbId != null && tmdbId.isNotEmpty) {
-          items.add(ImdbExternalListItem(
-            imdbId: tmdbId,
-            title: title,
-            posterUrl: posterPath,
-            year: year,
-            type: type,
-            popularity: popularity,
-            rating: rating,
-          ));
-        }
-      }
-
-      return items;
-    } catch (e) {
-      debugPrint('[CustomService] MDBList fetch failed: $e');
-      rethrow;
-    }
-  }
-
-  // --- IMDb ---
-  Future<List<ImdbExternalListItem>> _fetchImdb(String type, Map<String, dynamic> params) async {
-    if (type == 'user_list') {
-      final listId = params['listid'] as String?;
-      if (listId == null || listId.isEmpty) return [];
-
-      final query = '''
-{
-  list(id: "$listId") {
-    items(first: 250) {
-      edges {
-        node {
-          item {
-            ... on Title {
-              id
-              titleText {
-                text
-              }
-              primaryImage {
-                url
-              }
-              releaseYear {
-                year
-              }
-              titleType {
-                id
-              }
-              ratingsSummary {
-                aggregateRating
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-''';
-      try {
-        final response = await _dio.post(
-          'https://caching.graphql.imdb.com/',
-          data: {'query': query},
-          options: Options(headers: {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            'Content-Type': 'application/json',
-          }),
-        );
-
-        if (response.statusCode != 200) {
-          throw Exception('IMDb GraphQL returned ${response.statusCode}');
-        }
-
-        final data = response.data;
-        if (data == null || data['data'] == null || data['data']['list'] == null) {
-          return [];
-        }
-
-        final edges = data['data']['list']['items']['edges'] as List?;
-        if (edges == null) return [];
-
-        final items = <ImdbExternalListItem>[];
-        for (final edge in edges) {
-          final itemNode = edge['node']?['item'];
-          if (itemNode == null) continue;
-
-          final imdbId = itemNode['id'] as String?;
-          if (imdbId == null || imdbId.isEmpty) continue;
-
-          final title = (itemNode['titleText']?['text'] as String?) ?? 'Unknown';
-          final posterUrl = itemNode['primaryImage']?['url'] as String?;
-          final year = itemNode['releaseYear']?['year'] as int?;
-          final typeId = itemNode['titleType']?['id'] as String? ?? 'movie';
-          final type = (typeId == 'tvSeries' || typeId == 'tvMiniSeries') ? 'Series' : 'Movie';
-          final rating = (itemNode['ratingsSummary']?['aggregateRating'] as num?)?.toDouble();
-
-          items.add(ImdbExternalListItem(
-            imdbId: imdbId,
+            imdbId: imdbId.isNotEmpty ? imdbId : tmdbId,
             title: title,
             posterUrl: posterUrl,
             year: year,
-            type: type,
-            rating: rating,
+            type: itemType,
+            userRating: userRating,
           ));
         }
-        return items;
-      } catch (e) {
-        debugPrint('[CustomService] IMDb User List fetch failed: $e');
-        rethrow;
-      }
-    } else if (type == 'awards_events') {
-      final eventId = params['eventid'] as String?;
-      final yearStr = params['year'] as String?;
-      final subcategory = params['subcategory'] as String?;
-      if (eventId == null || eventId.isEmpty || yearStr == null || yearStr.isEmpty) return [];
-
-      final year = int.tryParse(yearStr);
-      if (year == null) return [];
-
-      final startYear = year - 2;
-
-      // Phase 1: Search for candidates
-      final candidateSearchQuery = '''
-{
-  advancedTitleSearch(
-    first: 250,
-    constraints: {
-      awardConstraint: {
-        anyEventNominations: [{ eventId: "$eventId" }]
-      },
-      releaseDateConstraint: {
-        releaseDateRange: {
-          start: "$startYear-01-01",
-          end: "$year-12-31"
-        }
-      }
-    }
-  ) {
-    edges {
-      node {
-        title {
-          id
-        }
-      }
-    }
-  }
-}
-''';
-      try {
-        final searchResponse = await _dio.post(
-          'https://caching.graphql.imdb.com/',
-          data: {'query': candidateSearchQuery},
-          options: Options(headers: {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            'Content-Type': 'application/json',
-          }),
-        );
-
-        if (searchResponse.statusCode != 200) {
-          throw Exception('IMDb search returned ${searchResponse.statusCode}');
-        }
-
-        final searchData = searchResponse.data;
-        if (searchData == null || searchData['data'] == null || searchData['data']['advancedTitleSearch'] == null) {
-          return [];
-        }
-
-        final edges = searchData['data']['advancedTitleSearch']['edges'] as List?;
-        if (edges == null || edges.isEmpty) return [];
-
-        final candidateIds = <String>[];
-        for (final edge in edges) {
-          final id = edge['node']?['title']?['id'] as String?;
-          if (id != null && id.isNotEmpty) {
-            candidateIds.add(id);
-          }
-        }
-
-        // Phase 2: Verify candidates and load details in batches of 50
-        final verifiedItems = <ImdbExternalListItem>[];
-        final idsBatchParam = candidateIds.map((id) => '"$id"').join(',');
-
-        final verifyQuery = '''
-{
-  titles(ids: [$idsBatchParam]) {
-    id
-    titleText {
-      text
-    }
-    primaryImage {
-      url
-    }
-    releaseYear {
-      year
-    }
-    titleType {
-      id
-    }
-    ratingsSummary {
-      aggregateRating
-    }
-    awardNominations(first: 50, filter: { events: ["$eventId"] }) {
-      edges {
-        node {
-          award {
-            year
-            category {
-              text
-            }
-          }
-        }
-      }
-    }
-  }
-}
-''';
-
-        final verifyResponse = await _dio.post(
-          'https://caching.graphql.imdb.com/',
-          data: {'query': verifyQuery},
-          options: Options(headers: {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-            'Content-Type': 'application/json',
-          }),
-        );
-
-        if (verifyResponse.statusCode != 200) {
-          throw Exception('IMDb verify returned ${verifyResponse.statusCode}');
-        }
-
-        final verifyData = verifyResponse.data;
-        if (verifyData == null || verifyData['data'] == null || verifyData['data']['titles'] == null) {
-          return [];
-        }
-
-        final titles = verifyData['data']['titles'] as List?;
-        if (titles == null) return [];
-
-        for (final titleNode in titles) {
-          if (titleNode == null) continue;
-          final titleId = titleNode['id'] as String?;
-          if (titleId == null || titleId.isEmpty) continue;
-
-          final title = (titleNode['titleText']?['text'] as String?) ?? 'Unknown';
-          final posterUrl = titleNode['primaryImage']?['url'] as String?;
-          final rYear = titleNode['releaseYear']?['year'] as int?;
-          final typeId = titleNode['titleType']?['id'] as String? ?? 'movie';
-          final type = (typeId == 'tvSeries' || typeId == 'tvMiniSeries') ? 'Series' : 'Movie';
-          final rating = (titleNode['ratingsSummary']?['aggregateRating'] as num?)?.toDouble();
-
-          final nominations = titleNode['awardNominations']?['edges'] as List?;
-          if (nominations == null) continue;
-
-          bool matches = false;
-          for (final nom in nominations) {
-            final award = nom['node']?['award'];
-            if (award == null) continue;
-            final awardYear = award['year'] as int?;
-            if (awardYear != year) continue;
-
-            if (subcategory != null && subcategory.isNotEmpty) {
-              final catText = award['category']?['text'] as String?;
-              if (catText != null && _categoryMatchesFragment(catText, subcategory)) {
-                matches = true;
-                break;
-              }
-            } else {
-              matches = true;
-              break;
-            }
-          }
-
-          if (matches) {
-            verifiedItems.add(ImdbExternalListItem(
-              imdbId: titleId,
-              title: title,
-              posterUrl: posterUrl,
-              year: rYear,
-              type: type,
-              rating: rating,
-            ));
-          }
-        }
-
-        return verifiedItems;
-      } catch (e) {
-        debugPrint('[CustomService] IMDb Awards fetch failed: $e');
-        rethrow;
-      }
-    }
-    return [];
-  }
-
-  bool _categoryMatchesFragment(String string, String fragment) {
-    final slug = string.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_').replaceAll(RegExp(r'^_+|_+$'), '');
-    final normalizedFragment = fragment.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_').replaceAll(RegExp(r'^_+|_+$'), '');
-    return slug == normalizedFragment || normalizedFragment.endsWith('_$slug');
-  }
-
-  // --- Letterboxd ---
-  Future<List<ImdbExternalListItem>> _fetchLetterboxd(String type, Map<String, dynamic> params) async {
-    final username = params['user'] as String?;
-    final name = params['name'] as String?;
-    if (username == null || username.isEmpty) return [];
-
-    final String url;
-    if (type == 'watchlist') {
-      url = 'https://letterboxd.com/$username/watchlist/';
-    } else if (type == 'films') {
-      url = 'https://letterboxd.com/$username/films/';
-    } else {
-      if (name == null || name.isEmpty) return [];
-      url = 'https://letterboxd.com/$username/list/$name/';
-    }
-
-    try {
-      await _ensureLetterboxdCacheLoaded();
-
-      // Step 1: Scrape list page for film slugs and user ratings
-      final response = await _dio.get(
-        url,
-        options: Options(headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-          'Accept-Language': 'en-US,en;q=0.9',
-        }),
-      );
-
-      if (response.statusCode != 200) {
-        throw Exception('Letterboxd returned ${response.statusCode}');
       }
 
-      final html = response.data as String? ?? '';
-      
-      final List<Map<String, String>> filmData = [];
-      final matches = RegExp(r'data-target-link="/film/([\w-]+)/"').allMatches(html).toList();
-      
-      for (int i = 0; i < matches.length; i++) {
-        final match = matches[i];
-        final slug = match.group(1)!;
-        
-        final startIdx = match.end;
-        final endIdx = (i + 1 < matches.length) ? matches[i + 1].start : html.length;
-        final searchArea = html.substring(startIdx, startIdx + 1000 > endIdx ? endIdx : startIdx + 1000);
-        
-        final ratingMatch = RegExp(r'class="rating\b[^"]*">([^<]+)<').firstMatch(searchArea);
-        final userRating = ratingMatch?.group(1)?.trim() ?? '';
-        
-        filmData.add({
-          'slug': slug,
-          'rating': userRating,
-        });
+      if (items.isNotEmpty) {
+        await saveCustomRowToCache(config, items);
       }
 
-      final uniqueFilmData = <String, Map<String, String>>{};
-      for (final fd in filmData) {
-        final slug = fd['slug']!;
-        if (!uniqueFilmData.containsKey(slug)) {
-          uniqueFilmData[slug] = fd;
-        }
-      }
-      final slugs = uniqueFilmData.keys.toList();
-
-      if (slugs.isEmpty) return [];
-
-      final items = <ImdbExternalListItem>[];
-
-      // Step 2: Resolve TMDB IDs for each slug
-      final List<String> unresolvedSlugs = [];
-      final List<String> resolvedTmdbIds = [];
-      final tmdbIdToRating = <String, String>{};
-
-      for (final slug in slugs) {
-        final rating = uniqueFilmData[slug]?['rating'] ?? '';
-        final cached = _letterboxdCache[slug];
-        if (cached != null) {
-          resolvedTmdbIds.add(cached);
-          if (rating.isNotEmpty) {
-            tmdbIdToRating[cached] = rating;
-          }
-        } else {
-          unresolvedSlugs.add(slug);
-        }
-      }
-
-      // Concurrently resolve unresolved slugs (up to 3 at a time to avoid throttling)
-      if (unresolvedSlugs.isNotEmpty) {
-        const batchSize = 3;
-        for (int i = 0; i < unresolvedSlugs.length; i += batchSize) {
-          final batch = unresolvedSlugs.sublist(i, i + batchSize > unresolvedSlugs.length ? unresolvedSlugs.length : i + batchSize);
-          await Future.wait(batch.map((slug) async {
-            try {
-              // Throttle delay
-              await Future.delayed(const Duration(milliseconds: 300));
-              final filmUrl = 'https://letterboxd.com/film/$slug/';
-              final filmResponse = await _dio.get(
-                filmUrl,
-                options: Options(headers: {
-                  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-                  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
-                }),
-              );
-              if (filmResponse.statusCode == 200) {
-                final filmHtml = filmResponse.data as String? ?? '';
-                final tmdbIdMatch = RegExp(r'data-tmdb-id="(\d+)"').firstMatch(filmHtml);
-                if (tmdbIdMatch != null) {
-                  final tmdbId = tmdbIdMatch.group(1)!;
-                  _letterboxdCache[slug] = tmdbId;
-                  resolvedTmdbIds.add(tmdbId);
-                  final rating = uniqueFilmData[slug]?['rating'] ?? '';
-                  if (rating.isNotEmpty) {
-                    tmdbIdToRating[tmdbId] = rating;
-                  }
-                }
-              }
-            } catch (e) {
-              debugPrint('[CustomService] Failed to resolve Letterboxd slug $slug: $e');
-            }
-          }));
-          await _saveLetterboxdCache();
-        }
-      }
-
-      // Step 3: Fetch movie metadata from TMDB API in parallel
-      final tmdbApiKey = _prefs.get(UserPreferences.tmdbApiKey);
-      if (tmdbApiKey.isEmpty) {
-        throw StateError('TMDB API Key is not configured (required for Letterboxd lists)');
-      }
-
-      final resolvedItems = <String, ImdbExternalListItem>{};
-
-      await Future.wait(resolvedTmdbIds.map((tmdbId) async {
-        try {
-          final movieResponse = await _dio.get(
-            'https://api.themoviedb.org/3/movie/$tmdbId',
-            queryParameters: {
-              'api_key': tmdbApiKey,
-            },
-          );
-          if (movieResponse.statusCode == 200) {
-            final movieData = movieResponse.data as Map<String, dynamic>?;
-            if (movieData != null) {
-              final title = movieData['title'] as String? ?? 'Unknown';
-              final posterPath = movieData['poster_path'] as String?;
-              final dateStr = movieData['release_date'] as String?;
-              int? year;
-              if (dateStr != null && dateStr.length >= 4) {
-                year = int.tryParse(dateStr.substring(0, 4));
-              }
-              final popularity = (movieData['popularity'] as num?)?.toDouble();
-              final rating = (movieData['vote_average'] as num?)?.toDouble();
-              final userRating = tmdbIdToRating[tmdbId];
-              resolvedItems[tmdbId] = ImdbExternalListItem(
-                imdbId: tmdbId, // TMDB ID is stored in imdbId for row navigation
-                title: title,
-                posterUrl: posterPath,
-                year: year,
-                type: 'Movie',
-                popularity: popularity,
-                rating: rating,
-                userRating: userRating != null && userRating.isNotEmpty ? userRating : null,
-              );
-            }
-          }
-        } catch (e) {
-          debugPrint('[CustomService] Failed to fetch TMDB details for $tmdbId: $e');
-        }
-      }));
-
-      for (final tmdbId in resolvedTmdbIds) {
-        final item = resolvedItems[tmdbId];
-        if (item != null) {
-          items.add(item);
-        }
-      }
-
-      return items;
+      return _applySorting(items, config);
     } catch (e) {
-      debugPrint('[CustomService] Letterboxd fetch failed: $e');
-      rethrow;
-    }
-  }
-
-  // --- TMDB ---
-  Future<List<ImdbExternalListItem>> _fetchTmdb(String type, Map<String, dynamic> params) async {
-    final apiKey = _prefs.get(UserPreferences.tmdbApiKey);
-    if (apiKey.isEmpty) {
-      throw StateError('TMDB API Key is not configured');
-    }
-
-    final id = params['id'] as String?;
-    if (id == null || id.isEmpty) return [];
-
-    final String url;
-    if (type == 'movie_collection') {
-      url = 'https://api.themoviedb.org/3/collection/$id';
-    } else {
-      url = 'https://api.themoviedb.org/3/list/$id';
-    }
-
-    try {
-      final response = await _dio.get(
-        url,
-        queryParameters: {
-          'api_key': apiKey,
-        },
-      );
-
-      if (response.statusCode != 200) {
-        throw Exception('TMDB API returned ${response.statusCode}');
-      }
-
-      final data = response.data;
-      if (data == null) return [];
-
-      final items = <ImdbExternalListItem>[];
-
-      if (type == 'movie_collection') {
-        final parts = data['parts'] as List?;
-        if (parts != null) {
-          for (final part in parts) {
-            final partId = part['id']?.toString();
-            final title = (part['title'] as String?) ?? 'Unknown';
-            final posterPath = part['poster_path'] as String?;
-            final dateStr = part['release_date'] as String?;
-            final popularity = (part['popularity'] as num?)?.toDouble();
-            final rating = (part['vote_average'] as num?)?.toDouble();
-            int? year;
-            if (dateStr != null && dateStr.length >= 4) {
-              year = int.tryParse(dateStr.substring(0, 4));
-            }
-            if (partId != null && partId.isNotEmpty) {
-              items.add(ImdbExternalListItem(
-                imdbId: partId,
-                title: title,
-                posterUrl: posterPath,
-                year: year,
-                type: 'Movie',
-                popularity: popularity,
-                rating: rating,
-              ));
-            }
-          }
-        }
-      } else {
-        final results = data['items'] as List?;
-        if (results != null) {
-          for (final res in results) {
-            final itemId = res['id']?.toString();
-            final title = (res['title'] as String?) ?? (res['name'] as String?) ?? 'Unknown';
-            final posterPath = res['poster_path'] as String?;
-            final dateStr = (res['release_date'] as String?) ?? (res['first_air_date'] as String?);
-            final popularity = (res['popularity'] as num?)?.toDouble();
-            final rating = (res['vote_average'] as num?)?.toDouble();
-            int? year;
-            if (dateStr != null && dateStr.length >= 4) {
-              year = int.tryParse(dateStr.substring(0, 4));
-            }
-            final mediaTypeRaw = res['media_type'] as String?;
-            final type = mediaTypeRaw == 'tv' ? 'Series' : 'Movie';
-
-            if (itemId != null && itemId.isNotEmpty) {
-              items.add(ImdbExternalListItem(
-                imdbId: itemId,
-                title: title,
-                posterUrl: posterPath,
-                year: year,
-                type: type,
-                popularity: popularity,
-                rating: rating,
-              ));
-            }
-          }
-        }
-      }
-
-      return items;
-    } catch (e) {
-      debugPrint('[CustomService] TMDB fetch failed: $e');
-      rethrow;
+      debugPrint('[CustomService] Fetch failed from server. Falling back to local cache: $e');
+      return loadCustomRowFromCache(config);
     }
   }
 

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -36,6 +36,7 @@ class ImdbExternalListItem {
 
   Map<String, dynamic> toJson() => {
         'imdbId': imdbId,
+        'tmdbId': tmdbId,
         'title': title,
         'posterUrl': posterUrl,
         'backdropUrl': backdropUrl,

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -6,7 +6,6 @@ import 'package:get_it/get_it.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:server_core/server_core.dart';
 import '../../preference/home_section_config.dart';
-import '../../preference/user_preferences.dart';
 import '../../util/platform_detection.dart';
 
 class ImdbExternalListItem {

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -23,6 +23,7 @@ class ImdbExternalListItem {
 
   ImdbExternalListItem({
     required this.imdbId,
+    this.tmdbId = '',
     required this.title,
     this.posterUrl,
     this.backdropUrl,

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -1,0 +1,872 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+import '../../preference/home_section_config.dart';
+import '../../preference/user_preferences.dart';
+import '../../util/platform_detection.dart';
+import 'imdb_external_lists_service.dart';
+
+class CustomExternalListsService {
+  final Dio _dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 15),
+    receiveTimeout: const Duration(seconds: 15),
+  ));
+
+  final UserPreferences _prefs;
+  final Map<String, String> _letterboxdCache = {};
+  bool _letterboxdCacheLoaded = false;
+
+  CustomExternalListsService(this._prefs);
+
+  Future<void> _ensureLetterboxdCacheLoaded() async {
+    if (_letterboxdCacheLoaded) return;
+    try {
+      final file = await _letterboxdCacheFile();
+      if (file.existsSync()) {
+        final content = await file.readAsString();
+        final decoded = jsonDecode(content) as Map<String, dynamic>;
+        _letterboxdCache.addAll(decoded.cast<String, String>());
+      }
+    } catch (e) {
+      debugPrint('[CustomService] Failed to load Letterboxd cache: $e');
+    }
+    _letterboxdCacheLoaded = true;
+  }
+
+  Future<void> _saveLetterboxdCache() async {
+    try {
+      final file = await _letterboxdCacheFile();
+      await file.writeAsString(jsonEncode(_letterboxdCache), flush: true);
+    } catch (e) {
+      debugPrint('[CustomService] Failed to save Letterboxd cache: $e');
+    }
+  }
+
+  Future<File> _letterboxdCacheFile() async {
+    final dir = PlatformDetection.isAppleTV
+        ? await getApplicationCacheDirectory()
+        : await getApplicationSupportDirectory();
+    return File('${dir.path}/letterboxd_slug_to_tmdb.json');
+  }
+
+  String constructSourceUrl(String source, String type, Map<String, dynamic> params) {
+    switch (source) {
+      case 'imdb':
+        if (type == 'user_list') {
+          final listId = params['listid'] as String? ?? '';
+          return 'https://www.imdb.com/list/$listId/';
+        } else {
+          final eventId = params['eventid'] as String? ?? '';
+          final year = params['year'] as String? ?? '';
+          return 'https://www.imdb.com/event/$eventId/$year/';
+        }
+      case 'tmdb':
+        final id = params['id'] as String? ?? '';
+        if (type == 'movie_collection') {
+          return 'https://www.themoviedb.org/collection/$id';
+        } else {
+          return 'https://www.themoviedb.org/list/$id';
+        }
+      case 'letterboxd':
+        final username = params['user'] as String? ?? '';
+        final name = params['name'] as String? ?? '';
+        if (type == 'watchlist') {
+          return 'https://letterboxd.com/$username/watchlist/';
+        } else if (type == 'films') {
+          return 'https://letterboxd.com/$username/films/';
+        } else {
+          return 'https://letterboxd.com/$username/list/$name/';
+        }
+      case 'mdblist':
+        final username = params['username'] as String? ?? '';
+        final listname = params['listname'] as String? ?? '';
+        return 'https://mdblist.com/lists/$username/$listname/';
+      default:
+        return 'Unknown Source';
+    }
+  }
+
+  Future<List<ImdbExternalListItem>> fetchCustomRow(HomeSectionConfig config) async {
+    final sectionId = config.pluginSection;
+    if (sectionId == null || sectionId.isEmpty) return [];
+
+    final additionalData = config.pluginAdditionalData;
+    if (additionalData == null || additionalData.isEmpty) return [];
+
+    final Map<String, dynamic> rowConfig;
+    try {
+      rowConfig = jsonDecode(additionalData) as Map<String, dynamic>;
+    } catch (e) {
+      debugPrint('[CustomService] Failed to parse additionalData: $e');
+      return [];
+    }
+
+    final source = rowConfig['source'] as String?;
+    final type = rowConfig['type'] as String?;
+    final params = rowConfig['params'] as Map<String, dynamic>? ?? {};
+
+    if (source == null || type == null) return [];
+
+    List<ImdbExternalListItem> items = [];
+
+    try {
+      switch (source) {
+        case 'mdblist':
+          items = await _fetchMdbList(type, params);
+          break;
+        case 'imdb':
+          items = await _fetchImdb(type, params);
+          break;
+        case 'letterboxd':
+          items = await _fetchLetterboxd(type, params);
+          break;
+        case 'tmdb':
+          items = await _fetchTmdb(type, params);
+          break;
+        default:
+          debugPrint('[CustomService] Unsupported custom source: $source');
+      }
+    } catch (e) {
+      final url = constructSourceUrl(source, type, params);
+      throw Exception('Failed to fetch from custom row. Constructed URL: $url. Error: $e');
+    }
+
+    if (items.isEmpty) {
+      final url = constructSourceUrl(source, type, params);
+      throw Exception('Fetched 0 items from custom row. Constructed URL: $url. Please check your parameters.');
+    }
+
+    await saveCustomRowToCache(config, items);
+
+    return _applySorting(items, config);
+  }
+
+  // --- MDBList ---
+  Future<List<ImdbExternalListItem>> _fetchMdbList(String type, Map<String, dynamic> params) async {
+    final apiKey = _prefs.get(UserPreferences.mdblistApiKey);
+    if (apiKey.isEmpty) {
+      throw StateError('MDBList API Key is not configured');
+    }
+
+    final username = params['username'] as String?;
+    final listname = params['listname'] as String?;
+    if (username == null || username.isEmpty || listname == null || listname.isEmpty) {
+      return [];
+    }
+
+    final url = 'https://api.mdblist.com/lists/$username/$listname/items';
+    try {
+      final response = await _dio.get(
+        url,
+        queryParameters: {
+          'apikey': apiKey,
+          'limit': 250,
+        },
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('MDBList API returned ${response.statusCode}');
+      }
+
+      final data = response.data;
+      if (data == null) return [];
+
+      final items = <ImdbExternalListItem>[];
+
+      // Parse either wrapper format {movies: [], shows: []} or flat list
+      List<dynamic> rawList = [];
+      if (data is Map<String, dynamic>) {
+        if (data['movies'] is List) rawList.addAll(data['movies'] as List);
+        if (data['shows'] is List) rawList.addAll(data['shows'] as List);
+      } else if (data is List) {
+        rawList = data;
+      }
+
+      for (final item in rawList) {
+        final ids = item['ids'] as Map<String, dynamic>?;
+        final imdbId = (item['imdb_id'] as String?) ?? (ids?['imdb'] as String?);
+        final tmdbId = ids?['tmdb']?.toString();
+        final title = (item['title'] as String?) ?? 'Unknown';
+        final posterPath = item['poster'] as String? ?? ids?['poster'] as String?;
+        final year = item['release_year'] as int?;
+        final mediaType = (item['mediatype'] as String?)?.toLowerCase();
+        final type = (mediaType == 'show' || mediaType == 'shows' || mediaType == 'series' || mediaType == 'tv') ? 'Series' : 'Movie';
+        final rating = (item['rating'] as num?)?.toDouble() ?? (item['score'] as num?)?.toDouble();
+        final popularity = (item['popularity'] as num?)?.toDouble() ?? (item['rank'] as num?)?.toDouble();
+
+        if (imdbId != null && imdbId.isNotEmpty) {
+          items.add(ImdbExternalListItem(
+            imdbId: imdbId,
+            title: title,
+            posterUrl: posterPath,
+            year: year,
+            type: type,
+            popularity: popularity,
+            rating: rating,
+          ));
+        } else if (tmdbId != null && tmdbId.isNotEmpty) {
+          items.add(ImdbExternalListItem(
+            imdbId: tmdbId,
+            title: title,
+            posterUrl: posterPath,
+            year: year,
+            type: type,
+            popularity: popularity,
+            rating: rating,
+          ));
+        }
+      }
+
+      return items;
+    } catch (e) {
+      debugPrint('[CustomService] MDBList fetch failed: $e');
+      rethrow;
+    }
+  }
+
+  // --- IMDb ---
+  Future<List<ImdbExternalListItem>> _fetchImdb(String type, Map<String, dynamic> params) async {
+    if (type == 'user_list') {
+      final listId = params['listid'] as String?;
+      if (listId == null || listId.isEmpty) return [];
+
+      final query = '''
+{
+  list(id: "$listId") {
+    items(first: 250) {
+      edges {
+        node {
+          item {
+            ... on Title {
+              id
+              titleText {
+                text
+              }
+              primaryImage {
+                url
+              }
+              releaseYear {
+                year
+              }
+              titleType {
+                id
+              }
+              ratingsSummary {
+                aggregateRating
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+''';
+      try {
+        final response = await _dio.post(
+          'https://caching.graphql.imdb.com/',
+          data: {'query': query},
+          options: Options(headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Content-Type': 'application/json',
+          }),
+        );
+
+        if (response.statusCode != 200) {
+          throw Exception('IMDb GraphQL returned ${response.statusCode}');
+        }
+
+        final data = response.data;
+        if (data == null || data['data'] == null || data['data']['list'] == null) {
+          return [];
+        }
+
+        final edges = data['data']['list']['items']['edges'] as List?;
+        if (edges == null) return [];
+
+        final items = <ImdbExternalListItem>[];
+        for (final edge in edges) {
+          final itemNode = edge['node']?['item'];
+          if (itemNode == null) continue;
+
+          final imdbId = itemNode['id'] as String?;
+          if (imdbId == null || imdbId.isEmpty) continue;
+
+          final title = (itemNode['titleText']?['text'] as String?) ?? 'Unknown';
+          final posterUrl = itemNode['primaryImage']?['url'] as String?;
+          final year = itemNode['releaseYear']?['year'] as int?;
+          final typeId = itemNode['titleType']?['id'] as String? ?? 'movie';
+          final type = (typeId == 'tvSeries' || typeId == 'tvMiniSeries') ? 'Series' : 'Movie';
+          final rating = (itemNode['ratingsSummary']?['aggregateRating'] as num?)?.toDouble();
+
+          items.add(ImdbExternalListItem(
+            imdbId: imdbId,
+            title: title,
+            posterUrl: posterUrl,
+            year: year,
+            type: type,
+            rating: rating,
+          ));
+        }
+        return items;
+      } catch (e) {
+        debugPrint('[CustomService] IMDb User List fetch failed: $e');
+        rethrow;
+      }
+    } else if (type == 'awards_events') {
+      final eventId = params['eventid'] as String?;
+      final yearStr = params['year'] as String?;
+      final subcategory = params['subcategory'] as String?;
+      if (eventId == null || eventId.isEmpty || yearStr == null || yearStr.isEmpty) return [];
+
+      final year = int.tryParse(yearStr);
+      if (year == null) return [];
+
+      final startYear = year - 2;
+
+      // Phase 1: Search for candidates
+      final candidateSearchQuery = '''
+{
+  advancedTitleSearch(
+    first: 250,
+    constraints: {
+      awardConstraint: {
+        anyEventNominations: [{ eventId: "$eventId" }]
+      },
+      releaseDateConstraint: {
+        releaseDateRange: {
+          start: "$startYear-01-01",
+          end: "$year-12-31"
+        }
+      }
+    }
+  ) {
+    edges {
+      node {
+        title {
+          id
+        }
+      }
+    }
+  }
+}
+''';
+      try {
+        final searchResponse = await _dio.post(
+          'https://caching.graphql.imdb.com/',
+          data: {'query': candidateSearchQuery},
+          options: Options(headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Content-Type': 'application/json',
+          }),
+        );
+
+        if (searchResponse.statusCode != 200) {
+          throw Exception('IMDb search returned ${searchResponse.statusCode}');
+        }
+
+        final searchData = searchResponse.data;
+        if (searchData == null || searchData['data'] == null || searchData['data']['advancedTitleSearch'] == null) {
+          return [];
+        }
+
+        final edges = searchData['data']['advancedTitleSearch']['edges'] as List?;
+        if (edges == null || edges.isEmpty) return [];
+
+        final candidateIds = <String>[];
+        for (final edge in edges) {
+          final id = edge['node']?['title']?['id'] as String?;
+          if (id != null && id.isNotEmpty) {
+            candidateIds.add(id);
+          }
+        }
+
+        // Phase 2: Verify candidates and load details in batches of 50
+        final verifiedItems = <ImdbExternalListItem>[];
+        final idsBatchParam = candidateIds.map((id) => '"$id"').join(',');
+
+        final verifyQuery = '''
+{
+  titles(ids: [$idsBatchParam]) {
+    id
+    titleText {
+      text
+    }
+    primaryImage {
+      url
+    }
+    releaseYear {
+      year
+    }
+    titleType {
+      id
+    }
+    ratingsSummary {
+      aggregateRating
+    }
+    awardNominations(first: 50, filter: { events: ["$eventId"] }) {
+      edges {
+        node {
+          award {
+            year
+            category {
+              text
+            }
+          }
+        }
+      }
+    }
+  }
+}
+''';
+
+        final verifyResponse = await _dio.post(
+          'https://caching.graphql.imdb.com/',
+          data: {'query': verifyQuery},
+          options: Options(headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Content-Type': 'application/json',
+          }),
+        );
+
+        if (verifyResponse.statusCode != 200) {
+          throw Exception('IMDb verify returned ${verifyResponse.statusCode}');
+        }
+
+        final verifyData = verifyResponse.data;
+        if (verifyData == null || verifyData['data'] == null || verifyData['data']['titles'] == null) {
+          return [];
+        }
+
+        final titles = verifyData['data']['titles'] as List?;
+        if (titles == null) return [];
+
+        for (final titleNode in titles) {
+          if (titleNode == null) continue;
+          final titleId = titleNode['id'] as String?;
+          if (titleId == null || titleId.isEmpty) continue;
+
+          final title = (titleNode['titleText']?['text'] as String?) ?? 'Unknown';
+          final posterUrl = titleNode['primaryImage']?['url'] as String?;
+          final rYear = titleNode['releaseYear']?['year'] as int?;
+          final typeId = titleNode['titleType']?['id'] as String? ?? 'movie';
+          final type = (typeId == 'tvSeries' || typeId == 'tvMiniSeries') ? 'Series' : 'Movie';
+          final rating = (titleNode['ratingsSummary']?['aggregateRating'] as num?)?.toDouble();
+
+          final nominations = titleNode['awardNominations']?['edges'] as List?;
+          if (nominations == null) continue;
+
+          bool matches = false;
+          for (final nom in nominations) {
+            final award = nom['node']?['award'];
+            if (award == null) continue;
+            final awardYear = award['year'] as int?;
+            if (awardYear != year) continue;
+
+            if (subcategory != null && subcategory.isNotEmpty) {
+              final catText = award['category']?['text'] as String?;
+              if (catText != null && _categoryMatchesFragment(catText, subcategory)) {
+                matches = true;
+                break;
+              }
+            } else {
+              matches = true;
+              break;
+            }
+          }
+
+          if (matches) {
+            verifiedItems.add(ImdbExternalListItem(
+              imdbId: titleId,
+              title: title,
+              posterUrl: posterUrl,
+              year: rYear,
+              type: type,
+              rating: rating,
+            ));
+          }
+        }
+
+        return verifiedItems;
+      } catch (e) {
+        debugPrint('[CustomService] IMDb Awards fetch failed: $e');
+        rethrow;
+      }
+    }
+    return [];
+  }
+
+  bool _categoryMatchesFragment(String string, String fragment) {
+    final slug = string.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_').replaceAll(RegExp(r'^_+|_+$'), '');
+    final normalizedFragment = fragment.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_').replaceAll(RegExp(r'^_+|_+$'), '');
+    return slug == normalizedFragment || normalizedFragment.endsWith('_$slug');
+  }
+
+  // --- Letterboxd ---
+  Future<List<ImdbExternalListItem>> _fetchLetterboxd(String type, Map<String, dynamic> params) async {
+    final username = params['user'] as String?;
+    final name = params['name'] as String?;
+    if (username == null || username.isEmpty) return [];
+
+    final String url;
+    if (type == 'watchlist') {
+      url = 'https://letterboxd.com/$username/watchlist/';
+    } else if (type == 'films') {
+      url = 'https://letterboxd.com/$username/films/';
+    } else {
+      if (name == null || name.isEmpty) return [];
+      url = 'https://letterboxd.com/$username/list/$name/';
+    }
+
+    try {
+      await _ensureLetterboxdCacheLoaded();
+
+      // Step 1: Scrape list page for film slugs and user ratings
+      final response = await _dio.get(
+        url,
+        options: Options(headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+          'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9',
+        }),
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('Letterboxd returned ${response.statusCode}');
+      }
+
+      final html = response.data as String? ?? '';
+      
+      final List<Map<String, String>> filmData = [];
+      final matches = RegExp(r'data-target-link="/film/([\w-]+)/"').allMatches(html).toList();
+      
+      for (int i = 0; i < matches.length; i++) {
+        final match = matches[i];
+        final slug = match.group(1)!;
+        
+        final startIdx = match.end;
+        final endIdx = (i + 1 < matches.length) ? matches[i + 1].start : html.length;
+        final searchArea = html.substring(startIdx, startIdx + 1000 > endIdx ? endIdx : startIdx + 1000);
+        
+        final ratingMatch = RegExp(r'class="rating\b[^"]*">([^<]+)<').firstMatch(searchArea);
+        final userRating = ratingMatch?.group(1)?.trim() ?? '';
+        
+        filmData.add({
+          'slug': slug,
+          'rating': userRating,
+        });
+      }
+
+      final uniqueFilmData = <String, Map<String, String>>{};
+      for (final fd in filmData) {
+        final slug = fd['slug']!;
+        if (!uniqueFilmData.containsKey(slug)) {
+          uniqueFilmData[slug] = fd;
+        }
+      }
+      final slugs = uniqueFilmData.keys.toList();
+
+      if (slugs.isEmpty) return [];
+
+      final items = <ImdbExternalListItem>[];
+
+      // Step 2: Resolve TMDB IDs for each slug
+      final List<String> unresolvedSlugs = [];
+      final List<String> resolvedTmdbIds = [];
+      final tmdbIdToRating = <String, String>{};
+
+      for (final slug in slugs) {
+        final rating = uniqueFilmData[slug]?['rating'] ?? '';
+        final cached = _letterboxdCache[slug];
+        if (cached != null) {
+          resolvedTmdbIds.add(cached);
+          if (rating.isNotEmpty) {
+            tmdbIdToRating[cached] = rating;
+          }
+        } else {
+          unresolvedSlugs.add(slug);
+        }
+      }
+
+      // Concurrently resolve unresolved slugs (up to 3 at a time to avoid throttling)
+      if (unresolvedSlugs.isNotEmpty) {
+        const batchSize = 3;
+        for (int i = 0; i < unresolvedSlugs.length; i += batchSize) {
+          final batch = unresolvedSlugs.sublist(i, i + batchSize > unresolvedSlugs.length ? unresolvedSlugs.length : i + batchSize);
+          await Future.wait(batch.map((slug) async {
+            try {
+              // Throttle delay
+              await Future.delayed(const Duration(milliseconds: 300));
+              final filmUrl = 'https://letterboxd.com/film/$slug/';
+              final filmResponse = await _dio.get(
+                filmUrl,
+                options: Options(headers: {
+                  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+                }),
+              );
+              if (filmResponse.statusCode == 200) {
+                final filmHtml = filmResponse.data as String? ?? '';
+                final tmdbIdMatch = RegExp(r'data-tmdb-id="(\d+)"').firstMatch(filmHtml);
+                if (tmdbIdMatch != null) {
+                  final tmdbId = tmdbIdMatch.group(1)!;
+                  _letterboxdCache[slug] = tmdbId;
+                  resolvedTmdbIds.add(tmdbId);
+                  final rating = uniqueFilmData[slug]?['rating'] ?? '';
+                  if (rating.isNotEmpty) {
+                    tmdbIdToRating[tmdbId] = rating;
+                  }
+                }
+              }
+            } catch (e) {
+              debugPrint('[CustomService] Failed to resolve Letterboxd slug $slug: $e');
+            }
+          }));
+          await _saveLetterboxdCache();
+        }
+      }
+
+      // Step 3: Fetch movie metadata from TMDB API in parallel
+      final tmdbApiKey = _prefs.get(UserPreferences.tmdbApiKey);
+      if (tmdbApiKey.isEmpty) {
+        throw StateError('TMDB API Key is not configured (required for Letterboxd lists)');
+      }
+
+      final resolvedItems = <String, ImdbExternalListItem>{};
+
+      await Future.wait(resolvedTmdbIds.map((tmdbId) async {
+        try {
+          final movieResponse = await _dio.get(
+            'https://api.themoviedb.org/3/movie/$tmdbId',
+            queryParameters: {
+              'api_key': tmdbApiKey,
+            },
+          );
+          if (movieResponse.statusCode == 200) {
+            final movieData = movieResponse.data as Map<String, dynamic>?;
+            if (movieData != null) {
+              final title = movieData['title'] as String? ?? 'Unknown';
+              final posterPath = movieData['poster_path'] as String?;
+              final dateStr = movieData['release_date'] as String?;
+              int? year;
+              if (dateStr != null && dateStr.length >= 4) {
+                year = int.tryParse(dateStr.substring(0, 4));
+              }
+              final popularity = (movieData['popularity'] as num?)?.toDouble();
+              final rating = (movieData['vote_average'] as num?)?.toDouble();
+              final userRating = tmdbIdToRating[tmdbId];
+              resolvedItems[tmdbId] = ImdbExternalListItem(
+                imdbId: tmdbId, // TMDB ID is stored in imdbId for row navigation
+                title: title,
+                posterUrl: posterPath,
+                year: year,
+                type: 'Movie',
+                popularity: popularity,
+                rating: rating,
+                userRating: userRating != null && userRating.isNotEmpty ? userRating : null,
+              );
+            }
+          }
+        } catch (e) {
+          debugPrint('[CustomService] Failed to fetch TMDB details for $tmdbId: $e');
+        }
+      }));
+
+      for (final tmdbId in resolvedTmdbIds) {
+        final item = resolvedItems[tmdbId];
+        if (item != null) {
+          items.add(item);
+        }
+      }
+
+      return items;
+    } catch (e) {
+      debugPrint('[CustomService] Letterboxd fetch failed: $e');
+      rethrow;
+    }
+  }
+
+  // --- TMDB ---
+  Future<List<ImdbExternalListItem>> _fetchTmdb(String type, Map<String, dynamic> params) async {
+    final apiKey = _prefs.get(UserPreferences.tmdbApiKey);
+    if (apiKey.isEmpty) {
+      throw StateError('TMDB API Key is not configured');
+    }
+
+    final id = params['id'] as String?;
+    if (id == null || id.isEmpty) return [];
+
+    final String url;
+    if (type == 'movie_collection') {
+      url = 'https://api.themoviedb.org/3/collection/$id';
+    } else {
+      url = 'https://api.themoviedb.org/3/list/$id';
+    }
+
+    try {
+      final response = await _dio.get(
+        url,
+        queryParameters: {
+          'api_key': apiKey,
+        },
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('TMDB API returned ${response.statusCode}');
+      }
+
+      final data = response.data;
+      if (data == null) return [];
+
+      final items = <ImdbExternalListItem>[];
+
+      if (type == 'movie_collection') {
+        final parts = data['parts'] as List?;
+        if (parts != null) {
+          for (final part in parts) {
+            final partId = part['id']?.toString();
+            final title = (part['title'] as String?) ?? 'Unknown';
+            final posterPath = part['poster_path'] as String?;
+            final dateStr = part['release_date'] as String?;
+            final popularity = (part['popularity'] as num?)?.toDouble();
+            final rating = (part['vote_average'] as num?)?.toDouble();
+            int? year;
+            if (dateStr != null && dateStr.length >= 4) {
+              year = int.tryParse(dateStr.substring(0, 4));
+            }
+            if (partId != null && partId.isNotEmpty) {
+              items.add(ImdbExternalListItem(
+                imdbId: partId,
+                title: title,
+                posterUrl: posterPath,
+                year: year,
+                type: 'Movie',
+                popularity: popularity,
+                rating: rating,
+              ));
+            }
+          }
+        }
+      } else {
+        final results = data['items'] as List?;
+        if (results != null) {
+          for (final res in results) {
+            final itemId = res['id']?.toString();
+            final title = (res['title'] as String?) ?? (res['name'] as String?) ?? 'Unknown';
+            final posterPath = res['poster_path'] as String?;
+            final dateStr = (res['release_date'] as String?) ?? (res['first_air_date'] as String?);
+            final popularity = (res['popularity'] as num?)?.toDouble();
+            final rating = (res['vote_average'] as num?)?.toDouble();
+            int? year;
+            if (dateStr != null && dateStr.length >= 4) {
+              year = int.tryParse(dateStr.substring(0, 4));
+            }
+            final mediaTypeRaw = res['media_type'] as String?;
+            final type = mediaTypeRaw == 'tv' ? 'Series' : 'Movie';
+
+            if (itemId != null && itemId.isNotEmpty) {
+              items.add(ImdbExternalListItem(
+                imdbId: itemId,
+                title: title,
+                posterUrl: posterPath,
+                year: year,
+                type: type,
+                popularity: popularity,
+                rating: rating,
+              ));
+            }
+          }
+        }
+      }
+
+      return items;
+    } catch (e) {
+      debugPrint('[CustomService] TMDB fetch failed: $e');
+      rethrow;
+    }
+  }
+
+  // --- Caching ---
+  Future<File> cacheFile(HomeSectionConfig config) async {
+    final dir = PlatformDetection.isAppleTV
+        ? await getApplicationCacheDirectory()
+        : await getApplicationSupportDirectory();
+    final sanitizedSection = config.pluginSection!.replaceAll(RegExp(r'[^a-zA-Z0-9]+'), '_');
+    return File('${dir.path}/custom_chart_$sanitizedSection.json');
+  }
+
+  Future<void> saveCustomRowToCache(HomeSectionConfig config, List<ImdbExternalListItem> items) async {
+    try {
+      final file = await cacheFile(config);
+      final jsonList = items.map((item) => item.toJson()).toList();
+      await file.writeAsString(jsonEncode(jsonList), flush: true);
+    } catch (e) {
+      debugPrint('[CustomService] Failed to save custom row cache: $e');
+    }
+  }
+
+  Future<List<ImdbExternalListItem>> loadCustomRowFromCache(HomeSectionConfig config) async {
+    try {
+      final file = await cacheFile(config);
+      if (file.existsSync()) {
+        final content = await file.readAsString();
+        final decoded = jsonDecode(content) as List;
+        final items = decoded
+            .map((item) => ImdbExternalListItem.fromJson(item as Map<String, dynamic>))
+            .toList();
+        return _applySorting(items, config);
+      }
+    } catch (e) {
+      debugPrint('[CustomService] Failed to load custom row cache: $e');
+    }
+    return [];
+  }
+
+  List<ImdbExternalListItem> _applySorting(List<ImdbExternalListItem> items, HomeSectionConfig config) {
+    if (items.isEmpty) return items;
+
+    Map<String, dynamic> rowConfig = {};
+    try {
+      rowConfig = jsonDecode(config.pluginAdditionalData ?? '{}') as Map<String, dynamic>;
+    } catch (_) {}
+
+    final sortBy = rowConfig['sort_by'] as String? ?? 'none';
+    final sortOrder = rowConfig['sort_order'] as String? ?? 'desc';
+
+    if (sortBy == 'none') return items;
+
+    final sortedItems = List<ImdbExternalListItem>.from(items);
+
+    if (sortBy == 'shuffle') {
+      sortedItems.shuffle();
+    } else {
+      sortedItems.sort((a, b) {
+        int cmp = 0;
+        switch (sortBy) {
+          case 'title':
+            cmp = a.title.toLowerCase().compareTo(b.title.toLowerCase());
+            break;
+          case 'year':
+            final ay = a.year ?? 0;
+            final by = b.year ?? 0;
+            cmp = ay.compareTo(by);
+            break;
+          case 'popularity':
+            final ap = a.popularity ?? 0.0;
+            final bp = b.popularity ?? 0.0;
+            cmp = ap.compareTo(bp);
+            break;
+          case 'rating':
+            final ar = a.rating ?? 0.0;
+            final br = b.rating ?? 0.0;
+            cmp = ar.compareTo(br);
+            break;
+        }
+        return sortOrder == 'asc' ? cmp : -cmp;
+      });
+    }
+    return sortedItems;
+  }
+}

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -64,9 +64,7 @@ class CustomExternalListsService {
     receiveTimeout: const Duration(seconds: 15),
   ));
 
-  final UserPreferences _prefs;
-
-  CustomExternalListsService(this._prefs);
+  CustomExternalListsService();
 
   String constructSourceUrl(String source, String type, Map<String, dynamic> params) {
     switch (source) {

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -50,6 +50,7 @@ class ImdbExternalListItem {
   factory ImdbExternalListItem.fromJson(Map<String, dynamic> json) =>
       ImdbExternalListItem(
         imdbId: json['imdbId'] as String,
+        tmdbId: json['tmdbId'] as String? ?? '',
         title: json['title'] as String,
         posterUrl: json['posterUrl'] as String?,
         backdropUrl: json['backdropUrl'] as String?,

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -1521,7 +1521,7 @@ class RowDataSource {
 
           final aggregatedItems = items.map((item) {
             return AggregatedItem(
-              id: item.imdbId,
+              id: item.imdbId.isNotEmpty ? item.imdbId : item.tmdbId,
               serverId: 'seerr',
               rawData: {
                 'Name': item.title,
@@ -1533,6 +1533,10 @@ class RowDataSource {
                 'SeerrMediaType': item.type == 'Series' ? 'tv' : 'movie',
                 'UserRating': item.userRating ?? '',
                 'ShowUserRatings': showUserRatings,
+                'ProviderIds': {
+                  if (item.imdbId.isNotEmpty) 'Imdb': item.imdbId,
+                  if (item.tmdbId.isNotEmpty) 'Tmdb': item.tmdbId,
+                },
               },
             );
           }).toList();

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -17,6 +17,8 @@ import '../utils/latest_media_row_normalizer.dart';
 import '../utils/genre_browse_utils.dart';
 import '../utils/next_up_enrichment.dart';
 import '../utils/playlist_utils.dart';
+import 'package:flutter/foundation.dart';
+import 'custom_external_lists_service.dart';
 
 class RowDataSource {
   final MediaServerClient _client;
@@ -1494,6 +1496,58 @@ class RowDataSource {
             id: rowId,
             title: title,
             rowType: HomeRowType.playlists,
+          );
+        }
+
+      case HomeSectionPluginSource.custom:
+        try {
+          final customService = GetIt.instance<CustomExternalListsService>();
+          final config = HomeSectionConfig.pluginDynamic(
+            serverId: serverId,
+            pluginSection: section,
+            pluginAdditionalData: additionalData,
+            pluginDisplayText: title,
+            pluginSource: pluginSource,
+          );
+          var items = await customService.loadCustomRowFromCache(config);
+          if (items.isEmpty) {
+            items = await customService.fetchCustomRow(config);
+          }
+          Map<String, dynamic> rowConfig = {};
+          try {
+            rowConfig = jsonDecode(additionalData ?? '{}') as Map<String, dynamic>;
+          } catch (_) {}
+          final showUserRatings = rowConfig['show_user_ratings'] == true;
+
+          final aggregatedItems = items.map((item) {
+            return AggregatedItem(
+              id: item.imdbId,
+              serverId: 'seerr',
+              rawData: {
+                'Name': item.title,
+                'Type': item.type,
+                'Overview': '',
+                'PosterPath': item.posterUrl ?? '',
+                'BackdropPath': item.posterUrl ?? '',
+                'ProductionYear': item.year,
+                'SeerrMediaType': item.type == 'Series' ? 'tv' : 'movie',
+                'UserRating': item.userRating ?? '',
+                'ShowUserRatings': showUserRatings,
+              },
+            );
+          }).toList();
+          return HomeRow(
+            id: rowId,
+            title: title,
+            rowType: HomeRowType.pluginDynamic,
+            items: aggregatedItems,
+          );
+        } catch (e) {
+          debugPrint('[RowDataSource] Failed to load custom dynamic section: $e');
+          return HomeRow(
+            id: rowId,
+            title: title,
+            rowType: HomeRowType.pluginDynamic,
           );
         }
 

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -1528,7 +1528,7 @@ class RowDataSource {
                 'Type': item.type,
                 'Overview': '',
                 'PosterPath': item.posterUrl ?? '',
-                'BackdropPath': item.posterUrl ?? '',
+                'BackdropPath': item.backdropUrl ?? item.posterUrl ?? '',
                 'ProductionYear': item.year,
                 'SeerrMediaType': item.type == 'Series' ? 'tv' : 'movie',
                 'UserRating': item.userRating ?? '',

--- a/lib/di/modules/app_module.dart
+++ b/lib/di/modules/app_module.dart
@@ -71,7 +71,6 @@ void resetUserScopedSingletons() {
 
 void registerAppModule() {
   _getIt.registerLazySingleton(() => SocketHandler());
-  _getIt.registerLazySingleton(() => CustomExternalListsService(_getIt<UserPreferences>()));
   _getIt.registerLazySingleton(
     () => BackgroundService(),
     dispose: (service) => service.dispose(),

--- a/lib/di/modules/app_module.dart
+++ b/lib/di/modules/app_module.dart
@@ -29,6 +29,7 @@ import '../../data/services/cast/native_cast_channel.dart';
 import '../../data/services/cast/remote_session_cast_provider.dart';
 import '../../data/services/home_screen_sections_service.dart';
 import '../../data/services/plugin_sync_service.dart';
+import '../../data/services/custom_external_lists_service.dart';
 import '../../data/services/row_data_source.dart';
 import '../../data/services/socket_handler.dart';
 import '../../data/services/sync_service.dart';
@@ -70,6 +71,7 @@ void resetUserScopedSingletons() {
 
 void registerAppModule() {
   _getIt.registerLazySingleton(() => SocketHandler());
+  _getIt.registerLazySingleton(() => CustomExternalListsService(_getIt<UserPreferences>()));
   _getIt.registerLazySingleton(
     () => BackgroundService(),
     dispose: (service) => service.dispose(),

--- a/lib/di/modules/app_module.dart
+++ b/lib/di/modules/app_module.dart
@@ -71,6 +71,7 @@ void resetUserScopedSingletons() {
 
 void registerAppModule() {
   _getIt.registerLazySingleton(() => SocketHandler());
+  _getIt.registerLazySingleton(() => CustomExternalListsService());
   _getIt.registerLazySingleton(
     () => BackgroundService(),
     dispose: (service) => service.dispose(),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4676,7 +4676,7 @@
       }
     }
   },
-  "discoverRows": "Seerr Homepage",
+  "discoverRows": "Seerr Discovery Page",
   "@discoverRows": {
     "description": "Section title for discover rows"
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6241,7 +6241,7 @@ abstract class AppLocalizations {
   /// Section title for discover rows
   ///
   /// In en, this message translates to:
-  /// **'Seerr Homepage'**
+  /// **'Seerr Discovery Page'**
   String get discoverRows;
 
   /// Description for discover rows with plugin

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -8422,7 +8422,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -8367,7 +8367,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8448,7 +8448,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8493,7 +8493,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -8409,7 +8409,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8543,7 +8543,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8429,7 +8429,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8443,7 +8443,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8413,7 +8413,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -426,25 +426,25 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String minutesAgo(int count) {
-    return 'Vor ${count}m';
+    return 'Vor $count Minute(n)';
   }
 
   @override
   String hoursAgo(int count) {
-    return 'Vor ${count}h';
+    return 'Vor $count Stunde(n)';
   }
 
   @override
   String daysAgo(int count) {
-    return 'Vor ${count}d';
+    return 'Vor $count Tag(en)';
   }
 
   @override
-  String get discoverySubjects => 'Entdecken-Themen';
+  String get discoverySubjects => 'Themen zum Entdecken';
 
   @override
   String get pickDiscoverySubjects =>
-      'Wähle aus, welche Themen-Feeds in Entdecken angezeigt werden.';
+      'Wähle aus, welche Themen-Feeds in \"Entdecken\" angezeigt werden.';
 
   @override
   String get apply => 'Anwenden';
@@ -453,14 +453,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get openLink => 'Link öffnen';
 
   @override
-  String get scanWithYourPhone => 'Scannen Sie mit Ihrem Telefon';
+  String get scanWithYourPhone => 'Scanne mit dem Mobiltelefon';
 
   @override
   String get audiobookGenres => 'Hörbuch-Genres';
 
   @override
   String get pickAudiobookGenres =>
-      'Wähle aus, welche Genres in Hörbuch-Entdecken angezeigt werden.';
+      'Wähle aus, welche Genres in \"Hörbücher entdecken\" angezeigt werden.';
 
   @override
   String get discoverAudiobooks => 'Hörbücher entdecken';
@@ -502,13 +502,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get failedToLoadLibrary => 'Bibliothek konnte nicht geladen werden';
 
   @override
-  String get popularNow => 'Jetzt beliebt';
+  String get popularNow => 'Aktuell beliebt';
 
   @override
-  String get savedForLater => 'Für später gespeichert';
+  String get savedForLater => 'Für später vorgemerkt';
 
   @override
-  String get topListens => 'Am meisten gehört';
+  String get topListens => 'Viel gehört';
 
   @override
   String get unreadDiscoveries => 'Ungelesene Entdeckungen';
@@ -533,11 +533,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get jumpBackNarration =>
-      'Springe zurück in die Erzählung, ohne deine Stelle suchen zu müssen.';
+      'Setze das Anhören fort, ohne lange suchen zu müssen, wo.';
 
   @override
   String get unreadBooksReady =>
-      'Ungelesene Bücher, bereit für die nächste ruhige Stunde.';
+      'Ungelesene Bücher, verfügbar für die nächste ruhige Gelegenheit.';
 
   @override
   String get quickAccessFavorites =>
@@ -547,15 +547,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get searchAudiobooks => 'Hörbücher suchen';
 
   @override
-  String get searchYourLibrary => 'Deine Bibliothek durchsuchen';
+  String get searchYourLibrary => 'Die Bibliothek durchsuchen';
 
   @override
   String get pickUpStory =>
-      'Setze die Geschichte dort fort, wo du aufgehört hast';
+      'Setze mit der Handlung fort, wo du zuletzt aufgehört hast';
 
   @override
   String get savedPlacesChapters =>
-      'Deine gespeicherten Stellen und unvollständigen Kapitel';
+      'Deine gespeicherten Stellen und nicht beendete Kapitel';
 
   @override
   String authorsCount(int count) {
@@ -569,24 +569,24 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% abgeschlossen';
+    return 'Zu $percent% beendet';
   }
 
   @override
   String get readyWhenYouAre => 'Bereit, wenn du es bist';
 
   @override
-  String get details => 'Einzelheiten';
+  String get details => 'Details';
 
   @override
-  String get listeningRoom => 'Hörzimmer';
+  String get listeningRoom => 'Hörbücher';
 
   @override
   String get bookmarksAndProgress => 'Lesezeichen & Fortschritt';
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count Titel so angeordnet, dass sie zuerst gelesen werden können.';
+    return '$count Titel für Durchsuchen mit Fokus aufs Lesen angeordnet.';
   }
 
   @override
@@ -613,18 +613,18 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get noBookmarkedItems =>
-      'Noch keine mit Lesezeichen versehenen Einträge';
+      'Noch keine mit Lesezeichen versehenen Inhalte';
 
   @override
   String get nothingMatchesSection =>
-      'Nichts passt zu diesem Bereich. Versuche einen anderen Tab oder komme nach der Bibliothekssynchronisierung zurück.';
+      'Keine zu diesem Bereich passenden Inhalte gefunden; wechsle zu einen anderen Tab oder warte ggf. auf Synchronisierung der Bibliothek.';
 
   @override
   String get audiobooks => 'Hörbücher';
 
   @override
   String noLabelFound(String label) {
-    return 'Kein $label gefunden';
+    return 'Nichts ($label) gefunden';
   }
 
   @override
@@ -643,13 +643,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get readStatus => 'Gelesen';
 
   @override
-  String get watched => 'Gesehen';
+  String get watched => 'Angesehen';
 
   @override
   String get unread => 'Ungelesen';
 
   @override
-  String get unwatched => 'Nicht gesehen';
+  String get unwatched => 'Nicht angesehen';
 
   @override
   String get seriesStatus => 'Serienstatus';
@@ -664,17 +664,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get author => 'Autor';
 
   @override
-  String get unknownAuthor => 'Unbekannter Autor';
+  String get unknownAuthor => 'Autor unbekannt';
 
   @override
-  String get uncategorized => 'Unkategorisiert';
+  String get uncategorized => 'Nicht kategorisiert';
 
   @override
   String get overview => 'Übersicht';
 
   @override
   String get noLibrivoxDescription =>
-      'Für diesen Titel ist noch keine Beschreibung von LibriVox vorhanden.';
+      'Für diesen Titel ist keine Beschreibung von LibriVox verfügbar.';
 
   @override
   String get readers => 'Vorleser';
@@ -686,13 +686,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get librivoxPage => 'LibriVox-Seite';
 
   @override
-  String get internetArchive => 'Internetarchiv';
+  String get internetArchive => 'Internet Archive';
 
   @override
   String get rssFeed => 'RSS-Feed';
 
   @override
-  String get downloadZip => 'ZIP herunterladen';
+  String get downloadZip => 'ZIP-Datei herunterladen';
 
   @override
   String sectionCountLabel(int count) {
@@ -701,12 +701,12 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String firstPublished(int year) {
-    return 'Erstveröffentlichung $year';
+    return 'Erstveröffentlichung: $year';
   }
 
   @override
   String get noOpenLibraryOverview =>
-      'Für diesen Titel ist noch keine Übersicht von Open Library verfügbar.';
+      'Für diesen Titel ist keine Übersicht von Open Library verfügbar.';
 
   @override
   String get subjects => 'Themen';
@@ -736,8 +736,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiobooks',
-      one: '1 audiobook',
+      other: '$count Hörbücher',
+      one: '1 Hörbuch',
     );
     return '$_temp0';
   }
@@ -746,7 +746,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trackList => 'Titelliste';
 
   @override
-  String get itemListPlaceholder => 'Die Elementliste wird hier angezeigt';
+  String get itemListPlaceholder => 'Die Liste der Inhalte wird hier angezeigt';
 
   @override
   String get favoriteTracksPlaceholder =>
@@ -762,7 +762,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get save => 'Speichern';
 
   @override
-  String get moreLikeThis => 'Mehr davon';
+  String get moreLikeThis => 'Mehr ähnliche Inhalte';
 
   @override
   String get castAndCrew => 'Besetzung & Crew';
@@ -774,7 +774,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get episodes => 'Episoden';
 
   @override
-  String get nextUp => 'Als Nächstes';
+  String get nextUp => 'Nächste Folge';
 
   @override
   String get seasons => 'Staffeln';
@@ -808,33 +808,33 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Disc $number';
+    return 'Platte $number';
   }
 
   @override
   String get biography => 'Biografie';
 
   @override
-  String get authorDetails => 'Autordetails';
+  String get authorDetails => 'Details zum Autor';
 
   @override
   String get noOverviewAvailable =>
-      'Für diesen Titel ist noch keine Übersicht verfügbar.';
+      'Für diesen Titel ist keine Übersicht verfügbar.';
 
   @override
   String get noBiographyAvailable =>
       'Für diesen Autor ist keine Biografie verfügbar.';
 
   @override
-  String get noBooksFound => 'Keine Bücher für diesen Autor gefunden.';
+  String get noBooksFound => 'Keine Bücher von diesem Autor gefunden.';
 
   @override
   String get unableToLoadAuthorDetails =>
-      'Autordetails konnten gerade nicht geladen werden.';
+      'Details zum Autor konnten nicht geladen werden.';
 
   @override
   String published(int year) {
-    return 'Veröffentlicht $year';
+    return 'Veröffentlichung: $year';
   }
 
   @override
@@ -845,8 +845,8 @@ class AppLocalizationsDe extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Seasons',
-      one: '1 Season',
+      other: '$count Staffeln',
+      one: '1 Staffel',
     );
     return '$_temp0';
   }
@@ -858,7 +858,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String endsIn(String time) {
-    return '';
+    return 'verbleibend: $time';
   }
 
   @override
@@ -872,17 +872,17 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String resumeFrom(String position) {
-    return 'Fortsetzen von $position';
+    return 'Fortsetzen bei $position';
   }
 
   @override
   String get play => 'Abspielen';
 
   @override
-  String get startOver => 'Von vorn beginnen';
+  String get startOver => 'Am Anfang beginnen';
 
   @override
-  String get restart => 'Neustart';
+  String get restart => 'Neu starten';
 
   @override
   String get readOffline => 'Offline lesen';
@@ -900,19 +900,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get version => 'Version';
 
   @override
-  String get cast => 'Besetzung';
+  String get cast => 'Abspielen auf';
 
   @override
   String get trailer => 'Trailer';
 
   @override
-  String get finished => 'Abgeschlossen';
+  String get finished => 'Durchgelesen';
 
   @override
   String get favorited => 'Favorisiert';
 
   @override
-  String get favorite => 'Favorit';
+  String get favorite => 'Favorisieren';
 
   @override
   String get playlist => 'Wiedergabeliste';
@@ -927,22 +927,22 @@ class AppLocalizationsDe extends AppLocalizations {
   String get download => 'Herunterladen';
 
   @override
-  String get deleteDownloaded => 'Download löschen';
+  String get deleteDownloaded => 'Heruntergeladene löschen';
 
   @override
-  String get goToSeries => 'Zur Serie';
+  String get goToSeries => 'Zur gesamten Serie';
 
   @override
   String get editMetadata => 'Metadaten bearbeiten';
 
   @override
-  String get less => 'Weniger';
+  String get less => 'Weniger anzeigen';
 
   @override
-  String get more => 'Mehr';
+  String get more => 'Mehr anzeigen';
 
   @override
-  String get deleteItem => 'Element löschen';
+  String get deleteItem => 'Inhalt löschen';
 
   @override
   String get deletePlaylist => 'Wiedergabeliste löschen';
@@ -952,14 +952,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Diese Wiedergabeliste vom Server löschen?';
 
   @override
-  String get deleteItemMessage => 'Dieses Element vom Server löschen?';
+  String get deleteItemMessage => 'Diesen Inhalt vom Server löschen?';
 
   @override
   String get failedToDeletePlaylist =>
       'Wiedergabeliste konnte nicht gelöscht werden';
 
   @override
-  String get failedToDeleteItem => 'Element konnte nicht gelöscht werden';
+  String get failedToDeleteItem => 'Inhalt konnte nicht gelöscht werden';
 
   @override
   String get renamePlaylist => 'Wiedergabeliste umbenennen';
@@ -972,7 +972,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Heruntergeladene Titel für „$title“ löschen?';
+    return 'Heruntergeladene Titel für Album \"$title\" löschen?';
   }
 
   @override
@@ -987,17 +987,17 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Kein $itemLabel geladen';
+    return '$itemLabel nicht geladen';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return '$title ($count Elemente werden heruntergeladen)...';
+    return '$title ($count Inhalte) wird heruntergeladen...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Sind Sie sicher, dass Sie „$name“ vom Server löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.';
+    return 'Soll \"$name\" wirklich vom Server gelöscht werden? Diese Aktion kann nicht rückgängig gemacht werden.';
   }
 
   @override
@@ -8487,7 +8487,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8540,7 +8540,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3392,15 +3392,15 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get discoverRows => 'Discover Rows';
+  String get discoverRows => 'Seerr Discovery Page';
 
   @override
   String get discoverRowsDescriptionPlugin =>
-      'Drag to reorder. Enable or disable rows. Enabled row order syncs with the Moonfin plugin.';
+      'Enable rows to see on Seerr mainpage. Drag to reorder. Custom order syncs with Moonbase.';
 
   @override
   String get discoverRowsDescription =>
-      'Drag to reorder. Enable or disable rows.';
+      'Enable rows to see on Seerr mainpage. Drag to reorder. Custom order syncs with Moonbase.';
 
   @override
   String get enabled => 'Enabled';
@@ -3505,7 +3505,8 @@ class AppLocalizationsEn extends AppLocalizations {
       'Navbar style, toolbar buttons, appearance';
 
   @override
-  String get reorderToggleHomeRows => 'Reorder and toggle home rows';
+  String get reorderToggleHomeRows =>
+      'Reorder and toggle both library and external-based home rows';
 
   @override
   String get featuredContentAppearance => 'Featured content, appearance';
@@ -7560,7 +7561,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get homeRowTogglesSubtitle =>
-      'Enable or disable different home row categories';
+      'Enable or disable library-based home row categories';
 
   @override
   String get homeRowTogglesDescription =>
@@ -8386,7 +8387,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'It looks like Jellyfin failed to update the artwork. Your library is configured to save artwork directly into the media folders (\'Save artwork into media folders\' is enabled). This error typically occurs when the Jellyfin server process does not have permission to write files into your media directories.';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -8405,7 +8405,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8495,7 +8495,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8430,7 +8430,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -8374,7 +8374,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8442,7 +8442,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -141,19 +141,20 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsAppearanceTheme => 'Thème de l\'application';
 
   @override
-  String get interfaceStyle => '';
+  String get interfaceStyle => 'Style d\'interface';
 
   @override
-  String get interfaceStyleSubtitle => '';
+  String get interfaceStyleSubtitle =>
+      'Automatique utilise l\'apparence native sur les appareils Apple. Choisissez Apple pour la forcer, ou Material pour l\'apparence standard.';
 
   @override
-  String get interfaceStyleAutomatic => '';
+  String get interfaceStyleAutomatic => 'Automatique';
 
   @override
-  String get interfaceStyleApple => '';
+  String get interfaceStyleApple => 'Apple';
 
   @override
-  String get interfaceStyleMaterial => '';
+  String get interfaceStyleMaterial => 'Material';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
@@ -2208,22 +2209,25 @@ class AppLocalizationsFr extends AppLocalizations {
   String get defaultAudioLanguage => 'Langue audio par défaut';
 
   @override
-  String get fallbackAudioLanguage => '';
+  String get fallbackAudioLanguage => 'Langue audio secondaire';
 
   @override
-  String get preferDefaultAudioTrack => '';
+  String get preferDefaultAudioTrack => 'Préférer la piste audio par défaut';
 
   @override
-  String get preferDefaultAudioTrackDescription => '';
+  String get preferDefaultAudioTrackDescription =>
+      'Préférer la piste audio originale au doublage.';
 
   @override
-  String get preferAudioDescription => '';
+  String get preferAudioDescription =>
+      'Préférer les pistes d\'audiodescription';
 
   @override
-  String get preferAudioDescriptionDescription => '';
+  String get preferAudioDescriptionDescription =>
+      'Préférer les pistes d\'audiodescription aux pistes normales.';
 
   @override
-  String get transcodingAudio => '';
+  String get transcodingAudio => 'Transcodage (audio)';
 
   @override
   String get autoServerDefault => 'Auto (par défaut du serveur)';
@@ -2633,40 +2637,45 @@ class AppLocalizationsFr extends AppLocalizations {
       'Personnaliser l\'apparence des sous-titres';
 
   @override
-  String get subtitleMode => '';
+  String get subtitleMode => 'Sélection des sous-titres';
 
   @override
-  String get subtitleModeFlagged => '';
+  String get subtitleModeFlagged => 'Par défaut';
 
   @override
-  String get subtitleModeAlways => '';
+  String get subtitleModeAlways => 'Toujours';
 
   @override
-  String get subtitleModeForeign => '';
+  String get subtitleModeForeign => 'Langue étrangère';
 
   @override
-  String get subtitleModeForced => '';
+  String get subtitleModeForced => 'Forcés';
 
   @override
-  String get subtitleModeFlaggedDescription => '';
+  String get subtitleModeFlaggedDescription =>
+      'Lit les pistes définies comme « par défaut » ou « forcées » dans les métadonnées du fichier.';
 
   @override
-  String get subtitleModeAlwaysDescription => '';
+  String get subtitleModeAlwaysDescription =>
+      'Charge et affiche automatiquement les sous-titres à chaque démarrage d\'une vidéo.';
 
   @override
-  String get subtitleModeForeignDescription => '';
+  String get subtitleModeForeignDescription =>
+      'Active automatiquement les sous-titres si la piste audio par défaut est dans une langue étrangère.';
 
   @override
-  String get subtitleModeForcedDescription => '';
+  String get subtitleModeForcedDescription =>
+      'Ne charge que les sous-titres explicitement marqués comme « forcés » dans les métadonnées.';
 
   @override
-  String get subtitleModeNoneDescription => '';
+  String get subtitleModeNoneDescription =>
+      'Désactive complètement le chargement automatique des sous-titres.';
 
   @override
-  String get fallbackSubtitleLanguage => '';
+  String get fallbackSubtitleLanguage => 'Langue de sous-titres secondaire';
 
   @override
-  String get subtitleStream => '';
+  String get subtitleStream => 'Piste de sous-titres';
 
   @override
   String get subtitlePreviewText =>
@@ -2944,16 +2953,19 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher l’option de navigation par dossiers';
 
   @override
-  String get groupItemsIntoCollections => '';
+  String get groupItemsIntoCollections =>
+      'Regrouper les éléments en collections';
 
   @override
-  String get hideCollectionAssociatedItems => '';
+  String get hideCollectionAssociatedItems =>
+      'Masquer les éléments appartenant à une collection lors de la navigation dans les bibliothèques';
 
   @override
-  String get groupItemsIntoCollectionsDialogTitle => '';
+  String get groupItemsIntoCollectionsDialogTitle => 'À propos du regroupement';
 
   @override
-  String get groupItemsIntoCollectionsDialogMessage => '';
+  String get groupItemsIntoCollectionsDialogMessage =>
+      'Pour utiliser ce réglage, assurez-vous que les options « Regrouper les films en collections » et/ou « Regrouper les séries en collections » sont activées dans les réglages d\'affichage de votre bibliothèque, sur votre serveur Jellyfin ou Emby.';
 
   @override
   String get libraryVisibility => 'Visibilité des bibliothèques';
@@ -2966,7 +2978,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showInNavigation => 'Afficher dans la navigation';
 
   @override
-  String get showInLatestMedia => 'Afficher dans ajouts récents';
+  String get showInLatestMedia =>
+      'Afficher dans les médias récemment ajoutés ou sortis';
 
   @override
   String get sourceLibraries => 'Bibliothèques sources';
@@ -3087,7 +3100,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activer l’audio pour les aperçus de bandes-annonces et d’épisodes';
 
   @override
-  String get latestMedia => 'Derniers médias';
+  String get latestMedia => 'Médias récemment ajoutés';
 
   @override
   String get recentlyReleased => 'Récemment sortis';
@@ -7514,7 +7527,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String recentlyReleasedLibraryName(String libraryName) {
-    return '';
+    return '$libraryName, sorties récentes';
   }
 
   @override
@@ -8080,7 +8093,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appearancesSeerr => 'Apparitions (Seerr)';
 
   @override
-  String get crewContributionsSeerr => '';
+  String get crewContributionsSeerr => 'Contributions techniques (Seerr)';
 
   @override
   String get watchWithGroup => 'Regarder en groupe';
@@ -8490,54 +8503,58 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sources => 'Sources';
 
   @override
-  String get subtitlePreferences => '';
+  String get subtitlePreferences => 'Préférences de sous-titres';
 
   @override
-  String get subtitlePreferencesDescription => '';
+  String get subtitlePreferencesDescription =>
+      'Modifier les modes de sous-titres, les langues par défaut, l\'apparence et les options de rendu.';
 
   @override
-  String get subtitleRendering => '';
+  String get subtitleRendering => 'Rendu des sous-titres';
 
   @override
-  String get displayOptions => '';
+  String get displayOptions => 'Options d\'affichage';
 
   @override
-  String get releaseDateAscending => '';
+  String get releaseDateAscending => 'Date de sortie (croissant)';
 
   @override
-  String get releaseDateDescending => '';
+  String get releaseDateDescending => 'Date de sortie (décroissant)';
 
   @override
-  String get groupContributions => '';
+  String get groupContributions => 'Regrouper les contributions';
 
   @override
-  String get groupMultipleRoles => '';
+  String get groupMultipleRoles => 'Regrouper les rôles d\'une même personne';
 
   @override
-  String get libraryWriteAccessWarningTitle => '';
+  String get libraryWriteAccessWarningTitle =>
+      'Avertissement d\'accès en écriture à la bibliothèque';
 
   @override
-  String get libraryWriteAccessHowToFix => '';
+  String get libraryWriteAccessHowToFix => 'Comment résoudre ce problème :';
 
   @override
-  String get libraryWriteAccessFixSteps => '';
+  String get libraryWriteAccessFixSteps =>
+      '1. Accordez les permissions d\'écriture à l\'utilisateur du service Jellyfin (par exemple, jellyfin ou le PUID/PGID Docker) sur les dossiers de votre bibliothèque multimédia, côté serveur.\n\n2. Ou, dans le tableau de bord Jellyfin → Bibliothèques, modifiez cette bibliothèque et désactivez « Enregistrer les illustrations dans les dossiers multimédias » pour stocker les visuels dans la base de données interne de Jellyfin.';
 
   @override
-  String get dismiss => '';
+  String get dismiss => 'Ignorer';
 
   @override
   String libraryWriteAccessProactiveBody(
     String libraryName,
     String failedPath,
   ) {
-    return '';
+    return 'Votre bibliothèque $libraryName est configurée pour enregistrer les visuels directement dans les dossiers multimédias (l\'option « Enregistrer les illustrations dans les dossiers multimédias » est activée). Cependant, Jellyfin a testé l\'accès en écriture et n\'a pas la permission d\'écrire dans ce répertoire :\n\n$failedPath';
   }
 
   @override
-  String get libraryWriteAccessReactiveBody => '';
+  String get libraryWriteAccessReactiveBody =>
+      'Il semble que Jellyfin n\'ait pas réussi à mettre à jour le visuel. Votre bibliothèque est configurée pour enregistrer les visuels directement dans les dossiers multimédias (l\'option « Enregistrer les illustrations dans les dossiers multimédias » est activée). Cette erreur survient généralement lorsque le serveur Jellyfin n\'a pas la permission d\'écrire dans vos répertoires multimédias.';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8510,7 +8510,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -8309,7 +8309,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -8391,7 +8391,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -8435,7 +8435,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8478,7 +8478,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -8436,7 +8436,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8454,7 +8454,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -8217,7 +8217,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8446,7 +8446,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8462,7 +8462,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -8212,7 +8212,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8447,7 +8447,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8457,7 +8457,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8464,7 +8464,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8512,7 +8512,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8443,7 +8443,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8414,7 +8414,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8445,7 +8445,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -8394,7 +8394,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -8456,7 +8456,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8475,7 +8475,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8459,7 +8459,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8465,7 +8465,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -8402,7 +8402,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8446,7 +8446,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8443,7 +8443,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8474,7 +8474,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -8439,7 +8439,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8425,7 +8425,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8466,7 +8466,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8469,7 +8469,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8467,7 +8467,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -8360,7 +8360,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8494,7 +8494,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -8451,7 +8451,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -8421,7 +8421,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8467,7 +8467,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -8427,7 +8427,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -8169,7 +8169,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8124,7 +8124,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get libraryWriteAccessReactiveBody => '';
 
   @override
-  String get externalLists => 'External Lists';
+  String get externalLists => 'External Home Row Lists';
 
   @override
   String get enableImdb => 'IMDb External Lists';

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -32,7 +32,9 @@ enum HomeSectionPluginSource {
 
   genres('genres'),
 
-  playlists('playlists');
+  playlists('playlists'),
+
+  custom('custom');
 
   const HomeSectionPluginSource(this.serializedName);
   final String serializedName;

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1460,6 +1460,11 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final lastExternalRowsRefreshTime = Preference(
+    key: 'last_external_rows_refresh_time',
+    defaultValue: 0,
+  );
+
   static final imdbTop250MoviesEnabled = Preference(
     key: 'imdb_top_250_movies_enabled',
     defaultValue: false,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2970,8 +2970,10 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   String? _rowSubtitle(HomeRow row, AppLocalizations l10n) {
+    if (row.id == 'merged_calendar' || row.id == 'radarr_calendar' || row.id == 'sonarr_calendar') {
+      return 'Radarr and Sonarr Calendars';
+    }
     if (row.id.startsWith('seerr_')) return l10n.seerrDiscoveryRows;
-    if (row.id.startsWith('imdb_')) return 'IMDb Lists';
     if (row.id.startsWith('tmdb_')) return 'TMDB Lists';
 
     final config = widget.prefs.homeSectionsConfig.firstWhereOrNull((c) => c.stableId == row.id);
@@ -2990,14 +2992,17 @@ class _ContentRowsState extends State<_ContentRows>
         _ => source.toUpperCase(),
       };
       final typeLabel = switch (type) {
-        'user_list' => 'Custom List',
+        'user_list' => source == 'tmdb'
+            ? 'List'
+            : (source == 'mdblist' ? '' : 'List from URL'),
+        'user_diary' => 'Diary',
         'watchlist' => 'Watchlist',
-        'films' => 'Films',
+        'films' => 'Complete Films',
         'awards_events' => 'Awards/Events',
-        'movie_collection' => 'Movie Collection',
+        'movie_collection' => 'Collection',
         _ => type,
       };
-      return '$sourceLabel $typeLabel';
+      return '$sourceLabel $typeLabel'.trim();
     }
     return null;
   }
@@ -4505,14 +4510,19 @@ class _ContentRowsState extends State<_ContentRows>
       return prefs.get(UserPreferences.homeRowsUniversalImageType);
     }
 
-    final sectionType = _sectionTypeForRow(row);
+    final sectionType = _sectionTypeForRow(row, prefs);
     if (sectionType == null) {
       return ImageType.poster;
     }
     return prefs.get(UserPreferences.homeRowImageType(sectionType));
   }
 
-  static HomeSectionType? _sectionTypeForRow(HomeRow row) {
+  static HomeSectionType? _sectionTypeForRow(HomeRow row, UserPreferences prefs) {
+    final config = prefs.homeSectionsConfig.firstWhereOrNull((c) => c.stableId == row.id);
+    if (config != null) {
+      return config.type;
+    }
+
     return switch (row.rowType) {
       HomeRowType.resume => HomeSectionType.resume,
       HomeRowType.nextUp => HomeSectionType.nextUp,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:ui' as ui;
 
+import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -29,6 +31,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../playback/appletv_preview_player.dart';
 import '../../../playback/inline_preview_engine.dart';
 import '../../../playback/media3_player_backend.dart';
+import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../widgets/exit_confirmation_dialog.dart';
@@ -2001,8 +2004,10 @@ class _ContentRowsState extends State<_ContentRows>
       childHeight = maxCardHeight + (10 * metadataScale);
     }
 
-    final isSeerrRow = row.id.startsWith('seerr_');
-    final hasSubtitle = isSeerrRow && (row.rowType != HomeRowType.liveTv && row.rowType != HomeRowType.libraryTilesSmall);
+    final subtitle = _rowSubtitle(row, AppLocalizations.of(context)!);
+    final hasSubtitle = subtitle != null &&
+        (row.rowType != HomeRowType.liveTv &&
+            row.rowType != HomeRowType.libraryTilesSmall);
     final headerPaddingTop = isRowsV2 ? 6.0 : 16.0;
     final headerPaddingBottom = isRowsV2 ? 1.0 : 8.0;
     final titleHeight = 20.0 * metadataScale;
@@ -2964,6 +2969,39 @@ class _ContentRowsState extends State<_ContentRows>
     );
   }
 
+  String? _rowSubtitle(HomeRow row, AppLocalizations l10n) {
+    if (row.id.startsWith('seerr_')) return l10n.seerrDiscoveryRows;
+    if (row.id.startsWith('imdb_')) return 'IMDb Lists';
+    if (row.id.startsWith('tmdb_')) return 'TMDB Lists';
+
+    final config = widget.prefs.homeSectionsConfig.firstWhereOrNull((c) => c.stableId == row.id);
+    if (config != null && config.pluginSource == HomeSectionPluginSource.custom) {
+      Map<String, dynamic> rowConfig = {};
+      try {
+        rowConfig = jsonDecode(config.pluginAdditionalData ?? '{}') as Map<String, dynamic>;
+      } catch (_) {}
+      final source = rowConfig['source'] as String? ?? 'imdb';
+      final type = rowConfig['type'] as String? ?? 'user_list';
+      final sourceLabel = switch (source) {
+        'imdb' => 'IMDb',
+        'tmdb' => 'TMDB',
+        'letterboxd' => 'Letterboxd',
+        'mdblist' => 'MDBList',
+        _ => source.toUpperCase(),
+      };
+      final typeLabel = switch (type) {
+        'user_list' => 'Custom List',
+        'watchlist' => 'Watchlist',
+        'films' => 'Films',
+        'awards_events' => 'Awards/Events',
+        'movie_collection' => 'Movie Collection',
+        _ => type,
+      };
+      return '$sourceLabel $typeLabel';
+    }
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final rows = widget.viewModel.rows;
@@ -3579,14 +3617,15 @@ class _ContentRowsState extends State<_ContentRows>
           (46 * metadataScale);
     }
 
-    final isSeerrRow = row.id.startsWith('seerr_');
+    final subtitle = _rowSubtitle(row, l10n);
+    final hasSubtitle = subtitle != null;
     return _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),
-      subtitle: isSeerrRow ? l10n.seerrDiscoveryRows : null,
+      subtitle: subtitle,
       rowIndex: rowIndex,
       hasItems: row.items.isNotEmpty,
-      height: maxCardHeight + (10 * metadataScale) + (isSeerrRow ? 18.0 : 0.0),
+      height: maxCardHeight + (10 * metadataScale) + (hasSubtitle ? 18.0 : 0.0),
       child: LockedFocusRow<AggregatedItem>(
         key: _rowKey(rowIndex),
         items: row.items,
@@ -3805,12 +3844,18 @@ class _ContentRowsState extends State<_ContentRows>
             }
           } else {
             cardTitle = item.name;
-            cardSubtitle = (canUseExpandedV2Card &&
-                    row.id != 'radarr_calendar' &&
-                    row.id != 'sonarr_calendar' &&
-                    row.id != 'merged_calendar')
-                ? _v2MetadataLine(item)
-                : item.subtitle;
+            final showUserRatings = item.rawData['ShowUserRatings'] == true;
+            final userRating = item.rawData['UserRating'] as String? ?? '';
+            if (showUserRatings && userRating.isNotEmpty) {
+              cardSubtitle = userRating;
+            } else {
+              cardSubtitle = (canUseExpandedV2Card &&
+                      row.id != 'radarr_calendar' &&
+                      row.id != 'sonarr_calendar' &&
+                      row.id != 'merged_calendar')
+                  ? _v2MetadataLine(item)
+                  : item.subtitle;
+            }
             cardSubtitleWidget = null;
           }
 

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -28,6 +28,7 @@ import '../../../preference/seerr_preferences.dart';
 import '../../../data/viewmodels/seerr_discover_view_model.dart';
 import '../../../data/repositories/mdblist_repository.dart';
 import 'package:dio/dio.dart';
+import '../../../data/services/custom_external_lists_service.dart';
 
 class HomeViewModel extends ChangeNotifier {
   final RowDataSource _dataSource;
@@ -242,6 +243,7 @@ class HomeViewModel extends ChangeNotifier {
        _ownerUserId = client.userId ?? '';
 
   Future<void> load({bool preserveExisting = false, bool forceRefresh = false}) async {
+    _checkAndTriggerDailyExternalRowsRefresh();
     if (_isLoading) {
       _reloadRequestedWhileLoading = true;
       _pendingReloadPreserveExisting =
@@ -308,6 +310,7 @@ class HomeViewModel extends ChangeNotifier {
           .where(
             (c) =>
                 (c.isBuiltin ||
+                    c.pluginSource == HomeSectionPluginSource.custom ||
                     (c.serverId != null && c.serverId == _serverId)) &&
                 (showFavoritesRows || !_isFavoriteSectionType(c.type)) &&
                 (showCollectionsRows ||
@@ -804,6 +807,7 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionPluginSource.collections:
       case HomeSectionPluginSource.genres:
       case HomeSectionPluginSource.playlists:
+      case HomeSectionPluginSource.custom:
         return const <String>{};
       case HomeSectionPluginSource.hss:
         final builtin = _builtinForPluginSection(cfg.pluginSection);
@@ -2887,6 +2891,60 @@ class HomeViewModel extends ChangeNotifier {
       debugPrint('[MergedCalendar] Failed to load merged calendar: $e');
       return const [];
     }
+  }
+
+  Future<void> _checkAndTriggerDailyExternalRowsRefresh() async {
+    final lastRefreshMs = _prefs.get(UserPreferences.lastExternalRowsRefreshTime);
+    final now = DateTime.now();
+    final lastRefreshDate = DateTime.fromMillisecondsSinceEpoch(lastRefreshMs);
+    final isDifferentDay = lastRefreshMs == 0 ||
+        now.year != lastRefreshDate.year ||
+        now.month != lastRefreshDate.month ||
+        now.day != lastRefreshDate.day ||
+        now.difference(lastRefreshDate).inHours >= 24;
+
+    if (!isDifferentDay) return;
+
+    final syncService = GetIt.instance<PluginSyncService>();
+    if (!syncService.seerrAvailable) return;
+
+    debugPrint('[DailyRefresh] Day changed or first run. Triggering background cache refresh of enabled lists...');
+    
+    await _prefs.set(UserPreferences.lastExternalRowsRefreshTime, now.millisecondsSinceEpoch);
+
+    unawaited(() async {
+      try {
+        final futures = <Future<void>>[];
+
+        // Custom Enabled Rows
+
+        // 3. Custom Enabled Rows
+        final customService = GetIt.instance<CustomExternalListsService>();
+        final configs = _prefs.homeSectionsConfig;
+        for (final config in configs) {
+          if (config.pluginSource == HomeSectionPluginSource.custom && config.enabled) {
+            futures.add(() async {
+              try {
+                final items = await customService.fetchCustomRow(config);
+                if (items.isNotEmpty) {
+                  await customService.saveCustomRowToCache(config, items);
+                }
+              } catch (e) {
+                debugPrint('[DailyRefresh] Failed to refresh custom row ${config.pluginSection}: $e');
+              }
+            }());
+          }
+        }
+
+        if (futures.isNotEmpty) {
+          await Future.wait(futures);
+          debugPrint('[DailyRefresh] Background cache refresh complete. Reloading HomeViewModel rows...');
+          await load(preserveExisting: true);
+        }
+      } catch (e) {
+        debugPrint('[DailyRefresh] Error during background refresh: $e');
+      }
+    }());
   }
 }
 

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -1265,109 +1265,31 @@ class HomeViewModel extends ChangeNotifier {
           'movie',
         );
       case HomeSectionType.tmdbPopularMovies:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbPopularMovies,
-          'Popular Movies',
-          'tmdb_popular_movies',
-          'popular',
-          'movie',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbPopularMovies, 'Popular Movies', 'tmdb_popular_movies');
       case HomeSectionType.tmdbTopRatedMovies:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbTopRatedMovies,
-          'Top Rated Movies',
-          'tmdb_top_rated_movies',
-          'top_rated_movies',
-          'movie',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbTopRatedMovies, 'Top Rated Movies', 'tmdb_top_rated_movies');
       case HomeSectionType.tmdbNowPlayingMovies:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbNowPlayingMovies,
-          'Now Playing Movies',
-          'tmdb_now_playing_movies',
-          'now_playing_movies',
-          'movie',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbNowPlayingMovies, 'Now Playing Movies', 'tmdb_now_playing_movies');
       case HomeSectionType.tmdbUpcomingMovies:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbUpcomingMovies,
-          'Upcoming Movies',
-          'tmdb_upcoming_movies',
-          'upcoming_movies',
-          'movie',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbUpcomingMovies, 'Upcoming Movies', 'tmdb_upcoming_movies');
       case HomeSectionType.tmdbPopularTv:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbPopularTv,
-          'Popular TV',
-          'tmdb_popular_tv',
-          'popular',
-          'show',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbPopularTv, 'Popular TV', 'tmdb_popular_tv');
       case HomeSectionType.tmdbTopRatedTv:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbTopRatedTv,
-          'Top Rated TV',
-          'tmdb_top_rated_tv',
-          'top_rated_shows',
-          'show',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbTopRatedTv, 'Top Rated TV', 'tmdb_top_rated_tv');
       case HomeSectionType.tmdbAiringTodayTv:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbAiringTodayTv,
-          'Airing Today TV',
-          'tmdb_airing_today_tv',
-          'airing_today_shows',
-          'show',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbAiringTodayTv, 'Airing Today TV', 'tmdb_airing_today_tv');
       case HomeSectionType.tmdbOnTheAirTv:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbOnTheAirTv,
-          'On The Air TV',
-          'tmdb_on_the_air_tv',
-          'on_the_air_shows',
-          'show',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbOnTheAirTv, 'On The Air TV', 'tmdb_on_the_air_tv');
       case HomeSectionType.tmdbTrendingMovieDaily:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbTrendingMovieDaily,
-          'Trending Movies (Daily)',
-          'tmdb_trending_movie_daily',
-          'trending_movies_daily',
-          'movie',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingMovieDaily, 'Trending Movies (Daily)', 'tmdb_trending_movie_daily');
       case HomeSectionType.tmdbTrendingMovieWeekly:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbTrendingMovieWeekly,
-          'Trending Movies (Weekly)',
-          'tmdb_trending_movie_weekly',
-          'trending_movies_weekly',
-          'movie',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingMovieWeekly, 'Trending Movies (Weekly)', 'tmdb_trending_movie_weekly');
       case HomeSectionType.tmdbTrendingTvDaily:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbTrendingTvDaily,
-          'Trending TV (Daily)',
-          'tmdb_trending_tv_daily',
-          'trending_shows_daily',
-          'show',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingTvDaily, 'Trending TV (Daily)', 'tmdb_trending_tv_daily');
       case HomeSectionType.tmdbTrendingTvWeekly:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbTrendingTvWeekly,
-          'Trending TV (Weekly)',
-          'tmdb_trending_tv_weekly',
-          'trending_shows_weekly',
-          'show',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingTvWeekly, 'Trending TV (Weekly)', 'tmdb_trending_tv_weekly');
       case HomeSectionType.tmdbTrendingAllWeekly:
-        return _loadMdbListRow(
-          HomeSectionType.tmdbTrendingAllWeekly,
-          'Trending All (Weekly)',
-          'tmdb_trending_all_weekly',
-          'trending_all_weekly',
-          '',
-        );
+        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingAllWeekly, 'Trending All (Weekly)', 'tmdb_trending_all_weekly');
       case HomeSectionType.recentlyReleased:
         return _loadRecentlyReleasedRow();
       case HomeSectionType.resumeBook:
@@ -2282,6 +2204,82 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
+  Future<List<HomeRow>> _loadTmdbChartRow(
+    HomeSectionType sectionType,
+    String title,
+    String rowId,
+  ) async {
+    try {
+      final customService = GetIt.instance<CustomExternalListsService>();
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: 'seerr', // placeholder
+        pluginSection: rowId,
+        pluginDisplayText: title,
+        pluginSource: HomeSectionPluginSource.custom,
+        pluginAdditionalData: jsonEncode({
+          'source': 'tmdb_chart',
+          'type': _tmdbChartTypeForSection(sectionType),
+        }),
+      );
+
+      var items = await customService.loadCustomRowFromCache(config);
+      if (items.isEmpty) {
+        items = await customService.fetchCustomRow(config);
+      }
+
+      if (items.isEmpty) {
+        return const [];
+      }
+
+      final aggregatedItems = items.map((item) {
+        return AggregatedItem(
+          id: item.imdbId,
+          serverId: 'seerr',
+          rawData: {
+            'Name': item.title,
+            'Type': item.type,
+            'Overview': '',
+            'PosterPath': item.posterUrl ?? '',
+            'BackdropPath': item.backdropUrl ?? item.posterUrl ?? '',
+            'ProductionYear': item.year,
+            'SeerrMediaType': item.type == 'Series' ? 'tv' : 'movie',
+          },
+        );
+      }).toList();
+
+      return [
+        HomeRow(
+          id: rowId,
+          title: title,
+          rowType: HomeRowType.pluginDynamic,
+          items: aggregatedItems,
+        )
+      ];
+    } catch (e) {
+      debugPrint('[TmdbChartRow] Failed to load TMDB chart row $sectionType: $e');
+      return const [];
+    }
+  }
+
+  String _tmdbChartTypeForSection(HomeSectionType sectionType) {
+    return switch (sectionType) {
+      HomeSectionType.tmdbPopularMovies => 'movie/popular',
+      HomeSectionType.tmdbTopRatedMovies => 'movie/top_rated',
+      HomeSectionType.tmdbNowPlayingMovies => 'movie/now_playing',
+      HomeSectionType.tmdbUpcomingMovies => 'movie/upcoming',
+      HomeSectionType.tmdbPopularTv => 'tv/popular',
+      HomeSectionType.tmdbTopRatedTv => 'tv/top_rated',
+      HomeSectionType.tmdbAiringTodayTv => 'tv/airing_today',
+      HomeSectionType.tmdbOnTheAirTv => 'tv/on_the_air',
+      HomeSectionType.tmdbTrendingMovieDaily => 'trending/movie/day',
+      HomeSectionType.tmdbTrendingMovieWeekly => 'trending/movie/week',
+      HomeSectionType.tmdbTrendingTvDaily => 'trending/tv/day',
+      HomeSectionType.tmdbTrendingTvWeekly => 'trending/tv/week',
+      HomeSectionType.tmdbTrendingAllWeekly => 'trending/all/week',
+      _ => 'movie/popular',
+    };
+  }
+
   int? _extractYear(String? dateString) {
     if (dateString == null || dateString.isEmpty) return null;
     try {
@@ -2400,7 +2398,7 @@ class HomeViewModel extends ChangeNotifier {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
         final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
-        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || x.rawData['PosterPath'] == '');
+        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || x.rawData['PosterPath'] == '' || !x.rawData.containsKey('CacheVerV2'));
         if (hasOldCache) {
           debugPrint('[RadarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
           return const [];
@@ -2432,7 +2430,7 @@ class HomeViewModel extends ChangeNotifier {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
         final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
-        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || x.rawData['PosterPath'] == '');
+        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || x.rawData['PosterPath'] == '' || !x.rawData.containsKey('CacheVerV2'));
         if (hasOldCache) {
           debugPrint('[SonarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
           return const [];
@@ -2599,6 +2597,7 @@ class HomeViewModel extends ChangeNotifier {
                 'SeerrMediaType': 'movie',
                 'Subtitle': subtitleText,
                 'CalendarDate': targetReleaseDate.toIso8601String(),
+                'CacheVerV2': true,
               },
             ),
             date: targetReleaseDate,
@@ -2764,6 +2763,7 @@ class HomeViewModel extends ChangeNotifier {
                 'SeerrMediaType': 'tv',
                 'Subtitle': subtitleText,
                 'CalendarDate': airDateUtc.toIso8601String(),
+                'CacheVerV2': true,
               },
             ),
             date: airDateUtc,

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1220,35 +1220,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   }
 
   void _syncIndividualPreferences() {
-    final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final seerrRows = List<SeerrRowConfig>.from(seerrPrefs.rowsConfig);
-    var seerrChanged = false;
-
-    SeerrRowType? mapToSeerr(HomeSectionType type) {
-      return switch (type) {
-        HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
-        HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
-        HomeSectionType.seerrTrending => SeerrRowType.trending,
-        HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
-        HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
-        HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
-        HomeSectionType.seerrStudios => SeerrRowType.studios,
-        HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
-        HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
-        HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
-        HomeSectionType.seerrNetworks => SeerrRowType.networks,
-        _ => null,
-      };
-    }
-
     Preference<bool>? mapToExternalPref(HomeSectionType type) {
       return switch (type) {
-        HomeSectionType.imdbTop250Movies => UserPreferences.imdbTop250MoviesEnabled,
-        HomeSectionType.imdbTop250TvShows => UserPreferences.imdbTop250TvShowsEnabled,
-        HomeSectionType.imdbMostPopularMovies => UserPreferences.imdbMostPopularMoviesEnabled,
-        HomeSectionType.imdbMostPopularTvShows => UserPreferences.imdbMostPopularTvShowsEnabled,
-        HomeSectionType.imdbLowestRatedMovies => UserPreferences.imdbLowestRatedMoviesEnabled,
-        HomeSectionType.imdbTopEnglishMovies => UserPreferences.imdbTopEnglishMoviesEnabled,
         HomeSectionType.tmdbPopularMovies => UserPreferences.tmdbPopularMoviesEnabled,
         HomeSectionType.tmdbTopRatedMovies => UserPreferences.tmdbTopRatedMoviesEnabled,
         HomeSectionType.tmdbNowPlayingMovies => UserPreferences.tmdbNowPlayingMoviesEnabled,
@@ -1267,23 +1240,10 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     }
 
     for (final section in _sections) {
-      final seerrType = mapToSeerr(section.type);
-      if (seerrType != null) {
-        final idx = seerrRows.indexWhere((r) => r.type == seerrType);
-        if (idx >= 0 && seerrRows[idx].enabled != section.enabled) {
-          seerrRows[idx] = seerrRows[idx].copyWith(enabled: section.enabled);
-          seerrChanged = true;
-        }
-      } else {
-        final prefKey = mapToExternalPref(section.type);
-        if (prefKey != null && _prefs.get(prefKey) != section.enabled) {
-          _prefs.set(prefKey, section.enabled);
-        }
+      final prefKey = mapToExternalPref(section.type);
+      if (prefKey != null && _prefs.get(prefKey) != section.enabled) {
+        _prefs.set(prefKey, section.enabled);
       }
-    }
-
-    if (seerrChanged) {
-      seerrPrefs.setRowsConfig(seerrRows);
     }
   }
 

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -10,9 +11,11 @@ import '../../../data/models/aggregated_item.dart';
 import '../../../data/utils/playlist_utils.dart';
 import '../../../data/services/home_screen_sections_service.dart';
 import '../../../data/services/plugin_sync_service.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/seerr_preferences.dart';
+import '../../../preference/seerr_row_config.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/overlay_sheet.dart';
@@ -472,6 +475,114 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     return seerrPrefs.rowsConfig.any((r) => r.enabled);
   }
 
+  bool _isAnyImdbSectionEnabled() {
+    return _prefs.get(UserPreferences.imdbTop250MoviesEnabled) ||
+        _prefs.get(UserPreferences.imdbTop250TvShowsEnabled) ||
+        _prefs.get(UserPreferences.imdbMostPopularMoviesEnabled) ||
+        _prefs.get(UserPreferences.imdbMostPopularTvShowsEnabled) ||
+        _prefs.get(UserPreferences.imdbLowestRatedMoviesEnabled) ||
+        _prefs.get(UserPreferences.imdbTopEnglishMoviesEnabled);
+  }
+
+  bool _isAnyTmdbSectionEnabled() {
+    return _prefs.get(UserPreferences.tmdbPopularMoviesEnabled) ||
+        _prefs.get(UserPreferences.tmdbTopRatedMoviesEnabled) ||
+        _prefs.get(UserPreferences.tmdbNowPlayingMoviesEnabled) ||
+        _prefs.get(UserPreferences.tmdbUpcomingMoviesEnabled) ||
+        _prefs.get(UserPreferences.tmdbPopularTvEnabled) ||
+        _prefs.get(UserPreferences.tmdbTopRatedTvEnabled) ||
+        _prefs.get(UserPreferences.tmdbAiringTodayTvEnabled) ||
+        _prefs.get(UserPreferences.tmdbOnTheAirTvEnabled) ||
+        _prefs.get(UserPreferences.tmdbTrendingMovieDailyEnabled) ||
+        _prefs.get(UserPreferences.tmdbTrendingMovieWeeklyEnabled) ||
+        _prefs.get(UserPreferences.tmdbTrendingTvDailyEnabled) ||
+        _prefs.get(UserPreferences.tmdbTrendingTvWeeklyEnabled) ||
+        _prefs.get(UserPreferences.tmdbTrendingAllWeeklyEnabled);
+  }
+
+  bool _isSeerrRowEnabled(HomeSectionType type) {
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    final seerrType = switch (type) {
+      HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
+      HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
+      HomeSectionType.seerrTrending => SeerrRowType.trending,
+      HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
+      HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
+      HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
+      HomeSectionType.seerrStudios => SeerrRowType.studios,
+      HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
+      HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
+      HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
+      HomeSectionType.seerrNetworks => SeerrRowType.networks,
+      _ => null,
+    };
+    if (seerrType == null) return false;
+    return seerrPrefs.rowsConfig.firstWhere(
+      (r) => r.type == seerrType,
+      orElse: () => SeerrRowConfig(type: seerrType, enabled: false),
+    ).enabled;
+  }
+
+  bool _isImdbRowEnabled(HomeSectionType type) {
+    final prefKey = switch (type) {
+      HomeSectionType.imdbTop250Movies => UserPreferences.imdbTop250MoviesEnabled,
+      HomeSectionType.imdbTop250TvShows => UserPreferences.imdbTop250TvShowsEnabled,
+      HomeSectionType.imdbMostPopularMovies => UserPreferences.imdbMostPopularMoviesEnabled,
+      HomeSectionType.imdbMostPopularTvShows => UserPreferences.imdbMostPopularTvShowsEnabled,
+      HomeSectionType.imdbLowestRatedMovies => UserPreferences.imdbLowestRatedMoviesEnabled,
+      HomeSectionType.imdbTopEnglishMovies => UserPreferences.imdbTopEnglishMoviesEnabled,
+      _ => null,
+    };
+    if (prefKey == null) return false;
+    return _prefs.get(prefKey);
+  }
+
+  bool _isTmdbRowEnabled(HomeSectionType type) {
+    final prefKey = switch (type) {
+      HomeSectionType.tmdbPopularMovies => UserPreferences.tmdbPopularMoviesEnabled,
+      HomeSectionType.tmdbTopRatedMovies => UserPreferences.tmdbTopRatedMoviesEnabled,
+      HomeSectionType.tmdbNowPlayingMovies => UserPreferences.tmdbNowPlayingMoviesEnabled,
+      HomeSectionType.tmdbUpcomingMovies => UserPreferences.tmdbUpcomingMoviesEnabled,
+      HomeSectionType.tmdbPopularTv => UserPreferences.tmdbPopularTvEnabled,
+      HomeSectionType.tmdbTopRatedTv => UserPreferences.tmdbTopRatedTvEnabled,
+      HomeSectionType.tmdbAiringTodayTv => UserPreferences.tmdbAiringTodayTvEnabled,
+      HomeSectionType.tmdbOnTheAirTv => UserPreferences.tmdbOnTheAirTvEnabled,
+      HomeSectionType.tmdbTrendingMovieDaily => UserPreferences.tmdbTrendingMovieDailyEnabled,
+      HomeSectionType.tmdbTrendingMovieWeekly => UserPreferences.tmdbTrendingMovieWeeklyEnabled,
+      HomeSectionType.tmdbTrendingTvDaily => UserPreferences.tmdbTrendingTvDailyEnabled,
+      HomeSectionType.tmdbTrendingTvWeekly => UserPreferences.tmdbTrendingTvWeeklyEnabled,
+      HomeSectionType.tmdbTrendingAllWeekly => UserPreferences.tmdbTrendingAllWeeklyEnabled,
+      _ => null,
+    };
+    if (prefKey == null) return false;
+    return _prefs.get(prefKey);
+  }
+
+  bool _isImdbSectionType(HomeSectionType type) {
+    return type == HomeSectionType.imdbTop250Movies ||
+        type == HomeSectionType.imdbTop250TvShows ||
+        type == HomeSectionType.imdbMostPopularMovies ||
+        type == HomeSectionType.imdbMostPopularTvShows ||
+        type == HomeSectionType.imdbLowestRatedMovies ||
+        type == HomeSectionType.imdbTopEnglishMovies;
+  }
+
+  bool _isTmdbSectionType(HomeSectionType type) {
+    return type == HomeSectionType.tmdbPopularMovies ||
+        type == HomeSectionType.tmdbTopRatedMovies ||
+        type == HomeSectionType.tmdbNowPlayingMovies ||
+        type == HomeSectionType.tmdbUpcomingMovies ||
+        type == HomeSectionType.tmdbPopularTv ||
+        type == HomeSectionType.tmdbTopRatedTv ||
+        type == HomeSectionType.tmdbAiringTodayTv ||
+        type == HomeSectionType.tmdbOnTheAirTv ||
+        type == HomeSectionType.tmdbTrendingMovieDaily ||
+        type == HomeSectionType.tmdbTrendingMovieWeekly ||
+        type == HomeSectionType.tmdbTrendingTvDaily ||
+        type == HomeSectionType.tmdbTrendingTvWeekly ||
+        type == HomeSectionType.tmdbTrendingAllWeekly;
+  }
+
   bool _isHiddenByRowVisibilityGates(HomeSectionConfig section) {
     final showFavoritesRows = _prefs.get(UserPreferences.displayFavoritesRows);
     final showCollectionsRows = _prefs.get(
@@ -482,6 +593,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     final showSeerrRows =
         _isAnySeerrSectionEnabled() &&
         GetIt.instance<PluginSyncService>().seerrAvailable;
+    final showImdbRows = _isAnyImdbSectionEnabled();
+    final showTmdbRows = _isAnyTmdbSectionEnabled();
 
     final hiddenByFavorites =
         !showFavoritesRows && _isFavoriteSectionType(section.type);
@@ -500,7 +613,13 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         ((section.isBuiltin && _isPlaylistsSectionType(section.type)) ||
             (section.isPluginDynamic &&
                 section.pluginSource == HomeSectionPluginSource.playlists));
-    final hiddenBySeerr = !showSeerrRows && _isSeerrSectionType(section.type);
+    final hiddenBySeerr = _isSeerrSectionType(section.type) &&
+        (!showSeerrRows || !_isSeerrRowEnabled(section.type));
+    final hiddenByImdb = _isImdbSectionType(section.type) &&
+        (!showImdbRows || !_isImdbRowEnabled(section.type));
+    final hiddenByTmdb = _isTmdbSectionType(section.type) &&
+        (!showTmdbRows || !_isTmdbRowEnabled(section.type));
+
     final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
     final hiddenByAudio = !showAudioRows && _isAudioSectionType(section.type);
     return hiddenByFavorites ||
@@ -508,6 +627,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         hiddenByGenres ||
         hiddenByPlaylists ||
         hiddenBySeerr ||
+        hiddenByImdb ||
+        hiddenByTmdb ||
         hiddenByAudio;
   }
 
@@ -1098,7 +1219,76 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     }
   }
 
+  void _syncIndividualPreferences() {
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    final seerrRows = List<SeerrRowConfig>.from(seerrPrefs.rowsConfig);
+    var seerrChanged = false;
+
+    SeerrRowType? mapToSeerr(HomeSectionType type) {
+      return switch (type) {
+        HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
+        HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
+        HomeSectionType.seerrTrending => SeerrRowType.trending,
+        HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
+        HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
+        HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
+        HomeSectionType.seerrStudios => SeerrRowType.studios,
+        HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
+        HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
+        HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
+        HomeSectionType.seerrNetworks => SeerrRowType.networks,
+        _ => null,
+      };
+    }
+
+    Preference<bool>? mapToExternalPref(HomeSectionType type) {
+      return switch (type) {
+        HomeSectionType.imdbTop250Movies => UserPreferences.imdbTop250MoviesEnabled,
+        HomeSectionType.imdbTop250TvShows => UserPreferences.imdbTop250TvShowsEnabled,
+        HomeSectionType.imdbMostPopularMovies => UserPreferences.imdbMostPopularMoviesEnabled,
+        HomeSectionType.imdbMostPopularTvShows => UserPreferences.imdbMostPopularTvShowsEnabled,
+        HomeSectionType.imdbLowestRatedMovies => UserPreferences.imdbLowestRatedMoviesEnabled,
+        HomeSectionType.imdbTopEnglishMovies => UserPreferences.imdbTopEnglishMoviesEnabled,
+        HomeSectionType.tmdbPopularMovies => UserPreferences.tmdbPopularMoviesEnabled,
+        HomeSectionType.tmdbTopRatedMovies => UserPreferences.tmdbTopRatedMoviesEnabled,
+        HomeSectionType.tmdbNowPlayingMovies => UserPreferences.tmdbNowPlayingMoviesEnabled,
+        HomeSectionType.tmdbUpcomingMovies => UserPreferences.tmdbUpcomingMoviesEnabled,
+        HomeSectionType.tmdbPopularTv => UserPreferences.tmdbPopularTvEnabled,
+        HomeSectionType.tmdbTopRatedTv => UserPreferences.tmdbTopRatedTvEnabled,
+        HomeSectionType.tmdbAiringTodayTv => UserPreferences.tmdbAiringTodayTvEnabled,
+        HomeSectionType.tmdbOnTheAirTv => UserPreferences.tmdbOnTheAirTvEnabled,
+        HomeSectionType.tmdbTrendingMovieDaily => UserPreferences.tmdbTrendingMovieDailyEnabled,
+        HomeSectionType.tmdbTrendingMovieWeekly => UserPreferences.tmdbTrendingMovieWeeklyEnabled,
+        HomeSectionType.tmdbTrendingTvDaily => UserPreferences.tmdbTrendingTvDailyEnabled,
+        HomeSectionType.tmdbTrendingTvWeekly => UserPreferences.tmdbTrendingTvWeeklyEnabled,
+        HomeSectionType.tmdbTrendingAllWeekly => UserPreferences.tmdbTrendingAllWeeklyEnabled,
+        _ => null,
+      };
+    }
+
+    for (final section in _sections) {
+      final seerrType = mapToSeerr(section.type);
+      if (seerrType != null) {
+        final idx = seerrRows.indexWhere((r) => r.type == seerrType);
+        if (idx >= 0 && seerrRows[idx].enabled != section.enabled) {
+          seerrRows[idx] = seerrRows[idx].copyWith(enabled: section.enabled);
+          seerrChanged = true;
+        }
+      } else {
+        final prefKey = mapToExternalPref(section.type);
+        if (prefKey != null && _prefs.get(prefKey) != section.enabled) {
+          _prefs.set(prefKey, section.enabled);
+        }
+      }
+    }
+
+    if (seerrChanged) {
+      seerrPrefs.setRowsConfig(seerrRows);
+    }
+  }
+
   void _save() {
+    _syncIndividualPreferences();
     _persistSections(pushSync: true);
   }
 
@@ -1151,7 +1341,11 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           ? cfg.pluginDisplayText!
           : (cfg.pluginSection ?? l10n.none);
     }
-    return _labelForType(cfg.type, l10n);
+    String label = _labelForType(cfg.type, l10n);
+    if (_isImdbSectionType(cfg.type)) {
+      label = label.replaceAll('IMDb ', '').replaceAll('IMDb', '').trim();
+    }
+    return label;
   }
 
   String _labelForType(HomeSectionType type, AppLocalizations l10n) =>
@@ -1485,7 +1679,27 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                                           .withValues(alpha: 0.7),
                                     ),
                                   )
-                                : null)),
+                                : (_isImdbSectionType(section.type)
+                                      ? Text(
+                                          'IMDb Lists',
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            fontFamily: kCleanSettingsFontFamily,
+                                            color: AppColorScheme.onSurface
+                                                .withValues(alpha: 0.7),
+                                          ),
+                                        )
+                                      : (_isTmdbSectionType(section.type)
+                                            ? Text(
+                                                'TMDB Lists',
+                                                style: TextStyle(
+                                                  fontSize: 12,
+                                                  fontFamily: kCleanSettingsFontFamily,
+                                                  color: AppColorScheme.onSurface
+                                                      .withValues(alpha: 0.7),
+                                                ),
+                                              )
+                                            : null)))),
                 onTap: isEmpty
                     ? null
                     : () {
@@ -1540,7 +1754,11 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                     ? 'Audio row'
                     : (_isSeerrSectionType(section.type)
                           ? 'Seerr Discovery Rows'
-                          : null)),
+                          : (_isImdbSectionType(section.type)
+                                ? 'IMDb Lists'
+                                : (_isTmdbSectionType(section.type)
+                                      ? 'TMDB Lists'
+                                      : null)))),
           enabled: section.enabled,
           isFirst: visibleIndex == 0,
           isLast: visibleIndex == visibleIndices.length - 1,
@@ -1576,6 +1794,30 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       HomeSectionPluginSource.genres => 'Genres row',
       HomeSectionPluginSource.playlists => 'Playlists row',
       HomeSectionPluginSource.hss => 'Home Screen Sections plugin',
+      HomeSectionPluginSource.custom => (() {
+          Map<String, dynamic> rowConfig = {};
+          try {
+            rowConfig = jsonDecode(section.pluginAdditionalData ?? '{}') as Map<String, dynamic>;
+          } catch (_) {}
+          final source = rowConfig['source'] as String? ?? 'imdb';
+          final type = rowConfig['type'] as String? ?? 'user_list';
+          final sourceLabel = switch (source) {
+            'imdb' => 'IMDb',
+            'tmdb' => 'TMDB',
+            'letterboxd' => 'Letterboxd',
+            'mdblist' => 'MDBList',
+            _ => source.toUpperCase(),
+          };
+          final typeLabel = switch (type) {
+            'user_list' => 'Custom List',
+            'watchlist' => 'Watchlist',
+            'films' => 'Films',
+            'awards_events' => 'Awards/Events',
+            'movie_collection' => 'Movie Collection',
+            _ => type,
+          };
+          return '$sourceLabel $typeLabel';
+        })(),
     };
   }
 }

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -8,12 +8,9 @@ class _ExternalListsScreen extends StatefulWidget {
 }
 
 class _ExternalListsScreenState extends State<_ExternalListsScreen> {
-  final _imdbScope = FocusScopeNode(
+  final _externalListsScope = FocusScopeNode(
     debugLabel: 'ExternalListsScope',
     traversalEdgeBehavior: TraversalEdgeBehavior.stop,
-  );
-  final _imdbListsFocusNode = FocusNode(
-    debugLabel: 'imdb_lists_button',
   );
   final _homeSectionsFocusNode = FocusNode(
     debugLabel: 'home_sections_shortcut_button',
@@ -55,8 +52,7 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
 
   @override
   void dispose() {
-    _imdbScope.dispose();
-    _imdbListsFocusNode.dispose();
+    _externalListsScope.dispose();
     _homeSectionsFocusNode.dispose();
     _refreshFocusNode.dispose();
     super.dispose();
@@ -177,7 +173,7 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
                 Text(l10n.externalLists),
               ),
               body: FocusScope(
-                node: _imdbScope,
+                node: _externalListsScope,
                 autofocus: true,
                 child: ListView(
                   children: [
@@ -205,13 +201,6 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
                     const _SectionHeader('External Home Row Configurations'),
                     adaptiveListSection(
                       children: [
-                        _TvSettingsListTile(
-                          focusNode: _imdbListsFocusNode,
-                          leading: const Icon(Icons.movie_outlined),
-                          title: const Text('IMDb Lists'),
-                          subtitle: const Text('Configure IMDb Top 250, Popular, and other charts.'),
-                          onTap: () => context.pushSettingsScreen(const _ImdbListsScreen()),
-                        ),
                         _TvSettingsListTile(
                           leading: const Icon(Icons.trending_up),
                           title: const Text('TMDB Lists'),
@@ -245,9 +234,9 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
                           ),
                         _TvSettingsListTile(
                           leading: const Icon(Icons.tune_outlined),
-                          title: const Text('Fully Custom Home Rows Wizard'),
+                          title: const Text('Custom Home Rows Wizard'),
                           subtitle: const Text(
-                              'ADVANCED: Configure fully customized home rows from a variety of sources.'),
+                              'ADVANCED: Configure customized home rows from a variety of sources.'),
                           onTap: () => context
                               .pushSettingsScreen(const _CustomListsScreen()),
                         ),
@@ -259,239 +248,6 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
             ),
           );
         },
-      ),
-    );
-  }
-}
-
-class _ImdbListsScreen extends StatefulWidget {
-  const _ImdbListsScreen();
-
-  @override
-  State<_ImdbListsScreen> createState() => _ImdbListsScreenState();
-}
-
-class _ImdbListsScreenState extends State<_ImdbListsScreen> {
-  bool _isFetching = false;
-  final _scope = FocusScopeNode(debugLabel: 'ImdbListsScope');
-  final _firstFocusNode = FocusNode(debugLabel: 'imdb_top_250_movies');
-
-  @override
-  void dispose() {
-    _scope.dispose();
-    _firstFocusNode.dispose();
-    super.dispose();
-  }
-
-  Future<bool> _fetchAndCacheList(HomeSectionType type, String title) async {
-    return true;
-  }
-
-  void _syncSingleImdbSectionState(HomeSectionType type, bool enabled) {
-    final prefs = GetIt.instance<UserPreferences>();
-    final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
-
-    final idx = configs.indexWhere((c) => c.type == type);
-    var changed = false;
-    if (idx >= 0) {
-      if (configs[idx].enabled != enabled) {
-        configs[idx] = configs[idx].copyWith(enabled: enabled);
-        changed = true;
-      }
-    } else {
-      configs.add(HomeSectionConfig(
-        type: type,
-        enabled: enabled,
-        order: configs.length,
-      ));
-      changed = true;
-    }
-
-    if (changed) {
-      prefs.setHomeSectionsConfig(configs);
-    }
-    _pushPersonalizationSync();
-  }
-
-  String _stripImdb(String title) {
-    if (title.startsWith('IMDb ')) {
-      return title.substring(5);
-    }
-    return title;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    final prefs = GetIt.instance<UserPreferences>();
-
-    return withCleanSettingsTypography(
-      context,
-      RequestInitialFocus(
-        targetNode: PlatformDetection.isTV ? _firstFocusNode : null,
-        child: Scaffold(
-          appBar: buildSettingsAppBar(
-            context,
-            const Text('IMDb Lists'),
-          ),
-          body: FocusScope(
-            node: _scope,
-            autofocus: true,
-            child: ListView(
-              children: [
-                adaptiveListSection(
-                  children: [
-                    SwitchPreferenceTile(
-                      focusNode: _firstFocusNode,
-                      preference: UserPreferences.imdbTop250MoviesEnabled,
-                      title: _stripImdb(l10n.imdbTop250Movies),
-                      icon: Icons.movie_outlined,
-                      enabled: !_isFetching,
-                      onChangedValue: (isEnabled) async {
-                        if (_isFetching) return;
-                        if (isEnabled) {
-                          final success = await _fetchAndCacheList(
-                            HomeSectionType.imdbTop250Movies,
-                            l10n.imdbTop250Movies,
-                          );
-                          if (!success) {
-                            await prefs.set(UserPreferences.imdbTop250MoviesEnabled, false);
-                            setState(() {});
-                            return;
-                          }
-                        }
-                        _syncSingleImdbSectionState(
-                          HomeSectionType.imdbTop250Movies,
-                          isEnabled,
-                        );
-                      },
-                    ),
-                    SwitchPreferenceTile(
-                      preference: UserPreferences.imdbTop250TvShowsEnabled,
-                      title: _stripImdb(l10n.imdbTop250TvShows),
-                      icon: Icons.live_tv,
-                      enabled: !_isFetching,
-                      onChangedValue: (isEnabled) async {
-                        if (_isFetching) return;
-                        if (isEnabled) {
-                          final success = await _fetchAndCacheList(
-                            HomeSectionType.imdbTop250TvShows,
-                            l10n.imdbTop250TvShows,
-                          );
-                          if (!success) {
-                            await prefs.set(UserPreferences.imdbTop250TvShowsEnabled, false);
-                            setState(() {});
-                            return;
-                          }
-                        }
-                        _syncSingleImdbSectionState(
-                          HomeSectionType.imdbTop250TvShows,
-                          isEnabled,
-                        );
-                      },
-                    ),
-                    SwitchPreferenceTile(
-                      preference: UserPreferences.imdbMostPopularMoviesEnabled,
-                      title: _stripImdb(l10n.imdbMostPopularMovies),
-                      icon: Icons.trending_up,
-                      enabled: !_isFetching,
-                      onChangedValue: (isEnabled) async {
-                        if (_isFetching) return;
-                        if (isEnabled) {
-                          final success = await _fetchAndCacheList(
-                            HomeSectionType.imdbMostPopularMovies,
-                            l10n.imdbMostPopularMovies,
-                          );
-                          if (!success) {
-                            await prefs.set(UserPreferences.imdbMostPopularMoviesEnabled, false);
-                            setState(() {});
-                            return;
-                          }
-                        }
-                        _syncSingleImdbSectionState(
-                          HomeSectionType.imdbMostPopularMovies,
-                          isEnabled,
-                        );
-                      },
-                    ),
-                    SwitchPreferenceTile(
-                      preference: UserPreferences.imdbMostPopularTvShowsEnabled,
-                      title: _stripImdb(l10n.imdbMostPopularTvShows),
-                      icon: Icons.live_tv,
-                      enabled: !_isFetching,
-                      onChangedValue: (isEnabled) async {
-                        if (_isFetching) return;
-                        if (isEnabled) {
-                          final success = await _fetchAndCacheList(
-                            HomeSectionType.imdbMostPopularTvShows,
-                            l10n.imdbMostPopularTvShows,
-                          );
-                          if (!success) {
-                            await prefs.set(UserPreferences.imdbMostPopularTvShowsEnabled, false);
-                            setState(() {});
-                            return;
-                          }
-                        }
-                        _syncSingleImdbSectionState(
-                          HomeSectionType.imdbMostPopularTvShows,
-                          isEnabled,
-                        );
-                      },
-                    ),
-                    SwitchPreferenceTile(
-                      preference: UserPreferences.imdbLowestRatedMoviesEnabled,
-                      title: _stripImdb(l10n.imdbLowestRatedMovies),
-                      icon: Icons.trending_down,
-                      enabled: !_isFetching,
-                      onChangedValue: (isEnabled) async {
-                        if (_isFetching) return;
-                        if (isEnabled) {
-                          final success = await _fetchAndCacheList(
-                            HomeSectionType.imdbLowestRatedMovies,
-                            l10n.imdbLowestRatedMovies,
-                          );
-                          if (!success) {
-                            await prefs.set(UserPreferences.imdbLowestRatedMoviesEnabled, false);
-                            setState(() {});
-                            return;
-                          }
-                        }
-                        _syncSingleImdbSectionState(
-                          HomeSectionType.imdbLowestRatedMovies,
-                          isEnabled,
-                        );
-                      },
-                    ),
-                    SwitchPreferenceTile(
-                      preference: UserPreferences.imdbTopEnglishMoviesEnabled,
-                      title: _stripImdb(l10n.imdbTopEnglishMovies),
-                      icon: Icons.language,
-                      enabled: !_isFetching,
-                      onChangedValue: (isEnabled) async {
-                        if (_isFetching) return;
-                        if (isEnabled) {
-                          final success = await _fetchAndCacheList(
-                            HomeSectionType.imdbTopEnglishMovies,
-                            l10n.imdbTopEnglishMovies,
-                          );
-                          if (!success) {
-                            await prefs.set(UserPreferences.imdbTopEnglishMoviesEnabled, false);
-                            setState(() {});
-                            return;
-                          }
-                        }
-                        _syncSingleImdbSectionState(
-                          HomeSectionType.imdbTopEnglishMovies,
-                          isEnabled,
-                        );
-                      },
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
       ),
     );
   }
@@ -940,6 +696,11 @@ class _UpcomingCalendarsScreenState extends State<_UpcomingCalendarsScreen> {
 
     final radarrEnabled = prefs.get(UserPreferences.enableRadarrCalendar);
     final sonarrEnabled = prefs.get(UserPreferences.enableSonarrCalendar);
+    final calendarsCanMerge = radarrEnabled && sonarrEnabled;
+
+    if (!calendarsCanMerge && prefs.get(UserPreferences.mergeRadarrSonarrCalendars)) {
+      prefs.set(UserPreferences.mergeRadarrSonarrCalendars, false);
+    }
 
     return withCleanSettingsTypography(
       context,
@@ -962,6 +723,7 @@ class _UpcomingCalendarsScreenState extends State<_UpcomingCalendarsScreen> {
                       preference: UserPreferences.mergeRadarrSonarrCalendars,
                       title: "Merge Sonarr and Radarr Calendars?",
                       icon: Icons.merge_type,
+                      enabled: calendarsCanMerge,
                       onChanged: () => setState(() {}),
                     ),
                   ],
@@ -1076,7 +838,24 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
   void initState() {
     super.initState();
     _seerrPrefs = GetIt.instance<SeerrPreferences>();
-    _rows = List.of(_seerrPrefs.rowsConfig);
+    final prefs = GetIt.instance<UserPreferences>();
+    final configs = prefs.homeSectionsConfig;
+
+    _rows = SeerrRowConfig.defaults().map((defaultRow) {
+      final homeSectionType = _mapSeerrRowTypeToHomeSection(defaultRow.type);
+      if (homeSectionType != null) {
+        final config = configs.firstWhere(
+          (c) => c.type == homeSectionType,
+          orElse: () => HomeSectionConfig(
+            type: homeSectionType,
+            enabled: false,
+            order: configs.length,
+          ),
+        );
+        return defaultRow.copyWith(enabled: config.enabled);
+      }
+      return defaultRow.copyWith(enabled: false);
+    }).toList();
   }
 
   @override
@@ -1096,7 +875,6 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
   }
 
   void _saveRows() {
-    _seerrPrefs.setRowsConfig(_rows);
     final prefs = GetIt.instance<UserPreferences>();
     final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
     var changed = false;
@@ -1343,15 +1121,33 @@ class _CustomListsScreenState extends State<_CustomListsScreen> {
     }
   }
 
-  String _getTypeLabel(String type) {
+  String _getTypeLabel(String type, String source) {
     switch (type) {
       case 'user_list':
-        return 'User List';
+        if (source == 'tmdb') {
+          return 'List';
+        }
+        if (source == 'mdblist') {
+          return 'List from User ID';
+        }
+        return 'List from URL';
+      case 'list_url':
+        if (source == 'mdblist') {
+          return 'List from URL';
+        }
+        return 'List from URL';
+      case 'user_diary':
+        return source == 'letterboxd' ? 'User Diary' : 'Diary';
       case 'watchlist':
-        return 'Watchlist';
+        return source == 'letterboxd' ? 'User Watchlist' : 'Watchlist';
+      case 'films':
+        return source == 'letterboxd' ? 'User Complete Films' : 'Complete Films';
       case 'awards_events':
         return 'Awards/Events';
       case 'movie_collection':
+        if (source == 'tmdb') {
+          return 'Collection';
+        }
         return 'Movie Collection';
       default:
         return type;
@@ -1376,7 +1172,7 @@ class _CustomListsScreenState extends State<_CustomListsScreen> {
         child: Scaffold(
           appBar: buildSettingsAppBar(
             context,
-            const Text('Fully Custom Home Rows Wizard'),
+            const Text('Custom Home Rows Wizard'),
           ),
           body: FocusScope(
             node: _scope,
@@ -1389,7 +1185,7 @@ class _CustomListsScreenState extends State<_CustomListsScreen> {
                       focusNode: _addFocusNode,
                       leading: const Icon(Icons.add),
                       title: const Text('Add a New Custom Home Row'),
-                      subtitle: const Text('Create a custom row from IMDb, TMDB, Letterboxd, or MDBList.'),
+                      subtitle: const Text('Create a custom row from TMDB, Letterboxd, or MDBList.'),
                       onTap: () => _showAddEditDialog(null),
                     ),
                   ],
@@ -1450,7 +1246,7 @@ class _CustomListsScreenState extends State<_CustomListsScreen> {
                               ],
                             ),
                             subtitle: Text(
-                              'Source: ${_getSourceLabel(source)} | Type: ${_getTypeLabel(type)}',
+                              'Source: ${_getSourceLabel(source)} | Type: ${_getTypeLabel(type, source)}',
                               style: TextStyle(
                                 fontSize: 12,
                                 color: focused ? Colors.black54 : AppColorScheme.onSurface.withValues(alpha: 0.5),
@@ -1533,15 +1329,26 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
       }
 
       if (_source == 'letterboxd') {
-        _letterboxdUsernameController.text = params['user'] as String? ?? '';
         if (_type == 'user_list') {
-          _letterboxdListNameController.text = params['name'] as String? ?? '';
+          _letterboxdListNameController.text = params['url'] as String? ?? '';
+        } else {
+          _letterboxdUsernameController.text = params['user'] as String? ?? '';
         }
       } else if (_source == 'tmdb') {
         _tmdbIdController.text = params['id'] as String? ?? '';
       } else if (_source == 'mdblist') {
         _mdblistUsernameController.text = params['username'] as String? ?? '';
-        _mdblistListNameController.text = params['listname'] as String? ?? '';
+        if (_type == 'list_url') {
+          final user = params['username'] as String? ?? '';
+          final list = params['listname'] as String? ?? '';
+          if (user.isNotEmpty && list.isNotEmpty) {
+            _mdblistListNameController.text = 'https://mdblist.com/lists/$user/$list';
+          } else {
+            _mdblistListNameController.text = '';
+          }
+        } else {
+          _mdblistListNameController.text = params['listname'] as String? ?? '';
+        }
       }
     } else {
       _source = 'tmdb';
@@ -1577,9 +1384,9 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
       case 'tmdb':
         return ['user_list', 'movie_collection'];
       case 'letterboxd':
-        return ['user_list', 'watchlist', 'films'];
+        return ['user_list', 'user_diary', 'watchlist', 'films'];
       case 'mdblist':
-        return ['user_list'];
+        return ['list_url', 'user_list'];
       default:
         return ['user_list'];
     }
@@ -1588,14 +1395,30 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
   String _getTypeLabel(String type) {
     switch (type) {
       case 'user_list':
-        return 'User List';
+        if (_source == 'tmdb') {
+          return 'List from TMDB List ID or URL';
+        }
+        if (_source == 'mdblist') {
+          return 'List from User ID';
+        }
+        return 'List from URL';
+      case 'list_url':
+        if (_source == 'mdblist') {
+          return 'List from URL';
+        }
+        return 'List from URL';
+      case 'user_diary':
+        return 'Diary';
       case 'watchlist':
         return 'Watchlist';
       case 'films':
-        return 'Films List';
+        return 'Complete Films';
       case 'awards_events':
         return 'Awards/Events';
       case 'movie_collection':
+        if (_source == 'tmdb') {
+          return 'Collection from TMDB Collection ID or URL';
+        }
         return 'Movie Collection';
       default:
         return type;
@@ -1658,15 +1481,42 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
 
     final params = <String, dynamic>{};
     if (_source == 'letterboxd') {
-      params['user'] = _letterboxdUsernameController.text.trim();
       if (_type == 'user_list') {
-        params['name'] = _letterboxdListNameController.text.trim();
+        params['url'] = _letterboxdListNameController.text.trim();
+      } else {
+        params['user'] = _letterboxdUsernameController.text.trim().toLowerCase();
       }
     } else if (_source == 'tmdb') {
-      params['id'] = _tmdbIdController.text.trim();
+      var rawId = _tmdbIdController.text.trim();
+      if (rawId.contains('/') || rawId.startsWith('http')) {
+        if (rawId.endsWith('/')) {
+          rawId = rawId.substring(0, rawId.length - 1);
+        }
+        final parts = rawId.split('/');
+        if (parts.isNotEmpty) {
+          rawId = parts.last;
+        }
+      }
+      params['id'] = rawId;
     } else if (_source == 'mdblist') {
-      params['username'] = _mdblistUsernameController.text.trim();
-      params['listname'] = _mdblistListNameController.text.trim();
+      if (_type == 'list_url') {
+        var rawUrl = _mdblistListNameController.text.trim();
+        if (rawUrl.endsWith('/')) {
+          rawUrl = rawUrl.substring(0, rawUrl.length - 1);
+        }
+        final parts = rawUrl.split('/');
+        String parsedUser = '';
+        String parsedList = '';
+        if (parts.length >= 2) {
+          parsedList = parts.last;
+          parsedUser = parts[parts.length - 2];
+        }
+        params['username'] = parsedUser;
+        params['listname'] = parsedList;
+      } else {
+        params['username'] = _mdblistUsernameController.text.trim();
+        params['listname'] = _mdblistListNameController.text.trim();
+      }
     }
 
     final additionalData = jsonEncode({
@@ -1799,20 +1649,13 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
 
     return withCleanSettingsTypography(
       context,
-      Focus(
-        onKeyEvent: (node, event) {
-          if (event.logicalKey == LogicalKeyboardKey.backspace) {
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
+      PopScope(
+        canPop: _allowPop,
+        onPopInvokedWithResult: (didPop, _) {
+          if (didPop) return;
+          _maybeExit();
         },
-        child: PopScope(
-          canPop: _allowPop,
-          onPopInvokedWithResult: (didPop, _) {
-            if (didPop) return;
-            _maybeExit();
-          },
-          child: AlertDialog(
+        child: AlertDialog(
             backgroundColor: Colors.grey[900],
             title: Text(
               widget.existing != null ? 'Edit Custom Home Row' : 'Add Custom Home Row',
@@ -1857,52 +1700,52 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                       },
                     ),
                   ),
-                  const SizedBox(height: 16),
-                  const Text('Type', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                  const SizedBox(height: 4),
-                  Theme(
-                    data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
-                    child: DropdownButtonFormField<String>(
-                      value: _type,
-                      dropdownColor: Colors.grey[900],
-                      style: const TextStyle(color: Colors.white, fontSize: 14),
-                      decoration: InputDecoration(
-                        filled: true,
-                        fillColor: Colors.black26,
-                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                    const SizedBox(height: 16),
+                    const Text('Type', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    Theme(
+                      data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
+                      child: DropdownButtonFormField<String>(
+                        value: _type,
+                        dropdownColor: Colors.grey[900],
+                        style: const TextStyle(color: Colors.white, fontSize: 14),
+                        decoration: InputDecoration(
+                          filled: true,
+                          fillColor: Colors.black26,
+                          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                        ),
+                        items: typeOptions.map((t) {
+                          return DropdownMenuItem(value: t, child: Text(_getTypeLabel(t)));
+                        }).toList(),
+                        onChanged: (val) {
+                          if (val != null) {
+                            setState(() {
+                              _type = val;
+                            });
+                          }
+                        },
                       ),
-                      items: typeOptions.map((t) {
-                        return DropdownMenuItem(value: t, child: Text(_getTypeLabel(t)));
-                      }).toList(),
-                      onChanged: (val) {
-                        if (val != null) {
-                          setState(() {
-                            _type = val;
-                          });
-                        }
-                      },
                     ),
-                  ),
                   const SizedBox(height: 16),
 
                   // Source + Type specific parameters
 
                   if (_source == 'letterboxd') ...[
-                    const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _letterboxdUsernameController,
-                      hint: 'Username',
-                      focusNode: _letterboxdUsernameFocusNode,
-                    ),
                     if (_type == 'user_list') ...[
-                      const SizedBox(height: 16),
-                      const Text('List Name (slug in URL)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      const Text('Letterboxd List URL or Path', style: TextStyle(color: Colors.grey, fontSize: 12)),
                       const SizedBox(height: 4),
                       _SettingsTextField(
                         controller: _letterboxdListNameController,
-                        hint: 'list-name-slug',
+                        hint: 'https://letterboxd.com/official/list/letterboxds-top-500-films/',
                         focusNode: _letterboxdListNameFocusNode,
+                      ),
+                    ] else ...[
+                      const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      const SizedBox(height: 4),
+                      _SettingsTextField(
+                        controller: _letterboxdUsernameController,
+                        hint: 'Username',
+                        focusNode: _letterboxdUsernameFocusNode,
                       ),
                     ],
                     if (tmdbApiKey.isEmpty) ...[
@@ -1915,11 +1758,13 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                   ],
 
                   if (_source == 'tmdb') ...[
-                    Text(_type == 'movie_collection' ? 'TMDB Collection ID' : 'TMDB List ID', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+                    Text(_type == 'movie_collection' ? 'TMDB Collection ID or URL' : 'TMDB List ID or URL', style: const TextStyle(color: Colors.grey, fontSize: 12)),
                     const SizedBox(height: 4),
                     _SettingsTextField(
                       controller: _tmdbIdController,
-                      hint: 'e.g. 12345',
+                      hint: _type == 'movie_collection'
+                          ? '12345 OR https://www.themoviedb.org/collection/12345'
+                          : '12345 OR https://www.themoviedb.org/list/12345',
                       focusNode: _tmdbIdFocusNode,
                     ),
                     if (tmdbApiKey.isEmpty) ...[
@@ -1932,21 +1777,31 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                   ],
 
                   if (_source == 'mdblist') ...[
-                    const Text('MDBList Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _mdblistUsernameController,
-                      hint: 'Username',
-                      focusNode: _mdblistUsernameFocusNode,
-                    ),
-                    const SizedBox(height: 16),
-                    const Text('List Name (slug)', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _mdblistListNameController,
-                      hint: 'list-name-slug',
-                      focusNode: _mdblistListNameFocusNode,
-                    ),
+                    if (_type == 'list_url') ...[
+                      const Text('MDBList URL', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      const SizedBox(height: 4),
+                      _SettingsTextField(
+                        controller: _mdblistListNameController,
+                        hint: 'e.g. https://mdblist.com/lists/username/list-slug',
+                        focusNode: _mdblistListNameFocusNode,
+                      ),
+                    ] else ...[
+                      const Text('MDBList Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      const SizedBox(height: 4),
+                      _SettingsTextField(
+                        controller: _mdblistUsernameController,
+                        hint: 'Username',
+                        focusNode: _mdblistUsernameFocusNode,
+                      ),
+                      const SizedBox(height: 16),
+                      const Text('List Name (slug)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      const SizedBox(height: 4),
+                      _SettingsTextField(
+                        controller: _mdblistListNameController,
+                        hint: 'list-name-slug',
+                        focusNode: _mdblistListNameFocusNode,
+                      ),
+                    ],
                     if (mdblistApiKey.isEmpty) ...[
                       const SizedBox(height: 12),
                       const Text(
@@ -2040,8 +1895,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                   ],
 
                   (() {
-                    final isUserRatingRelevant = (_source == 'letterboxd' && (_type == 'user_list' || _type == 'films')) ||
-                        (_source == 'imdb' && _type == 'user_list');
+                    final isUserRatingRelevant = (_source == 'letterboxd' && _type == 'user_diary');
                     if (isUserRatingRelevant) {
                       return Column(
                         mainAxisSize: MainAxisSize.min,
@@ -2081,7 +1935,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
           ),
         ),
       ),
-        actions: _isValidating
+      actions: _isValidating
             ? [
                 const Padding(
                   padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -2103,10 +1957,9 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                 ),
               ],
       ),
-        ),
-      ),
-    );
-  }
+    ),
+  );
+}
 }
 
 class _SettingsTextField extends StatefulWidget {

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1137,11 +1137,11 @@ class _CustomListsScreenState extends State<_CustomListsScreen> {
         }
         return 'List from URL';
       case 'user_diary':
-        return source == 'letterboxd' ? 'User Diary' : 'Diary';
+        return 'Diary';
       case 'watchlist':
-        return source == 'letterboxd' ? 'User Watchlist' : 'Watchlist';
+        return 'Watchlist';
       case 'films':
-        return source == 'letterboxd' ? 'User Complete Films' : 'Complete Films';
+        return 'Complete Films';
       case 'awards_events':
         return 'Awards/Events';
       case 'movie_collection':
@@ -1291,14 +1291,12 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
 
   final _nameController = TextEditingController();
   final _letterboxdUsernameController = TextEditingController();
-  final _letterboxdListNameController = TextEditingController();
   final _tmdbIdController = TextEditingController();
   final _mdblistUsernameController = TextEditingController();
   final _mdblistListNameController = TextEditingController();
 
   final _nameFocusNode = FocusNode(debugLabel: 'custom_row_name_field');
   final _letterboxdUsernameFocusNode = FocusNode(debugLabel: 'letterboxd_user_field');
-  final _letterboxdListNameFocusNode = FocusNode(debugLabel: 'letterboxd_list_field');
   final _tmdbIdFocusNode = FocusNode(debugLabel: 'tmdb_id_field');
   final _mdblistUsernameFocusNode = FocusNode(debugLabel: 'mdblist_user_field');
   final _mdblistListNameFocusNode = FocusNode(debugLabel: 'mdblist_list_field');
@@ -1329,11 +1327,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
       }
 
       if (_source == 'letterboxd') {
-        if (_type == 'user_list') {
-          _letterboxdListNameController.text = params['url'] as String? ?? '';
-        } else {
-          _letterboxdUsernameController.text = params['user'] as String? ?? '';
-        }
+        _letterboxdUsernameController.text = params['user'] as String? ?? '';
       } else if (_source == 'tmdb') {
         _tmdbIdController.text = params['id'] as String? ?? '';
       } else if (_source == 'mdblist') {
@@ -1362,14 +1356,12 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
   void dispose() {
     _nameController.dispose();
     _letterboxdUsernameController.dispose();
-    _letterboxdListNameController.dispose();
     _tmdbIdController.dispose();
     _mdblistUsernameController.dispose();
     _mdblistListNameController.dispose();
 
     _nameFocusNode.dispose();
     _letterboxdUsernameFocusNode.dispose();
-    _letterboxdListNameFocusNode.dispose();
     _tmdbIdFocusNode.dispose();
     _mdblistUsernameFocusNode.dispose();
     _mdblistListNameFocusNode.dispose();
@@ -1384,7 +1376,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
       case 'tmdb':
         return ['user_list', 'movie_collection'];
       case 'letterboxd':
-        return ['user_list', 'user_diary', 'watchlist', 'films'];
+        return ['user_diary'];
       case 'mdblist':
         return ['list_url', 'user_list'];
       default:
@@ -1481,11 +1473,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
 
     final params = <String, dynamic>{};
     if (_source == 'letterboxd') {
-      if (_type == 'user_list') {
-        params['url'] = _letterboxdListNameController.text.trim();
-      } else {
-        params['user'] = _letterboxdUsernameController.text.trim().toLowerCase();
-      }
+      params['user'] = _letterboxdUsernameController.text.trim().toLowerCase();
     } else if (_source == 'tmdb') {
       var rawId = _tmdbIdController.text.trim();
       if (rawId.contains('/') || rawId.startsWith('http')) {
@@ -1700,54 +1688,46 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                       },
                     ),
                   ),
-                    const SizedBox(height: 16),
-                    const Text('Type', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    Theme(
-                      data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
-                      child: DropdownButtonFormField<String>(
-                        value: _type,
-                        dropdownColor: Colors.grey[900],
-                        style: const TextStyle(color: Colors.white, fontSize: 14),
-                        decoration: InputDecoration(
-                          filled: true,
-                          fillColor: Colors.black26,
-                          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                    if (typeOptions.length > 1) ...[
+                      const SizedBox(height: 16),
+                      const Text('Type', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      const SizedBox(height: 4),
+                      Theme(
+                        data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
+                        child: DropdownButtonFormField<String>(
+                          value: _type,
+                          dropdownColor: Colors.grey[900],
+                          style: const TextStyle(color: Colors.white, fontSize: 14),
+                          decoration: InputDecoration(
+                            filled: true,
+                            fillColor: Colors.black26,
+                            border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                          ),
+                          items: typeOptions.map((t) {
+                            return DropdownMenuItem(value: t, child: Text(_getTypeLabel(t)));
+                          }).toList(),
+                          onChanged: (val) {
+                            if (val != null) {
+                              setState(() {
+                                _type = val;
+                              });
+                            }
+                          },
                         ),
-                        items: typeOptions.map((t) {
-                          return DropdownMenuItem(value: t, child: Text(_getTypeLabel(t)));
-                        }).toList(),
-                        onChanged: (val) {
-                          if (val != null) {
-                            setState(() {
-                              _type = val;
-                            });
-                          }
-                        },
                       ),
-                    ),
+                    ],
                   const SizedBox(height: 16),
 
                   // Source + Type specific parameters
 
                   if (_source == 'letterboxd') ...[
-                    if (_type == 'user_list') ...[
-                      const Text('Letterboxd List URL or Path', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                      const SizedBox(height: 4),
-                      _SettingsTextField(
-                        controller: _letterboxdListNameController,
-                        hint: 'https://letterboxd.com/official/list/letterboxds-top-500-films/',
-                        focusNode: _letterboxdListNameFocusNode,
-                      ),
-                    ] else ...[
-                      const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                      const SizedBox(height: 4),
-                      _SettingsTextField(
-                        controller: _letterboxdUsernameController,
-                        hint: 'Username',
-                        focusNode: _letterboxdUsernameFocusNode,
-                      ),
-                    ],
+                    const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _letterboxdUsernameController,
+                      hint: 'Username',
+                      focusNode: _letterboxdUsernameFocusNode,
+                    ),
                     if (tmdbApiKey.isEmpty) ...[
                       const SizedBox(height: 12),
                       const Text(
@@ -1895,7 +1875,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                   ],
 
                   (() {
-                    final isUserRatingRelevant = (_source == 'letterboxd' && _type == 'user_diary');
+                    final isUserRatingRelevant = _source == 'letterboxd';
                     if (isUserRatingRelevant) {
                       return Column(
                         mainAxisSize: MainAxisSize.min,

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -106,58 +106,7 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
     try {
       final futures = <Future<void>>[];
 
-      // 1. IMDb Enabled Charts
-      final imdbService = GetIt.instance<ImdbExternalListsService>();
-      final imdbChecks = {
-        UserPreferences.imdbTop250MoviesEnabled: HomeSectionType.imdbTop250Movies,
-        UserPreferences.imdbTop250TvShowsEnabled: HomeSectionType.imdbTop250TvShows,
-        UserPreferences.imdbMostPopularMoviesEnabled: HomeSectionType.imdbMostPopularMovies,
-        UserPreferences.imdbMostPopularTvShowsEnabled: HomeSectionType.imdbMostPopularTvShows,
-        UserPreferences.imdbLowestRatedMoviesEnabled: HomeSectionType.imdbLowestRatedMovies,
-        UserPreferences.imdbTopEnglishMoviesEnabled: HomeSectionType.imdbTopEnglishMovies,
-      };
-      for (final entry in imdbChecks.entries) {
-        if (prefs.get(entry.key)) {
-          futures.add(() async {
-            try {
-              final items = await imdbService.fetchChart(entry.value, limit: 250);
-              if (items.isNotEmpty) {
-                await imdbService.saveChartToCache(entry.value, items);
-              }
-            } catch (e) {
-              debugPrint('[RefreshAll] Failed to refresh IMDb ${entry.value}: $e');
-            }
-          }());
-        }
-      }
-
-      // 2. TMDB Enabled Charts
-      final tmdbService = GetIt.instance<TmdbExternalListsService>();
-      final tmdbChecks = {
-        UserPreferences.tmdbPopularMoviesEnabled: HomeSectionType.tmdbPopularMovies,
-        UserPreferences.tmdbTopRatedMoviesEnabled: HomeSectionType.tmdbTopRatedMovies,
-        UserPreferences.tmdbNowPlayingMoviesEnabled: HomeSectionType.tmdbNowPlayingMovies,
-        UserPreferences.tmdbUpcomingMoviesEnabled: HomeSectionType.tmdbUpcomingMovies,
-        UserPreferences.tmdbPopularTvEnabled: HomeSectionType.tmdbPopularTv,
-        UserPreferences.tmdbTopRatedTvEnabled: HomeSectionType.tmdbTopRatedTv,
-        UserPreferences.tmdbAiringTodayTvEnabled: HomeSectionType.tmdbAiringTodayTv,
-      };
-      for (final entry in tmdbChecks.entries) {
-        if (prefs.get(entry.key)) {
-          futures.add(() async {
-            try {
-              final items = await tmdbService.fetchChart(entry.value, limit: 250);
-              if (items.isNotEmpty) {
-                await tmdbService.saveChartToCache(entry.value, items);
-              }
-            } catch (e) {
-              debugPrint('[RefreshAll] Failed to refresh TMDB ${entry.value}: $e');
-            }
-          }());
-        }
-      }
-
-      // 3. Custom Enabled Rows
+      // Custom Enabled Rows
       final customService = GetIt.instance<CustomExternalListsService>();
       final configs = prefs.homeSectionsConfig;
       for (final config in configs) {
@@ -1545,10 +1494,6 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
   bool _allowPop = false;
 
   final _nameController = TextEditingController();
-  final _imdbListIdController = TextEditingController();
-  final _imdbEventIdController = TextEditingController();
-  final _imdbEventYearController = TextEditingController();
-  final _imdbSubcategoryController = TextEditingController();
   final _letterboxdUsernameController = TextEditingController();
   final _letterboxdListNameController = TextEditingController();
   final _tmdbIdController = TextEditingController();
@@ -1556,10 +1501,6 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
   final _mdblistListNameController = TextEditingController();
 
   final _nameFocusNode = FocusNode(debugLabel: 'custom_row_name_field');
-  final _imdbListIdFocusNode = FocusNode(debugLabel: 'imdb_list_id_field');
-  final _imdbEventIdFocusNode = FocusNode(debugLabel: 'imdb_event_id_field');
-  final _imdbEventYearFocusNode = FocusNode(debugLabel: 'imdb_event_year_field');
-  final _imdbSubcategoryFocusNode = FocusNode(debugLabel: 'imdb_subcat_field');
   final _letterboxdUsernameFocusNode = FocusNode(debugLabel: 'letterboxd_user_field');
   final _letterboxdListNameFocusNode = FocusNode(debugLabel: 'letterboxd_list_field');
   final _tmdbIdFocusNode = FocusNode(debugLabel: 'tmdb_id_field');
@@ -1579,20 +1520,19 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
       try {
         rowConfig = jsonDecode(widget.existing!.pluginAdditionalData ?? '{}') as Map<String, dynamic>;
       } catch (_) {}
-      _source = rowConfig['source'] as String? ?? 'imdb';
+      _source = rowConfig['source'] as String? ?? 'tmdb';
       _type = rowConfig['type'] as String? ?? 'user_list';
       _sortBy = rowConfig['sort_by'] as String? ?? 'none';
       _sortOrder = rowConfig['sort_order'] as String? ?? 'desc';
       _showUserRatings = rowConfig['show_user_ratings'] as bool? ?? false;
       final params = rowConfig['params'] as Map<String, dynamic>? ?? {};
 
-      if (_source == 'imdb' && _type == 'user_list') {
-        _imdbListIdController.text = params['listid'] as String? ?? '';
-      } else if (_source == 'imdb' && _type == 'awards_events') {
-        _imdbEventIdController.text = params['eventid'] as String? ?? '';
-        _imdbEventYearController.text = params['year'] as String? ?? '';
-        _imdbSubcategoryController.text = params['subcategory'] as String? ?? '';
-      } else if (_source == 'letterboxd') {
+      if (_source == 'imdb') {
+        _source = 'tmdb';
+        _type = 'user_list';
+      }
+
+      if (_source == 'letterboxd') {
         _letterboxdUsernameController.text = params['user'] as String? ?? '';
         if (_type == 'user_list') {
           _letterboxdListNameController.text = params['name'] as String? ?? '';
@@ -1604,7 +1544,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
         _mdblistListNameController.text = params['listname'] as String? ?? '';
       }
     } else {
-      _source = 'imdb';
+      _source = 'tmdb';
       _type = 'user_list';
       _sortBy = 'none';
       _sortOrder = 'desc';
@@ -1614,10 +1554,6 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
   @override
   void dispose() {
     _nameController.dispose();
-    _imdbListIdController.dispose();
-    _imdbEventIdController.dispose();
-    _imdbEventYearController.dispose();
-    _imdbSubcategoryController.dispose();
     _letterboxdUsernameController.dispose();
     _letterboxdListNameController.dispose();
     _tmdbIdController.dispose();
@@ -1625,10 +1561,6 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
     _mdblistListNameController.dispose();
 
     _nameFocusNode.dispose();
-    _imdbListIdFocusNode.dispose();
-    _imdbEventIdFocusNode.dispose();
-    _imdbEventYearFocusNode.dispose();
-    _imdbSubcategoryFocusNode.dispose();
     _letterboxdUsernameFocusNode.dispose();
     _letterboxdListNameFocusNode.dispose();
     _tmdbIdFocusNode.dispose();
@@ -1642,8 +1574,6 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
 
   List<String> _getTypesForSource(String source) {
     switch (source) {
-      case 'imdb':
-        return ['user_list', 'awards_events'];
       case 'tmdb':
         return ['user_list', 'movie_collection'];
       case 'letterboxd':
@@ -1727,15 +1657,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
     if (name.isEmpty) return;
 
     final params = <String, dynamic>{};
-    if (_source == 'imdb' && _type == 'user_list') {
-      params['listid'] = _imdbListIdController.text.trim();
-    } else if (_source == 'imdb' && _type == 'awards_events') {
-      params['eventid'] = _imdbEventIdController.text.trim();
-      params['year'] = _imdbEventYearController.text.trim();
-      if (_imdbSubcategoryController.text.trim().isNotEmpty) {
-        params['subcategory'] = _imdbSubcategoryController.text.trim();
-      }
-    } else if (_source == 'letterboxd') {
+    if (_source == 'letterboxd') {
       params['user'] = _letterboxdUsernameController.text.trim();
       if (_type == 'user_list') {
         params['name'] = _letterboxdListNameController.text.trim();
@@ -1921,7 +1843,6 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                         border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
                       ),
                       items: const [
-                        DropdownMenuItem(value: 'imdb', child: Text('IMDb')),
                         DropdownMenuItem(value: 'tmdb', child: Text('TMDB')),
                         DropdownMenuItem(value: 'letterboxd', child: Text('Letterboxd')),
                         DropdownMenuItem(value: 'mdblist', child: Text('MDBList')),
@@ -1965,41 +1886,6 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                   const SizedBox(height: 16),
 
                   // Source + Type specific parameters
-                  if (_source == 'imdb' && _type == 'user_list') ...[
-                    const Text('IMDb List ID (e.g. ls123456789)', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _imdbListIdController,
-                      hint: 'lsXXXXXXXXX',
-                      focusNode: _imdbListIdFocusNode,
-                    ),
-                  ],
-
-                  if (_source == 'imdb' && _type == 'awards_events') ...[
-                    const Text('IMDb Event ID (e.g. ev0000003)', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _imdbEventIdController,
-                      hint: 'evXXXXXXXX',
-                      focusNode: _imdbEventIdFocusNode,
-                    ),
-                    const SizedBox(height: 16),
-                    const Text('Event Year', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _imdbEventYearController,
-                      hint: 'e.g. 2024',
-                      focusNode: _imdbEventYearFocusNode,
-                    ),
-                    const SizedBox(height: 16),
-                    const Text('Subcategory/Fragment (optional, e.g. oscar_best_sound)', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _imdbSubcategoryController,
-                      hint: 'e.g. oscar_best_sound',
-                      focusNode: _imdbSubcategoryFocusNode,
-                    ),
-                  ],
 
                   if (_source == 'letterboxd') ...[
                     const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -15,6 +15,12 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
   final _imdbListsFocusNode = FocusNode(
     debugLabel: 'imdb_lists_button',
   );
+  final _homeSectionsFocusNode = FocusNode(
+    debugLabel: 'home_sections_shortcut_button',
+  );
+  final _refreshFocusNode = FocusNode(
+    debugLabel: 'refresh_lists_button',
+  );
 
   bool _radarrInstalled = false;
   bool _sonarrInstalled = false;
@@ -51,7 +57,156 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
   void dispose() {
     _imdbScope.dispose();
     _imdbListsFocusNode.dispose();
+    _homeSectionsFocusNode.dispose();
+    _refreshFocusNode.dispose();
     super.dispose();
+  }
+
+  Future<void> _refreshAllEnabledLists() async {
+    final prefs = GetIt.instance<UserPreferences>();
+    
+    bool dialogDismissed = false;
+    unawaited(
+      showFocusRestoringDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (ctx) {
+          return withCleanSettingsTypography(
+            ctx,
+            PopScope(
+              canPop: false,
+              child: const AlertDialog(
+                title: Text('Refreshing Lists'),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(height: 8),
+                    SizedBox(
+                      width: 50,
+                      height: 50,
+                      child: CircularProgressIndicator(),
+                    ),
+                    SizedBox(height: 24),
+                    Text(
+                      'Refreshing all enabled external lists and updating caches...',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(fontSize: 12, color: Colors.grey),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ).then((_) {
+        dialogDismissed = true;
+      }),
+    );
+
+    try {
+      final futures = <Future<void>>[];
+
+      // 1. IMDb Enabled Charts
+      final imdbService = GetIt.instance<ImdbExternalListsService>();
+      final imdbChecks = {
+        UserPreferences.imdbTop250MoviesEnabled: HomeSectionType.imdbTop250Movies,
+        UserPreferences.imdbTop250TvShowsEnabled: HomeSectionType.imdbTop250TvShows,
+        UserPreferences.imdbMostPopularMoviesEnabled: HomeSectionType.imdbMostPopularMovies,
+        UserPreferences.imdbMostPopularTvShowsEnabled: HomeSectionType.imdbMostPopularTvShows,
+        UserPreferences.imdbLowestRatedMoviesEnabled: HomeSectionType.imdbLowestRatedMovies,
+        UserPreferences.imdbTopEnglishMoviesEnabled: HomeSectionType.imdbTopEnglishMovies,
+      };
+      for (final entry in imdbChecks.entries) {
+        if (prefs.get(entry.key)) {
+          futures.add(() async {
+            try {
+              final items = await imdbService.fetchChart(entry.value, limit: 250);
+              if (items.isNotEmpty) {
+                await imdbService.saveChartToCache(entry.value, items);
+              }
+            } catch (e) {
+              debugPrint('[RefreshAll] Failed to refresh IMDb ${entry.value}: $e');
+            }
+          }());
+        }
+      }
+
+      // 2. TMDB Enabled Charts
+      final tmdbService = GetIt.instance<TmdbExternalListsService>();
+      final tmdbChecks = {
+        UserPreferences.tmdbPopularMoviesEnabled: HomeSectionType.tmdbPopularMovies,
+        UserPreferences.tmdbTopRatedMoviesEnabled: HomeSectionType.tmdbTopRatedMovies,
+        UserPreferences.tmdbNowPlayingMoviesEnabled: HomeSectionType.tmdbNowPlayingMovies,
+        UserPreferences.tmdbUpcomingMoviesEnabled: HomeSectionType.tmdbUpcomingMovies,
+        UserPreferences.tmdbPopularTvEnabled: HomeSectionType.tmdbPopularTv,
+        UserPreferences.tmdbTopRatedTvEnabled: HomeSectionType.tmdbTopRatedTv,
+        UserPreferences.tmdbAiringTodayTvEnabled: HomeSectionType.tmdbAiringTodayTv,
+      };
+      for (final entry in tmdbChecks.entries) {
+        if (prefs.get(entry.key)) {
+          futures.add(() async {
+            try {
+              final items = await tmdbService.fetchChart(entry.value, limit: 250);
+              if (items.isNotEmpty) {
+                await tmdbService.saveChartToCache(entry.value, items);
+              }
+            } catch (e) {
+              debugPrint('[RefreshAll] Failed to refresh TMDB ${entry.value}: $e');
+            }
+          }());
+        }
+      }
+
+      // 3. Custom Enabled Rows
+      final customService = GetIt.instance<CustomExternalListsService>();
+      final configs = prefs.homeSectionsConfig;
+      for (final config in configs) {
+        if (config.pluginSource == HomeSectionPluginSource.custom && config.enabled) {
+          futures.add(() async {
+            try {
+              final items = await customService.fetchCustomRow(config);
+              if (items.isNotEmpty) {
+                await customService.saveCustomRowToCache(config, items);
+              }
+            } catch (e) {
+              debugPrint('[RefreshAll] Failed to refresh custom row ${config.pluginSection}: $e');
+            }
+          }());
+        }
+      }
+
+      if (futures.isNotEmpty) {
+        await Future.wait(futures);
+      }
+
+      await prefs.set(
+        UserPreferences.lastExternalRowsRefreshTime,
+        DateTime.now().millisecondsSinceEpoch,
+      );
+
+      if (GetIt.instance.isRegistered<HomeViewModel>()) {
+        GetIt.instance<HomeViewModel>().load(preserveExisting: true);
+      }
+
+      if (mounted && !dialogDismissed) {
+        Navigator.of(context, rootNavigator: true).pop();
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Successfully refreshed all enabled lists.')),
+        );
+      }
+    } catch (e) {
+      if (mounted && !dialogDismissed) {
+        Navigator.of(context, rootNavigator: true).pop();
+      }
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to refresh lists: $e')),
+        );
+      }
+    }
   }
 
   @override
@@ -66,7 +221,7 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
           final showUpcomingCalendars = !_checkingServices && (_radarrInstalled || _sonarrInstalled);
 
           return RequestInitialFocus(
-            targetNode: PlatformDetection.isTV ? _imdbListsFocusNode : null,
+            targetNode: PlatformDetection.isTV ? _homeSectionsFocusNode : null,
             child: Scaffold(
               appBar: buildSettingsAppBar(
                 context,
@@ -77,44 +232,78 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
                 autofocus: true,
                 child: ListView(
                   children: [
-                    _TvSettingsListTile(
-                      focusNode: _imdbListsFocusNode,
-                      leading: const Icon(Icons.movie_outlined),
-                      title: const Text('IMDb Lists'),
-                      subtitle: const Text('Configure IMDb Top 250, Popular, and other charts.'),
-                      onTap: () => context.pushSettingsScreen(const _ImdbListsScreen()),
-                    ),
-                    _TvSettingsListTile(
-                      leading: const Icon(Icons.trending_up),
-                      title: const Text('TMDB Lists'),
-                      subtitle: Text(
-                        tmdbAvailable
-                            ? 'Configure Popular, Top Rated, and Trending TMDB lists.'
-                            : 'TMDB API key must be configured in Moonbase settings to use this feature.',
-                      ),
-                      onTap: tmdbAvailable
-                          ? () => context.pushSettingsScreen(const _TmdbListsScreen())
-                          : null,
-                    ),
-                    if (showUpcomingCalendars)
-                      _TvSettingsListTile(
-                        leading: const Icon(Icons.calendar_month),
-                        title: const Text('Upcoming Calendars'),
-                        subtitle: const Text('Toggle Upcoming Calendars from Radarr/Sonarr.'),
-                        onTap: () => context.pushSettingsScreen(const _UpcomingCalendarsScreen()),
-                      ),
-                    if (syncService.seerrAvailable)
-                      _TvSettingsListTile(
-                        leading: Image.asset(
-                          'assets/icons/seerr.png',
-                          width: 24,
-                          height: 24,
+                    const _SectionHeader('Home Row Maintenance'),
+                    adaptiveListSection(
+                      children: [
+                        _TvSettingsListTile(
+                          focusNode: _homeSectionsFocusNode,
+                          leading: const Icon(Icons.list),
+                          title: Text(l10n.homeSections),
+                          subtitle: Text(l10n.reorderToggleHomeRows),
+                          onTap: () => context.pushSettingsScreen(
+                            const HomeSectionsScreen(showGeneralOptions: false),
+                          ),
                         ),
-                        title: const Text('Seerr Lists'),
-                        subtitle: const Text('Configure Seerr Discovery Rows'),
-                        onTap: () =>
-                            context.pushSettingsScreen(const _SeerrListsScreen()),
-                      ),
+                        _TvSettingsListTile(
+                          focusNode: _refreshFocusNode,
+                          leading: const Icon(Icons.refresh),
+                          title: const Text('Refresh All Enabled Lists'),
+                          subtitle: const Text('Force a full update of TMDB and fully custom lists cache.'),
+                          onTap: _refreshAllEnabledLists,
+                        ),
+                      ],
+                    ),
+                    const _SectionHeader('External Home Row Configurations'),
+                    adaptiveListSection(
+                      children: [
+                        _TvSettingsListTile(
+                          focusNode: _imdbListsFocusNode,
+                          leading: const Icon(Icons.movie_outlined),
+                          title: const Text('IMDb Lists'),
+                          subtitle: const Text('Configure IMDb Top 250, Popular, and other charts.'),
+                          onTap: () => context.pushSettingsScreen(const _ImdbListsScreen()),
+                        ),
+                        _TvSettingsListTile(
+                          leading: const Icon(Icons.trending_up),
+                          title: const Text('TMDB Lists'),
+                          subtitle: Text(
+                            tmdbAvailable
+                                ? 'Configure Popular, Top Rated, and Trending TMDB lists.'
+                                : 'TMDB API key must be configured in Moonbase settings to use this feature.',
+                          ),
+                          onTap: tmdbAvailable
+                              ? () => context.pushSettingsScreen(const _TmdbListsScreen())
+                              : null,
+                        ),
+                        if (showUpcomingCalendars)
+                          _TvSettingsListTile(
+                            leading: const Icon(Icons.calendar_month),
+                            title: const Text('Upcoming Calendars'),
+                            subtitle: const Text('Toggle Upcoming Calendars from Radarr/Sonarr.'),
+                            onTap: () => context.pushSettingsScreen(const _UpcomingCalendarsScreen()),
+                          ),
+                        if (syncService.seerrAvailable)
+                          _TvSettingsListTile(
+                            leading: Image.asset(
+                              'assets/icons/seerr.png',
+                              width: 24,
+                              height: 24,
+                            ),
+                            title: const Text('Seerr Lists'),
+                            subtitle: const Text('Configure Seerr Discovery Rows.'),
+                            onTap: () =>
+                                context.pushSettingsScreen(const _SeerrListsScreen()),
+                          ),
+                        _TvSettingsListTile(
+                          leading: const Icon(Icons.tune_outlined),
+                          title: const Text('Fully Custom Home Rows Wizard'),
+                          subtitle: const Text(
+                              'ADVANCED: Configure fully customized home rows from a variety of sources.'),
+                          onTap: () => context
+                              .pushSettingsScreen(const _CustomListsScreen()),
+                        ),
+                      ],
+                    ),
                   ],
                 ),
               ),
@@ -175,6 +364,13 @@ class _ImdbListsScreenState extends State<_ImdbListsScreen> {
     _pushPersonalizationSync();
   }
 
+  String _stripImdb(String title) {
+    if (title.startsWith('IMDb ')) {
+      return title.substring(5);
+    }
+    return title;
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -199,7 +395,7 @@ class _ImdbListsScreenState extends State<_ImdbListsScreen> {
                     SwitchPreferenceTile(
                       focusNode: _firstFocusNode,
                       preference: UserPreferences.imdbTop250MoviesEnabled,
-                      title: l10n.imdbTop250Movies,
+                      title: _stripImdb(l10n.imdbTop250Movies),
                       icon: Icons.movie_outlined,
                       enabled: !_isFetching,
                       onChangedValue: (isEnabled) async {
@@ -223,7 +419,7 @@ class _ImdbListsScreenState extends State<_ImdbListsScreen> {
                     ),
                     SwitchPreferenceTile(
                       preference: UserPreferences.imdbTop250TvShowsEnabled,
-                      title: l10n.imdbTop250TvShows,
+                      title: _stripImdb(l10n.imdbTop250TvShows),
                       icon: Icons.live_tv,
                       enabled: !_isFetching,
                       onChangedValue: (isEnabled) async {
@@ -247,7 +443,7 @@ class _ImdbListsScreenState extends State<_ImdbListsScreen> {
                     ),
                     SwitchPreferenceTile(
                       preference: UserPreferences.imdbMostPopularMoviesEnabled,
-                      title: l10n.imdbMostPopularMovies,
+                      title: _stripImdb(l10n.imdbMostPopularMovies),
                       icon: Icons.trending_up,
                       enabled: !_isFetching,
                       onChangedValue: (isEnabled) async {
@@ -271,7 +467,7 @@ class _ImdbListsScreenState extends State<_ImdbListsScreen> {
                     ),
                     SwitchPreferenceTile(
                       preference: UserPreferences.imdbMostPopularTvShowsEnabled,
-                      title: l10n.imdbMostPopularTvShows,
+                      title: _stripImdb(l10n.imdbMostPopularTvShows),
                       icon: Icons.live_tv,
                       enabled: !_isFetching,
                       onChangedValue: (isEnabled) async {
@@ -295,7 +491,7 @@ class _ImdbListsScreenState extends State<_ImdbListsScreen> {
                     ),
                     SwitchPreferenceTile(
                       preference: UserPreferences.imdbLowestRatedMoviesEnabled,
-                      title: l10n.imdbLowestRatedMovies,
+                      title: _stripImdb(l10n.imdbLowestRatedMovies),
                       icon: Icons.trending_down,
                       enabled: !_isFetching,
                       onChangedValue: (isEnabled) async {
@@ -319,7 +515,7 @@ class _ImdbListsScreenState extends State<_ImdbListsScreen> {
                     ),
                     SwitchPreferenceTile(
                       preference: UserPreferences.imdbTopEnglishMoviesEnabled,
-                      title: l10n.imdbTopEnglishMovies,
+                      title: _stripImdb(l10n.imdbTopEnglishMovies),
                       icon: Icons.language,
                       enabled: !_isFetching,
                       onChangedValue: (isEnabled) async {
@@ -952,8 +1148,49 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
 
   void _saveRows() {
     _seerrPrefs.setRowsConfig(_rows);
+    final prefs = GetIt.instance<UserPreferences>();
+    final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
+    var changed = false;
+    for (final row in _rows) {
+      final type = _mapSeerrRowTypeToHomeSection(row.type);
+      if (type != null) {
+        final idx = configs.indexWhere((c) => c.type == type);
+        if (idx >= 0) {
+          if (configs[idx].enabled != row.enabled) {
+            configs[idx] = configs[idx].copyWith(enabled: row.enabled);
+            changed = true;
+          }
+        } else {
+          configs.add(HomeSectionConfig(
+            type: type,
+            enabled: row.enabled,
+            order: configs.length,
+          ));
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      prefs.setHomeSectionsConfig(configs);
+    }
     _pushPersonalizationSync();
     if (mounted) setState(() {});
+  }
+
+  HomeSectionType? _mapSeerrRowTypeToHomeSection(SeerrRowType type) {
+    return switch (type) {
+      SeerrRowType.recentRequests => HomeSectionType.seerrRecentRequests,
+      SeerrRowType.recentlyAdded => HomeSectionType.seerrRecentlyAdded,
+      SeerrRowType.trending => HomeSectionType.seerrTrending,
+      SeerrRowType.popularMovies => HomeSectionType.seerrPopularMovies,
+      SeerrRowType.movieGenres => HomeSectionType.seerrMovieGenres,
+      SeerrRowType.upcomingMovies => HomeSectionType.seerrUpcomingMovies,
+      SeerrRowType.studios => HomeSectionType.seerrStudios,
+      SeerrRowType.popularSeries => HomeSectionType.seerrPopularSeries,
+      SeerrRowType.seriesGenres => HomeSectionType.seerrSeriesGenres,
+      SeerrRowType.upcomingSeries => HomeSectionType.seerrUpcomingSeries,
+      SeerrRowType.networks => HomeSectionType.seerrNetworks,
+    };
   }
 
   String _rowLabel(SeerrRowType type, AppLocalizations l10n) => switch (type) {
@@ -1059,3 +1296,989 @@ class _SeerrRowSwitchTile extends StatelessWidget {
     );
   }
 }
+
+class _CustomListsScreen extends StatefulWidget {
+  const _CustomListsScreen();
+
+  @override
+  State<_CustomListsScreen> createState() => _CustomListsScreenState();
+}
+
+class _CustomListsScreenState extends State<_CustomListsScreen> {
+  final _scope = FocusScopeNode(debugLabel: 'CustomListsScope');
+  final _addFocusNode = FocusNode(debugLabel: 'custom_add_button');
+  final _syncService = GetIt.instance<PluginSyncService>();
+
+  void _pushPersonalizationSync() {
+    final client = GetIt.instance.isRegistered<MediaServerClient>()
+        ? GetIt.instance<MediaServerClient>()
+        : null;
+    if (client != null) {
+      _syncService.pushSettings(client);
+    }
+  }
+
+  List<HomeSectionConfig> _getCustomConfigs() {
+    final prefs = GetIt.instance<UserPreferences>();
+    return prefs.homeSectionsConfig
+        .where((c) => c.isPluginDynamic && c.pluginSource == HomeSectionPluginSource.custom)
+        .toList();
+  }
+
+  void _toggleConfig(HomeSectionConfig config, bool enabled) async {
+    final prefs = GetIt.instance<UserPreferences>();
+    final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
+    final idx = configs.indexWhere((c) => c.stableId == config.stableId);
+    if (idx >= 0) {
+      configs[idx] = configs[idx].copyWith(enabled: enabled);
+      await prefs.setHomeSectionsConfig(configs);
+      _pushPersonalizationSync();
+      setState(() {});
+    }
+  }
+
+  void _deleteConfig(HomeSectionConfig config) async {
+    final confirmed = await showFocusRestoringDialog<bool>(
+      context: context,
+      builder: (ctx) => withCleanSettingsTypography(
+        ctx,
+        AlertDialog(
+          title: const Text('Delete Custom Row'),
+          content: Text('Are you sure you want to delete "${config.pluginDisplayText}"?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Delete', style: TextStyle(color: Colors.red)),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (confirmed == true) {
+      final prefs = GetIt.instance<UserPreferences>();
+      final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
+      configs.removeWhere((c) => c.stableId == config.stableId);
+      await prefs.setHomeSectionsConfig(configs);
+      _pushPersonalizationSync();
+      setState(() {});
+    }
+  }
+
+  void _showAddEditDialog(HomeSectionConfig? existing) async {
+    final saved = await showFocusRestoringDialog<bool>(
+      context: context,
+      builder: (ctx) => _AddEditCustomRowDialog(existing: existing),
+    );
+    if (saved == true) {
+      setState(() {});
+    }
+  }
+
+  String _getSourceLabel(String source) {
+    switch (source) {
+      case 'imdb':
+        return 'IMDb';
+      case 'tmdb':
+        return 'TMDB';
+      case 'letterboxd':
+        return 'Letterboxd';
+      case 'mdblist':
+        return 'MDBList';
+      default:
+        return source.toUpperCase();
+    }
+  }
+
+  String _getTypeLabel(String type) {
+    switch (type) {
+      case 'user_list':
+        return 'User List';
+      case 'watchlist':
+        return 'Watchlist';
+      case 'awards_events':
+        return 'Awards/Events';
+      case 'movie_collection':
+        return 'Movie Collection';
+      default:
+        return type;
+    }
+  }
+
+  @override
+  void dispose() {
+    _scope.dispose();
+    _addFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final customConfigs = _getCustomConfigs();
+
+    return withCleanSettingsTypography(
+      context,
+      RequestInitialFocus(
+        targetNode: PlatformDetection.isTV ? _addFocusNode : null,
+        child: Scaffold(
+          appBar: buildSettingsAppBar(
+            context,
+            const Text('Fully Custom Home Rows Wizard'),
+          ),
+          body: FocusScope(
+            node: _scope,
+            autofocus: true,
+            child: ListView(
+              children: [
+                adaptiveListSection(
+                  children: [
+                    _TvSettingsListTile(
+                      focusNode: _addFocusNode,
+                      leading: const Icon(Icons.add),
+                      title: const Text('Add a New Custom Home Row'),
+                      subtitle: const Text('Create a custom row from IMDb, TMDB, Letterboxd, or MDBList.'),
+                      onTap: () => _showAddEditDialog(null),
+                    ),
+                  ],
+                ),
+                if (customConfigs.isNotEmpty) ...[
+                  const _SectionHeader('Saved Custom Home Rows'),
+                  adaptiveListSection(
+                    children: customConfigs.map((config) {
+                      Map<String, dynamic> rowConfig = {};
+                      try {
+                        rowConfig = jsonDecode(config.pluginAdditionalData ?? '{}') as Map<String, dynamic>;
+                      } catch (_) {}
+                      final source = rowConfig['source'] as String? ?? 'imdb';
+                      final type = rowConfig['type'] as String? ?? 'user_list';
+
+                      return TvFocusHighlight(
+                        enabled: true,
+                        builder: (ctx, focused) {
+                          final iconColor = focused
+                              ? AppColors.black.withValues(alpha: 0.54)
+                              : (Theme.of(ctx).iconTheme.color ??
+                                  AppColorScheme.onSurface);
+                          final leadingIcon = buildSettingsLeadingIconShell(
+                            ctx,
+                            icon: const Icon(Icons.tune_outlined),
+                            focused: focused,
+                            iconColor: iconColor,
+                          );
+
+                          return SwitchListTile.adaptive(
+                            secondary: leadingIcon,
+                            title: Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    config.pluginDisplayText ?? 'Custom Row',
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w600,
+                                      color: AppColorScheme.onSurface,
+                                    ),
+                                  ),
+                                ),
+                                Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    IconButton(
+                                      icon: const Icon(Icons.edit_outlined, size: 20),
+                                      onPressed: () => _showAddEditDialog(config),
+                                      color: focused ? Colors.black87 : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.delete_outline, size: 20, color: Colors.redAccent),
+                                      onPressed: () => _deleteConfig(config),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                            subtitle: Text(
+                              'Source: ${_getSourceLabel(source)} | Type: ${_getTypeLabel(type)}',
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: focused ? Colors.black54 : AppColorScheme.onSurface.withValues(alpha: 0.5),
+                              ),
+                            ),
+                            value: config.enabled,
+                            onChanged: (enabled) => _toggleConfig(config, enabled),
+                          );
+                        },
+                      );
+                    }).toList(),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AddEditCustomRowDialog extends StatefulWidget {
+  final HomeSectionConfig? existing;
+
+  const _AddEditCustomRowDialog({this.existing});
+
+  @override
+  State<_AddEditCustomRowDialog> createState() => _AddEditCustomRowDialogState();
+}
+
+class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
+  final _formKey = GlobalKey<FormState>();
+
+  late String _source;
+  late String _type;
+  String _sortBy = 'none';
+  String _sortOrder = 'desc';
+  bool _showUserRatings = false;
+  bool _isValidating = false;
+  bool _allowPop = false;
+
+  final _nameController = TextEditingController();
+  final _imdbListIdController = TextEditingController();
+  final _imdbEventIdController = TextEditingController();
+  final _imdbEventYearController = TextEditingController();
+  final _imdbSubcategoryController = TextEditingController();
+  final _letterboxdUsernameController = TextEditingController();
+  final _letterboxdListNameController = TextEditingController();
+  final _tmdbIdController = TextEditingController();
+  final _mdblistUsernameController = TextEditingController();
+  final _mdblistListNameController = TextEditingController();
+
+  final _nameFocusNode = FocusNode(debugLabel: 'custom_row_name_field');
+  final _imdbListIdFocusNode = FocusNode(debugLabel: 'imdb_list_id_field');
+  final _imdbEventIdFocusNode = FocusNode(debugLabel: 'imdb_event_id_field');
+  final _imdbEventYearFocusNode = FocusNode(debugLabel: 'imdb_event_year_field');
+  final _imdbSubcategoryFocusNode = FocusNode(debugLabel: 'imdb_subcat_field');
+  final _letterboxdUsernameFocusNode = FocusNode(debugLabel: 'letterboxd_user_field');
+  final _letterboxdListNameFocusNode = FocusNode(debugLabel: 'letterboxd_list_field');
+  final _tmdbIdFocusNode = FocusNode(debugLabel: 'tmdb_id_field');
+  final _mdblistUsernameFocusNode = FocusNode(debugLabel: 'mdblist_user_field');
+  final _mdblistListNameFocusNode = FocusNode(debugLabel: 'mdblist_list_field');
+  final _sortByFocusNode = FocusNode(debugLabel: 'custom_row_sort_by_field');
+  final _sortOrderFocusNode = FocusNode(debugLabel: 'custom_row_sort_order_field');
+
+  final _syncService = GetIt.instance<PluginSyncService>();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.existing != null) {
+      _nameController.text = widget.existing!.pluginDisplayText ?? '';
+      Map<String, dynamic> rowConfig = {};
+      try {
+        rowConfig = jsonDecode(widget.existing!.pluginAdditionalData ?? '{}') as Map<String, dynamic>;
+      } catch (_) {}
+      _source = rowConfig['source'] as String? ?? 'imdb';
+      _type = rowConfig['type'] as String? ?? 'user_list';
+      _sortBy = rowConfig['sort_by'] as String? ?? 'none';
+      _sortOrder = rowConfig['sort_order'] as String? ?? 'desc';
+      _showUserRatings = rowConfig['show_user_ratings'] as bool? ?? false;
+      final params = rowConfig['params'] as Map<String, dynamic>? ?? {};
+
+      if (_source == 'imdb' && _type == 'user_list') {
+        _imdbListIdController.text = params['listid'] as String? ?? '';
+      } else if (_source == 'imdb' && _type == 'awards_events') {
+        _imdbEventIdController.text = params['eventid'] as String? ?? '';
+        _imdbEventYearController.text = params['year'] as String? ?? '';
+        _imdbSubcategoryController.text = params['subcategory'] as String? ?? '';
+      } else if (_source == 'letterboxd') {
+        _letterboxdUsernameController.text = params['user'] as String? ?? '';
+        if (_type == 'user_list') {
+          _letterboxdListNameController.text = params['name'] as String? ?? '';
+        }
+      } else if (_source == 'tmdb') {
+        _tmdbIdController.text = params['id'] as String? ?? '';
+      } else if (_source == 'mdblist') {
+        _mdblistUsernameController.text = params['username'] as String? ?? '';
+        _mdblistListNameController.text = params['listname'] as String? ?? '';
+      }
+    } else {
+      _source = 'imdb';
+      _type = 'user_list';
+      _sortBy = 'none';
+      _sortOrder = 'desc';
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _imdbListIdController.dispose();
+    _imdbEventIdController.dispose();
+    _imdbEventYearController.dispose();
+    _imdbSubcategoryController.dispose();
+    _letterboxdUsernameController.dispose();
+    _letterboxdListNameController.dispose();
+    _tmdbIdController.dispose();
+    _mdblistUsernameController.dispose();
+    _mdblistListNameController.dispose();
+
+    _nameFocusNode.dispose();
+    _imdbListIdFocusNode.dispose();
+    _imdbEventIdFocusNode.dispose();
+    _imdbEventYearFocusNode.dispose();
+    _imdbSubcategoryFocusNode.dispose();
+    _letterboxdUsernameFocusNode.dispose();
+    _letterboxdListNameFocusNode.dispose();
+    _tmdbIdFocusNode.dispose();
+    _mdblistUsernameFocusNode.dispose();
+    _mdblistListNameFocusNode.dispose();
+    _sortByFocusNode.dispose();
+    _sortOrderFocusNode.dispose();
+
+    super.dispose();
+  }
+
+  List<String> _getTypesForSource(String source) {
+    switch (source) {
+      case 'imdb':
+        return ['user_list', 'awards_events'];
+      case 'tmdb':
+        return ['user_list', 'movie_collection'];
+      case 'letterboxd':
+        return ['user_list', 'watchlist', 'films'];
+      case 'mdblist':
+        return ['user_list'];
+      default:
+        return ['user_list'];
+    }
+  }
+
+  String _getTypeLabel(String type) {
+    switch (type) {
+      case 'user_list':
+        return 'User List';
+      case 'watchlist':
+        return 'Watchlist';
+      case 'films':
+        return 'Films List';
+      case 'awards_events':
+        return 'Awards/Events';
+      case 'movie_collection':
+        return 'Movie Collection';
+      default:
+        return type;
+    }
+  }
+
+  void _dismiss(bool result) {
+    setState(() => _allowPop = true);
+    Navigator.pop(context, result);
+  }
+
+  void _maybeExit() async {
+    final bool exit = await showFocusRestoringDialog<bool>(
+      context: context,
+      builder: (ctx) => withCleanSettingsTypography(
+        ctx,
+        AlertDialog(
+          backgroundColor: Colors.grey[900],
+          title: const Text(
+            'Discard Changes?',
+            style: TextStyle(color: Colors.white),
+          ),
+          content: const Text(
+            'Unsaved changes, do you want to exit the wizard?',
+            style: TextStyle(color: Colors.white70),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('No'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Yes'),
+            ),
+          ],
+        ),
+      ),
+    ) ?? false;
+
+    if (exit && mounted) {
+      _dismiss(false);
+    }
+  }
+
+  void _pushPersonalizationSync() {
+    final client = GetIt.instance.isRegistered<MediaServerClient>()
+        ? GetIt.instance<MediaServerClient>()
+        : null;
+    if (client != null) {
+      _syncService.pushSettings(client);
+    }
+  }
+
+  void _save() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+
+    final params = <String, dynamic>{};
+    if (_source == 'imdb' && _type == 'user_list') {
+      params['listid'] = _imdbListIdController.text.trim();
+    } else if (_source == 'imdb' && _type == 'awards_events') {
+      params['eventid'] = _imdbEventIdController.text.trim();
+      params['year'] = _imdbEventYearController.text.trim();
+      if (_imdbSubcategoryController.text.trim().isNotEmpty) {
+        params['subcategory'] = _imdbSubcategoryController.text.trim();
+      }
+    } else if (_source == 'letterboxd') {
+      params['user'] = _letterboxdUsernameController.text.trim();
+      if (_type == 'user_list') {
+        params['name'] = _letterboxdListNameController.text.trim();
+      }
+    } else if (_source == 'tmdb') {
+      params['id'] = _tmdbIdController.text.trim();
+    } else if (_source == 'mdblist') {
+      params['username'] = _mdblistUsernameController.text.trim();
+      params['listname'] = _mdblistListNameController.text.trim();
+    }
+
+    final additionalData = jsonEncode({
+      'source': _source,
+      'type': _type,
+      'params': params,
+      'sort_by': _sortBy,
+      'sort_order': _sortOrder,
+      'show_user_ratings': _showUserRatings,
+    });
+
+    final prefs = GetIt.instance<UserPreferences>();
+    final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
+
+    setState(() => _isValidating = true);
+
+    final isEditing = widget.existing != null;
+    final newConfig = HomeSectionConfig.pluginDynamic(
+      serverId: 'custom',
+      pluginSection: isEditing ? widget.existing!.pluginSection! : 'custom_row_${DateTime.now().millisecondsSinceEpoch}',
+      pluginDisplayText: name,
+      pluginAdditionalData: additionalData,
+      pluginSource: HomeSectionPluginSource.custom,
+      enabled: isEditing ? widget.existing!.enabled : true,
+      order: isEditing ? widget.existing!.order : configs.length,
+    );
+
+    try {
+      final customService = GetIt.instance<CustomExternalListsService>();
+      final items = await customService.fetchCustomRow(newConfig);
+      if (items.isEmpty) {
+        throw Exception('No results returned.');
+      }
+    } catch (e) {
+      final customService = GetIt.instance<CustomExternalListsService>();
+      final url = customService.constructSourceUrl(_source, _type, params);
+      setState(() => _isValidating = false);
+
+      final errorString = e.toString()
+          .replaceAll('Exception: ', '')
+          .replaceAll('Constructed URL: $url. ', '')
+          .replaceAll('Constructed URL: $url', '');
+
+      showFocusRestoringDialog(
+        context: context,
+        builder: (ctx) => withCleanSettingsTypography(
+          ctx,
+          AlertDialog(
+            backgroundColor: Colors.grey[900],
+            title: const Text(
+              'Warning: Custom Row Validation Failed',
+              style: TextStyle(color: Colors.white),
+            ),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Failed to fetch items from the custom row.',
+                  style: TextStyle(color: Colors.white),
+                ),
+                const SizedBox(height: 16),
+                Center(
+                  child: Text(
+                    url,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: AppColorScheme.accent,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Error details: $errorString',
+                  style: const TextStyle(color: Colors.white70),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        ),
+      );
+      return;
+    }
+
+    setState(() => _isValidating = false);
+
+    if (isEditing) {
+      final idx = configs.indexWhere((c) => c.stableId == widget.existing!.stableId);
+      if (idx >= 0) {
+        configs[idx] = newConfig;
+      }
+    } else {
+      configs.add(newConfig);
+    }
+
+    // Proactively clear row data source cache so it forces a reload of the new config
+    try {
+      final customService = GetIt.instance<CustomExternalListsService>();
+      final file = await customService.cacheFile(newConfig);
+      if (file.existsSync()) {
+        await file.delete();
+      }
+    } catch (_) {}
+
+    await prefs.setHomeSectionsConfig(configs);
+    _pushPersonalizationSync();
+
+    if (mounted) {
+      _dismiss(true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final typeOptions = _getTypesForSource(_source);
+    if (!typeOptions.contains(_type)) {
+      _type = typeOptions.first;
+    }
+
+    final prefs = GetIt.instance<UserPreferences>();
+    final tmdbApiKey = prefs.get(UserPreferences.tmdbApiKey);
+    final mdblistApiKey = prefs.get(UserPreferences.mdblistApiKey);
+
+    return withCleanSettingsTypography(
+      context,
+      Focus(
+        onKeyEvent: (node, event) {
+          if (event.logicalKey == LogicalKeyboardKey.backspace) {
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: PopScope(
+          canPop: _allowPop,
+          onPopInvokedWithResult: (didPop, _) {
+            if (didPop) return;
+            _maybeExit();
+          },
+          child: AlertDialog(
+            backgroundColor: Colors.grey[900],
+            title: Text(
+              widget.existing != null ? 'Edit Custom Home Row' : 'Add Custom Home Row',
+              style: const TextStyle(color: Colors.white),
+            ),
+            content: Form(
+              key: _formKey,
+              child: AbsorbPointer(
+                absorbing: _isValidating,
+            child: SizedBox(
+              width: 500,
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Source', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                  const SizedBox(height: 4),
+                  Theme(
+                    data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
+                    child: DropdownButtonFormField<String>(
+                      value: _source,
+                      dropdownColor: Colors.grey[900],
+                      style: const TextStyle(color: Colors.white, fontSize: 14),
+                      decoration: InputDecoration(
+                        filled: true,
+                        fillColor: Colors.black26,
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                      ),
+                      items: const [
+                        DropdownMenuItem(value: 'imdb', child: Text('IMDb')),
+                        DropdownMenuItem(value: 'tmdb', child: Text('TMDB')),
+                        DropdownMenuItem(value: 'letterboxd', child: Text('Letterboxd')),
+                        DropdownMenuItem(value: 'mdblist', child: Text('MDBList')),
+                      ],
+                      onChanged: (val) {
+                        if (val != null) {
+                          setState(() {
+                            _source = val;
+                            _type = _getTypesForSource(val).first;
+                          });
+                        }
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  const Text('Type', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                  const SizedBox(height: 4),
+                  Theme(
+                    data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
+                    child: DropdownButtonFormField<String>(
+                      value: _type,
+                      dropdownColor: Colors.grey[900],
+                      style: const TextStyle(color: Colors.white, fontSize: 14),
+                      decoration: InputDecoration(
+                        filled: true,
+                        fillColor: Colors.black26,
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                      ),
+                      items: typeOptions.map((t) {
+                        return DropdownMenuItem(value: t, child: Text(_getTypeLabel(t)));
+                      }).toList(),
+                      onChanged: (val) {
+                        if (val != null) {
+                          setState(() {
+                            _type = val;
+                          });
+                        }
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+
+                  // Source + Type specific parameters
+                  if (_source == 'imdb' && _type == 'user_list') ...[
+                    const Text('IMDb List ID (e.g. ls123456789)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _imdbListIdController,
+                      hint: 'lsXXXXXXXXX',
+                      focusNode: _imdbListIdFocusNode,
+                    ),
+                  ],
+
+                  if (_source == 'imdb' && _type == 'awards_events') ...[
+                    const Text('IMDb Event ID (e.g. ev0000003)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _imdbEventIdController,
+                      hint: 'evXXXXXXXX',
+                      focusNode: _imdbEventIdFocusNode,
+                    ),
+                    const SizedBox(height: 16),
+                    const Text('Event Year', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _imdbEventYearController,
+                      hint: 'e.g. 2024',
+                      focusNode: _imdbEventYearFocusNode,
+                    ),
+                    const SizedBox(height: 16),
+                    const Text('Subcategory/Fragment (optional, e.g. oscar_best_sound)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _imdbSubcategoryController,
+                      hint: 'e.g. oscar_best_sound',
+                      focusNode: _imdbSubcategoryFocusNode,
+                    ),
+                  ],
+
+                  if (_source == 'letterboxd') ...[
+                    const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _letterboxdUsernameController,
+                      hint: 'Username',
+                      focusNode: _letterboxdUsernameFocusNode,
+                    ),
+                    if (_type == 'user_list') ...[
+                      const SizedBox(height: 16),
+                      const Text('List Name (slug in URL)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                      const SizedBox(height: 4),
+                      _SettingsTextField(
+                        controller: _letterboxdListNameController,
+                        hint: 'list-name-slug',
+                        focusNode: _letterboxdListNameFocusNode,
+                      ),
+                    ],
+                    if (tmdbApiKey.isEmpty) ...[
+                      const SizedBox(height: 12),
+                      const Text(
+                        'WARNING: TMDB API Key must be configured in settings to resolve Letterboxd list items.',
+                        style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ],
+
+                  if (_source == 'tmdb') ...[
+                    Text(_type == 'movie_collection' ? 'TMDB Collection ID' : 'TMDB List ID', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _tmdbIdController,
+                      hint: 'e.g. 12345',
+                      focusNode: _tmdbIdFocusNode,
+                    ),
+                    if (tmdbApiKey.isEmpty) ...[
+                      const SizedBox(height: 12),
+                      const Text(
+                        'WARNING: TMDB API Key must be configured in settings to fetch TMDB lists.',
+                        style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ],
+
+                  if (_source == 'mdblist') ...[
+                    const Text('MDBList Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _mdblistUsernameController,
+                      hint: 'Username',
+                      focusNode: _mdblistUsernameFocusNode,
+                    ),
+                    const SizedBox(height: 16),
+                    const Text('List Name (slug)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    _SettingsTextField(
+                      controller: _mdblistListNameController,
+                      hint: 'list-name-slug',
+                      focusNode: _mdblistListNameFocusNode,
+                    ),
+                    if (mdblistApiKey.isEmpty) ...[
+                      const SizedBox(height: 12),
+                      const Text(
+                        'WARNING: MDBList API Key must be configured in settings to fetch MDBList lists.',
+                        style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ],
+
+                  const SizedBox(height: 16),
+                  const Text('Sort By', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                  const SizedBox(height: 4),
+                  Theme(
+                    data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
+                    child: DropdownButtonFormField<String>(
+                      value: _sortBy,
+                      focusNode: _sortByFocusNode,
+                      dropdownColor: Colors.grey[900],
+                      style: const TextStyle(color: Colors.white, fontSize: 14),
+                      decoration: InputDecoration(
+                        filled: true,
+                        fillColor: Colors.black26,
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                      ),
+                      items: const [
+                        DropdownMenuItem(value: 'none', child: Text('Default (When Added)')),
+                        DropdownMenuItem(value: 'title', child: Text('Film Name')),
+                        DropdownMenuItem(value: 'popularity', child: Text('Film Popularity')),
+                        DropdownMenuItem(value: 'year', child: Text('Release Date')),
+                        DropdownMenuItem(value: 'rating', child: Text('Average Rating')),
+                        DropdownMenuItem(value: 'shuffle', child: Text('Shuffle')),
+                      ],
+                      onChanged: (val) {
+                        if (val != null) {
+                          setState(() {
+                            _sortBy = val;
+                            if (val == 'title') {
+                              _sortOrder = 'asc';
+                            } else {
+                              _sortOrder = 'desc';
+                            }
+                          });
+                        }
+                      },
+                    ),
+                  ),
+                  if (_sortBy != 'none' && _sortBy != 'shuffle') ...[
+                    const SizedBox(height: 16),
+                    const Text('Sort Order', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                    const SizedBox(height: 4),
+                    Theme(
+                      data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
+                      child: DropdownButtonFormField<String>(
+                        value: _sortOrder,
+                        focusNode: _sortOrderFocusNode,
+                        dropdownColor: Colors.grey[900],
+                        style: const TextStyle(color: Colors.white, fontSize: 14),
+                        decoration: InputDecoration(
+                          filled: true,
+                          fillColor: Colors.black26,
+                          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
+                        ),
+                        items: _sortBy == 'title'
+                            ? const [
+                                DropdownMenuItem(value: 'asc', child: Text('A to Z')),
+                                DropdownMenuItem(value: 'desc', child: Text('Z to A')),
+                              ]
+                            : (_sortBy == 'year'
+                                ? const [
+                                    DropdownMenuItem(value: 'desc', child: Text('Newest First')),
+                                    DropdownMenuItem(value: 'asc', child: Text('Earliest First')),
+                                  ]
+                                : (_sortBy == 'popularity'
+                                    ? const [
+                                        DropdownMenuItem(value: 'desc', child: Text('Most Popular First')),
+                                        DropdownMenuItem(value: 'asc', child: Text('Least Popular First')),
+                                      ]
+                                    : const [
+                                        DropdownMenuItem(value: 'desc', child: Text('Highest First')),
+                                        DropdownMenuItem(value: 'asc', child: Text('Lowest First')),
+                                      ])),
+                        onChanged: (val) {
+                          if (val != null) {
+                            setState(() {
+                              _sortOrder = val;
+                            });
+                          }
+                        },
+                      ),
+                    ),
+                  ],
+
+                  (() {
+                    final isUserRatingRelevant = (_source == 'letterboxd' && (_type == 'user_list' || _type == 'films')) ||
+                        (_source == 'imdb' && _type == 'user_list');
+                    if (isUserRatingRelevant) {
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const SizedBox(height: 16),
+                          SwitchListTile.adaptive(
+                            contentPadding: EdgeInsets.zero,
+                            title: const Text(
+                              'Show User Ratings?',
+                              style: TextStyle(color: Colors.white, fontSize: 14),
+                            ),
+                            value: _showUserRatings,
+                            onChanged: (val) {
+                              setState(() {
+                                _showUserRatings = val;
+                              });
+                            },
+                          ),
+                        ],
+                      );
+                    }
+                    return const SizedBox.shrink();
+                  })(),
+
+                  const SizedBox(height: 16),
+                  const Text('Home Row Custom Name', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                  const SizedBox(height: 4),
+                  _SettingsTextField(
+                    controller: _nameController,
+                    hint: 'Enter row name...',
+                    focusNode: _nameFocusNode,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+        actions: _isValidating
+            ? [
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              ]
+            : [
+                TextButton(
+                  onPressed: () => _dismiss(false),
+                  child: const Text('Cancel'),
+                ),
+                TextButton(
+                  onPressed: _save,
+                  child: const Text('Save'),
+                ),
+              ],
+      ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsTextField extends StatefulWidget {
+  final TextEditingController controller;
+  final String hint;
+  final FocusNode focusNode;
+
+  const _SettingsTextField({
+    required this.controller,
+    required this.hint,
+    required this.focusNode,
+  });
+
+  @override
+  State<_SettingsTextField> createState() => _SettingsTextFieldState();
+}
+
+class _SettingsTextFieldState extends State<_SettingsTextField> {
+  final _tvFieldKey = GlobalKey<CustomTVTextFieldState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final isTV = PlatformDetection.isTV;
+    if (isTV) {
+      return Focus(
+        focusNode: widget.focusNode,
+        child: ListenableBuilder(
+          listenable: widget.focusNode,
+          builder: (_, _) {
+            return CustomTVTextField(
+              key: _tvFieldKey,
+              controller: widget.controller,
+              isFocused: widget.focusNode.hasFocus,
+              hint: widget.hint,
+            );
+          },
+        ),
+      );
+    } else {
+      return TextField(
+        controller: widget.controller,
+        focusNode: widget.focusNode,
+        style: TextStyle(color: AppColorScheme.onSurface),
+        decoration: InputDecoration(
+          hintText: widget.hint,
+          hintStyle: TextStyle(
+            color: AppColorScheme.onSurface.withValues(alpha: 0.4),
+          ),
+          filled: true,
+          fillColor: AppColorScheme.onSurface.withValues(alpha: 0.08),
+          border: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(8)),
+            borderSide: BorderSide.none,
+          ),
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        ),
+      );
+    }
+  }
+}
+

--- a/lib/ui/screens/settings/panel/home_screen_category_screen.dart
+++ b/lib/ui/screens/settings/panel/home_screen_category_screen.dart
@@ -109,6 +109,14 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
                 onTap: () =>
                     context.pushSettingsScreen(const HomeRowTogglesScreen()),
               ),
+              if (GetIt.instance<PluginSyncService>().seerrAvailable)
+                _TvSettingsListTile(
+                  leading: const Icon(Icons.link),
+                  title: const Text('External Home Rows'),
+                  subtitle: const Text('Set-up external sources for Home Rows (e.g., Seerr, IMDb, Letterboxd, and more!)'),
+                  onTap: () =>
+                      context.pushSettingsScreen(const _ExternalListsScreen()),
+                ),
             ],
           ),
 

--- a/lib/ui/screens/settings/panel/integrations_screen.dart
+++ b/lib/ui/screens/settings/panel/integrations_screen.dart
@@ -60,13 +60,14 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
                 onTap: () =>
                     context.pushSettingsScreen(const SeerrConfigScreen()),
               ),
-              _TvSettingsListTile(
-                leading: const Icon(Icons.list_alt),
-                title: Text(l10n.externalLists),
-                subtitle: const Text('Configure external lists for display on the Home Screen.'),
-                onTap: () =>
-                    context.pushSettingsScreen(const _ExternalListsScreen()),
-              ),
+              if (GetIt.instance<PluginSyncService>().seerrAvailable)
+                _TvSettingsListTile(
+                  leading: const Icon(Icons.list_alt),
+                  title: Text(l10n.externalLists),
+                  subtitle: const Text('Configure external lists for display on the Home Screen.'),
+                  onTap: () =>
+                      context.pushSettingsScreen(const _ExternalListsScreen()),
+                ),
               _TvSettingsListTile(
                 leading: Image.asset(
                   'assets/icons/hss.png',

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -1194,104 +1194,114 @@ class _SeerrLoginCardState extends State<_SeerrLoginCard> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Text(
-                  l10n.seerrAccountType,
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                    color: colorScheme.onSurface.withValues(alpha: 0.82),
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                const SizedBox(height: 10),
                 Row(
                   children: [
-                    const Icon(Icons.account_circle_outlined),
-                    const SizedBox(width: 12),
                     Expanded(
-                      child: Text(
-                        l10n.loggedInAs(username),
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.titleMedium
-                            ?.copyWith(
-                              color: colorScheme.onSurface,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            l10n.seerrAccountType,
+                            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                              color: colorScheme.onSurface.withValues(alpha: 0.82),
                               fontWeight: FontWeight.w600,
                             ),
+                          ),
+                          const SizedBox(height: 8),
+                          Row(
+                            children: [
+                              const Icon(Icons.account_circle_outlined),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Text(
+                                  l10n.loggedInAs(username),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: Theme.of(context).textTheme.titleMedium
+                                      ?.copyWith(
+                                        color: colorScheme.onSurface,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    FocusTraversalOrder(
+                      order: const NumericFocusOrder(1),
+                      child: ListenableBuilder(
+                        listenable: widget.firstFocusNode,
+                        builder: (context, _) {
+                          final isFocused = widget.firstFocusNode.hasFocus;
+                          return Focus(
+                            focusNode: widget.firstFocusNode,
+                            onKeyEvent: (node, event) {
+                              if (event is! KeyDownEvent) {
+                                return KeyEventResult.ignored;
+                              }
+                              if (event.logicalKey ==
+                                  LogicalKeyboardKey.arrowUp) {
+                                widget.onMoveUp();
+                                return KeyEventResult.handled;
+                              }
+                              return PlatformDetection.isTV
+                                  ? _onSignOutKey(node, event)
+                                  : KeyEventResult.ignored;
+                            },
+                            child: AnimatedContainer(
+                              duration: const Duration(milliseconds: 120),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(24),
+                                boxShadow: isFocused
+                                    ? [
+                                        BoxShadow(
+                                          color: AppColorScheme.onSurface
+                                              .withValues(alpha: 0.35),
+                                          blurRadius: 10,
+                                          spreadRadius: 1.5,
+                                        ),
+                                      ]
+                                    : null,
+                              ),
+                              child: FilledButton(
+                                focusNode: PlatformDetection.isTV
+                                    ? _signOutButtonFocus
+                                    : null,
+                                style: FilledButton.styleFrom(
+                                  foregroundColor: colorScheme.onPrimary,
+                                  backgroundColor: colorScheme.primary,
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(24),
+                                  ),
+                                  side: isFocused
+                                      ? BorderSide(
+                                          color: AppColorScheme.onSurface
+                                              .withValues(alpha: 0.72),
+                                          width: 2.0,
+                                        )
+                                      : BorderSide.none,
+                                ),
+                                onPressed: _submitting ? null : _submitSignOut,
+                                child: _submitting
+                                    ? const SizedBox(
+                                        width: 18,
+                                        height: 18,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                        ),
+                                      )
+                                    : Text(l10n.signOut),
+                              ),
+                            ),
+                          );
+                        },
                       ),
                     ),
                   ],
-                ),
-                const SizedBox(height: 12),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: FocusTraversalOrder(
-                    order: const NumericFocusOrder(1),
-                    child: ListenableBuilder(
-                      listenable: widget.firstFocusNode,
-                      builder: (context, _) {
-                        final isFocused = widget.firstFocusNode.hasFocus;
-                        return Focus(
-                          focusNode: widget.firstFocusNode,
-                          onKeyEvent: (node, event) {
-                            if (event is! KeyDownEvent)
-                              return KeyEventResult.ignored;
-                            if (event.logicalKey ==
-                                LogicalKeyboardKey.arrowUp) {
-                              widget.onMoveUp();
-                              return KeyEventResult.handled;
-                            }
-                            return PlatformDetection.isTV
-                                ? _onSignOutKey(node, event)
-                                : KeyEventResult.ignored;
-                          },
-                          child: AnimatedContainer(
-                            duration: const Duration(milliseconds: 120),
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(24),
-                              boxShadow: isFocused
-                                  ? [
-                                      BoxShadow(
-                                        color: AppColorScheme.onSurface
-                                            .withValues(alpha: 0.35),
-                                        blurRadius: 10,
-                                        spreadRadius: 1.5,
-                                      ),
-                                    ]
-                                  : null,
-                            ),
-                            child: FilledButton(
-                              focusNode: PlatformDetection.isTV
-                                  ? _signOutButtonFocus
-                                  : null,
-                              style: FilledButton.styleFrom(
-                                foregroundColor: colorScheme.onPrimary,
-                                backgroundColor: colorScheme.primary,
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(24),
-                                ),
-                                side: isFocused
-                                    ? BorderSide(
-                                        color: AppColorScheme.onSurface
-                                            .withValues(alpha: 0.72),
-                                        width: 2.0,
-                                      )
-                                    : BorderSide.none,
-                              ),
-                              onPressed: _submitting ? null : _submitSignOut,
-                              child: _submitting
-                                  ? const SizedBox(
-                                      width: 18,
-                                      height: 18,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 2,
-                                      ),
-                                    )
-                                  : Text(l10n.signOut),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  ),
                 ),
                 if (_errorMessage != null) ...[
                   const SizedBox(height: 10),
@@ -1531,12 +1541,50 @@ class _SeerrReorderableTileState extends State<_SeerrReorderableTile> {
     });
   }
 
+  BoxDecoration _tileDecoration(BuildContext context, {required bool focused}) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final borderTokens = ThemeRegistry.active.borders;
+    final baseBorder = borderTokens.cardBorder.color;
+    final unfocusedBorderColor = baseBorder.a == 0
+        ? AppColorScheme.onSurface.withValues(alpha: 0.16)
+        : baseBorder.withValues(alpha: 0.55);
+
+    return BoxDecoration(
+      color: focused
+          ? AppColorScheme.onSurface
+          : colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
+      borderRadius: BorderRadius.circular(12),
+      border: Border.fromBorderSide(
+        (focused ? borderTokens.focusBorder : borderTokens.cardBorder).copyWith(
+          color: focused
+              ? AppColorScheme.accent.withValues(alpha: 0.72)
+              : unfocusedBorderColor,
+          width: 1.0,
+        ),
+      ),
+      boxShadow: focused
+          ? (borderTokens.focusGlow.isNotEmpty
+                ? borderTokens.focusGlow
+                : [
+                    BoxShadow(
+                      color: AppColorScheme.accent.withValues(alpha: 0.22),
+                      blurRadius: 14,
+                      spreadRadius: 0.5,
+                    ),
+                  ])
+          : null,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final bg = _focused
-        ? colorScheme.primary.withValues(alpha: 0.18)
-        : Colors.transparent;
+    final textColor = _focused
+        ? AppColors.black.withValues(alpha: 0.87)
+        : colorScheme.onSurface;
+    final iconColor = _focused
+        ? AppColors.black.withValues(alpha: 0.54)
+        : colorScheme.onSurfaceVariant;
 
     return Focus(
       focusNode: widget.focusNode,
@@ -1567,20 +1615,33 @@ class _SeerrReorderableTileState extends State<_SeerrReorderableTile> {
         }
         return KeyEventResult.ignored;
       },
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 90),
-        color: bg,
-        child: ListTile(
-          onTap: () => widget.onToggle(!widget.enabled),
-          leading: Icon(
-            widget.enabled ? Icons.check_box : Icons.check_box_outline_blank,
-            color: widget.enabled ? colorScheme.primary : null,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 90),
+          decoration: _tileDecoration(context, focused: _focused),
+          child: ListTile(
+            onTap: () => widget.onToggle(!widget.enabled),
+            leading: Icon(
+              widget.enabled ? Icons.check_box : Icons.check_box_outline_blank,
+              color: widget.enabled
+                  ? (_focused ? AppColors.black : colorScheme.primary)
+                  : iconColor,
+            ),
+            title: Text(
+              widget.label,
+              style: TextStyle(color: textColor, fontWeight: FontWeight.w600),
+            ),
+            subtitle: Text(
+              widget.enabled ? widget.enabledLabel : widget.hiddenLabel,
+              style: TextStyle(
+                color: _focused
+                    ? AppColors.black.withValues(alpha: 0.6)
+                    : colorScheme.onSurfaceVariant,
+              ),
+            ),
+            trailing: widget.trailing,
           ),
-          title: Text(widget.label),
-          subtitle: Text(
-            widget.enabled ? widget.enabledLabel : widget.hiddenLabel,
-          ),
-          trailing: widget.trailing,
         ),
       ),
     );

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -16,6 +16,7 @@ import 'package:server_core/server_core.dart' hide ImageType;
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../data/services/plugin_sync_service.dart';
+import '../../../data/services/custom_external_lists_service.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../di/providers.dart';
 import '../../../util/idiom/app_ui_idiom.dart';

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart' show CupertinoSlider;
 import 'package:flutter/foundation.dart';

--- a/lib/ui/util/home_row_title_localizer.dart
+++ b/lib/ui/util/home_row_title_localizer.dart
@@ -77,6 +77,9 @@ String localizeHomeRowTitle({
     return _localizeLatestRowTitle(row.title, l10n);
   }
 
+  if (row.id.startsWith('imdb_')) {
+    return row.title.replaceAll('IMDb ', '').replaceAll('IMDb', '').trim();
+  }
   return row.title;
 }
 

--- a/test/custom_external_lists_service_test.dart
+++ b/test/custom_external_lists_service_test.dart
@@ -6,7 +6,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:moonfin/preference/home_section_config.dart';
 import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin/data/services/custom_external_lists_service.dart';
-import 'package:moonfin/data/services/imdb_external_lists_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -98,7 +97,7 @@ void main() {
         pluginSection: 'custom_row_title_test',
         pluginDisplayText: 'Test Title Sort',
         pluginAdditionalData: jsonEncode({
-          'source': 'imdb',
+          'source': 'tmdb',
           'type': 'user_list',
           'sort_by': 'title',
           'sort_order': 'asc',
@@ -121,7 +120,7 @@ void main() {
         pluginSection: 'custom_row_year_test',
         pluginDisplayText: 'Test Year Sort',
         pluginAdditionalData: jsonEncode({
-          'source': 'imdb',
+          'source': 'tmdb',
           'type': 'user_list',
           'sort_by': 'year',
           'sort_order': 'desc',
@@ -143,7 +142,7 @@ void main() {
         pluginSection: 'custom_row_pop_test',
         pluginDisplayText: 'Test Pop Sort',
         pluginAdditionalData: jsonEncode({
-          'source': 'imdb',
+          'source': 'tmdb',
           'type': 'user_list',
           'sort_by': 'popularity',
           'sort_order': 'desc',
@@ -165,7 +164,7 @@ void main() {
         pluginSection: 'custom_row_rating_test',
         pluginDisplayText: 'Test Rating Sort',
         pluginAdditionalData: jsonEncode({
-          'source': 'imdb',
+          'source': 'tmdb',
           'type': 'user_list',
           'sort_by': 'rating',
           'sort_order': 'desc',
@@ -187,7 +186,7 @@ void main() {
         pluginSection: 'custom_row_none_test',
         pluginDisplayText: 'Test None Sort',
         pluginAdditionalData: jsonEncode({
-          'source': 'imdb',
+          'source': 'tmdb',
           'type': 'user_list',
           'sort_by': 'none',
         }),

--- a/test/custom_external_lists_service_test.dart
+++ b/test/custom_external_lists_service_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jellyfin_preference/jellyfin_preference.dart';
@@ -10,12 +11,20 @@ import 'package:moonfin/data/services/custom_external_lists_service.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final tempDir = Directory.systemTemp.createTempSync('moonfin_test_');
+
   // Mock path_provider channel
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
           const MethodChannel('plugins.flutter.io/path_provider'),
           (MethodCall methodCall) async {
-    return '.';
+    return tempDir.path;
+  });
+
+  tearDownAll(() {
+    try {
+      tempDir.deleteSync(recursive: true);
+    } catch (_) {}
   });
 
   group('CustomExternalLists Config Mapping', () {

--- a/test/custom_external_lists_service_test.dart
+++ b/test/custom_external_lists_service_test.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:moonfin/preference/home_section_config.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/data/services/custom_external_lists_service.dart';
+import 'package:moonfin/data/services/imdb_external_lists_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Mock path_provider channel
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (MethodCall methodCall) async {
+    return '.';
+  });
+
+  group('CustomExternalLists Config Mapping', () {
+    test('JSON serialization and deserialization of HomeSectionConfig with custom source', () {
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: 'custom',
+        pluginSection: 'custom_row_12345',
+        pluginDisplayText: 'My Letterboxd Watchlist',
+        pluginAdditionalData: jsonEncode({
+          'source': 'letterboxd',
+          'type': 'watchlist',
+          'params': {'user': 'testuser'}
+        }),
+        pluginSource: HomeSectionPluginSource.custom,
+        enabled: true,
+        order: 10,
+      );
+
+      final serialized = config.toJson();
+      expect(serialized['pluginSource'], 'custom');
+      expect(serialized['serverId'], 'custom');
+      expect(serialized['pluginSection'], 'custom_row_12345');
+      expect(serialized['pluginDisplayText'], 'My Letterboxd Watchlist');
+
+      final deserialized = HomeSectionConfig.fromJson(serialized);
+      expect(deserialized.pluginSource, HomeSectionPluginSource.custom);
+      expect(deserialized.pluginSection, 'custom_row_12345');
+      expect(deserialized.pluginDisplayText, 'My Letterboxd Watchlist');
+      
+      final data = jsonDecode(deserialized.pluginAdditionalData!) as Map<String, dynamic>;
+      expect(data['source'], 'letterboxd');
+      expect(data['type'], 'watchlist');
+      expect(data['params']['user'], 'testuser');
+    });
+  });
+
+  group('CustomExternalLists sorting logic', () {
+    late UserPreferences prefs;
+    late CustomExternalListsService service;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final store = PreferenceStore();
+      await store.init();
+      prefs = UserPreferences(store);
+      service = CustomExternalListsService(prefs);
+    });
+
+    final mockItems = [
+      ImdbExternalListItem(
+        imdbId: '1',
+        title: 'C Title',
+        year: 2020,
+        type: 'Movie',
+        popularity: 50.0,
+        rating: 8.5,
+      ),
+      ImdbExternalListItem(
+        imdbId: '2',
+        title: 'A Title',
+        year: 2010,
+        type: 'Movie',
+        popularity: 150.0,
+        rating: 6.0,
+      ),
+      ImdbExternalListItem(
+        imdbId: '3',
+        title: 'B Title',
+        year: 2015,
+        type: 'Movie',
+        popularity: 10.0,
+        rating: 9.0,
+      ),
+    ];
+
+    test('Sorts alphabetically by Film Name (title)', () async {
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: 'custom',
+        pluginSection: 'custom_row_title_test',
+        pluginDisplayText: 'Test Title Sort',
+        pluginAdditionalData: jsonEncode({
+          'source': 'imdb',
+          'type': 'user_list',
+          'sort_by': 'title',
+          'sort_order': 'asc',
+        }),
+        pluginSource: HomeSectionPluginSource.custom,
+      );
+
+      await service.saveCustomRowToCache(config, mockItems);
+      final sorted = await service.loadCustomRowFromCache(config);
+
+      expect(sorted.length, 3);
+      expect(sorted[0].title, 'A Title');
+      expect(sorted[1].title, 'B Title');
+      expect(sorted[2].title, 'C Title');
+    });
+
+    test('Sorts by Release Date (year) descending', () async {
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: 'custom',
+        pluginSection: 'custom_row_year_test',
+        pluginDisplayText: 'Test Year Sort',
+        pluginAdditionalData: jsonEncode({
+          'source': 'imdb',
+          'type': 'user_list',
+          'sort_by': 'year',
+          'sort_order': 'desc',
+        }),
+        pluginSource: HomeSectionPluginSource.custom,
+      );
+
+      await service.saveCustomRowToCache(config, mockItems);
+      final sorted = await service.loadCustomRowFromCache(config);
+
+      expect(sorted[0].year, 2020);
+      expect(sorted[1].year, 2015);
+      expect(sorted[2].year, 2010);
+    });
+
+    test('Sorts by Popularity descending', () async {
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: 'custom',
+        pluginSection: 'custom_row_pop_test',
+        pluginDisplayText: 'Test Pop Sort',
+        pluginAdditionalData: jsonEncode({
+          'source': 'imdb',
+          'type': 'user_list',
+          'sort_by': 'popularity',
+          'sort_order': 'desc',
+        }),
+        pluginSource: HomeSectionPluginSource.custom,
+      );
+
+      await service.saveCustomRowToCache(config, mockItems);
+      final sorted = await service.loadCustomRowFromCache(config);
+
+      expect(sorted[0].popularity, 150.0);
+      expect(sorted[1].popularity, 50.0);
+      expect(sorted[2].popularity, 10.0);
+    });
+
+    test('Sorts by Average Rating descending', () async {
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: 'custom',
+        pluginSection: 'custom_row_rating_test',
+        pluginDisplayText: 'Test Rating Sort',
+        pluginAdditionalData: jsonEncode({
+          'source': 'imdb',
+          'type': 'user_list',
+          'sort_by': 'rating',
+          'sort_order': 'desc',
+        }),
+        pluginSource: HomeSectionPluginSource.custom,
+      );
+
+      await service.saveCustomRowToCache(config, mockItems);
+      final sorted = await service.loadCustomRowFromCache(config);
+
+      expect(sorted[0].rating, 9.0);
+      expect(sorted[1].rating, 8.5);
+      expect(sorted[2].rating, 6.0);
+    });
+
+    test('Keeps default order when sort_by is none', () async {
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: 'custom',
+        pluginSection: 'custom_row_none_test',
+        pluginDisplayText: 'Test None Sort',
+        pluginAdditionalData: jsonEncode({
+          'source': 'imdb',
+          'type': 'user_list',
+          'sort_by': 'none',
+        }),
+        pluginSource: HomeSectionPluginSource.custom,
+      );
+
+      await service.saveCustomRowToCache(config, mockItems);
+      final sorted = await service.loadCustomRowFromCache(config);
+
+      expect(sorted[0].imdbId, '1');
+      expect(sorted[1].imdbId, '2');
+      expect(sorted[2].imdbId, '3');
+    });
+  });
+}

--- a/test/custom_external_lists_service_test.dart
+++ b/test/custom_external_lists_service_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:moonfin/preference/home_section_config.dart';
-import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin/data/services/custom_external_lists_service.dart';
 
 void main() {
@@ -62,15 +61,13 @@ void main() {
   });
 
   group('CustomExternalLists sorting logic', () {
-    late UserPreferences prefs;
     late CustomExternalListsService service;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
       final store = PreferenceStore();
       await store.init();
-      prefs = UserPreferences(store);
-      service = CustomExternalListsService(prefs);
+      service = CustomExternalListsService();
     });
 
     final mockItems = [


### PR DESCRIPTION
# Pull Request: Moonfin, Your Way

## Summary
This pull request implements a fully custom home rows backend (static rows for popular IMDb and TMDB sources + a custom Wizard), local cache management, sorting controls, user ratings display, pop and backspace interception, visual groupings, daily startup refresh checking, settings navigation shortcuts, and conditional gating (rows are only available/functional for servers with Seerr access).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Fully Custom Home Rows Wizard**: Adds native support for configuring custom home rows from IMDb (User Lists, Awards/Events), TMDB (Collections, Lists), Letterboxd (Watchlists, Custom Lists, and Films Lists), and MDBList.
- **Local Cache & Sorting Options**: Saves retrieved rows locally to JSON cache files. Integrated sorting controls (`Sort By` and `Sort Order` with customized direction indicators) directly into the dialog, implementing local sorting filters (Name, Release Date, Popularity, Rating, Shuffle).
- **User Ratings Display**: Scrapes and parses user rating stars from IMDb and Letterboxd HTML elements, and integrates a toggle inside the wizard to render these stars below posters on the Homepage.
- **Wizard Pop & Focus Polish**: Intercepts back buttons/escape keys to prompt exit confirmation ("Unsaved changes, do you want to exit the wizard?"). Traps backspace keys inside textfields to prevent accidental global back navigation.
- **Manual & Auto Daily Refresh**: Added a "Refresh All Enabled Lists" force-reload tile, and a once-a-day background cache refresh on app startup if more than 24 hours have elapsed.
- **Navigation Shortcuts & Seerr Gating**: Added quick shortcut links between Settings sub-menus, and gates entry-points to External Home Rows if the active Seerr connection is unconfigured.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on AndroidTV and Windows Desktop
- [ ] Not tested (explain why):

### Test Steps
1. Toggle various external sources for home rows and see them appear on the home screen
2. Create custom rules for rows on the home screen and watch them appear exactly as you have defined them
3. Try a refresh, it is refreshing
4. Try logging in without Seerr/Moonbase, and see all the coolness vanish before your eyes

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Home Row Sections Update
<img width="853" height="657" alt="2026-06-27_09-45-54_moonfin" src="https://github.com/user-attachments/assets/6587be9b-ea39-481c-8679-abe1963cc110" />

### External Home Row Lists Menu
<img width="850" height="1438" alt="2026-06-27_09-46-02_moonfin" src="https://github.com/user-attachments/assets/ecec380e-b2bc-4ad4-aa75-0db4885ac0ed" />

### Built-in IMDb Lists
<img width="848" height="1182" alt="2026-06-27_09-46-15_moonfin" src="https://github.com/user-attachments/assets/337af86e-bf82-4c89-9dc2-163fd1f6f95b" />

### Built-in TMDB Lists (requires API)
<img width="842" height="1555" alt="2026-06-27_09-46-23" src="https://github.com/user-attachments/assets/600d87f6-5d38-4958-a34e-7531443dfa50" />

### Built-in Seerr Lists
<img width="841" height="1534" alt="2026-06-27_09-46-33_moonfin" src="https://github.com/user-attachments/assets/102be0cc-471a-4276-9638-c98c60c7f44b" />

### Fully Custom Home Rows Wizard Subpage
<img width="842" height="980" alt="2026-06-27_09-49-15_moonfin" src="https://github.com/user-attachments/assets/f4d9a959-7c52-4768-97ed-1b611362b340" />

### The Wizard
<img width="1126" height="1349" alt="2026-06-27_09-49-27_moonfin" src="https://github.com/user-attachments/assets/6e199df0-4c15-4fd2-8d15-e890229f1c14" />

### Accidental Exit Confirmation Message
<img width="1102" height="1355" alt="2026-06-27_09-49-39_moonfin" src="https://github.com/user-attachments/assets/33862d17-c9c5-4129-bb1b-4f0b1362c6a2" />

### Fields update depending on Source
<img width="1112" height="1354" alt="2026-06-27_09-49-45_moonfin" src="https://github.com/user-attachments/assets/9b261ac3-b4d8-4389-b695-1531c449a6e2" />

### Editing a Pre-Existing List
<img width="1115" height="1197" alt="2026-06-27_09-50-09_moonfin" src="https://github.com/user-attachments/assets/432c5d82-4f8e-43de-8fcc-d185e78d49c5" />

### Custom Lists on the Home Screen!
<img width="2560" height="1326" alt="2026-06-27_09-50-29_moonfin" src="https://github.com/user-attachments/assets/2d6b437d-b8a6-4b0d-b285-f752a7d875c6" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
