### PR TITLE
ui: Fix custom home row dialog keyboard trapping and alignment on TV

### DIFF
--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -99,7 +99,7 @@ class CustomExternalListsService {
     }
   }
 
-  Future<List<ImdbExternalListItem>> fetchCustomRow(HomeSectionConfig config) async {
+  Future<List<ImdbExternalListItem>> fetchCustomRow(HomeSectionConfig config, {bool forceRefresh = false}) async {
     final sectionId = config.pluginSection;
     if (sectionId == null || sectionId.isEmpty) return [];
 
@@ -117,6 +117,10 @@ class CustomExternalListsService {
     final source = rowConfig['source'] as String?;
     final type = rowConfig['type'] as String?;
     final params = rowConfig['params'] as Map<String, dynamic>? ?? {};
+    final modifiableParams = Map<String, dynamic>.from(params);
+    if (forceRefresh) {
+      modifiableParams['_nocache'] = DateTime.now().millisecondsSinceEpoch.toString();
+    }
 
     if (source == null || type == null) return [];
 
@@ -138,7 +142,7 @@ class CustomExternalListsService {
       return loadCustomRowFromCache(config);
     }
 
-    final paramsJson = jsonEncode(params);
+    final paramsJson = jsonEncode(modifiableParams);
     final url = '$baseUrl/Moonfin/CustomRows/Items';
 
     try {
@@ -148,9 +152,21 @@ class CustomExternalListsService {
           'source': source,
           'type': type,
           'params': paramsJson,
+          if (forceRefresh) ...{
+            'refresh': 'true',
+            'nocache': 'true',
+            '_': DateTime.now().millisecondsSinceEpoch.toString(),
+          },
         },
         options: Options(
-          headers: {'Authorization': 'MediaBrowser Token="$token"'},
+          headers: {
+            'Authorization': 'MediaBrowser Token="$token"',
+            if (forceRefresh) ...{
+              'Cache-Control': 'no-cache, no-store, must-revalidate',
+              'Pragma': 'no-cache',
+              'Expires': '0',
+            },
+          },
         ),
       );
 

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -119,6 +119,9 @@ class CustomExternalListsService {
     final params = rowConfig['params'] as Map<String, dynamic>? ?? {};
     final modifiableParams = Map<String, dynamic>.from(params);
     if (forceRefresh) {
+      // The plugin keys its cache on source:type:sha256(params), so changing params
+      // is what actually forces a fresh fetch. This is an authed Dio call with no HTTP
+      // cache in between, so cache-control headers and query flags would do nothing.
       modifiableParams['_nocache'] = DateTime.now().millisecondsSinceEpoch.toString();
     }
 
@@ -152,21 +155,9 @@ class CustomExternalListsService {
           'source': source,
           'type': type,
           'params': paramsJson,
-          if (forceRefresh) ...{
-            'refresh': 'true',
-            'nocache': 'true',
-            '_': DateTime.now().millisecondsSinceEpoch.toString(),
-          },
         },
         options: Options(
-          headers: {
-            'Authorization': 'MediaBrowser Token="$token"',
-            if (forceRefresh) ...{
-              'Cache-Control': 'no-cache, no-store, must-revalidate',
-              'Pragma': 'no-cache',
-              'Expires': '0',
-            },
-          },
+          headers: {'Authorization': 'MediaBrowser Token="$token"'},
         ),
       );
 

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -1421,6 +1421,7 @@ class RowDataSource {
     required String serverId,
     String? additionalData,
     HomeSectionPluginSource pluginSource = HomeSectionPluginSource.collections,
+    bool forceRefresh = false,
   }) async {
     switch (pluginSource) {
       case HomeSectionPluginSource.collections:
@@ -1526,9 +1527,14 @@ class RowDataSource {
             pluginDisplayText: title,
             pluginSource: pluginSource,
           );
-          var items = await customService.loadCustomRowFromCache(config);
-          if (items.isEmpty) {
-            items = await customService.fetchCustomRow(config);
+          List<ImdbExternalListItem> items;
+          if (forceRefresh) {
+            items = await customService.fetchCustomRow(config, forceRefresh: true);
+          } else {
+            items = await customService.loadCustomRowFromCache(config);
+            if (items.isEmpty) {
+              items = await customService.fetchCustomRow(config);
+            }
           }
           Map<String, dynamic> rowConfig = {};
           try {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -706,6 +706,7 @@ class HomeViewModel extends ChangeNotifier {
         serverId: cfg.serverId ?? _serverId,
         additionalData: cfg.pluginAdditionalData,
         pluginSource: cfg.pluginSource,
+        forceRefresh: forceRefresh,
       );
       return [row];
     }

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -109,7 +109,7 @@ class _ExternalListsScreenState extends State<_ExternalListsScreen> {
         if (config.pluginSource == HomeSectionPluginSource.custom && config.enabled) {
           futures.add(() async {
             try {
-              final items = await customService.fetchCustomRow(config);
+              final items = await customService.fetchCustomRow(config, forceRefresh: true);
               if (items.isNotEmpty) {
                 await customService.saveCustomRowToCache(config, items);
               }
@@ -1302,12 +1302,16 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
   final _mdblistListNameFocusNode = FocusNode(debugLabel: 'mdblist_list_field');
   final _sortByFocusNode = FocusNode(debugLabel: 'custom_row_sort_by_field');
   final _sortOrderFocusNode = FocusNode(debugLabel: 'custom_row_sort_order_field');
+  final _sourceFocusNode = FocusNode(debugLabel: 'custom_row_source_field');
+  final _typeFocusNode = FocusNode(debugLabel: 'custom_row_type_field');
+  final _showUserRatingsFocusNode = FocusNode(debugLabel: 'custom_row_show_user_ratings');
 
   final _syncService = GetIt.instance<PluginSyncService>();
 
   @override
   void initState() {
     super.initState();
+    CustomTVTextField.isKeyboardVisibleNotifier.value = false;
     if (widget.existing != null) {
       _nameController.text = widget.existing!.pluginDisplayText ?? '';
       Map<String, dynamic> rowConfig = {};
@@ -1354,6 +1358,7 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
 
   @override
   void dispose() {
+    CustomTVTextField.isKeyboardVisibleNotifier.value = false;
     _nameController.dispose();
     _letterboxdUsernameController.dispose();
     _tmdbIdController.dispose();
@@ -1367,6 +1372,9 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
     _mdblistListNameFocusNode.dispose();
     _sortByFocusNode.dispose();
     _sortOrderFocusNode.dispose();
+    _sourceFocusNode.dispose();
+    _typeFocusNode.dispose();
+    _showUserRatingsFocusNode.dispose();
 
     super.dispose();
   }
@@ -1643,13 +1651,45 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
           if (didPop) return;
           _maybeExit();
         },
-        child: AlertDialog(
-            backgroundColor: Colors.grey[900],
-            title: Text(
-              widget.existing != null ? 'Edit Custom Home Row' : 'Add Custom Home Row',
-              style: const TextStyle(color: Colors.white),
-            ),
-            content: Form(
+        child: Align(
+          alignment: PlatformDetection.isTV ? const Alignment(0, -0.8) : Alignment.center,
+          child: ValueListenableBuilder<bool>(
+            valueListenable: CustomTVTextField.isKeyboardVisibleNotifier,
+            builder: (context, isKeyboardVisible, child) {
+              return AlertDialog(
+                backgroundColor: Colors.grey[900],
+                insetPadding: PlatformDetection.isTV
+                    ? EdgeInsets.fromLTRB(40, 24, 40, isKeyboardVisible ? 280 : 24)
+                    : const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
+                title: Text(
+                  widget.existing != null ? 'Edit Custom Home Row' : 'Add Custom Home Row',
+                  style: const TextStyle(color: Colors.white),
+                ),
+                content: child!,
+                actions: _isValidating
+                    ? [
+                        const Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                          child: SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                        )
+                      ]
+                    : [
+                        TextButton(
+                          onPressed: () => _dismiss(false),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: _save,
+                          child: const Text('Save'),
+                        ),
+                      ],
+              );
+            },
+            child: Form(
               key: _formKey,
               child: AbsorbPointer(
                 absorbing: _isValidating,
@@ -1660,219 +1700,357 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                   mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text('Source', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                  const SizedBox(height: 4),
-                  Theme(
-                    data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
-                    child: DropdownButtonFormField<String>(
-                      value: _source,
-                      dropdownColor: Colors.grey[900],
-                      style: const TextStyle(color: Colors.white, fontSize: 14),
-                      decoration: InputDecoration(
-                        filled: true,
-                        fillColor: Colors.black26,
-                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
-                      ),
-                      items: const [
-                        DropdownMenuItem(value: 'tmdb', child: Text('TMDB')),
-                        DropdownMenuItem(value: 'letterboxd', child: Text('Letterboxd')),
-                        DropdownMenuItem(value: 'mdblist', child: Text('MDBList')),
-                      ],
-                      onChanged: (val) {
-                        if (val != null) {
-                          setState(() {
-                            _source = val;
-                            _type = _getTypesForSource(val).first;
-                          });
-                        }
-                      },
-                    ),
-                  ),
-                    if (typeOptions.length > 1) ...[
-                      const SizedBox(height: 16),
-                      const Text('Type', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                      const SizedBox(height: 4),
-                      Theme(
-                        data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
-                        child: DropdownButtonFormField<String>(
-                          value: _type,
-                          dropdownColor: Colors.grey[900],
-                          style: const TextStyle(color: Colors.white, fontSize: 14),
-                          decoration: InputDecoration(
-                            filled: true,
-                            fillColor: Colors.black26,
-                            border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
-                          ),
-                          items: typeOptions.map((t) {
-                            return DropdownMenuItem(value: t, child: Text(_getTypeLabel(t)));
-                          }).toList(),
-                          onChanged: (val) {
-                            if (val != null) {
-                              setState(() {
-                                _type = val;
-                              });
-                            }
-                          },
-                        ),
-                      ),
-                    ],
-                  const SizedBox(height: 16),
-
-                  // Source + Type specific parameters
-
-                  if (_source == 'letterboxd') ...[
-                    const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _letterboxdUsernameController,
-                      hint: 'Username',
-                      focusNode: _letterboxdUsernameFocusNode,
-                    ),
-                    if (tmdbApiKey.isEmpty) ...[
-                      const SizedBox(height: 12),
-                      const Text(
-                        'WARNING: TMDB API Key must be configured in settings to resolve Letterboxd list items.',
-                        style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ],
-
-                  if (_source == 'tmdb') ...[
-                    Text(_type == 'movie_collection' ? 'TMDB Collection ID or URL' : 'TMDB List ID or URL', style: const TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    _SettingsTextField(
-                      controller: _tmdbIdController,
-                      hint: _type == 'movie_collection'
-                          ? '12345 OR https://www.themoviedb.org/collection/12345'
-                          : '12345 OR https://www.themoviedb.org/list/12345',
-                      focusNode: _tmdbIdFocusNode,
-                    ),
-                    if (tmdbApiKey.isEmpty) ...[
-                      const SizedBox(height: 12),
-                      const Text(
-                        'WARNING: TMDB API Key must be configured in settings to fetch TMDB lists.',
-                        style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ],
-
-                  if (_source == 'mdblist') ...[
-                    if (_type == 'list_url') ...[
-                      const Text('MDBList URL', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                      const SizedBox(height: 4),
-                      _SettingsTextField(
-                        controller: _mdblistListNameController,
-                        hint: 'e.g. https://mdblist.com/lists/username/list-slug',
-                        focusNode: _mdblistListNameFocusNode,
-                      ),
-                    ] else ...[
-                      const Text('MDBList Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                      const SizedBox(height: 4),
-                      _SettingsTextField(
-                        controller: _mdblistUsernameController,
-                        hint: 'Username',
-                        focusNode: _mdblistUsernameFocusNode,
-                      ),
-                      const SizedBox(height: 16),
-                      const Text('List Name (slug)', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                      const SizedBox(height: 4),
-                      _SettingsTextField(
-                        controller: _mdblistListNameController,
-                        hint: 'list-name-slug',
-                        focusNode: _mdblistListNameFocusNode,
-                      ),
-                    ],
-                    if (mdblistApiKey.isEmpty) ...[
-                      const SizedBox(height: 12),
-                      const Text(
-                        'WARNING: MDBList API Key must be configured in settings to fetch MDBList lists.',
-                        style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ],
-
-                  const SizedBox(height: 16),
-                  const Text('Sort By', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                  const SizedBox(height: 4),
-                  Theme(
-                    data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
-                    child: DropdownButtonFormField<String>(
-                      value: _sortBy,
-                      focusNode: _sortByFocusNode,
-                      dropdownColor: Colors.grey[900],
-                      style: const TextStyle(color: Colors.white, fontSize: 14),
-                      decoration: InputDecoration(
-                        filled: true,
-                        fillColor: Colors.black26,
-                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
-                      ),
-                      items: const [
-                        DropdownMenuItem(value: 'none', child: Text('Default (When Added)')),
-                        DropdownMenuItem(value: 'title', child: Text('Film Name')),
-                        DropdownMenuItem(value: 'popularity', child: Text('Film Popularity')),
-                        DropdownMenuItem(value: 'year', child: Text('Release Date')),
-                        DropdownMenuItem(value: 'rating', child: Text('Average Rating')),
-                        DropdownMenuItem(value: 'shuffle', child: Text('Shuffle')),
-                      ],
-                      onChanged: (val) {
-                        if (val != null) {
-                          setState(() {
-                            _sortBy = val;
-                            if (val == 'title') {
-                              _sortOrder = 'asc';
-                            } else {
-                              _sortOrder = 'desc';
-                            }
-                          });
-                        }
-                      },
-                    ),
-                  ),
-                  if (_sortBy != 'none' && _sortBy != 'shuffle') ...[
-                    const SizedBox(height: 16),
-                    const Text('Sort Order', style: TextStyle(color: Colors.grey, fontSize: 12)),
-                    const SizedBox(height: 4),
-                    Theme(
-                      data: Theme.of(context).copyWith(canvasColor: Colors.grey[900]),
-                      child: DropdownButtonFormField<String>(
-                        value: _sortOrder,
-                        focusNode: _sortOrderFocusNode,
-                        dropdownColor: Colors.grey[900],
-                        style: const TextStyle(color: Colors.white, fontSize: 14),
-                        decoration: InputDecoration(
-                          filled: true,
-                          fillColor: Colors.black26,
-                          border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
-                        ),
-                        items: _sortBy == 'title'
-                            ? const [
-                                DropdownMenuItem(value: 'asc', child: Text('A to Z')),
-                                DropdownMenuItem(value: 'desc', child: Text('Z to A')),
-                              ]
-                            : (_sortBy == 'year'
-                                ? const [
-                                    DropdownMenuItem(value: 'desc', child: Text('Newest First')),
-                                    DropdownMenuItem(value: 'asc', child: Text('Earliest First')),
-                                  ]
-                                : (_sortBy == 'popularity'
-                                    ? const [
-                                        DropdownMenuItem(value: 'desc', child: Text('Most Popular First')),
-                                        DropdownMenuItem(value: 'asc', child: Text('Least Popular First')),
-                                      ]
-                                    : const [
-                                        DropdownMenuItem(value: 'desc', child: Text('Highest First')),
-                                        DropdownMenuItem(value: 'asc', child: Text('Lowest First')),
-                                      ])),
-                        onChanged: (val) {
-                          if (val != null) {
-                            setState(() {
-                              _sortOrder = val;
-                            });
-                          }
-                        },
-                      ),
-                    ),
-                  ],
+                   const Text('Source', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                   const SizedBox(height: 4),
+                   ListenableBuilder(
+                     listenable: _sourceFocusNode,
+                     builder: (context, child) {
+                       final hasFocus = _sourceFocusNode.hasFocus;
+                       return Theme(
+                         data: Theme.of(context).copyWith(
+                           canvasColor: Colors.grey[900],
+                           focusColor: AppColorScheme.accent.withValues(alpha: 0.25),
+                         ),
+                         child: DropdownButtonFormField<String>(
+                           value: _source,
+                           focusNode: _sourceFocusNode,
+                           dropdownColor: Colors.grey[900],
+                           style: const TextStyle(color: Colors.white, fontSize: 14),
+                           decoration: InputDecoration(
+                             filled: true,
+                             fillColor: hasFocus ? AppColorScheme.buttonFocused : Colors.black26,
+                             border: OutlineInputBorder(
+                               borderRadius: BorderRadius.circular(8),
+                               borderSide: BorderSide(
+                                 color: hasFocus
+                                     ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                     : Colors.transparent,
+                                 width: 1.0,
+                               ),
+                             ),
+                             enabledBorder: OutlineInputBorder(
+                               borderRadius: BorderRadius.circular(8),
+                               borderSide: BorderSide(
+                                 color: hasFocus
+                                     ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                     : Colors.transparent,
+                                 width: 1.0,
+                               ),
+                             ),
+                             focusedBorder: OutlineInputBorder(
+                               borderRadius: BorderRadius.circular(8),
+                               borderSide: BorderSide(
+                                 color: AppColorScheme.accent.withValues(alpha: 0.72),
+                                 width: 1.5,
+                               ),
+                             ),
+                             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                           ),
+                           items: const [
+                             DropdownMenuItem(value: 'tmdb', child: Text('TMDB')),
+                             DropdownMenuItem(value: 'letterboxd', child: Text('Letterboxd')),
+                             DropdownMenuItem(value: 'mdblist', child: Text('MDBList')),
+                           ],
+                           onChanged: (val) {
+                             if (val != null) {
+                               setState(() {
+                                 _source = val;
+                                 _type = _getTypesForSource(val).first;
+                               });
+                             }
+                           },
+                         ),
+                       );
+                     },
+                   ),
+                     if (typeOptions.length > 1) ...[
+                       const SizedBox(height: 16),
+                       const Text('Type', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                       const SizedBox(height: 4),
+                       ListenableBuilder(
+                         listenable: _typeFocusNode,
+                         builder: (context, child) {
+                           final hasFocus = _typeFocusNode.hasFocus;
+                           return Theme(
+                             data: Theme.of(context).copyWith(
+                               canvasColor: Colors.grey[900],
+                               focusColor: AppColorScheme.accent.withValues(alpha: 0.25),
+                             ),
+                             child: DropdownButtonFormField<String>(
+                               value: _type,
+                               focusNode: _typeFocusNode,
+                               dropdownColor: Colors.grey[900],
+                               style: const TextStyle(color: Colors.white, fontSize: 14),
+                               decoration: InputDecoration(
+                                 filled: true,
+                                 fillColor: hasFocus ? AppColorScheme.buttonFocused : Colors.black26,
+                                 border: OutlineInputBorder(
+                                   borderRadius: BorderRadius.circular(8),
+                                   borderSide: BorderSide(
+                                     color: hasFocus
+                                         ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                         : Colors.transparent,
+                                     width: 1.0,
+                                   ),
+                                 ),
+                                 enabledBorder: OutlineInputBorder(
+                                   borderRadius: BorderRadius.circular(8),
+                                   borderSide: BorderSide(
+                                     color: hasFocus
+                                         ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                         : Colors.transparent,
+                                     width: 1.0,
+                                   ),
+                                 ),
+                                 focusedBorder: OutlineInputBorder(
+                                   borderRadius: BorderRadius.circular(8),
+                                   borderSide: BorderSide(
+                                     color: AppColorScheme.accent.withValues(alpha: 0.72),
+                                     width: 1.5,
+                                   ),
+                                 ),
+                                 contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                               ),
+                               items: typeOptions.map((t) {
+                                 return DropdownMenuItem(value: t, child: Text(_getTypeLabel(t)));
+                               }).toList(),
+                               onChanged: (val) {
+                                 if (val != null) {
+                                   setState(() {
+                                     _type = val;
+                                   });
+                                 }
+                               },
+                             ),
+                           );
+                         },
+                       ),
+                     ],
+                   const SizedBox(height: 16),
+ 
+                   // Source + Type specific parameters
+ 
+                   if (_source == 'letterboxd') ...[
+                     const Text('Letterboxd Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                     const SizedBox(height: 4),
+                     _SettingsTextField(
+                       controller: _letterboxdUsernameController,
+                       hint: 'Username',
+                       focusNode: _letterboxdUsernameFocusNode,
+                     ),
+                     if (tmdbApiKey.isEmpty) ...[
+                       const SizedBox(height: 12),
+                       const Text(
+                         'WARNING: TMDB API Key must be configured in settings to resolve Letterboxd list items.',
+                         style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
+                       ),
+                     ],
+                   ],
+ 
+                   if (_source == 'tmdb') ...[
+                     Text(_type == 'movie_collection' ? 'TMDB Collection ID or URL' : 'TMDB List ID or URL', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+                     const SizedBox(height: 4),
+                     _SettingsTextField(
+                       controller: _tmdbIdController,
+                       hint: _type == 'movie_collection'
+                           ? '12345 OR https://www.themoviedb.org/collection/12345'
+                           : '12345 OR https://www.themoviedb.org/list/12345',
+                       focusNode: _tmdbIdFocusNode,
+                     ),
+                     if (tmdbApiKey.isEmpty) ...[
+                       const SizedBox(height: 12),
+                       const Text(
+                         'WARNING: TMDB API Key must be configured in settings to fetch TMDB lists.',
+                         style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
+                       ),
+                     ],
+                   ],
+ 
+                   if (_source == 'mdblist') ...[
+                     if (_type == 'list_url') ...[
+                       const Text('MDBList URL', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                       const SizedBox(height: 4),
+                       _SettingsTextField(
+                         controller: _mdblistListNameController,
+                         hint: 'e.g. https://mdblist.com/lists/username/list-slug',
+                         focusNode: _mdblistListNameFocusNode,
+                       ),
+                     ] else ...[
+                       const Text('MDBList Username', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                       const SizedBox(height: 4),
+                       _SettingsTextField(
+                         controller: _mdblistUsernameController,
+                         hint: 'Username',
+                         focusNode: _mdblistUsernameFocusNode,
+                       ),
+                       const SizedBox(height: 16),
+                       const Text('List Name (slug)', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                       const SizedBox(height: 4),
+                       _SettingsTextField(
+                         controller: _mdblistListNameController,
+                         hint: 'list-name-slug',
+                         focusNode: _mdblistListNameFocusNode,
+                       ),
+                     ],
+                     if (mdblistApiKey.isEmpty) ...[
+                       const SizedBox(height: 12),
+                       const Text(
+                         'WARNING: MDBList API Key must be configured in settings to fetch MDBList lists.',
+                         style: TextStyle(color: Colors.orangeAccent, fontSize: 11, fontWeight: FontWeight.bold),
+                       ),
+                     ],
+                   ],
+ 
+                   const SizedBox(height: 16),
+                   const Text('Sort By', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                   const SizedBox(height: 4),
+                   ListenableBuilder(
+                     listenable: _sortByFocusNode,
+                     builder: (context, child) {
+                       final hasFocus = _sortByFocusNode.hasFocus;
+                       return Theme(
+                         data: Theme.of(context).copyWith(
+                           canvasColor: Colors.grey[900],
+                           focusColor: AppColorScheme.accent.withValues(alpha: 0.25),
+                         ),
+                         child: DropdownButtonFormField<String>(
+                           value: _sortBy,
+                           focusNode: _sortByFocusNode,
+                           dropdownColor: Colors.grey[900],
+                           style: const TextStyle(color: Colors.white, fontSize: 14),
+                           decoration: InputDecoration(
+                             filled: true,
+                             fillColor: hasFocus ? AppColorScheme.buttonFocused : Colors.black26,
+                             border: OutlineInputBorder(
+                               borderRadius: BorderRadius.circular(8),
+                               borderSide: BorderSide(
+                                 color: hasFocus
+                                     ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                     : Colors.transparent,
+                                 width: 1.0,
+                               ),
+                             ),
+                             enabledBorder: OutlineInputBorder(
+                               borderRadius: BorderRadius.circular(8),
+                               borderSide: BorderSide(
+                                 color: hasFocus
+                                     ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                     : Colors.transparent,
+                                 width: 1.0,
+                               ),
+                             ),
+                             focusedBorder: OutlineInputBorder(
+                               borderRadius: BorderRadius.circular(8),
+                               borderSide: BorderSide(
+                                 color: AppColorScheme.accent.withValues(alpha: 0.72),
+                                 width: 1.5,
+                               ),
+                             ),
+                             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                           ),
+                           items: const [
+                             DropdownMenuItem(value: 'none', child: Text('Default (When Added)')),
+                             DropdownMenuItem(value: 'title', child: Text('Film Name')),
+                             DropdownMenuItem(value: 'popularity', child: Text('Film Popularity')),
+                             DropdownMenuItem(value: 'year', child: Text('Release Date')),
+                             DropdownMenuItem(value: 'rating', child: Text('Average Rating')),
+                             DropdownMenuItem(value: 'shuffle', child: Text('Shuffle')),
+                           ],
+                           onChanged: (val) {
+                             if (val != null) {
+                               setState(() {
+                                 _sortBy = val;
+                                 if (val == 'title') {
+                                   _sortOrder = 'asc';
+                                 } else {
+                                   _sortOrder = 'desc';
+                                 }
+                               });
+                             }
+                           },
+                         ),
+                       );
+                     },
+                   ),
+                   if (_sortBy != 'none' && _sortBy != 'shuffle') ...[
+                     const SizedBox(height: 16),
+                     const Text('Sort Order', style: TextStyle(color: Colors.grey, fontSize: 12)),
+                     const SizedBox(height: 4),
+                     ListenableBuilder(
+                       listenable: _sortOrderFocusNode,
+                       builder: (context, child) {
+                         final hasFocus = _sortOrderFocusNode.hasFocus;
+                         return Theme(
+                           data: Theme.of(context).copyWith(
+                             canvasColor: Colors.grey[900],
+                             focusColor: AppColorScheme.accent.withValues(alpha: 0.25),
+                           ),
+                           child: DropdownButtonFormField<String>(
+                             value: _sortOrder,
+                             focusNode: _sortOrderFocusNode,
+                             dropdownColor: Colors.grey[900],
+                             style: const TextStyle(color: Colors.white, fontSize: 14),
+                             decoration: InputDecoration(
+                               filled: true,
+                               fillColor: hasFocus ? AppColorScheme.buttonFocused : Colors.black26,
+                               border: OutlineInputBorder(
+                                 borderRadius: BorderRadius.circular(8),
+                                 borderSide: BorderSide(
+                                   color: hasFocus
+                                       ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                       : Colors.transparent,
+                                   width: 1.0,
+                                 ),
+                               ),
+                               enabledBorder: OutlineInputBorder(
+                                 borderRadius: BorderRadius.circular(8),
+                                 borderSide: BorderSide(
+                                   color: hasFocus
+                                       ? AppColorScheme.accent.withValues(alpha: 0.72)
+                                       : Colors.transparent,
+                                   width: 1.0,
+                                 ),
+                               ),
+                               focusedBorder: OutlineInputBorder(
+                                 borderRadius: BorderRadius.circular(8),
+                                 borderSide: BorderSide(
+                                   color: AppColorScheme.accent.withValues(alpha: 0.72),
+                                   width: 1.5,
+                                 ),
+                               ),
+                               contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                             ),
+                             items: _sortBy == 'title'
+                                 ? const [
+                                     DropdownMenuItem(value: 'asc', child: Text('A to Z')),
+                                     DropdownMenuItem(value: 'desc', child: Text('Z to A')),
+                                   ]
+                                 : (_sortBy == 'year'
+                                     ? const [
+                                         DropdownMenuItem(value: 'desc', child: Text('Newest First')),
+                                         DropdownMenuItem(value: 'asc', child: Text('Earliest First')),
+                                       ]
+                                     : (_sortBy == 'popularity'
+                                         ? const [
+                                             DropdownMenuItem(value: 'desc', child: Text('Most Popular First')),
+                                             DropdownMenuItem(value: 'asc', child: Text('Least Popular First')),
+                                           ]
+                                         : const [
+                                             DropdownMenuItem(value: 'desc', child: Text('Highest First')),
+                                             DropdownMenuItem(value: 'asc', child: Text('Lowest First')),
+                                           ])),
+                             onChanged: (val) {
+                               if (val != null) {
+                                 setState(() {
+                                   _sortOrder = val;
+                                 });
+                               }
+                             },
+                           ),
+                         );
+                       },
+                     ),
+                   ],
 
                   (() {
                     final isUserRatingRelevant = _source == 'letterboxd';
@@ -1882,17 +2060,28 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           const SizedBox(height: 16),
-                          SwitchListTile.adaptive(
-                            contentPadding: EdgeInsets.zero,
-                            title: const Text(
-                              'Show User Ratings?',
-                              style: TextStyle(color: Colors.white, fontSize: 14),
-                            ),
-                            value: _showUserRatings,
-                            onChanged: (val) {
-                              setState(() {
-                                _showUserRatings = val;
-                              });
+                          TvFocusHighlight(
+                            enabled: true,
+                            builder: (context, focused) {
+                              return SwitchListTile.adaptive(
+                                focusNode: _showUserRatingsFocusNode,
+                                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                                title: Text(
+                                  'Show User Ratings?',
+                                  style: TextStyle(
+                                    color: focused
+                                        ? AppColors.black.withValues(alpha: 0.87)
+                                        : Colors.white,
+                                    fontSize: 14,
+                                  ),
+                                ),
+                                value: _showUserRatings,
+                                onChanged: (val) {
+                                  setState(() {
+                                    _showUserRatings = val;
+                                  });
+                                },
+                              );
                             },
                           ),
                         ],
@@ -1915,31 +2104,11 @@ class _AddEditCustomRowDialogState extends State<_AddEditCustomRowDialog> {
           ),
         ),
       ),
-      actions: _isValidating
-            ? [
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  child: SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                )
-              ]
-            : [
-                TextButton(
-                  onPressed: () => _dismiss(false),
-                  child: const Text('Cancel'),
-                ),
-                TextButton(
-                  onPressed: _save,
-                  child: const Text('Save'),
-                ),
-              ],
-      ),
     ),
-  );
-}
+  ),
+),
+);
+  }
 }
 
 class _SettingsTextField extends StatefulWidget {
@@ -1961,19 +2130,110 @@ class _SettingsTextFieldState extends State<_SettingsTextField> {
   final _tvFieldKey = GlobalKey<CustomTVTextFieldState>();
 
   @override
+  void initState() {
+    super.initState();
+    widget.focusNode.addListener(_onFocusChange);
+    CustomTVTextField.isKeyboardVisibleNotifier.addListener(_onKeyboardVisibilityChange);
+  }
+
+  @override
+  void dispose() {
+    widget.focusNode.removeListener(_onFocusChange);
+    CustomTVTextField.isKeyboardVisibleNotifier.removeListener(_onKeyboardVisibilityChange);
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    if (widget.focusNode.hasFocus) {
+      _ensureVisible();
+    }
+  }
+
+  void _onKeyboardVisibilityChange() {
+    if (widget.focusNode.hasFocus && CustomTVTextField.isKeyboardVisibleNotifier.value) {
+      _ensureVisible();
+    }
+  }
+
+  void _ensureVisible() {
+    Future.delayed(const Duration(milliseconds: 150), () {
+      if (!mounted) return;
+      try {
+        Scrollable.ensureVisible(
+          context,
+          duration: const Duration(milliseconds: 300),
+          alignment: 0.5,
+          curve: Curves.easeInOut,
+        );
+      } catch (_) {}
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final isTV = PlatformDetection.isTV;
     if (isTV) {
       return Focus(
         focusNode: widget.focusNode,
+        onKeyEvent: (node, event) {
+          if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+            return KeyEventResult.ignored;
+          }
+          final isKeyboardVisible = _tvFieldKey.currentState?.isKeyboardVisible ?? false;
+          if (event.logicalKey.isBackKey) {
+            if (isKeyboardVisible) {
+              _tvFieldKey.currentState?.closeKeyboard();
+              widget.focusNode.requestFocus();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          }
+          if (event.logicalKey == LogicalKeyboardKey.enter ||
+              event.logicalKey == LogicalKeyboardKey.select) {
+            if (!isKeyboardVisible) {
+              _tvFieldKey.currentState?.openKeyboard();
+              return KeyEventResult.handled;
+            }
+          }
+          if (!isKeyboardVisible) {
+            if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+              FocusScope.of(context).nextFocus();
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              FocusScope.of(context).previousFocus();
+              return KeyEventResult.handled;
+            }
+          }
+          return KeyEventResult.ignored;
+        },
         child: ListenableBuilder(
           listenable: widget.focusNode,
           builder: (_, _) {
+            final focused = widget.focusNode.hasFocus;
             return CustomTVTextField(
               key: _tvFieldKey,
               controller: widget.controller,
-              isFocused: widget.focusNode.hasFocus,
+              isFocused: focused,
               hint: widget.hint,
+              preferSystemIme: GetIt.instance<UserPreferences>().get(
+                UserPreferences.preferSystemImeKeyboard,
+              ),
+              filled: true,
+              fillColor: focused
+                  ? AppColorScheme.buttonFocused
+                  : Colors.black26,
+              borderRadius: 8,
+              borderColor: focused
+                  ? AppColorScheme.accent.withValues(alpha: 0.72)
+                  : Colors.transparent,
+              focusedBorderColor: AppColorScheme.accent,
+              hintStyle: TextStyle(
+                color: AppColorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+              onFieldSubmitted: (_) {
+                widget.focusNode.requestFocus();
+              },
             );
           },
         ),

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -828,7 +828,6 @@ class _SeerrListsScreen extends StatefulWidget {
 }
 
 class _SeerrListsScreenState extends State<_SeerrListsScreen> {
-  late final SeerrPreferences _seerrPrefs;
   late List<SeerrRowConfig> _rows;
   final _syncService = GetIt.instance<PluginSyncService>();
   final _scope = FocusScopeNode(debugLabel: 'SeerrListsScope');
@@ -837,7 +836,6 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
   @override
   void initState() {
     super.initState();
-    _seerrPrefs = GetIt.instance<SeerrPreferences>();
     final prefs = GetIt.instance<UserPreferences>();
     final configs = prefs.homeSectionsConfig;
 

--- a/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
+++ b/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
@@ -178,6 +178,7 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
     _initAnimation();
     widget.controller.addListener(_onTextChanged);
     _systemInputFocusNode.addListener(_onSystemInputFocusChanged);
+    _systemInputFocusNode.canRequestFocus = false;
   }
 
   void _onTextChanged() {
@@ -311,6 +312,8 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
       _keyboardController.hide(false);
     }
 
+    _systemInputFocusNode.canRequestFocus = true;
+
     if (!_useSystemImeSession) {
       setState(() {
         _useSystemImeSession = true;
@@ -328,6 +331,16 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
       _useSystemImeSession = false;
     });
     _notifyVisibilityChanged();
+
+    _systemInputFocusNode.unfocus();
+    _systemInputFocusNode.canRequestFocus = false;
+
+    try {
+      final parentFocus = Focus.of(context);
+      if (parentFocus.canRequestFocus) {
+        parentFocus.requestFocus();
+      }
+    } catch (_) {}
   }
 
   void _requestSystemInputFocus() {
@@ -375,6 +388,9 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
       ),
     ).whenComplete(() {
       _isOverlayOpen.value = false;
+      if (_keyboardController.isVisible) {
+        _keyboardController.hide(false);
+      }
 
       final focusToRestore = _focusToRestoreAfterOverlay;
       _focusToRestoreAfterOverlay = null;
@@ -420,27 +436,30 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
               child: Stack(
                 children: [
                   Positioned.fill(
-                    child: IgnorePointer(
-                      ignoring: !_isSystemImeActive,
-                      child: Opacity(
-                        opacity: _isSystemImeActive ? 0.01 : 0.0,
-                        child: TextField(
-                          controller: widget.controller,
-                          focusNode: _systemInputFocusNode,
-                          readOnly: !_isSystemImeActive,
-                          showCursor: _isSystemImeActive,
-                          keyboardType: _systemKeyboardType(),
-                          textInputAction: TextInputAction.done,
-                          obscureText: widget.obscureText,
-                          decoration: const InputDecoration(
-                            border: InputBorder.none,
-                            isDense: true,
-                            contentPadding: EdgeInsets.zero,
+                    child: ExcludeFocus(
+                      excluding: !_isSystemImeActive,
+                      child: IgnorePointer(
+                        ignoring: !_isSystemImeActive,
+                        child: Opacity(
+                          opacity: _isSystemImeActive ? 0.01 : 0.0,
+                          child: TextField(
+                            controller: widget.controller,
+                            focusNode: _systemInputFocusNode,
+                            readOnly: !_isSystemImeActive,
+                            showCursor: _isSystemImeActive,
+                            keyboardType: _systemKeyboardType(),
+                            textInputAction: TextInputAction.done,
+                            obscureText: widget.obscureText,
+                            decoration: const InputDecoration(
+                              border: InputBorder.none,
+                              isDense: true,
+                              contentPadding: EdgeInsets.zero,
+                            ),
+                            onSubmitted: (value) {
+                              widget.onFieldSubmitted?.call(value);
+                              _deactivateSystemIme();
+                            },
                           ),
-                          onSubmitted: (value) {
-                            widget.onFieldSubmitted?.call(value);
-                            _deactivateSystemIme();
-                          },
                         ),
                       ),
                     ),
@@ -453,6 +472,7 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
                           widget.isFocused ||
                           _keyboardController.isVisible ||
                           _isSystemImeActive,
+                      showCursor: _keyboardController.isVisible || _isSystemImeActive,
                       blinkAnimation: _blinkAnimation,
                       hasError: error != null,
                       scrollController: _scrollController,
@@ -487,6 +507,7 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
 class _FieldDisplay extends StatelessWidget {
   final CustomTVTextField widget;
   final bool hasFocus;
+  final bool showCursor;
   final Animation<double> blinkAnimation;
   final bool hasError;
   final ScrollController scrollController;
@@ -494,6 +515,7 @@ class _FieldDisplay extends StatelessWidget {
   const _FieldDisplay({
     required this.widget,
     required this.hasFocus,
+    required this.showCursor,
     required this.blinkAnimation,
     required this.scrollController,
     this.hasError = false,
@@ -573,7 +595,7 @@ class _FieldDisplay extends StatelessWidget {
                     WidgetSpan(
                       alignment: PlaceholderAlignment.middle,
                       child: Visibility(
-                        visible: hasFocus,
+                        visible: showCursor,
                         maintainSize: true,
                         maintainAnimation: true,
                         maintainState: true,


### PR DESCRIPTION
# Pull Request

## Summary
Fix custom home row dialog keyboard trapping, layout alignment, and auto-scrolling on TV clients, as well as fixing the cache-busting behavior for custom row feeds.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #654 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **TV Focus & Navigation Fixes**: Updated `CustomTVTextField` to prevent keyboard focus traps and focus loss after system IME deactivation.
- **Dynamic Keyboard Padding**: Shift the custom home row edit/add dialog up dynamically above the virtual keyboard by listening to `CustomTVTextField.isKeyboardVisibleNotifier`.
- **Keyboard State Resets**: Added resets for the static keyboard visibility notifier in dialog's `initState` and `dispose` to prevent dialog shrinking across sessions.
- **Viewport Auto-Scrolling**: Added listeners to scroll focused inputs into the center of the viewport via `Scrollable.ensureVisible` when layout shrinks.
- **Server Cache-Busting**: Injected a unique `_nocache` timestamp parameter directly inside the generic `params` map to force a server-side cache miss on `forceRefresh` (bypassing the 24h Jellyfin/Emby cache).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open the "Custom Home Rows Wizard" dialog on Nvidia Shield TV.
2. Edit a custom Letterboxd row name.
3. Observe that the dialog shifts up when the keyboard is open, and auto-scrolls to keep the active text field centered and visible.
4. Close the keyboard and observe the dialog centered properly.
5. Trigger "Refresh All Enabled Lists" and verify the home row updates with latest RSS feed items.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-06-29_06-25-18" src="https://github.com/user-attachments/assets/df84da83-59d6-42cd-bbc2-797efdb3a0dd" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-06-29_06-25-35" src="https://github.com/user-attachments/assets/5f3d845b-4698-4bdc-b8fa-bcc92b5772a2" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-06-29_06-25-41" src="https://github.com/user-attachments/assets/b47ba936-b74b-4ce0-b548-69e508775a38" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
