### PR TITLE
fix(seerr): trigger infinite scroll when grid fits on screen or focused near bottom

### DIFF
--- a/lib/ui/screens/seerr/seerr_browse_screen.dart
+++ b/lib/ui/screens/seerr/seerr_browse_screen.dart
@@ -101,7 +101,24 @@ class _SeerrBrowseScreenState extends State<SeerrBrowseScreen> {
   }
 
   void _onChanged() {
-    if (mounted) setState(() {});
+    if (mounted) {
+      setState(() {});
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final vm = _vm;
+        if (vm == null ||
+            vm.state.isLoading ||
+            vm.state.isLoadingMore ||
+            !vm.state.canLoadMore) {
+          return;
+        }
+        if (!_scrollController.hasClients) return;
+        final pos = _scrollController.position;
+        if (pos.maxScrollExtent <= 0) {
+          vm.loadMore();
+        }
+      });
+    }
   }
 
   @override
@@ -244,10 +261,14 @@ class _SeerrBrowseScreenState extends State<SeerrBrowseScreen> {
                     focusColor: resolvedFocusColor,
                     cardFocusExpansion: cardExpansion,
                     suppressFocusGlow: suppressFocusGlow,
-                    onFocus:
-                        isMobile
-                            ? null
-                            : () => setState(() => _focusedItem = item),
+                    onFocus: isMobile
+                        ? null
+                        : () {
+                            setState(() => _focusedItem = item);
+                            if (index >= s.items.length - 8) {
+                              _vm?.loadMore();
+                            }
+                          },
                     onHoverStart:
                         isMobile
                             ? null


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the bug where entering a Seerr category (such as a Studio, Network, or Genre) only loads the first page of 20 items on desktop (Windows, macOS) and TV viewports, while infinite scrolling succeeds on mobile viewports.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #[175](https://github.com/Moonfin-Client/Plugin/issues/175)
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added a post-frame callback viewport check on state update in `SeerrBrowseScreen` (`seerr_browse_screen.dart`). If the initial page items fit entirely in the viewport without causing scrollable range overflow (`maxScrollExtent <= 0`), the screen will automatically request the next page until the viewport is filled.
- Added a focus-based load-more trigger inside the focused card callback (`onFocus`). When keyboard or remote DPAD navigation focuses items near the end of the loaded list (within the last 8 items), a request for the next page is dispatched.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Windows Desktop
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Seerr discover page.
2. Click on a Studio (e.g. Disney), Network (e.g. Netflix), or Genre.
3. Verify that the grid of items automatically requests additional pages and populates scrollable screen space.
4. Verify that scrolling down or focusing cards near the bottom continues to load additional items.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
