### PR TITLE
Feature/Two More Core Home Row Implementations

### DIFF
--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -51,8 +51,7 @@ class AggregatedItem {
   Duration? get runtime =>
       runTimeTicks != null ? Duration(microseconds: runTimeTicks! ~/ 10) : null;
 
-  List<String> get genres =>
-      (rawData['Genres'] as List?)?.cast<String>() ?? const [];
+  List<String> get genres => _toListOfStrings(rawData['Genres']);
 
   String? get primaryImageTag =>
       (rawData['ImageTags'] as Map?)?['Primary'] as String?;
@@ -64,14 +63,13 @@ class AggregatedItem {
 
   String? get primaryImageItemId => rawData['PrimaryImageItemId']?.toString();
 
-  List<String> get backdropImageTags =>
-      (rawData['BackdropImageTags'] as List?)?.cast<String>() ?? const [];
+  List<String> get backdropImageTags => _toListOfStrings(rawData['BackdropImageTags']);
 
   String? get parentBackdropItemId =>
       rawData['ParentBackdropItemId']?.toString();
 
   List<String> get parentBackdropImageTags =>
-      (rawData['ParentBackdropImageTags'] as List?)?.cast<String>() ?? const [];
+      _toListOfStrings(rawData['ParentBackdropImageTags']);
 
   String? get logoImageTag =>
       (rawData['ImageTags'] as Map?)?['Logo'] as String?;
@@ -181,49 +179,48 @@ class AggregatedItem {
   }
 
   List<String> get productionLocations =>
-      (rawData['ProductionLocations'] as List?)?.cast<String>() ?? const [];
+      _toListOfStrings(rawData['ProductionLocations']);
 
   String? get albumArtist => rawData['AlbumArtist'] as String?;
   String? get album => rawData['Album'] as String?;
   String? get albumId => rawData['AlbumId']?.toString();
   String? get albumPrimaryImageTag =>
       rawData['AlbumPrimaryImageTag'] as String?;
-  List<String> get artists =>
-      (rawData['Artists'] as List?)?.cast<String>() ?? const [];
+  List<String> get artists => _toListOfStrings(rawData['Artists']);
   String? get parentId => rawData['ParentId']?.toString();
   int? get recursiveItemCount => _toInt(rawData['RecursiveItemCount']);
   List<Map<String, dynamic>> get albumArtists =>
-      (rawData['AlbumArtists'] as List?)?.cast<Map<String, dynamic>>() ??
-      const [];
+      _toListOfMaps(rawData['AlbumArtists']);
 
   Map<String, String> get providerIds {
     final ids = rawData['ProviderIds'] as Map?;
-    return ids?.cast<String, String>() ?? const {};
+    if (ids == null) return const {};
+    final result = <String, String>{};
+    ids.forEach((k, v) {
+      if (k != null && v != null) {
+        result[k.toString()] = v.toString();
+      }
+    });
+    return result;
   }
 
   String? get tmdbId => providerIds['Tmdb'];
   String? get imdbId => providerIds['Imdb'];
 
-  List<Map<String, dynamic>> get people =>
-      (rawData['People'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
+  List<Map<String, dynamic>> get people => _toListOfMaps(rawData['People']);
 
-  List<Map<String, dynamic>> get studios =>
-      (rawData['Studios'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
+  List<Map<String, dynamic>> get studios => _toListOfMaps(rawData['Studios']);
 
   List<Map<String, dynamic>> get mediaSources =>
-      (rawData['MediaSources'] as List?)?.cast<Map<String, dynamic>>() ??
-      const [];
+      _toListOfMaps(rawData['MediaSources']);
 
   List<Map<String, dynamic>> get mediaStreams =>
-      (rawData['MediaStreams'] as List?)?.cast<Map<String, dynamic>>() ??
-      const [];
+      _toListOfMaps(rawData['MediaStreams']);
 
   List<Map<String, dynamic>> get remoteTrailers =>
-      (rawData['RemoteTrailers'] as List?)?.cast<Map<String, dynamic>>() ??
-      const [];
+      _toListOfMaps(rawData['RemoteTrailers']);
 
-  List<Map<String, dynamic>> get chapters =>
-      (rawData['Chapters'] as List?)?.cast<Map<String, dynamic>>() ?? const [];
+  List<Map<String, dynamic>> get chapters => _toListOfMaps(rawData['Chapters']);
 
   String? get videoResolution {
     for (final stream in mediaStreams) {
@@ -348,5 +345,21 @@ class AggregatedItem {
       }
     }
     return name;
+  }
+
+  static List<Map<String, dynamic>> _toListOfMaps(dynamic value) {
+    if (value is! List) return const [];
+    return value
+        .map((e) {
+          if (e is Map) return Map<String, dynamic>.from(e);
+          return null;
+        })
+        .whereType<Map<String, dynamic>>()
+        .toList();
+  }
+
+  static List<String> _toListOfStrings(dynamic value) {
+    if (value is! List) return const [];
+    return value.map((e) => e?.toString()).whereType<String>().toList();
   }
 }

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1363,8 +1363,28 @@ class PluginSyncService extends ChangeNotifier {
       if (type == prefs.HomeSectionType.none || present.contains(type)) {
         continue;
       }
+      
+      var isEnabled = false;
+      if (type == prefs.HomeSectionType.rewatch) {
+        isEnabled = _prefs.get(UserPreferences.displayRewatchRow);
+      } else if (type == prefs.HomeSectionType.sinceYouWatched1 ||
+          type == prefs.HomeSectionType.sinceYouWatched2 ||
+          type == prefs.HomeSectionType.sinceYouWatched3 ||
+          type == prefs.HomeSectionType.sinceYouWatched4 ||
+          type == prefs.HomeSectionType.sinceYouWatched5) {
+        final localPref = switch (type) {
+          prefs.HomeSectionType.sinceYouWatched1 => UserPreferences.sinceYouWatched1Enabled,
+          prefs.HomeSectionType.sinceYouWatched2 => UserPreferences.sinceYouWatched2Enabled,
+          prefs.HomeSectionType.sinceYouWatched3 => UserPreferences.sinceYouWatched3Enabled,
+          prefs.HomeSectionType.sinceYouWatched4 => UserPreferences.sinceYouWatched4Enabled,
+          prefs.HomeSectionType.sinceYouWatched5 => UserPreferences.sinceYouWatched5Enabled,
+          _ => throw StateError('Invalid type'),
+        };
+        isEnabled = _prefs.get(localPref);
+      }
+      
       sections.add(
-        HomeSectionConfig(type: type, enabled: false, order: order++),
+        HomeSectionConfig(type: type, enabled: isEnabled, order: order++),
       );
     }
     return order;

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -18,6 +18,10 @@ import '../utils/genre_browse_utils.dart';
 import '../utils/next_up_enrichment.dart';
 import '../utils/playlist_utils.dart';
 import 'package:flutter/foundation.dart';
+import '../repositories/seerr_repository.dart';
+import '../../preference/seerr_preferences.dart';
+import '../services/seerr/seerr_api_models.dart';
+import '../viewmodels/seerr_discover_view_model.dart';
 import 'custom_external_lists_service.dart';
 
 class RowDataSource {
@@ -45,6 +49,9 @@ class RowDataSource {
   static const _minimalFields =
       'Type,UserData,RunTimeTicks,ProductionYear,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,SeriesId';
+
+  // Cache for local recommendations to make them practically instantaneous
+  static final Map<String, List<Map<String, dynamic>>> _recommendationCache = {};
 
   // Cap image tags to one per type (server returns all by default)
   static const _imageTypes = 'Primary,Backdrop,Thumb';
@@ -1751,6 +1758,769 @@ class RowDataSource {
       return ('DateCreated', 'Descending');
     }
     return ('SortName', 'Ascending');
+  }
+
+  int? _extractYear(String? dateString) {
+    if (dateString == null || dateString.isEmpty) return null;
+    final parsed = DateTime.tryParse(dateString);
+    return parsed?.year;
+  }
+
+  int _getRatingLevel(String? rating) {
+    if (rating == null || rating.isEmpty) return 100;
+    final clean = rating.trim().toUpperCase();
+
+    // Movies (US/Global)
+    if (clean == 'G') return 1;
+    if (clean == 'PG') return 2;
+    if (clean == 'PG-13') return 3;
+    if (clean == 'R') return 4;
+    if (clean == 'NC-17') return 5;
+
+    // TV Shows (US/Global)
+    if (clean == 'TV-Y' || clean == 'TV-Y7') return 1;
+    if (clean == 'TV-G') return 1;
+    if (clean == 'TV-PG') return 2;
+    if (clean == 'TV-14') return 3;
+    if (clean == 'TV-MA') return 4;
+
+    // UK Ratings
+    if (clean == 'U' || clean == 'UC') return 1;
+    if (clean == 'PG') return 2;
+    if (clean == '12' || clean == '12A') return 3;
+    if (clean == '15') return 4;
+    if (clean == '18') return 5;
+
+    // Fallback: parse numbers if found (e.g. "12", "16", "18")
+    final match = RegExp(r'\d+').firstMatch(clean);
+    if (match != null) {
+      final age = int.tryParse(match.group(0)!);
+      if (age != null) {
+        if (age <= 7) return 1;
+        if (age <= 12) return 2;
+        if (age <= 15) return 3;
+        if (age <= 17) return 4;
+        return 5;
+      }
+    }
+
+    return 3; // Default intermediate severity level
+  }
+
+  Future<HomeRow> loadSinceYouWatchedRow(String serverId, int rowIndex) async {
+    final prefs = GetIt.instance<UserPreferences>();
+    final sourceType = prefs.get(UserPreferences.sinceYouWatchedSourceType);
+    final sourceItemType = prefs.get(UserPreferences.sinceYouWatchedSourceItem);
+    final isLocal = prefs.get(UserPreferences.sinceYouWatchedSource) == SinceYouWatchedSource.local;
+
+    final List<String> queryItemTypes;
+    if (sourceItemType == SinceYouWatchedSourceItem.recentlyWatched) {
+      if (sourceType == SinceYouWatchedSourceType.movies) {
+        queryItemTypes = const ['Movie'];
+      } else if (sourceType == SinceYouWatchedSourceType.shows) {
+        queryItemTypes = const ['Episode'];
+      } else {
+        queryItemTypes = const ['Movie', 'Episode'];
+      }
+    } else {
+      if (sourceType == SinceYouWatchedSourceType.movies) {
+        queryItemTypes = const ['Movie'];
+      } else if (sourceType == SinceYouWatchedSourceType.shows) {
+        queryItemTypes = const ['Series'];
+      } else {
+        queryItemTypes = const ['Movie', 'Series'];
+      }
+    }
+
+    final List<String> candidateItemTypes = switch (sourceType) {
+      SinceYouWatchedSourceType.movies => const ['Movie'],
+      SinceYouWatchedSourceType.shows => const ['Series'],
+      SinceYouWatchedSourceType.both => const ['Movie', 'Series'],
+    };
+
+    // Fetch the list of possible base items (specifying Tags and People fields to avoid subsequent detail calls)
+    List<AggregatedItem> baseItems = [];
+    if (sourceItemType == SinceYouWatchedSourceItem.recentlyWatched) {
+      final res = await _getItemsWithFallback(
+        sortBy: 'DatePlayed',
+        sortOrder: 'Descending',
+        filters: const ['IsPlayed'],
+        recursive: true,
+        includeItemTypes: queryItemTypes,
+        limit: 30, // Query more items to ensure we get enough unique shows
+        fields: '$_fields,Tags,People,SeriesId',
+      );
+      final rawBaseItems = _parseItems(res, serverId);
+      
+      // Resolve Episode items to their parent Series (Show) items
+      final resolvedBaseItems = <AggregatedItem>[];
+      final seenSeriesIds = <String>{};
+      final episodeToSeriesMap = <String, String>{}; // Episode ID -> Series ID
+      final seriesIdsToFetch = <String>[];
+      
+      for (final item in rawBaseItems) {
+        if (item.type == 'Movie') {
+          resolvedBaseItems.add(item);
+        } else if (item.type == 'Episode') {
+          final sId = item.rawData['SeriesId']?.toString();
+          if (sId != null && sId.isNotEmpty) {
+            episodeToSeriesMap[item.id] = sId;
+            if (!seenSeriesIds.contains(sId)) {
+              seenSeriesIds.add(sId);
+              seriesIdsToFetch.add(sId);
+            }
+          }
+        } else if (item.type == 'Series') {
+          resolvedBaseItems.add(item);
+        }
+      }
+      
+      if (seriesIdsToFetch.isNotEmpty) {
+        try {
+          final seriesRes = await _client.itemsApi.getItems(
+            ids: seriesIdsToFetch,
+            fields: '$_fields,Tags,People',
+          );
+          final fetchedSeries = _parseItems(seriesRes, serverId);
+          final seriesMap = {for (final s in fetchedSeries) s.id: s};
+          
+          final finalItems = <AggregatedItem>[];
+          final addedSeriesIds = <String>{};
+          
+          for (final item in rawBaseItems) {
+            if (item.type == 'Movie') {
+              finalItems.add(item);
+            } else if (item.type == 'Episode') {
+              final sId = episodeToSeriesMap[item.id];
+              if (sId != null) {
+                final seriesItem = seriesMap[sId];
+                if (seriesItem != null && !addedSeriesIds.contains(sId)) {
+                  addedSeriesIds.add(sId);
+                  finalItems.add(seriesItem);
+                }
+              }
+            } else if (item.type == 'Series') {
+              if (!addedSeriesIds.contains(item.id)) {
+                addedSeriesIds.add(item.id);
+                finalItems.add(item);
+              }
+            }
+          }
+          baseItems = finalItems;
+        } catch (_) {
+          baseItems = rawBaseItems;
+        }
+      } else {
+        baseItems = resolvedBaseItems;
+      }
+    } else if (sourceItemType == SinceYouWatchedSourceItem.favorites) {
+      final res = await _getItemsWithFallback(
+        isFavorite: true,
+        filters: const ['IsPlayed'],
+        recursive: true,
+        includeItemTypes: queryItemTypes,
+        limit: 30,
+        fields: '$_fields,Tags,People',
+      );
+      baseItems = _parseItems(res, serverId);
+    } else {
+      // Random
+      final res = await _getItemsWithFallback(
+        sortBy: 'Random',
+        filters: const ['IsPlayed'],
+        recursive: true,
+        includeItemTypes: queryItemTypes,
+        limit: 30,
+        fields: '$_fields,Tags,People',
+      );
+      baseItems = _parseItems(res, serverId);
+    }
+
+    final sourceIdx = rowIndex - 1;
+    if (sourceIdx >= baseItems.length) {
+      return HomeRow(
+        id: 'sinceYouWatched$rowIndex',
+        title: 'Since you watched',
+        rowType: HomeRowType.latestMedia,
+        items: const [],
+      );
+    }
+
+    final baseItem = baseItems[sourceIdx];
+    final itemDetail = baseItem.rawData;
+    final baseItemName = baseItem.name;
+
+    List<AggregatedItem> recommendedItems = [];
+
+    if (isLocal) {
+      final genres = (itemDetail['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+      final tags = (itemDetail['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+      final people = (itemDetail['People'] as List?)?.map((e) => e is Map ? Map<String, dynamic>.from(e) : null).whereType<Map<String, dynamic>>().toList() ?? const <Map<String, dynamic>>[];
+
+      final actorNames = people
+          .where((p) => p['Type'] == 'Actor')
+          .map((p) => p['Name']?.toString())
+          .whereType<String>()
+          .toList();
+      final directorNames = people
+          .where((p) => p['Type'] == 'Director')
+          .map((p) => p['Name']?.toString())
+          .whereType<String>()
+          .toList();
+      final writerNames = people
+          .where((p) => p['Type'] == 'Writer')
+          .map((p) => p['Name']?.toString())
+          .whereType<String>()
+          .toList();
+
+      final actorIds = people
+          .where((p) => p['Type'] == 'Actor')
+          .map((p) => p['Id']?.toString())
+          .whereType<String>()
+          .toList();
+      final directorIds = people
+          .where((p) => p['Type'] == 'Director')
+          .map((p) => p['Id']?.toString())
+          .whereType<String>()
+          .toList();
+      final writerIds = people
+          .where((p) => p['Type'] == 'Writer')
+          .map((p) => p['Id']?.toString())
+          .whereType<String>()
+          .toList();
+
+      final candidatesMap = <String, Map<String, dynamic>>{};
+      final futures = <Future<void>>[];
+
+      // Fetch candidates matching genres in parallel
+      if (genres.isNotEmpty) {
+        futures.add(() async {
+          try {
+            final cacheKey = 'genres:${candidateItemTypes.join(",")}:${genres.join(",")}';
+            if (_recommendationCache.containsKey(cacheKey)) {
+              final cached = _recommendationCache[cacheKey]!;
+              for (final item in cached) {
+                final id = item['Id']?.toString() ?? '';
+                if (id.isNotEmpty) candidatesMap[id] = item;
+              }
+              return;
+            }
+            final res = await _client.itemsApi.getItems(
+              includeItemTypes: candidateItemTypes,
+              genres: genres,
+              recursive: true,
+              limit: 80,
+              fields: 'Genres,Tags,People,UserData,OfficialRating',
+            );
+            final items = (res['Items'] as List? ?? [])
+                .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
+                .whereType<Map<String, dynamic>>()
+                .toList();
+            _recommendationCache[cacheKey] = items;
+            for (final item in items) {
+              final id = item['Id']?.toString() ?? '';
+              if (id.isNotEmpty) candidatesMap[id] = item;
+            }
+          } catch (_) {}
+        }());
+      }
+
+      // Fetch candidates matching tags in parallel
+      if (tags.isNotEmpty) {
+        futures.add(() async {
+          try {
+            final cacheKey = 'tags:${candidateItemTypes.join(",")}:${tags.join(",")}';
+            if (_recommendationCache.containsKey(cacheKey)) {
+              final cached = _recommendationCache[cacheKey]!;
+              for (final item in cached) {
+                final id = item['Id']?.toString() ?? '';
+                if (id.isNotEmpty) candidatesMap[id] = item;
+              }
+              return;
+            }
+            final res = await _client.itemsApi.getItems(
+              includeItemTypes: candidateItemTypes,
+              tags: tags,
+              recursive: true,
+              limit: 80,
+              fields: 'Genres,Tags,People,UserData,OfficialRating',
+            );
+            final items = (res['Items'] as List? ?? [])
+                .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
+                .whereType<Map<String, dynamic>>()
+                .toList();
+            _recommendationCache[cacheKey] = items;
+            for (final item in items) {
+              final id = item['Id']?.toString() ?? '';
+              if (id.isNotEmpty) candidatesMap[id] = item;
+            }
+          } catch (_) {}
+        }());
+      }
+
+      // Fetch candidates matching any directors, writers, or actors in parallel using a single combined query
+      final allPersonIds = [
+        ...directorIds.take(2),
+        ...writerIds.take(2),
+        ...actorIds.take(3),
+      ];
+      if (allPersonIds.isNotEmpty) {
+        futures.add(() async {
+          try {
+            final cacheKey = 'people:${candidateItemTypes.join(",")}:${allPersonIds.join(",")}';
+            if (_recommendationCache.containsKey(cacheKey)) {
+              final cached = _recommendationCache[cacheKey]!;
+              for (final item in cached) {
+                final id = item['Id']?.toString() ?? '';
+                if (id.isNotEmpty) candidatesMap[id] = item;
+              }
+              return;
+            }
+            final res = await _client.itemsApi.getItems(
+              includeItemTypes: candidateItemTypes,
+              personIds: allPersonIds,
+              recursive: true,
+              limit: 80,
+              fields: 'Genres,Tags,People,UserData,OfficialRating',
+            );
+            final items = (res['Items'] as List? ?? [])
+                .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
+                .whereType<Map<String, dynamic>>()
+                .toList();
+            _recommendationCache[cacheKey] = items;
+            for (final item in items) {
+              final id = item['Id']?.toString() ?? '';
+              if (id.isNotEmpty) candidatesMap[id] = item;
+            }
+          } catch (_) {}
+        }());
+      }
+
+      await Future.wait(futures);
+
+      final includeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
+      final sourceRating = baseItem.officialRating;
+      final sourceRatingLevel = _getRatingLevel(sourceRating);
+
+      final scoredCandidates = <MapEntry<Map<String, dynamic>, double>>[];
+
+      for (final candidate in candidatesMap.values) {
+        final id = candidate['Id']?.toString() ?? '';
+        if (id.isEmpty || id == baseItem.id) continue;
+
+        // Played check
+        final userData = candidate['UserData'] as Map?;
+        final isPlayed = userData?['Played'] as bool? ?? false;
+        if (!includeWatched && isPlayed) continue;
+
+        // Parental rating constraint upper bound
+        final candRating = candidate['OfficialRating'] as String?;
+        if (_getRatingLevel(candRating) > sourceRatingLevel) continue;
+
+        double score = 0.0;
+
+        // Score genres (+2.0 each)
+        final cGenres = (candidate['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+        for (final g in genres) {
+          if (cGenres.contains(g)) score += 2.0;
+        }
+
+        // Score tags (+1.0 each)
+        final cTags = (candidate['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+        for (final t in tags) {
+          if (cTags.contains(t)) score += 1.0;
+        }
+
+        // Score people
+        final cPeople = (candidate['People'] as List?)?.map((e) => e is Map ? Map<String, dynamic>.from(e) : null).whereType<Map<String, dynamic>>().toList() ?? const <Map<String, dynamic>>[];
+        final cActors = cPeople.where((p) => p['Type'] == 'Actor').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+        final cDirectors = cPeople.where((p) => p['Type'] == 'Director').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+        final cWriters = cPeople.where((p) => p['Type'] == 'Writer').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+
+        for (final a in actorNames) {
+          if (cActors.contains(a)) score += 3.0;
+        }
+        for (final d in directorNames) {
+          if (cDirectors.contains(d)) score += 4.0;
+        }
+        for (final w in writerNames) {
+          if (cWriters.contains(w)) score += 4.0;
+        }
+
+        if (score >= 1.0) {
+          scoredCandidates.add(MapEntry(candidate, score));
+        }
+      }
+
+      // Sort by score desc, then by premiere date desc
+      scoredCandidates.sort((a, b) {
+        final scoreCompare = b.value.compareTo(a.value);
+        if (scoreCompare != 0) return scoreCompare;
+        final dateA = a.key['PremiereDate'] as String? ?? '';
+        final dateB = b.key['PremiereDate'] as String? ?? '';
+        return dateB.compareTo(dateA);
+      });
+
+      recommendedItems = scoredCandidates
+          .take(15)
+          .map((e) => AggregatedItem(
+                id: e.key['Id']?.toString() ?? '',
+                serverId: serverId,
+                rawData: e.key,
+              ))
+          .toList();
+    } else {
+      // Online
+      var tmdbId = baseItem.tmdbId;
+      if (tmdbId == null || tmdbId.isEmpty) {
+        try {
+          final details = await _client.itemsApi.getItem(baseItem.id);
+          final pIds = details['ProviderIds'] as Map?;
+          tmdbId = pIds?['Tmdb']?.toString();
+          if (tmdbId == null || tmdbId.isEmpty) {
+            final imdbId = pIds?['Imdb']?.toString();
+            if (imdbId != null && imdbId.isNotEmpty) {
+              try {
+                final repo = await GetIt.instance.getAsync<SeerrRepository>();
+                await repo.ensureInitialized();
+                if (repo.isAvailable) {
+                  final searchPage = await repo.search(imdbId);
+                  if (searchPage.results.isNotEmpty) {
+                    tmdbId = searchPage.results.first.id.toString();
+                  }
+                }
+              } catch (_) {}
+            }
+          }
+        } catch (e) {
+          print('[RowDataSource] Failed to resolve TMDB ID for online recommendations: $e');
+        }
+      }
+
+      if (tmdbId != null && tmdbId.isNotEmpty) {
+        final tmdbIdInt = int.tryParse(tmdbId);
+        if (tmdbIdInt != null) {
+          final apiKey = prefs.get(UserPreferences.tmdbApiKey);
+          if (apiKey.isNotEmpty) {
+            try {
+              final dio = Dio(BaseOptions(
+                connectTimeout: const Duration(seconds: 10),
+                receiveTimeout: const Duration(seconds: 10),
+              ));
+              final isTv = baseItem.type == 'Series';
+              final path = isTv
+                  ? 'tv/$tmdbIdInt/recommendations'
+                  : 'movie/$tmdbIdInt/recommendations';
+              final url = 'https://api.themoviedb.org/3/$path';
+              final response = await dio.get(
+                url,
+                queryParameters: {
+                  'api_key': apiKey,
+                  'language': 'en-US',
+                  'page': 1,
+                },
+              );
+              if (response.statusCode == 200 && response.data != null) {
+                final results = response.data['results'] as List? ?? [];
+                recommendedItems = results.map((res) {
+                  final idVal = res['id'];
+                  final id = idVal?.toString() ?? '';
+                  final title = (res['title'] as String?) ?? (res['name'] as String?) ?? 'Unknown';
+                  final posterPath = res['poster_path'] as String? ?? '';
+                  final backdropPath = res['backdrop_path'] as String? ?? '';
+                  
+                  final dateStr = (res['release_date'] as String?) ?? (res['first_air_date'] as String?);
+                  int? year;
+                  if (dateStr != null && dateStr.length >= 4) {
+                    year = int.tryParse(dateStr.substring(0, 4));
+                  }
+                  
+                  final mediaTypeRaw = res['media_type'] as String?;
+                  final String type;
+                  if (mediaTypeRaw != null) {
+                    type = mediaTypeRaw == 'tv' ? 'Series' : 'Movie';
+                  } else {
+                    type = isTv ? 'Series' : 'Movie';
+                  }
+                  
+                  return AggregatedItem(
+                    id: id,
+                    serverId: 'seerr',
+                    rawData: {
+                      'Name': title,
+                      'Type': type,
+                      'Overview': res['overview'] as String? ?? '',
+                      'PosterPath': posterPath,
+                      'BackdropPath': backdropPath,
+                      'ProductionYear': year,
+                      'SeerrMediaType': type == 'Series' ? 'tv' : 'movie',
+                    },
+                  );
+                }).take(15).toList();
+              }
+            } catch (e) {
+              print('[RowDataSource] Direct TMDB recommendation query failed: $e');
+            }
+          }
+
+          if (recommendedItems.isEmpty) {
+            try {
+              final repo = await GetIt.instance.getAsync<SeerrRepository>();
+              await repo.ensureInitialized();
+              if (repo.isAvailable) {
+                final isTv = baseItem.type == 'Series';
+                final page = isTv
+                    ? await repo.getTvRecommendations(tmdbIdInt)
+                    : await repo.getMovieRecommendations(tmdbIdInt);
+
+                final blockNsfw = GetIt.instance<SeerrPreferences>().blockNsfw;
+
+                final filtered = page.results.where((item) {
+                  if (item.isBlacklisted) return false;
+                  if (blockNsfw) {
+                    if (item.adult) return false;
+                    final text = '${item.displayTitle} ${item.overview ?? ''}';
+                    if (SeerrDiscoverViewModel.nsfwPatterns.any((p) => p.hasMatch(text))) {
+                      return false;
+                    }
+                  }
+                  return true;
+                }).toList();
+
+                recommendedItems = filtered.map((item) {
+                  return AggregatedItem(
+                    id: item.id.toString(),
+                    serverId: 'seerr',
+                    rawData: {
+                      'Name': item.displayTitle,
+                      'Type': item.mediaType == 'tv' ? 'Series' : 'Movie',
+                      'Overview': item.overview ?? '',
+                      'PosterPath': item.posterPath ?? '',
+                      'BackdropPath': item.backdropPath ?? '',
+                      'ProductionYear': _extractYear(item.releaseDate ?? item.firstAirDate),
+                      'SeerrMediaType': item.mediaType,
+                    },
+                  );
+                }).take(15).toList();
+              }
+            } catch (_) {}
+          }
+        }
+      }
+    }
+
+    return HomeRow(
+      id: 'sinceYouWatched$rowIndex',
+      title: 'Since you watched "$baseItemName"',
+      rowType: HomeRowType.latestMedia,
+      items: recommendedItems,
+    );
+  }
+
+  Future<HomeRow> loadRewatchRow(String serverId) async {
+    final prefs = GetIt.instance<UserPreferences>();
+    final includeMovies = prefs.get(UserPreferences.rewatchIncludeMovies);
+    final includeShows = prefs.get(UserPreferences.rewatchIncludeShows);
+    final includeCollections = prefs.get(UserPreferences.rewatchIncludeCollections);
+    final sortBy = prefs.get(UserPreferences.rewatchSortBy);
+
+    final watchedItems = <AggregatedItem>[];
+    final seriesLastPlayedDates = <String, String>{};
+
+    // 1. Movies
+    if (includeMovies) {
+      try {
+        final res = await _getItemsWithFallback(
+          includeItemTypes: const ['Movie'],
+          filters: const ['IsPlayed'],
+          sortBy: 'DatePlayed',
+          sortOrder: 'Descending',
+          recursive: true,
+          limit: 50,
+          fields: '$_fields,UserData',
+        );
+        watchedItems.addAll(_parseItems(res, serverId));
+      } catch (_) {}
+    }
+
+    // 2. Shows
+    if (includeShows) {
+      try {
+        final res = await _getItemsWithFallback(
+          includeItemTypes: const ['Episode'],
+          filters: const ['IsPlayed'],
+          sortBy: 'DatePlayed',
+          sortOrder: 'Descending',
+          recursive: true,
+          limit: 100,
+          fields: 'SeriesId,UserData',
+        );
+        final episodes = _parseItems(res, serverId);
+        final seriesIds = <String>[];
+        
+        for (final ep in episodes) {
+          final sId = ep.rawData['SeriesId']?.toString();
+          if (sId != null && sId.isNotEmpty) {
+            final lpDate = ep.rawData['UserData']?['LastPlayedDate']?.toString() ?? '';
+            if (lpDate.isNotEmpty) {
+              final existing = seriesLastPlayedDates[sId] ?? '';
+              if (lpDate.compareTo(existing) > 0) {
+                seriesLastPlayedDates[sId] = lpDate;
+              }
+            }
+            if (!seriesIds.contains(sId)) {
+              seriesIds.add(sId);
+            }
+          }
+        }
+            
+        if (seriesIds.isNotEmpty) {
+          final seriesRes = await _client.itemsApi.getItems(
+            ids: seriesIds,
+            fields: '$_fields,UserData',
+          );
+          final parsedSeries = _parseItems(seriesRes, serverId);
+          
+          final checkFutures = parsedSeries.map((s) async {
+            final userData = s.rawData['UserData'] as Map?;
+            final isPlayed = userData?['Played'] as bool? ?? false;
+            final unplayedCount = s.rawData['UnplayedItemCount'] as int? ?? userData?['UnplayedItemCount'] as int? ?? 0;
+            
+            if (!isPlayed || unplayedCount > 0) return null;
+            
+            try {
+              final episodesRes = await _client.itemsApi.getItems(
+                parentId: s.id,
+                includeItemTypes: const ['Episode'],
+                recursive: true,
+                filters: const ['IsUnplayed'],
+                limit: 1,
+              );
+              final itemsCount = episodesRes['TotalRecordCount'] as int? ?? (episodesRes['Items'] as List?)?.length ?? 0;
+              if (itemsCount == 0) {
+                return s;
+              }
+            } catch (_) {
+              return s;
+            }
+            return null;
+          }).toList();
+          
+          final checkedResults = await Future.wait(checkFutures);
+          final filteredSeries = checkedResults.whereType<AggregatedItem>().toList();
+          watchedItems.addAll(filteredSeries);
+        }
+      } catch (_) {}
+    }
+
+    // 3. Collections
+    final collectionLastPlayedDates = <String, String>{};
+    if (includeCollections) {
+      try {
+        final res = await _getItemsWithFallback(
+          includeItemTypes: const ['BoxSet'],
+          recursive: true,
+          limit: 50,
+          fields: '$_fields',
+        );
+        final collections = _parseItems(res, serverId);
+        
+        final collectionFutures = collections.map((col) async {
+          try {
+            final childrenRes = await _client.itemsApi.getItems(
+              parentId: col.id,
+              recursive: true,
+              fields: 'UserData',
+            );
+            final children = childrenRes['Items'] as List? ?? [];
+            if (children.isNotEmpty && children.every((c) => (c['UserData']?['Played'] as bool?) == true)) {
+              // Find max LastPlayedDate of children to assign to the collection
+              String maxLp = '';
+              for (final c in children) {
+                final lp = c['UserData']?['LastPlayedDate']?.toString() ?? '';
+                if (lp.compareTo(maxLp) > 0) maxLp = lp;
+              }
+              return {
+                'col': col,
+                'isPlayed': true,
+                'lastPlayed': maxLp,
+              };
+            }
+          } catch (_) {}
+          return {
+            'col': col,
+            'isPlayed': false,
+            'lastPlayed': '',
+          };
+        }).toList();
+
+        final collectionInfos = await Future.wait(collectionFutures);
+        for (final info in collectionInfos) {
+          if (info['isPlayed'] as bool) {
+            watchedItems.add(info['col'] as AggregatedItem);
+            collectionLastPlayedDates[(info['col'] as AggregatedItem).id] = info['lastPlayed'] as String;
+          }
+        }
+      } catch (_) {}
+    }
+
+    // Sort the watchedItems
+    if (sortBy == RewatchSortBy.recentlyWatched) {
+      watchedItems.sort((a, b) {
+        String lpA = a.rawData['UserData']?['LastPlayedDate']?.toString() ?? '';
+        if (a.type == 'BoxSet' && collectionLastPlayedDates.containsKey(a.id)) {
+          lpA = collectionLastPlayedDates[a.id]!;
+        } else if (a.type == 'Series' && seriesLastPlayedDates.containsKey(a.id)) {
+          lpA = seriesLastPlayedDates[a.id]!;
+        }
+        
+        String lpB = b.rawData['UserData']?['LastPlayedDate']?.toString() ?? '';
+        if (b.type == 'BoxSet' && collectionLastPlayedDates.containsKey(b.id)) {
+          lpB = collectionLastPlayedDates[b.id]!;
+        } else if (b.type == 'Series' && seriesLastPlayedDates.containsKey(b.id)) {
+          lpB = seriesLastPlayedDates[b.id]!;
+        }
+        return lpB.compareTo(lpA);
+      });
+    } else {
+      watchedItems.shuffle();
+    }
+
+    // Take top 15 and resolve rewatch entries in parallel
+    final resolveFutures = watchedItems.take(15).map((item) async {
+      if (item.type == 'Movie') {
+        return item;
+      } else if (item.type == 'BoxSet') {
+        return item;
+      } else if (item.type == 'Series') {
+        // Fetch first episode of this series
+        try {
+          final epRes = await _getItemsWithFallback(
+            parentId: item.id,
+            includeItemTypes: const ['Episode'],
+            recursive: true,
+            sortBy: 'SortName,ProductionYear',
+            sortOrder: 'Ascending',
+            limit: 1,
+          );
+          final eps = _parseItems(epRes, serverId);
+          if (eps.isNotEmpty) {
+            return eps.first;
+          }
+        } catch (_) {}
+        return item;
+      }
+      return item;
+    }).toList();
+
+    final resolvedItems = await Future.wait(resolveFutures);
+
+    return HomeRow(
+      id: 'rewatch',
+      title: 'Rewatch',
+      rowType: HomeRowType.latestMedia,
+      items: resolvedItems,
+    );
   }
 }
 

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2077,7 +2077,7 @@ class RowDataSource {
       if (allPersonIds.isNotEmpty) {
         futures.add(() async {
           try {
-            final cacheKey = 'people:${candidateItemTypes.join(",")}:${allPersonIds.join(",")}';
+            final cacheKey = '$serverId:people:${candidateItemTypes.join(",")}:${allPersonIds.join(",")}';
             if (_recommendationCache.containsKey(cacheKey)) {
               final cached = _recommendationCache[cacheKey]!;
               for (final item in cached) {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2059,7 +2059,7 @@ class RowDataSource {
                 .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
                 .whereType<Map<String, dynamic>>()
                 .toList();
-            _recommendationCache[cacheKey] = items;
+            _cacheRecommendations(cacheKey, items);
             for (final item in items) {
               final id = item['Id']?.toString() ?? '';
               if (id.isNotEmpty) candidatesMap[id] = item;

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2039,7 +2039,7 @@ class RowDataSource {
       if (tags.isNotEmpty) {
         futures.add(() async {
           try {
-            final cacheKey = 'tags:${candidateItemTypes.join(",")}:${tags.join(",")}';
+            final cacheKey = '$serverId:tags:${candidateItemTypes.join(",")}:${tags.join(",")}';
             if (_recommendationCache.containsKey(cacheKey)) {
               final cached = _recommendationCache[cacheKey]!;
               for (final item in cached) {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -50,7 +50,18 @@ class RowDataSource {
       'ParentBackdropItemId,ParentBackdropImageTags,SeriesId';
 
   // Cache for local recommendations to make them practically instantaneous
+  static const int _recommendationCacheMaxEntries = 64;
   static final Map<String, List<Map<String, dynamic>>> _recommendationCache = {};
+
+  static void clearRecommendationCache() => _recommendationCache.clear();
+
+  static void _cacheRecommendations(String key, List<Map<String, dynamic>> items) {
+    _recommendationCache.remove(key);
+    _recommendationCache[key] = items;
+    while (_recommendationCache.length > _recommendationCacheMaxEntries) {
+      _recommendationCache.remove(_recommendationCache.keys.first);
+    }
+  }
 
   // Cap image tags to one per type (server returns all by default)
   static const _imageTypes = 'Primary,Backdrop,Thumb';

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2026,7 +2026,7 @@ class RowDataSource {
                 .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
                 .whereType<Map<String, dynamic>>()
                 .toList();
-            _recommendationCache[cacheKey] = items;
+            _cacheRecommendations(cacheKey, items);
             for (final item in items) {
               final id = item['Id']?.toString() ?? '';
               if (id.isNotEmpty) candidatesMap[id] = item;

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -20,7 +20,6 @@ import '../utils/playlist_utils.dart';
 import 'package:flutter/foundation.dart';
 import '../repositories/seerr_repository.dart';
 import '../../preference/seerr_preferences.dart';
-import '../services/seerr/seerr_api_models.dart';
 import '../viewmodels/seerr_discover_view_model.dart';
 import 'custom_external_lists_service.dart';
 

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2006,7 +2006,7 @@ class RowDataSource {
       if (genres.isNotEmpty) {
         futures.add(() async {
           try {
-            final cacheKey = 'genres:${candidateItemTypes.join(",")}:${genres.join(",")}';
+            final cacheKey = '$serverId:genres:${candidateItemTypes.join(",")}:${genres.join(",")}';
             if (_recommendationCache.containsKey(cacheKey)) {
               final cached = _recommendationCache[cacheKey]!;
               for (final item in cached) {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2097,7 +2097,7 @@ class RowDataSource {
                 .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
                 .whereType<Map<String, dynamic>>()
                 .toList();
-            _recommendationCache[cacheKey] = items;
+            _cacheRecommendations(cacheKey, items);
             for (final item in items) {
               final id = item['Id']?.toString() ?? '';
               if (id.isNotEmpty) candidatesMap[id] = item;

--- a/lib/di/modules/app_module.dart
+++ b/lib/di/modules/app_module.dart
@@ -62,6 +62,7 @@ void resetUserScopedSingletons() {
   unregister<TmdbRepository>();
   unregister<MdbListRepository>();
   unregister<RowDataSource>();
+  RowDataSource.clearRecommendationCache();
   unregister<ItemMutationRepository>();
   unregister<SearchRepository>();
   unregister<UserViewsRepository>();

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -286,6 +286,12 @@ enum HomeSectionType {
   tmdbTrendingAllWeekly('tmdb_trending_all_weekly'),
   radarrCalendar('radarr_calendar'),
   sonarrCalendar('sonarr_calendar'),
+  sinceYouWatched1('sinceyouwatched1'),
+  sinceYouWatched2('sinceyouwatched2'),
+  sinceYouWatched3('sinceyouwatched3'),
+  sinceYouWatched4('sinceyouwatched4'),
+  sinceYouWatched5('sinceyouwatched5'),
+  rewatch('rewatch'),
   none('none');
 
   const HomeSectionType(this.serializedName);
@@ -444,3 +450,59 @@ enum ScreensaverTimeout {
   const ScreensaverTimeout(this.minutes);
   final int minutes;
 }
+
+enum SinceYouWatchedSource {
+  local,
+  online;
+
+  String get displayName => this == local ? 'Local' : 'Online';
+}
+
+enum SinceYouWatchedSourceType {
+  movies,
+  shows,
+  both;
+
+  String get displayName {
+    switch (this) {
+      case movies: return 'Movies';
+      case shows: return 'Shows';
+      case both: return 'Both';
+    }
+  }
+}
+
+enum SinceYouWatchedSourceItem {
+  recentlyWatched,
+  favorites,
+  random;
+
+  String get displayName {
+    switch (this) {
+      case recentlyWatched: return 'Recently Watched';
+      case favorites: return 'Favorites';
+      case random: return 'Random';
+    }
+  }
+}
+
+enum SinceYouWatchedNumRows {
+  one(1),
+  two(2),
+  three(3),
+  four(4),
+  five(5);
+
+  const SinceYouWatchedNumRows(this.value);
+  final int value;
+
+  String get displayName => value.toString();
+}
+
+enum RewatchSortBy {
+  recentlyWatched,
+  random;
+
+  String get displayName => this == recentlyWatched ? 'Recently Watched' : 'Random';
+}
+

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -688,6 +688,90 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final displaySinceYouWatchedRows = Preference(
+    key: 'pref_display_since_you_watched_rows',
+    defaultValue: false,
+  );
+
+  static final sinceYouWatched1Enabled = Preference(
+    key: 'since_you_watched_1_enabled',
+    defaultValue: false,
+  );
+
+  static final sinceYouWatched2Enabled = Preference(
+    key: 'since_you_watched_2_enabled',
+    defaultValue: false,
+  );
+
+  static final sinceYouWatched3Enabled = Preference(
+    key: 'since_you_watched_3_enabled',
+    defaultValue: false,
+  );
+
+  static final sinceYouWatched4Enabled = Preference(
+    key: 'since_you_watched_4_enabled',
+    defaultValue: false,
+  );
+
+  static final sinceYouWatched5Enabled = Preference(
+    key: 'since_you_watched_5_enabled',
+    defaultValue: false,
+  );
+
+  static final sinceYouWatchedSource = EnumPreference(
+    key: 'pref_since_you_watched_source',
+    defaultValue: SinceYouWatchedSource.local,
+    values: SinceYouWatchedSource.values,
+  );
+
+  static final sinceYouWatchedSourceType = EnumPreference(
+    key: 'pref_since_you_watched_source_type',
+    defaultValue: SinceYouWatchedSourceType.movies,
+    values: SinceYouWatchedSourceType.values,
+  );
+
+  static final sinceYouWatchedSourceItem = EnumPreference(
+    key: 'pref_since_you_watched_source_item',
+    defaultValue: SinceYouWatchedSourceItem.recentlyWatched,
+    values: SinceYouWatchedSourceItem.values,
+  );
+
+  static final sinceYouWatchedNumRows = EnumPreference(
+    key: 'pref_since_you_watched_num_rows',
+    defaultValue: SinceYouWatchedNumRows.one,
+    values: SinceYouWatchedNumRows.values,
+  );
+
+  static final sinceYouWatchedIncludeWatched = Preference(
+    key: 'pref_since_you_watched_include_watched',
+    defaultValue: false,
+  );
+
+  static final displayRewatchRow = Preference(
+    key: 'pref_display_rewatch_row',
+    defaultValue: false,
+  );
+
+  static final rewatchSortBy = EnumPreference(
+    key: 'pref_rewatch_sort_by',
+    defaultValue: RewatchSortBy.recentlyWatched,
+    values: RewatchSortBy.values,
+  );
+
+  static final rewatchIncludeMovies = Preference(
+    key: 'pref_rewatch_include_movies',
+    defaultValue: true,
+  );
+
+  static final rewatchIncludeShows = Preference(
+    key: 'pref_rewatch_include_shows',
+    defaultValue: true,
+  );
+
+  static final rewatchIncludeCollections = Preference(
+    key: 'pref_rewatch_include_collections',
+    defaultValue: true,
+  );
   static final favoritesRowSortBy = EnumPreference(
     key: 'pref_favorites_row_sort_by',
     defaultValue: LibrarySortBy.name,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -346,7 +346,11 @@ class _HomeShellState extends State<_HomeShell>
       _themeMusicService.fadeOutAndStop();
       return;
     }
-    _viewModel.refresh(preserveExisting: true);
+    Future.delayed(const Duration(milliseconds: 300), () {
+      if (mounted) {
+        _viewModel.refresh(preserveExisting: true);
+      }
+    });
     _maybeRegisterThemeMusic();
     if (_selectedItem != null) {
       _maybePlayThemeMusic(_selectedItem);
@@ -1971,10 +1975,21 @@ class _ContentRowsState extends State<_ContentRows>
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
     final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
+    final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
 
     double childHeight = 0.0;
     if (row.isLoading) {
-      childHeight = 220.0 * metadataScale;
+      if (row.rowType == HomeRowType.liveTv ||
+          row.rowType == HomeRowType.libraryTilesSmall) {
+        final squarePosterSide = _squarePosterSide(posterSize);
+        childHeight = squarePosterSide + (56 * metadataScale);
+      } else if (isRowsV2) {
+        final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;
+        childHeight = imageHeight + (_v2MetadataHeightBudget(prefs) * metadataScale) + (10 * metadataScale);
+      } else {
+        final imageHeight = posterSize.portraitHeight.toDouble() * platformScale;
+        childHeight = imageHeight + (46 * metadataScale) + (10 * metadataScale);
+      }
     } else if (row.rowType == HomeRowType.liveTv ||
         row.rowType == HomeRowType.libraryTilesSmall) {
       final squarePosterSide = _squarePosterSide(posterSize);
@@ -1984,7 +1999,6 @@ class _ContentRowsState extends State<_ContentRows>
       final rowImageType = isSeerrRowOverride
           ? ImageType.thumb
           : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
-      final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
       var maxCardHeight = 220.0 * metadataScale;
       if (isRowsV2) {
         final imageHeight = posterSize.portraitHeight.toDouble() * platformScale * 2;

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -224,6 +224,24 @@ class HomeViewModel extends ChangeNotifier {
         _prefs.get(UserPreferences.tmdbTrendingAllWeeklyEnabled);
   }
 
+  static bool _isSinceYouWatchedSectionType(HomeSectionType type) {
+    return type == HomeSectionType.sinceYouWatched1 ||
+        type == HomeSectionType.sinceYouWatched2 ||
+        type == HomeSectionType.sinceYouWatched3 ||
+        type == HomeSectionType.sinceYouWatched4 ||
+        type == HomeSectionType.sinceYouWatched5;
+  }
+
+  static int _getSinceYouWatchedIndex(HomeSectionType type) {
+    switch (type) {
+      case HomeSectionType.sinceYouWatched1: return 1;
+      case HomeSectionType.sinceYouWatched2: return 2;
+      case HomeSectionType.sinceYouWatched3: return 3;
+      case HomeSectionType.sinceYouWatched4: return 4;
+      case HomeSectionType.sinceYouWatched5: return 5;
+      default: return 0;
+    }
+  }
   ImageApi imageApiForServer(String serverId) {
     if (!_multiServerEnabled) return _dataSource.imageApi;
     return _multiServerRepo.getImageApiForServer(serverId);
@@ -304,6 +322,9 @@ class HomeViewModel extends ChangeNotifier {
           GetIt.instance<PluginSyncService>().seerrAvailable;
       final showImdbRows = _isAnyImdbSectionEnabled();
       final showTmdbRows = _isAnyTmdbSectionEnabled();
+      final showSinceYouWatched = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
+      final sinceYouWatchedNum = _prefs.get(UserPreferences.sinceYouWatchedNumRows).value;
+      final showRewatch = _prefs.get(UserPreferences.displayRewatchRow);
 
       // Plugin-dynamic sections only make sense on the active server.
       final visibleConfigsRaw = configs
@@ -333,7 +354,9 @@ class HomeViewModel extends ChangeNotifier {
                 (!_isImdbSectionType(c.type) || (showImdbRows && _isImdbSectionEnabled(c.type))) &&
                 (!_isTmdbSectionType(c.type) || (showTmdbRows && _isTmdbSectionEnabled(c.type))) &&
                 (c.type != HomeSectionType.radarrCalendar || _prefs.get(UserPreferences.enableRadarrCalendar)) &&
-                (c.type != HomeSectionType.sonarrCalendar || _prefs.get(UserPreferences.enableSonarrCalendar)),
+                (c.type != HomeSectionType.sonarrCalendar || _prefs.get(UserPreferences.enableSonarrCalendar)) &&
+                (!_isSinceYouWatchedSectionType(c.type) || (showSinceYouWatched && _getSinceYouWatchedIndex(c.type) <= sinceYouWatchedNum)) &&
+                (c.type != HomeSectionType.rewatch || showRewatch),
           )
           .toList(growable: false);
 
@@ -420,6 +443,9 @@ class HomeViewModel extends ChangeNotifier {
             debugPrint('[Home] Failed to load section $cfg: $e');
             sectionRows = const <HomeRow>[];
           }
+          final currentConfigs = _prefs.activeHomeSectionConfigs;
+          final isStillActive = currentConfigs.any((c) => c.stableId == cfg.stableId);
+          if (!isStillActive) return;
           // Cleanup runs even when the load failed, so the section's loading
           // placeholder is cleared instead of spinning forever.
           final loadedRows = sectionRows
@@ -556,7 +582,9 @@ class HomeViewModel extends ChangeNotifier {
         // Plugin-dynamic rows (per-collection, per-playlist, etc.) have IDs
         // starting with 'pluginDynamic:' and must NOT be claimed here.
         return row.rowType == HomeRowType.latestMedia &&
-            !row.id.startsWith('pluginDynamic:');
+            !row.id.startsWith('pluginDynamic:') &&
+            !row.id.startsWith('sinceYouWatched') &&
+            row.id != 'rewatch';
       case HomeSectionType.favoriteMovies:
       case HomeSectionType.favoriteSeries:
       case HomeSectionType.favoriteEpisodes:
@@ -661,6 +689,15 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.mediaBar:
       case HomeSectionType.recentlyReleased:
         return row.rowType == HomeRowType.recentlyReleased;
+      case HomeSectionType.sinceYouWatched1:
+      case HomeSectionType.sinceYouWatched2:
+      case HomeSectionType.sinceYouWatched3:
+      case HomeSectionType.sinceYouWatched4:
+      case HomeSectionType.sinceYouWatched5:
+        final idx = _getSinceYouWatchedIndex(cfg.type);
+        return row.rowType == HomeRowType.latestMedia && row.id == 'sinceYouWatched$idx';
+      case HomeSectionType.rewatch:
+        return row.rowType == HomeRowType.latestMedia && row.id == 'rewatch';
       case HomeSectionType.resumeBook:
       case HomeSectionType.none:
         return false;
@@ -931,6 +968,18 @@ class HomeViewModel extends ChangeNotifier {
         return const {'radarrCalendar'};
       case HomeSectionType.sonarrCalendar:
         return const {'sonarrCalendar'};
+      case HomeSectionType.sinceYouWatched1:
+        return const {'sinceYouWatched1'};
+      case HomeSectionType.sinceYouWatched2:
+        return const {'sinceYouWatched2'};
+      case HomeSectionType.sinceYouWatched3:
+        return const {'sinceYouWatched3'};
+      case HomeSectionType.sinceYouWatched4:
+        return const {'sinceYouWatched4'};
+      case HomeSectionType.sinceYouWatched5:
+        return const {'sinceYouWatched5'};
+      case HomeSectionType.rewatch:
+        return const {'rewatch'};
       case HomeSectionType.mediaBar:
       case HomeSectionType.none:
         return const <String>{};
@@ -1292,6 +1341,17 @@ class HomeViewModel extends ChangeNotifier {
         return _loadTmdbChartRow(HomeSectionType.tmdbTrendingAllWeekly, 'Trending All (Weekly)', 'tmdb_trending_all_weekly');
       case HomeSectionType.recentlyReleased:
         return _loadRecentlyReleasedRow();
+      case HomeSectionType.sinceYouWatched1:
+      case HomeSectionType.sinceYouWatched2:
+      case HomeSectionType.sinceYouWatched3:
+      case HomeSectionType.sinceYouWatched4:
+      case HomeSectionType.sinceYouWatched5:
+        final rowIndex = _getSinceYouWatchedIndex(section);
+        final row = await _dataSource.loadSinceYouWatchedRow(_serverId, rowIndex);
+        return [row];
+      case HomeSectionType.rewatch:
+        final row = await _dataSource.loadRewatchRow(_serverId);
+        return [row];
       case HomeSectionType.resumeBook:
       case HomeSectionType.none:
         return [];
@@ -1722,6 +1782,25 @@ class HomeViewModel extends ChangeNotifier {
           id: 'recentlyReleased',
           title: l10n.recentlyReleased,
           rowType: HomeRowType.recentlyReleased,
+          isLoading: true,
+        );
+      case HomeSectionType.sinceYouWatched1:
+      case HomeSectionType.sinceYouWatched2:
+      case HomeSectionType.sinceYouWatched3:
+      case HomeSectionType.sinceYouWatched4:
+      case HomeSectionType.sinceYouWatched5:
+        final index = _getSinceYouWatchedIndex(section);
+        return HomeRow(
+          id: 'sinceYouWatched$index',
+          title: 'Since you watched',
+          rowType: HomeRowType.latestMedia,
+          isLoading: true,
+        );
+      case HomeSectionType.rewatch:
+        return HomeRow(
+          id: 'rewatch',
+          title: 'Rewatch',
+          rowType: HomeRowType.latestMedia,
           isLoading: true,
         );
       case HomeSectionType.resumeBook:

--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -6,6 +6,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import '../../../data/services/plugin_sync_service.dart';
 import '../home/home_view_model.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../widgets/adaptive/adaptive_list_section.dart';
@@ -68,7 +69,7 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
 
   void _reloadHomeRows() {
     if (!GetIt.instance.isRegistered<HomeViewModel>()) return;
-    GetIt.instance<HomeViewModel>().load(preserveExisting: true);
+    GetIt.instance<HomeViewModel>().load(preserveExisting: false);
   }
 
   void _onFavoritesRowsToggleChanged() {
@@ -131,6 +132,110 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
     _reloadHomeRows();
   }
 
+  bool _getSinceYouWatchedLocalPrefEnabled(HomeSectionType type) {
+    return switch (type) {
+      HomeSectionType.sinceYouWatched1 => _prefs.get(UserPreferences.sinceYouWatched1Enabled),
+      HomeSectionType.sinceYouWatched2 => _prefs.get(UserPreferences.sinceYouWatched2Enabled),
+      HomeSectionType.sinceYouWatched3 => _prefs.get(UserPreferences.sinceYouWatched3Enabled),
+      HomeSectionType.sinceYouWatched4 => _prefs.get(UserPreferences.sinceYouWatched4Enabled),
+      HomeSectionType.sinceYouWatched5 => _prefs.get(UserPreferences.sinceYouWatched5Enabled),
+      _ => false,
+    };
+  }
+
+  void _updateSinceYouWatchedPrefs() {
+    final showSinceYouWatched = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
+    final sinceYouWatchedNum = _prefs.get(UserPreferences.sinceYouWatchedNumRows).value;
+
+    _prefs.set(UserPreferences.sinceYouWatched1Enabled, showSinceYouWatched && sinceYouWatchedNum >= 1);
+    _prefs.set(UserPreferences.sinceYouWatched2Enabled, showSinceYouWatched && sinceYouWatchedNum >= 2);
+    _prefs.set(UserPreferences.sinceYouWatched3Enabled, showSinceYouWatched && sinceYouWatchedNum >= 3);
+    _prefs.set(UserPreferences.sinceYouWatched4Enabled, showSinceYouWatched && sinceYouWatchedNum >= 4);
+    _prefs.set(UserPreferences.sinceYouWatched5Enabled, showSinceYouWatched && sinceYouWatchedNum >= 5);
+  }
+
+  void _onSinceYouWatchedRowsToggleChanged() {
+    _updateSinceYouWatchedPrefs();
+    final configs = List<HomeSectionConfig>.from(_prefs.homeSectionsConfig);
+    var changed = false;
+    final types = {
+      HomeSectionType.sinceYouWatched1,
+      HomeSectionType.sinceYouWatched2,
+      HomeSectionType.sinceYouWatched3,
+      HomeSectionType.sinceYouWatched4,
+      HomeSectionType.sinceYouWatched5,
+    };
+    for (var i = 0; i < configs.length; i++) {
+      if (types.contains(configs[i].type)) {
+        final isEnabled = _getSinceYouWatchedLocalPrefEnabled(configs[i].type);
+        if (configs[i].enabled != isEnabled) {
+          configs[i] = configs[i].copyWith(enabled: isEnabled);
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      _prefs.setHomeSectionsConfig(configs);
+    }
+    _pushPersonalizationSync();
+    _reloadHomeRows();
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  void _onSinceYouWatchedConfigChanged() {
+    _updateSinceYouWatchedPrefs();
+    final configs = List<HomeSectionConfig>.from(_prefs.homeSectionsConfig);
+    var changed = false;
+    final types = {
+      HomeSectionType.sinceYouWatched1,
+      HomeSectionType.sinceYouWatched2,
+      HomeSectionType.sinceYouWatched3,
+      HomeSectionType.sinceYouWatched4,
+      HomeSectionType.sinceYouWatched5,
+    };
+    for (var i = 0; i < configs.length; i++) {
+      if (types.contains(configs[i].type)) {
+        final isEnabled = _getSinceYouWatchedLocalPrefEnabled(configs[i].type);
+        if (configs[i].enabled != isEnabled) {
+          configs[i] = configs[i].copyWith(enabled: isEnabled);
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      _prefs.setHomeSectionsConfig(configs);
+    }
+    _pushPersonalizationSync();
+    _reloadHomeRows();
+  }
+
+  void _onRewatchRowToggleChanged() {
+    final enabled = _prefs.get(UserPreferences.displayRewatchRow);
+    final configs = List<HomeSectionConfig>.from(_prefs.homeSectionsConfig);
+    var changed = false;
+    for (var i = 0; i < configs.length; i++) {
+      if (configs[i].type == HomeSectionType.rewatch) {
+        if (configs[i].enabled != enabled) {
+          configs[i] = configs[i].copyWith(enabled: enabled);
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      _prefs.setHomeSectionsConfig(configs);
+    }
+    _pushPersonalizationSync();
+    _reloadHomeRows();
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  void _onRewatchConfigChanged() {
+    _pushPersonalizationSync();
+    _reloadHomeRows();
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -144,6 +249,9 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
     final showGenresRows = _prefs.get(UserPreferences.displayGenresRows);
     final showPlaylistsRows = _prefs.get(UserPreferences.displayPlaylistsRows);
     final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
+    final showSinceYouWatchedRows = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
+    final sinceYouWatchedSource = _prefs.get(UserPreferences.sinceYouWatchedSource);
+    final showRewatchRow = _prefs.get(UserPreferences.displayRewatchRow);
 
     final borderTokens = ThemeRegistry.active.borders;
     final baseBorder = borderTokens.cardBorder.color;
@@ -269,6 +377,65 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                 ],
               ),
 
+              _SectionHeader('SINCE YOU WATCHED'),
+              adaptiveListSection(
+                children: [
+                  SwitchPreferenceTile(
+                    preference: UserPreferences.displaySinceYouWatchedRows,
+                    title: 'Display Since You Watched Rows',
+                    subtitle: 'Show and customize Since You Watched rows in Home Sections.',
+                    icon: Icons.recommend,
+                    onChanged: _onSinceYouWatchedRowsToggleChanged,
+                  ),
+                  if (showSinceYouWatchedRows) ...[
+                    EnumPreferenceTile<SinceYouWatchedSource>(
+                      preference: UserPreferences.sinceYouWatchedSource,
+                      title: 'Source',
+                      description: "Choose recommendation source (the local-content-only Moonfin special or TMDB's similarity metric. Note: Online recommendations require Seerr integration).",
+                      icon: Icons.source,
+                      values: SinceYouWatchedSource.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    EnumPreferenceTile<SinceYouWatchedSourceType>(
+                      preference: UserPreferences.sinceYouWatchedSourceType,
+                      title: 'Source Type',
+                      description: 'Choose type of items to recommend',
+                      icon: Icons.merge_type,
+                      values: SinceYouWatchedSourceType.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    EnumPreferenceTile<SinceYouWatchedSourceItem>(
+                      preference: UserPreferences.sinceYouWatchedSourceItem,
+                      title: 'Source Item',
+                      description: 'Choose which source item to base recommendations on',
+                      icon: Icons.play_circle_filled,
+                      values: SinceYouWatchedSourceItem.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    EnumPreferenceTile<SinceYouWatchedNumRows>(
+                      preference: UserPreferences.sinceYouWatchedNumRows,
+                      title: 'Number of Rows to Add',
+                      description: 'Choose how many Since You Watched rows to display (1-5)',
+                      icon: Icons.format_list_numbered,
+                      values: SinceYouWatchedNumRows.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onSinceYouWatchedConfigChanged,
+                    ),
+                    if (sinceYouWatchedSource != SinceYouWatchedSource.online)
+                      SwitchPreferenceTile(
+                        preference: UserPreferences.sinceYouWatchedIncludeWatched,
+                        title: 'Include Previously Watched',
+                        subtitle: 'Include watched items in recommendations',
+                        icon: Icons.history,
+                        onChanged: _onSinceYouWatchedConfigChanged,
+                      ),
+                  ],
+                ],
+              ),
+
               _SectionHeader(l10n.collections),
               adaptiveListSection(
                 children: [
@@ -363,6 +530,50 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                       labelOf: (v) => v.displayName,
                       onChanged: _onPlaylistsSortChanged,
                     ),
+                ],
+              ),
+              _SectionHeader('REWATCH'),
+              adaptiveListSection(
+                children: [
+                  SwitchPreferenceTile(
+                    preference: UserPreferences.displayRewatchRow,
+                    title: 'Display Rewatch Row',
+                    subtitle: 'Show Rewatch row in Home Sections',
+                    icon: Icons.replay,
+                    onChanged: _onRewatchRowToggleChanged,
+                  ),
+                  if (showRewatchRow) ...[
+                    EnumPreferenceTile<RewatchSortBy>(
+                      preference: UserPreferences.rewatchSortBy,
+                      title: 'Sort By',
+                      description: 'Choose sorting method for completed items',
+                      icon: Icons.sort,
+                      values: RewatchSortBy.values,
+                      labelOf: (v) => v.displayName,
+                      onChanged: _onRewatchConfigChanged,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.rewatchIncludeMovies,
+                      title: 'Include Movies',
+                      subtitle: 'Show watched movies in the rewatch row',
+                      icon: Icons.movie,
+                      onChanged: _onRewatchConfigChanged,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.rewatchIncludeShows,
+                      title: 'Include Shows',
+                      subtitle: 'Show watched TV shows in the rewatch row',
+                      icon: Icons.tv,
+                      onChanged: _onRewatchConfigChanged,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.rewatchIncludeCollections,
+                      title: 'Include Collections',
+                      subtitle: 'Show watched collections in the rewatch row',
+                      icon: Icons.collections,
+                      onChanged: _onRewatchConfigChanged,
+                    ),
+                  ],
                 ],
               ),
               const SizedBox(height: 32),

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../../data/models/aggregated_item.dart';
@@ -41,6 +42,8 @@ const EdgeInsets _kHomeSectionTileOuterPadding = EdgeInsets.fromLTRB(
 BoxDecoration _homeSectionTileDecoration(
   BuildContext context, {
   required bool focused,
+  HomeSectionType? type,
+  bool mergeEnabled = false,
 }) {
   final colorScheme = Theme.of(context).colorScheme;
   final borderTokens = ThemeRegistry.active.borders;
@@ -48,6 +51,35 @@ BoxDecoration _homeSectionTileDecoration(
   final unfocusedBorderColor = baseBorder.a == 0
       ? AppColorScheme.onSurface.withValues(alpha: 0.16)
       : baseBorder.withValues(alpha: 0.55);
+
+  final isMergedResume = mergeEnabled && type == HomeSectionType.resume;
+  final isMergedNextUp = mergeEnabled && type == HomeSectionType.nextUp;
+
+  if (isMergedResume || isMergedNextUp) {
+    final borderColor = focused
+        ? AppColorScheme.accent.withValues(alpha: 0.72)
+        : const Color(0xFF00F0FF); // Neon cyan border for merged rows
+    final borderWidth = focused ? 2.0 : 1.5;
+
+    return BoxDecoration(
+      color: focused
+          ? AppColorScheme.onSurface
+          : colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
+      borderRadius: isMergedResume
+          ? const BorderRadius.vertical(top: Radius.circular(_kHomeSectionTileRadius))
+          : const BorderRadius.vertical(bottom: Radius.circular(_kHomeSectionTileRadius)),
+      border: Border(
+        top: isMergedResume
+            ? BorderSide(color: borderColor, width: borderWidth)
+            : BorderSide.none,
+        bottom: isMergedNextUp
+            ? BorderSide(color: borderColor, width: borderWidth)
+            : BorderSide.none,
+        left: BorderSide(color: borderColor, width: borderWidth),
+        right: BorderSide(color: borderColor, width: borderWidth),
+      ),
+    );
+  }
 
   return BoxDecoration(
     color: focused
@@ -393,6 +425,25 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         type == HomeSectionType.audioPlaylists;
   }
 
+  bool _isSinceYouWatchedSectionType(HomeSectionType type) {
+    return type == HomeSectionType.sinceYouWatched1 ||
+        type == HomeSectionType.sinceYouWatched2 ||
+        type == HomeSectionType.sinceYouWatched3 ||
+        type == HomeSectionType.sinceYouWatched4 ||
+        type == HomeSectionType.sinceYouWatched5;
+  }
+
+  int _getSinceYouWatchedIndex(HomeSectionType type) {
+    switch (type) {
+      case HomeSectionType.sinceYouWatched1: return 1;
+      case HomeSectionType.sinceYouWatched2: return 2;
+      case HomeSectionType.sinceYouWatched3: return 3;
+      case HomeSectionType.sinceYouWatched4: return 4;
+      case HomeSectionType.sinceYouWatched5: return 5;
+      default: return 0;
+    }
+  }
+
   bool _isCollectionsSectionType(HomeSectionType type) {
     return type == HomeSectionType.collections;
   }
@@ -622,6 +673,16 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
     final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
     final hiddenByAudio = !showAudioRows && _isAudioSectionType(section.type);
+
+    final showSinceYouWatched = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
+    final sinceYouWatchedNum = _prefs.get(UserPreferences.sinceYouWatchedNumRows).value;
+    final showRewatch = _prefs.get(UserPreferences.displayRewatchRow);
+
+    final hiddenBySinceYouWatched = _isSinceYouWatchedSectionType(section.type) &&
+        (!showSinceYouWatched || _getSinceYouWatchedIndex(section.type) > sinceYouWatchedNum);
+
+    final hiddenByRewatch = section.type == HomeSectionType.rewatch && !showRewatch;
+
     return hiddenByFavorites ||
         hiddenByCollections ||
         hiddenByGenres ||
@@ -629,13 +690,19 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         hiddenBySeerr ||
         hiddenByImdb ||
         hiddenByTmdb ||
-        hiddenByAudio;
+        hiddenByAudio ||
+        hiddenBySinceYouWatched ||
+        hiddenByRewatch;
   }
 
   List<int> _visibleSectionIndices() {
     final visible = <int>[];
+    final mergeEnabled = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
     for (var i = 0; i < _sections.length; i++) {
       if (_isHiddenByRowVisibilityGates(_sections[i])) continue;
+      if (mergeEnabled && _sections[i].type == HomeSectionType.nextUp) {
+        continue;
+      }
       visible.add(i);
     }
     return visible;
@@ -651,6 +718,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     _sections = all.where((s) => s.type != HomeSectionType.mediaBar).toList();
     final addedBuiltins = _ensureBuiltinSectionsPresent();
     _mergeDiscoveredPluginSections();
+    _enforceMergeAdjacency();
     _rebuildFocusNodes();
     if (addedBuiltins) {
       _persistSections(pushSync: false);
@@ -1220,7 +1288,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   }
 
   void _syncIndividualPreferences() {
-    Preference<bool>? mapToExternalPref(HomeSectionType type) {
+    Preference<bool>? mapToPref(HomeSectionType type) {
       return switch (type) {
         HomeSectionType.tmdbPopularMovies => UserPreferences.tmdbPopularMoviesEnabled,
         HomeSectionType.tmdbTopRatedMovies => UserPreferences.tmdbTopRatedMoviesEnabled,
@@ -1235,12 +1303,18 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         HomeSectionType.tmdbTrendingTvDaily => UserPreferences.tmdbTrendingTvDailyEnabled,
         HomeSectionType.tmdbTrendingTvWeekly => UserPreferences.tmdbTrendingTvWeeklyEnabled,
         HomeSectionType.tmdbTrendingAllWeekly => UserPreferences.tmdbTrendingAllWeeklyEnabled,
+        HomeSectionType.rewatch => UserPreferences.displayRewatchRow,
+        HomeSectionType.sinceYouWatched1 => UserPreferences.sinceYouWatched1Enabled,
+        HomeSectionType.sinceYouWatched2 => UserPreferences.sinceYouWatched2Enabled,
+        HomeSectionType.sinceYouWatched3 => UserPreferences.sinceYouWatched3Enabled,
+        HomeSectionType.sinceYouWatched4 => UserPreferences.sinceYouWatched4Enabled,
+        HomeSectionType.sinceYouWatched5 => UserPreferences.sinceYouWatched5Enabled,
         _ => null,
       };
     }
 
     for (final section in _sections) {
-      final prefKey = mapToExternalPref(section.type);
+      final prefKey = mapToPref(section.type);
       if (prefKey != null && _prefs.get(prefKey) != section.enabled) {
         _prefs.set(prefKey, section.enabled);
       }
@@ -1277,20 +1351,90 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     });
   }
 
-  void _moveSectionByActualIndex(int fromIndex, int toIndex) {
-    if (fromIndex < 0 || fromIndex >= _sections.length) return;
-    if (toIndex < 0 || toIndex >= _sections.length) return;
-    if (fromIndex == toIndex) return;
+  void _enforceMergeAdjacency() {
+    final merge = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
+    if (!merge) return;
+    final resumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
+    final nextUpIdx = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
+    if (resumeIdx < 0 || nextUpIdx < 0) return;
+    if ((resumeIdx - nextUpIdx).abs() == 1) return;
+
     setState(() {
-      final item = _sections.removeAt(fromIndex);
-      _sections.insert(toIndex, item);
-      final node = _focusNodes.removeAt(fromIndex);
-      _focusNodes.insert(toIndex, node);
+      final nextUpItem = _sections.removeAt(nextUpIdx);
+      final nextUpNode = _focusNodes.removeAt(nextUpIdx);
+
+      final newResumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
+      _sections.insert(newResumeIdx + 1, nextUpItem);
+      _focusNodes.insert(newResumeIdx + 1, nextUpNode);
     });
     _save();
+  }
+
+  void _moveSection(int fromIndex, int toIndex) {
+    if (fromIndex < 0 || fromIndex >= _sections.length) return;
+    if (toIndex < 0 || toIndex > _sections.length) return;
+    if (fromIndex == toIndex) return;
+
+    final merge = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
+    final resumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
+    final nextUpIdx = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
+
+    final isMergeActive = merge && resumeIdx >= 0 && nextUpIdx >= 0 && (resumeIdx - nextUpIdx).abs() == 1;
+
+    setState(() {
+      if (isMergeActive && (fromIndex == resumeIdx || fromIndex == nextUpIdx)) {
+        final first = resumeIdx < nextUpIdx ? resumeIdx : nextUpIdx;
+        final item1 = _sections.removeAt(first);
+        final node1 = _focusNodes.removeAt(first);
+        final item2 = _sections.removeAt(first);
+        final node2 = _focusNodes.removeAt(first);
+
+        var targetIndex = toIndex;
+        if (targetIndex > first) {
+          if (targetIndex <= first + 2) {
+            targetIndex = first;
+          } else {
+            targetIndex -= 2;
+          }
+        }
+
+        _sections.insert(targetIndex, item1);
+        _focusNodes.insert(targetIndex, node1);
+        _sections.insert(targetIndex + 1, item2);
+        _focusNodes.insert(targetIndex + 1, node2);
+      } else {
+        var targetIndex = toIndex;
+        if (isMergeActive) {
+          final first = resumeIdx < nextUpIdx ? resumeIdx : nextUpIdx;
+          if (targetIndex == first + 1) {
+            targetIndex = first + 2;
+          }
+        }
+
+        final item = _sections.removeAt(fromIndex);
+        final node = _focusNodes.removeAt(fromIndex);
+        _sections.insert(targetIndex, item);
+        _focusNodes.insert(targetIndex, node);
+      }
+    });
+    _save();
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (toIndex < _focusNodes.length) {
-        _focusSectionAndEnsureVisible(toIndex);
+      var focusIndex = toIndex;
+      if (isMergeActive && (fromIndex == resumeIdx || fromIndex == nextUpIdx)) {
+        final first = resumeIdx < nextUpIdx ? resumeIdx : nextUpIdx;
+        var targetIndex = toIndex;
+        if (targetIndex > first) {
+          if (targetIndex <= first + 2) {
+            targetIndex = first;
+          } else {
+            targetIndex -= 2;
+          }
+        }
+        focusIndex = targetIndex;
+      }
+      if (focusIndex < _focusNodes.length) {
+        _focusSectionAndEnsureVisible(focusIndex);
       }
     });
   }
@@ -1375,6 +1519,12 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         HomeSectionType.tmdbTrendingTvDaily => 'Trending TV (Daily)',
         HomeSectionType.tmdbTrendingTvWeekly => 'Trending TV (Weekly)',
         HomeSectionType.tmdbTrendingAllWeekly => 'Trending All (Weekly)',
+        HomeSectionType.sinceYouWatched1 => 'Since You Watched Row 1',
+        HomeSectionType.sinceYouWatched2 => 'Since You Watched Row 2',
+        HomeSectionType.sinceYouWatched3 => 'Since You Watched Row 3',
+        HomeSectionType.sinceYouWatched4 => 'Since You Watched Row 4',
+        HomeSectionType.sinceYouWatched5 => 'Since You Watched Row 5',
+        HomeSectionType.rewatch => 'Rewatch',
         HomeSectionType.none => l10n.none,
       };
 
@@ -1504,6 +1654,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           value: _prefs.get(UserPreferences.mergeContinueWatchingNextUp),
           onChanged: (value) {
             _setMergeContinueWatchingNextUp(value);
+            if (value) {
+              _enforceMergeAdjacency();
+            }
             setState(() {});
           },
         ),
@@ -1534,18 +1687,140 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
         if (toActual == fromActual) return;
 
-        setState(() {
-          final item = _sections.removeAt(fromActual);
-          _sections.insert(toActual, item);
-          final node = _focusNodes.removeAt(fromActual);
-          _focusNodes.insert(toActual, node);
-        });
-        _save();
+        _moveSection(fromActual, toActual);
       },
       itemBuilder: (context, index) {
         final sectionIndex = visibleIndices[index];
         final section = _sections[sectionIndex];
         final isEmpty = _emptySectionIds.contains(section.stableId);
+
+        final mergeEnabled = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
+        final isMergedResume = mergeEnabled && section.type == HomeSectionType.resume;
+
+        if (isMergedResume) {
+          final nextUpIndex = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
+          if (nextUpIndex >= 0) {
+            final nextUpSection = _sections[nextUpIndex];
+            final isNextUpEmpty = _emptySectionIds.contains(nextUpSection.stableId);
+
+            return Padding(
+              key: const ValueKey('merged_resume_nextup'),
+              padding: _kHomeSectionTileOuterPadding,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
+                  borderRadius: BorderRadius.circular(_kHomeSectionTileRadius),
+                  border: Border.all(
+                    color: const Color(0xFF00F0FF), // Neon cyan border
+                    width: 1.5,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          // 1. Continue Watching Tile
+                          Opacity(
+                            opacity: isEmpty ? 0.45 : 1.0,
+                            child: ListTile(
+                              focusColor: Colors.transparent,
+                              hoverColor: Colors.transparent,
+                              contentPadding: const EdgeInsets.only(left: 16, right: 8, top: 4, bottom: 4),
+                              minLeadingWidth: 44,
+                              horizontalTitleGap: 14,
+                              leading: buildSettingsLeadingIconShell(
+                                context,
+                                icon: Icon(
+                                  (section.enabled && !isEmpty)
+                                      ? Icons.check_box
+                                      : Icons.check_box_outline_blank,
+                                ),
+                                focused: false,
+                                iconColor: AppColorScheme.onSurface.withValues(alpha: 0.78),
+                              ),
+                              title: Text(
+                                _labelFor(section, l10n),
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: kCleanSettingsFontFamily,
+                                ),
+                              ),
+                              onTap: isEmpty
+                                  ? null
+                                  : () {
+                                      setState(() {
+                                        _sections[sectionIndex] = section.copyWith(
+                                          enabled: !section.enabled,
+                                        );
+                                      });
+                                      _save();
+                                    },
+                            ),
+                          ),
+                          const Divider(height: 1, color: Color(0xFF00F0FF), indent: 16, endIndent: 16),
+                          // 2. Next Up Tile
+                          Opacity(
+                            opacity: isNextUpEmpty ? 0.45 : 1.0,
+                            child: ListTile(
+                              focusColor: Colors.transparent,
+                              hoverColor: Colors.transparent,
+                              contentPadding: const EdgeInsets.only(left: 16, right: 8, top: 4, bottom: 4),
+                              minLeadingWidth: 44,
+                              horizontalTitleGap: 14,
+                              leading: buildSettingsLeadingIconShell(
+                                context,
+                                icon: Icon(
+                                  (nextUpSection.enabled && !isNextUpEmpty)
+                                      ? Icons.check_box
+                                      : Icons.check_box_outline_blank,
+                                ),
+                                focused: false,
+                                iconColor: AppColorScheme.onSurface.withValues(alpha: 0.78),
+                              ),
+                              title: Text(
+                                _labelFor(nextUpSection, l10n),
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: kCleanSettingsFontFamily,
+                                ),
+                              ),
+                              onTap: isNextUpEmpty
+                                  ? null
+                                  : () {
+                                      setState(() {
+                                        _sections[nextUpIndex] = nextUpSection.copyWith(
+                                          enabled: !nextUpSection.enabled,
+                                        );
+                                      });
+                                      _save();
+                                    },
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    // Centered unified drag handle
+                    Padding(
+                      padding: const EdgeInsets.only(right: 16),
+                      child: ReorderableDragStartListener(
+                        index: index,
+                        child: const Icon(
+                          Icons.drag_handle,
+                          color: Color(0xFF00F0FF), // Neon cyan handle
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+        }
+
         return Padding(
           key: ValueKey(section.stableId),
           padding: _kHomeSectionTileOuterPadding,
@@ -1706,6 +1981,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         return _HomeSectionTile(
           key: ValueKey(section.stableId),
           focusNode: _focusNodes[sectionIndex],
+          type: section.type,
           autofocus: visibleIndex == 0,
           label: _labelFor(section, l10n),
           subtitle: section.isPluginDynamic
@@ -1731,14 +2007,14 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           },
           onMoveUp: () {
             if (visibleIndex == 0) return;
-            _moveSectionByActualIndex(
+            _moveSection(
               sectionIndex,
               visibleIndices[visibleIndex - 1],
             );
           },
           onMoveDown: () {
             if (visibleIndex >= visibleIndices.length - 1) return;
-            _moveSectionByActualIndex(
+            _moveSection(
               sectionIndex,
               visibleIndices[visibleIndex + 1],
             );
@@ -1805,6 +2081,7 @@ class _DiscoveredPlaylistRow {
 
 class _HomeSectionTile extends StatefulWidget {
   final FocusNode focusNode;
+  final HomeSectionType type;
   final String label;
   final String? subtitle;
   final bool enabled;
@@ -1819,6 +2096,7 @@ class _HomeSectionTile extends StatefulWidget {
   const _HomeSectionTile({
     super.key,
     required this.focusNode,
+    required this.type,
     required this.label,
     this.subtitle,
     required this.enabled,
@@ -1905,7 +2183,14 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 90),
             curve: Curves.easeOut,
-            decoration: _homeSectionTileDecoration(context, focused: _focused),
+            decoration: _homeSectionTileDecoration(
+              context,
+              focused: _focused,
+              type: widget.type,
+              mergeEnabled: GetIt.instance<UserPreferences>().get(
+                UserPreferences.mergeContinueWatchingNextUp,
+              ),
+            ),
             child: ListTile(
               focusColor: Colors.transparent,
               hoverColor: Colors.transparent,

--- a/lib/ui/util/home_row_title_localizer.dart
+++ b/lib/ui/util/home_row_title_localizer.dart
@@ -64,6 +64,8 @@ String localizeHomeRowTitle({
       return l10n.seriesGenres;
     case 'seerr_networks':
       return l10n.networks;
+    case 'rewatch':
+      return 'Rewatch';
   }
 
   if (row.id.startsWith('resume_')) return l10n.continueWatching;

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -374,6 +374,7 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
             subtitle: widget.subtitle != null
                 ? Text(widget.subtitle!, style: _kSettingsSubtitleTextStyle)
                 : null,
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             value: widget.inverted ? !value : value,
             onChanged: widget.enabled
                 ? (v) {
@@ -468,7 +469,8 @@ class _EnumPreferenceTileState<T extends Enum>
                     style: _kSettingsDescriptionTextStyle,
                   )
                 : null,
-            isThreeLine: widget.description != null,
+            isThreeLine: false,
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             onTap: () => _showPicker(context, current),
           );
         },


### PR DESCRIPTION
# Pull Request

## Summary
This pull request implements the core home row sections for "Since You Watched" and "Rewatch" with advanced filtering and TMDB similarity/Seerr recommendations support.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Since You Watched Core Rows**:
  - Implemented Customizable "Since You Watched" home rows displaying local recommendations (genre/tag similarity heuristic) or online TMDB/Seerr similarity rows.
  - Added robust dynamic TMDB ID resolution from Jellyfin provider metadata or IMDb lookup via Seerr to support TMDB recommendation queries.
  - Added preference tiles and section toggles under Settings -> Home Row Toggles.
  - Automatically hides "Include Previously Watched" setting when the recommendations source is Online.
  - Constrained base items for "favorites" and "random" to only include watched items (`IsPlayed`).

- **Rewatch Core Row**:
  - Implemented Watched Show date-based resolution using episode watch histories to ensure accurate sorting.
  - Implemented verification of unplayed and virtual placeholder episodes (upcoming unreleased episodes) to exclude airing shows and backlog shows while including ended/between-season shows.

- **CW&NU**: Small UI change. If CW&NU are merged, they now "stick together" in the Home Sections area, which provides visual accuracy of how they behave on the home screen without any weirdness from merging them.
 
## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Android TV and Windows Desktop
- [ ] Not tested (explain why):

### Test Steps
1. Launch settings, go to **Home Row Toggles**.
2. Configure **Since You Watched** rows, change source between **Local** and **Online**, and verify toggle visibility.
3. Verify the **Rewatch** row lists completed shows and movies sorted by watch date, and excludes shows with unplayed virtual upcoming episode placeholders.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

#### Since You Watched Settings
<img width="849" height="1196" alt="2026-06-27_14-44-30_moonfin" src="https://github.com/user-attachments/assets/c3b531d9-fe7a-426a-9a0f-1c68c92b821c" />

### Since You Watched (online via TMDB + Seerr)
<img width="2560" height="993" alt="2026-06-27_14-44-01_moonfin" src="https://github.com/user-attachments/assets/d90514fe-8e85-4670-8047-05a2b5613199" />

### Since You Watched (local algorithm for TV show)
<img width="2074" height="985" alt="2026-06-27_14-45-40_moonfin" src="https://github.com/user-attachments/assets/bef473f6-88bb-4a1b-9b16-9a562baad4c8" />

### Since You Watched (local algorithm for movie)
<img width="2330" height="1001" alt="2026-06-27_14-46-06_moonfin" src="https://github.com/user-attachments/assets/3ecfbbd4-4bbf-40c4-9a87-f09c8ab77ba6" />

### Rewatch Settings Menu
<img width="865" height="968" alt="2026-06-27_15-11-31_moonfin" src="https://github.com/user-attachments/assets/4bba7214-2a6c-4b22-8f85-dd1edb7e9077" />

### Rewatch on Home Screen
<img width="2560" height="1103" alt="2026-06-27_15-12-06" src="https://github.com/user-attachments/assets/01af9913-4fc9-4912-b955-ce2f90a9f5ea" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
