### PR TITLE
fix(settings): preventing double snackbars

### DIFF
--- a/lib/ui/widgets/settings/settings_panel.dart
+++ b/lib/ui/widgets/settings/settings_panel.dart
@@ -60,7 +60,11 @@ class SettingsPanel extends StatelessWidget {
     final Widget body = SizedBox(
       width: panelWidth,
       height: double.infinity,
-      child: SettingsListTypography(child: _SettingsNavigator(initial: child)),
+      child: SettingsListTypography(
+        child: ScaffoldMessenger(
+          child: _SettingsNavigator(initial: child),
+        ),
+      ),
     );
     Widget content;
     if (glass) {


### PR DESCRIPTION
# Pull Request: Seeing Double

## Summary
This pull request resolves the issue where snackbars shown from within settings screens were displayed on both the main home screen (left) and the settings panel (right) concurrently.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Isolate Settings Scaffold Messenger**: Wrapped the settings panel navigator in its own localized `ScaffoldMessenger` inside `settings_panel.dart`. This ensures that all settings snackbars triggered via `ScaffoldMessenger.of(context)` are isolated to display only at the bottom of the settings sliding panel and are hidden from the main homepage's `Scaffold`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Windows Desktop
- [ ] Not tested (explain why):

### Test Steps
1. Launch settings, go to **About -> Diagnostics**.
2. Tap **Copy logs to clipboard** or **Check for Updates**
3. Verify that the snackbar notification is displayed only inside the settings panel on the right.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="2536" height="1500" alt="2026-06-27_10-19-14_moonfin" src="https://github.com/user-attachments/assets/5995d7a3-e30b-4b3d-bfd1-d4da991794c8" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
