### PR TITLE
fix range error on login

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2924,6 +2924,11 @@ class _ContentRowsState extends State<_ContentRows>
   @override
   Widget build(BuildContext context) {
     final rows = widget.viewModel.rows;
+    // Guard against a stale focused-row index pointing past the end of the
+    // (potentially shorter) new row list
+    if (_activeFocusedRowIndex != null && _activeFocusedRowIndex! >= rows.length) {
+      _activeFocusedRowIndex = null;
+    }
     final prefs = widget.prefs;
     final posterSize =
         (_isHomeRowsStyleV2() &&
@@ -4447,8 +4452,9 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   static bool _isLatestMusicRow(HomeRow row) {
-    if (row.rowType != HomeRowType.latestMedia || row.items.isEmpty)
+    if (row.rowType != HomeRowType.latestMedia || row.items.isEmpty) {
       return false;
+    }
     return row.items.every(
       (item) =>
           item.type == 'Audio' ||


### PR DESCRIPTION
## Summary
Fix range errors from stale row indexes on new logins

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- added a check in _ContentRowsState build method to guard against stale row index values
- wrapped a multi line if statement missing {}'s to remove a lint warning

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. clean app data, build, do a fresh login
2. verify no rangeerror gets thrown

## Screenshots (if applicable)

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
