### PR TITLE
fix focused button to follow buttonFocused color instead of onSurface…

### DIFF
--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -158,7 +158,7 @@ BoxDecoration _settingsTileDecoration(
   if (AppUiIdiomResolver.isApple) {
     if (!focused) return const BoxDecoration();
     return BoxDecoration(
-      color: AppColorScheme.onSurface.withValues(alpha: 0.14),
+      color: AppColorScheme.buttonFocused.withValues(alpha: 0.14),
       borderRadius: BorderRadius.circular(8),
       border: Border.all(
         color: AppColorScheme.accent.withValues(alpha: 0.9),
@@ -184,7 +184,7 @@ BoxDecoration _settingsTileDecoration(
 
   return BoxDecoration(
     color: focused
-        ? AppColorScheme.onSurface
+        ? AppColorScheme.buttonFocused
         : colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
     borderRadius: BorderRadius.circular(_kSettingsTileRadius),
     border: Border.fromBorderSide(


### PR DESCRIPTION
… color

# Pull Request

## Summary
Selected buttons in settings panel are following onSurface (for text on default surface) color instead of the expected buttonFocused color 

## Related Issues
Link related issues or tickets separated by commas.

- Closes https://github.com/Moonfin-Client/Themes/issues/2, #668 
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- replaced onSurface with buttonFocused in preference_tiles.dart _settingsTileDecoration when focused
- 
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Before: 
<img width="1080" height="2340" alt="Screenshot_20260628_170317" src="https://github.com/user-attachments/assets/8f24480e-bd30-47c6-8d8c-daf3526ccd2a" />
<img width="1080" height="2340" alt="Screenshot_20260628_170300" src="https://github.com/user-attachments/assets/5255e937-c855-4618-a4a6-a997fe18194c" />

After:
<img width="1080" height="2340" alt="Screenshot_20260628_170254" src="https://github.com/user-attachments/assets/fc8f362f-462f-41f0-8e64-90de64a5c217" />
<img width="1080" height="2340" alt="Screenshot_20260628_170243" src="https://github.com/user-attachments/assets/79b767cc-6355-4822-ab69-bbfaa3b4e3d5" />

Note: moonfin/neon may need theme updates if you want them to look how they did before (so change buttonFocused to match onSurface for those 2 themes). But now at least custom themes will match what the theme editor tells users to expect

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
