### PR TITLE
fix(downloads): fix custom path cache invalidation and remove empty TV series/seasons when deleting episodes

### DIFF
--- a/lib/data/repositories/offline_repository.dart
+++ b/lib/data/repositories/offline_repository.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:drift/drift.dart';
 
@@ -105,34 +104,6 @@ class OfflineRepository {
     await (_db.delete(_db.downloadedItems)
           ..where((t) => t.itemId.equals(itemId)))
         .go();
-  }
-
-  Future<void> cleanupEpisodeContainers(
-    String? seriesId,
-    String? seasonId,
-    String imageDirPath,
-  ) async {
-    if (seasonId != null) {
-      final seasonEpisodes = await getSeasonEpisodes(seasonId);
-      if (seasonEpisodes.isEmpty) {
-        await deleteItem(seasonId);
-        final seasonImageDir = Directory('$imageDirPath/$seasonId');
-        if (await seasonImageDir.exists()) {
-          await seasonImageDir.delete(recursive: true);
-        }
-      }
-    }
-
-    if (seriesId != null) {
-      final seriesEpisodes = await getSeriesEpisodes(seriesId);
-      if (seriesEpisodes.isEmpty) {
-        await deleteItem(seriesId);
-        final seriesImageDir = Directory('$imageDirPath/$seriesId');
-        if (await seriesImageDir.exists()) {
-          await seriesImageDir.delete(recursive: true);
-        }
-      }
-    }
   }
 
   Future<void> deleteSeriesItems(String seriesId) async {

--- a/lib/data/repositories/offline_repository.dart
+++ b/lib/data/repositories/offline_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:drift/drift.dart';
 
@@ -104,6 +105,34 @@ class OfflineRepository {
     await (_db.delete(_db.downloadedItems)
           ..where((t) => t.itemId.equals(itemId)))
         .go();
+  }
+
+  Future<void> cleanupEpisodeContainers(
+    String? seriesId,
+    String? seasonId,
+    String imageDirPath,
+  ) async {
+    if (seasonId != null) {
+      final seasonEpisodes = await getSeasonEpisodes(seasonId);
+      if (seasonEpisodes.isEmpty) {
+        await deleteItem(seasonId);
+        final seasonImageDir = Directory('$imageDirPath/$seasonId');
+        if (await seasonImageDir.exists()) {
+          await seasonImageDir.delete(recursive: true);
+        }
+      }
+    }
+
+    if (seriesId != null) {
+      final seriesEpisodes = await getSeriesEpisodes(seriesId);
+      if (seriesEpisodes.isEmpty) {
+        await deleteItem(seriesId);
+        final seriesImageDir = Directory('$imageDirPath/$seriesId');
+        if (await seriesImageDir.exists()) {
+          await seriesImageDir.delete(recursive: true);
+        }
+      }
+    }
   }
 
   Future<void> deleteSeriesItems(String seriesId) async {

--- a/lib/data/services/download_service.dart
+++ b/lib/data/services/download_service.dart
@@ -9,6 +9,7 @@ import 'package:dio/dio.dart';
 import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
+import 'package:path/path.dart' as p;
 import 'package:server_core/server_core.dart';
 
 import '../../platform/ios_storage.dart';
@@ -228,8 +229,7 @@ class DownloadService extends ChangeNotifier {
   OfflineRepository get _offlineRepo => GetIt.instance<OfflineRepository>();
 
   String _fileNameBaseFromPath(String savePath) {
-    final fileName = savePath.split(PlatformDetection.pathSeparator).last;
-    return fileName.replaceAll(RegExp(r'\.[^.]+$'), '');
+    return p.basenameWithoutExtension(savePath);
   }
 
   Future<void> _deleteSubtitleFiles(Directory dir, String fileNameBase) async {
@@ -243,7 +243,7 @@ class DownloadService extends ChangeNotifier {
         continue;
       }
 
-      final name = entity.path.split(PlatformDetection.pathSeparator).last;
+      final name = p.basename(entity.path);
       if (name.startsWith(prefix)) {
         await entity.delete();
       }
@@ -256,7 +256,7 @@ class DownloadService extends ChangeNotifier {
   ) async {
     var current = start;
 
-    while (current.path.startsWith(root.path) && current.path != root.path) {
+    while (p.isWithin(root.path, current.path) && !p.equals(current.path, root.path)) {
       if (!await current.exists()) {
         current = current.parent;
         continue;

--- a/lib/ui/screens/downloads/saved_media_screen.dart
+++ b/lib/ui/screens/downloads/saved_media_screen.dart
@@ -9,8 +9,10 @@ import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/database/offline_database.dart';
+import '../../../data/models/aggregated_item.dart';
 import '../../../data/providers/offline_providers.dart';
 import '../../../data/repositories/offline_repository.dart';
+import '../../../data/services/download_service.dart';
 import '../../../data/services/storage_path_service.dart';
 import '../../../di/providers.dart';
 import '../../../l10n/app_localizations.dart';
@@ -434,27 +436,9 @@ class _SavedMediaScreenState extends ConsumerState<SavedMediaScreen> {
   }
 
   Future<void> _deleteItem(DownloadedItem item) async {
-    final repo = GetIt.instance<OfflineRepository>();
-    final imageDir = await GetIt.instance<StoragePathService>()
-        .getImageCacheDir();
-
-    if (item.localFilePath != null) {
-      final file = File(item.localFilePath!);
-      if (await file.exists()) await file.delete();
-    }
-
-    final itemImageDir = Directory('${imageDir.path}/${item.itemId}');
-    if (await itemImageDir.exists()) {
-      await itemImageDir.delete(recursive: true);
-    }
-
-    if (item.type == 'Series') {
-      await repo.deleteSeriesItems(item.itemId);
-    } else if (item.type == 'Season') {
-      await repo.deleteSeasonItems(item.itemId);
-    } else {
-      await repo.deleteItem(item.itemId);
-    }
+    final downloadService = GetIt.instance<DownloadService>();
+    final aggregatedItem = AggregatedItem.fromOffline(item);
+    await downloadService.deleteDownloadedFiles(aggregatedItem);
   }
 
   String _filterLabel(_Filter f) => switch (f) {

--- a/lib/ui/screens/downloads/saved_media_screen.dart
+++ b/lib/ui/screens/downloads/saved_media_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -11,9 +10,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import '../../../data/database/offline_database.dart';
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/providers/offline_providers.dart';
-import '../../../data/repositories/offline_repository.dart';
 import '../../../data/services/download_service.dart';
-import '../../../data/services/storage_path_service.dart';
 import '../../../di/providers.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../util/platform_detection.dart';

--- a/lib/ui/screens/downloads/saved_season_screen.dart
+++ b/lib/ui/screens/downloads/saved_season_screen.dart
@@ -8,8 +8,10 @@ import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/database/offline_database.dart';
+import '../../../data/models/aggregated_item.dart';
 import '../../../data/providers/offline_providers.dart';
 import '../../../data/repositories/offline_repository.dart';
+import '../../../data/services/download_service.dart';
 import '../../../data/services/storage_path_service.dart';
 import '../../../util/platform_detection.dart';
 import '../../../l10n/app_localizations.dart';
@@ -129,16 +131,9 @@ class SavedSeasonScreen extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
-    final repo = GetIt.instance<OfflineRepository>();
-    if (episode.localFilePath != null) {
-      final file = File(episode.localFilePath!);
-      if (await file.exists()) await file.delete();
-    }
-    final imageDir = await GetIt.instance<StoragePathService>().getImageCacheDir();
-    final itemImageDir = Directory('${imageDir.path}/${episode.itemId}');
-    if (await itemImageDir.exists()) await itemImageDir.delete(recursive: true);
-
-    await repo.deleteItem(episode.itemId);
+    final downloadService = GetIt.instance<DownloadService>();
+    final item = AggregatedItem.fromOffline(episode);
+    await downloadService.deleteDownloadedFiles(item);
   }
 }
 

--- a/lib/ui/screens/downloads/saved_season_screen.dart
+++ b/lib/ui/screens/downloads/saved_season_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,9 +9,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import '../../../data/database/offline_database.dart';
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/providers/offline_providers.dart';
-import '../../../data/repositories/offline_repository.dart';
 import '../../../data/services/download_service.dart';
-import '../../../data/services/storage_path_service.dart';
 import '../../../util/platform_detection.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../playback/offline_playback_launcher.dart';

--- a/lib/ui/screens/downloads/storage_management_screen.dart
+++ b/lib/ui/screens/downloads/storage_management_screen.dart
@@ -6,6 +6,7 @@ import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/database/offline_database.dart';
+import '../../../data/models/aggregated_item.dart';
 import '../../../data/providers/offline_providers.dart';
 import '../../../data/repositories/offline_repository.dart';
 import '../../../data/services/download_service.dart';
@@ -340,19 +341,12 @@ class _StorageManagementScreenState extends ConsumerState<StorageManagementScree
     if (confirmed != true) return;
 
     final repo = GetIt.instance<OfflineRepository>();
-    final storagePath = GetIt.instance<StoragePathService>();
-    final imageDir = await storagePath.getImageCacheDir();
+    final downloadService = GetIt.instance<DownloadService>();
 
     for (final itemId in _selected) {
       final item = await repo.getItem(itemId);
       if (item == null) continue;
-      if (item.localFilePath != null) {
-        final f = File(item.localFilePath!);
-        if (await f.exists()) await f.delete();
-      }
-      final imgDir = Directory('${imageDir.path}/$itemId');
-      if (await imgDir.exists()) await imgDir.delete(recursive: true);
-      await repo.deleteItem(itemId);
+      await downloadService.deleteDownloadedFiles(AggregatedItem.fromOffline(item));
     }
 
     setState(() {

--- a/lib/ui/screens/settings/panel/offline_downloads_screen.dart
+++ b/lib/ui/screens/settings/panel/offline_downloads_screen.dart
@@ -74,6 +74,9 @@ class _OfflineDownloadsScreenState extends State<_OfflineDownloadsScreen> {
                       initialDirectory: initialDir,
                     );
                   },
+                  onChanged: (_) {
+                    GetIt.instance<StoragePathService>().clearCache();
+                  },
                 ),
                 IntPickerPreferenceTile(
                   preference: UserPreferences.downloadConcurrentCount,

--- a/lib/ui/screens/settings/panel/settings_panel_tiles.dart
+++ b/lib/ui/screens/settings/panel/settings_panel_tiles.dart
@@ -6,6 +6,7 @@ class _EditableStringPreferenceTile extends StatefulWidget {
   final IconData icon;
   final String hintText;
   final Future<String?> Function()? pickPath;
+  final void Function(String)? onChanged;
 
   const _EditableStringPreferenceTile({
     required this.preference,
@@ -13,6 +14,7 @@ class _EditableStringPreferenceTile extends StatefulWidget {
     required this.icon,
     required this.hintText,
     this.pickPath,
+    this.onChanged,
   });
 
   @override
@@ -103,6 +105,7 @@ class _EditableStringPreferenceTileState
     controller.dispose();
     if (next == null) return;
     _binding.value = next;
+    widget.onChanged?.call(next);
   }
 }
 

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -17,6 +17,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/custom_external_lists_service.dart';
+import '../../../data/services/storage_path_service.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../di/providers.dart';
 import '../../../util/idiom/app_ui_idiom.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1135,7 +1135,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # Local Storage
   shared_preferences: ^2.5.5
   flutter_secure_storage: ^10.0.0
+  path: ^1.9.1
   path_provider: ^2.1.5
   permission_handler: ^12.0.1
   drift: ^2.28.2


### PR DESCRIPTION
# Pull Request

## Summary
- Fixes the bug where updating the custom downloads folder path does not take effect for new downloads until the app is restarted (due to StoragePathService cache not being invalidated).
- Fixes the bug where deleting TV show episodes leaves orphaned Series and Season metadata folders, .srt files, and database rows behind (causing empty show/season headers to remain in "Saved Media" and causing disk storage leaks).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #632, #615 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Settings Cache Invalidation: Added onChanged callback support to _EditableStringPreferenceTile and registered it on the custom download path settings tile to call GetIt.instance<StoragePathService>().clearCache() when the folder path is modified, ensuring new downloads write to the new location immediately.
* Empty Series/Season Cleanup: Implemented cleanupEpisodeContainers helper method in OfflineRepository to check for and delete empty Series/Season database entries and image cache directories when their last episode is deleted.
* Unified File Deletion: Refactored SavedSeasonScreen, StorageManagementScreen, and SavedMediaScreen to delegate folder, file (video and .srt subtitles), image cache, and database deletions to the unified DownloadService.deleteDownloadedFiles method.
* Platform-Agnostic Path Parsing: Replaced custom path-separator string parsing in DownloadService with package:path utilities (p.basenameWithoutExtension, p.basename, p.isWithin, and p.equals). This fixes a bug on Windows where mixed path separators (backslash vs. forward slash) caused subtitle prefix matching to fail (leaving .srt files behind) and blocked the recursive parent directory cleanup, ensuring that empty Series/Season folders are correctly deleted from the disk.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to settings, modify the Custom Download Path, and verify that new downloads write to the new path immediately without restarting.
2. Download several TV episodes (with subtitles).
3. Navigate to "Saved Media" and delete the episodes.
4. Verify that the matching `.srt` files and empty parent directories are completely deleted from the disk and the show is removed from the UI list.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Downloaded episode on Windows into custom folder:
<img width="200" alt="2026-06-28_23-07-37_explorer" src="https://github.com/user-attachments/assets/77a424c4-5645-486c-ba45-fb5b66f4fcfe" />

### Download folder post removing the single episode:
<img width="200" alt="2026-06-28_23-08-05_explorer" src="https://github.com/user-attachments/assets/4a9905ee-9305-4e7a-81f6-35627cf2072d" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
