### PR TITLE
Refresh home after Seerr bootstrap

### DIFF
--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import '../../ui/navigation/app_router.dart';
 import '../../ui/navigation/destinations.dart';
+import '../../ui/navigation/home_refresh_bus.dart';
 
 import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
@@ -272,11 +273,14 @@ class SessionRepository {
 
     await _pluginSyncService.syncOnLogin(client, serverId: serverId);
 
-    await _pluginSyncService.configureSeerr(
+    final seerrAvailable = await _pluginSyncService.configureSeerr(
       client,
       username: username ?? user.name,
       password: password,
     );
+    if (seerrAvailable) {
+      homeRefreshBus.requestNowOrAfterNavigation();
+    }
   }
 
   Future<void> destroyCurrentSession() async {

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -510,7 +510,7 @@ class PluginSyncService extends ChangeNotifier {
         password: password,
       );
       await _refreshAvailabilityStatus(client);
-      return seerrRepo.isAvailable;
+      return seerrAvailable;
     } catch (_) {
       return false;
     }

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -491,15 +491,15 @@ class PluginSyncService extends ChangeNotifier {
     }
   }
 
-  Future<void> configureSeerr(
+  Future<bool> configureSeerr(
     MediaServerClient client, {
     String? username,
     String? password,
   }) async {
-    if (!_pluginAvailable) return;
+    if (!_pluginAvailable) return false;
 
     final token = client.accessToken;
-    if (token == null || token.isEmpty) return;
+    if (token == null || token.isEmpty) return false;
 
     try {
       final seerrRepo = await GetIt.instance.getAsync<SeerrRepository>();
@@ -509,7 +509,11 @@ class PluginSyncService extends ChangeNotifier {
         username: username,
         password: password,
       );
-    } catch (_) {}
+      await _refreshAvailabilityStatus(client);
+      return seerrRepo.isAvailable;
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<void> pushSettings(MediaServerClient client) async {

--- a/lib/ui/navigation/home_refresh_bus.dart
+++ b/lib/ui/navigation/home_refresh_bus.dart
@@ -1,20 +1,33 @@
 import 'package:flutter/foundation.dart';
 
-final ValueNotifier<int> homeRefreshBus = ValueNotifier<int>(0);
-bool _pendingHomeRefresh = false;
+final homeRefreshBus = HomeRefreshBus();
 
-void requestHomeRefresh() {
-  homeRefreshBus.value = homeRefreshBus.value + 1;
-}
+class HomeRefreshBus extends ValueNotifier<int> {
+  HomeRefreshBus() : super(0);
 
-void requestHomeRefreshAfterNavigation() {
-  _pendingHomeRefresh = true;
-}
+  bool _pendingRefresh = false;
 
-bool consumePendingHomeRefresh() {
-  if (!_pendingHomeRefresh) {
-    return false;
+  void request() {
+    value = value + 1;
   }
-  _pendingHomeRefresh = false;
-  return true;
+
+  void requestAfterNavigation() {
+    _pendingRefresh = true;
+  }
+
+  void requestNowOrAfterNavigation() {
+    if (hasListeners) {
+      request();
+    } else {
+      requestAfterNavigation();
+    }
+  }
+
+  bool consumePending() {
+    if (!_pendingRefresh) {
+      return false;
+    }
+    _pendingRefresh = false;
+    return true;
+  }
 }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -27,6 +27,7 @@ import '../../../data/services/background_service.dart';
 import '../../widgets/rating_display.dart';
 import '../../../data/services/theme_music_service.dart';
 import '../../../data/services/media_server_client_factory.dart';
+import '../../../data/services/plugin_sync_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../playback/appletv_preview_player.dart';
 import '../../../playback/inline_preview_engine.dart';
@@ -92,6 +93,7 @@ class _HomeShellState extends State<_HomeShell>
   final _backgroundService = GetIt.instance<BackgroundService>();
   final _userPrefs = GetIt.instance<UserPreferences>();
   final _themeMusicService = GetIt.instance<ThemeMusicService>();
+  final _pluginSyncService = GetIt.instance<PluginSyncService>();
   late final HomeViewModel _viewModel;
 
   AggregatedItem? _selectedItem;
@@ -108,6 +110,7 @@ class _HomeShellState extends State<_HomeShell>
   bool _lastMultiServer = false;
   bool _lastMergeContinueWatchingNextUp = false;
   String _lastBlockedParentalRatings = '';
+  bool _lastSeerrAvailable = false;
   bool _themeMusicRegistered = false;
   String? _lastObservedPath;
   ModalRoute<dynamic>? _observedRoute;
@@ -123,7 +126,7 @@ class _HomeShellState extends State<_HomeShell>
     appRouter.routerDelegate.addListener(_onRouteChanged);
     _lastObservedPath = appRouter.routerDelegate.currentConfiguration.uri.path;
     homeRefreshBus.addListener(_onHomeRefreshRequested);
-    if (consumePendingHomeRefresh()) {
+    if (homeRefreshBus.consumePending()) {
       _viewModel.refresh(preserveExisting: true);
     }
     _backgroundSub = _backgroundService.backgroundStream.listen((url) {
@@ -147,6 +150,8 @@ class _HomeShellState extends State<_HomeShell>
     _lastBlockedParentalRatings = _userPrefs.get(
       UserPreferences.blockedParentalRatings,
     );
+    _lastSeerrAvailable = _pluginSyncService.seerrAvailable;
+    _pluginSyncService.addListener(_onPluginSyncChanged);
     _userPrefs.addListener(_onPrefsChanged);
     _maybeRegisterThemeMusic();
     _viewModel.load(preserveExisting: _viewModel.rows.isNotEmpty);
@@ -179,6 +184,7 @@ class _HomeShellState extends State<_HomeShell>
     _backgroundSub?.cancel();
     _viewModel.mediaBarViewModel.removeListener(_onMediaBarStateChanged);
     _viewModel.removeListener(_onViewModelChanged);
+    _pluginSyncService.removeListener(_onPluginSyncChanged);
     _userPrefs.removeListener(_onPrefsChanged);
     if (_themeMusicRegistered) {
       _themeMusicService.unregisterDetailScreen(this);
@@ -189,6 +195,14 @@ class _HomeShellState extends State<_HomeShell>
 
   void _onViewModelChanged() {
     if (mounted) setState(() {});
+  }
+
+  void _onPluginSyncChanged() {
+    if (!mounted) return;
+    final seerrAvailable = _pluginSyncService.seerrAvailable;
+    if (seerrAvailable == _lastSeerrAvailable) return;
+    _lastSeerrAvailable = seerrAvailable;
+    _viewModel.refresh(preserveExisting: true);
   }
 
   void _onMediaBarStateChanged() {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -117,13 +117,6 @@ class HomeViewModel extends ChangeNotifier {
         type == HomeSectionType.seerrNetworks;
   }
 
-
-
-  bool _isAnySeerrSectionEnabled() {
-    final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    return seerrPrefs.rowsConfig.any((r) => r.enabled);
-  }
-
   static bool _isTmdbSectionType(HomeSectionType type) {
     return type == HomeSectionType.tmdbPopularMovies ||
         type == HomeSectionType.tmdbTopRatedMovies ||
@@ -282,9 +275,7 @@ class HomeViewModel extends ChangeNotifier {
         UserPreferences.displayPlaylistsRows,
       );
       final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
-      final showSeerrRows =
-          _isAnySeerrSectionEnabled() &&
-          GetIt.instance<PluginSyncService>().seerrAvailable;
+      final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
       final showTmdbRows = _isAnyTmdbSectionEnabled();
       final showSinceYouWatched = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
       final sinceYouWatchedNum = _prefs.get(UserPreferences.sinceYouWatchedNumRows).value;

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -13,8 +13,6 @@ import '../../../data/utils/playlist_utils.dart';
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
-import '../../../preference/seerr_preferences.dart';
-import '../../../preference/seerr_row_config.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/overlay_sheet.dart';
@@ -516,12 +514,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     }
   }
 
-  bool _isAnySeerrSectionEnabled() {
-    final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    return seerrPrefs.rowsConfig.any((r) => r.enabled);
-  }
-
-
   bool _isAnyTmdbSectionEnabled() {
     return _prefs.get(UserPreferences.tmdbPopularMoviesEnabled) ||
         _prefs.get(UserPreferences.tmdbTopRatedMoviesEnabled) ||
@@ -537,30 +529,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         _prefs.get(UserPreferences.tmdbTrendingTvWeeklyEnabled) ||
         _prefs.get(UserPreferences.tmdbTrendingAllWeeklyEnabled);
   }
-
-  bool _isSeerrRowEnabled(HomeSectionType type) {
-    final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final seerrType = switch (type) {
-      HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
-      HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
-      HomeSectionType.seerrTrending => SeerrRowType.trending,
-      HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
-      HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
-      HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
-      HomeSectionType.seerrStudios => SeerrRowType.studios,
-      HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
-      HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
-      HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
-      HomeSectionType.seerrNetworks => SeerrRowType.networks,
-      _ => null,
-    };
-    if (seerrType == null) return false;
-    return seerrPrefs.rowsConfig.firstWhere(
-      (r) => r.type == seerrType,
-      orElse: () => SeerrRowConfig(type: seerrType, enabled: false),
-    ).enabled;
-  }
-
 
   bool _isTmdbRowEnabled(HomeSectionType type) {
     final prefKey = switch (type) {
@@ -607,9 +575,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     );
     final showGenresRows = _prefs.get(UserPreferences.displayGenresRows);
     final showPlaylistsRows = _prefs.get(UserPreferences.displayPlaylistsRows);
-    final showSeerrRows =
-        _isAnySeerrSectionEnabled() &&
-        GetIt.instance<PluginSyncService>().seerrAvailable;
+    final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
     final showTmdbRows = _isAnyTmdbSectionEnabled();
 
     final hiddenByFavorites =
@@ -629,8 +595,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         ((section.isBuiltin && _isPlaylistsSectionType(section.type)) ||
             (section.isPluginDynamic &&
                 section.pluginSource == HomeSectionPluginSource.playlists));
-    final hiddenBySeerr = _isSeerrSectionType(section.type) &&
-        (!showSeerrRows || !_isSeerrRowEnabled(section.type));
+    final hiddenBySeerr =
+        _isSeerrSectionType(section.type) && !showSeerrRows;
     final hiddenByTmdb = _isTmdbSectionType(section.type) &&
         (!showTmdbRows || !_isTmdbRowEnabled(section.type));
 

--- a/lib/ui/screens/settings/library_settings_screen.dart
+++ b/lib/ui/screens/settings/library_settings_screen.dart
@@ -97,7 +97,7 @@ class _LibraryVisibilityScreenState extends State<LibraryVisibilityScreen> {
     _saveQueue = _saveQueue.then((_) async {
       try {
         await _viewsRepo.updateUserConfiguration(updated);
-        requestHomeRefreshAfterNavigation();
+        homeRefreshBus.requestAfterNavigation();
       } catch (_) {
         if (!mounted || opId != _lastQueuedOpId) return;
         setState(() => _config = config);

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -807,11 +807,11 @@ class _LeftSidebarState extends State<LeftSidebar> {
                   onPressed: () {
                     _onNavigate();
                     if (_isActive(Destinations.home)) {
-                      requestHomeRefresh();
+                      homeRefreshBus.request();
                       _exitSidebarToContent();
                       return;
                     }
-                    requestHomeRefreshAfterNavigation();
+                    homeRefreshBus.requestAfterNavigation();
                     _markNavigationAwayFromSidebar();
                     context.go(Destinations.home);
                   },

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -149,10 +149,10 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
         isActive: _isActive(Destinations.home),
         onTap: () {
           if (_isActive(Destinations.home)) {
-            requestHomeRefresh();
+            homeRefreshBus.request();
             return;
           }
-          requestHomeRefreshAfterNavigation();
+          homeRefreshBus.requestAfterNavigation();
           context.go(Destinations.home);
         },
       ),

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -841,10 +841,10 @@ class _TopToolbarState extends State<TopToolbar> {
                     },
                     onPressed: () {
                       if (_isActive(Destinations.home)) {
-                        requestHomeRefresh();
+                        homeRefreshBus.request();
                         return;
                       }
-                      requestHomeRefreshAfterNavigation();
+                      homeRefreshBus.requestAfterNavigation();
                       context.go(Destinations.home);
                     },
                   ),


### PR DESCRIPTION
# Pull Request

## Summary

Fixes a startup timing issue where Seerr home rows configured through the plugin-backed Home Sections layout only appeared after opening the Home Row settings screen.

Home now reacts to Seerr availability changes directly, and Seerr Home Sections are gated by `PluginSyncService.seerrAvailable` instead of the legacy `SeerrPreferences.rowsConfig` row configuration.

## Related Issues

None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Added a small `HomeRefreshBus` abstraction for immediate and pending Home refresh requests.
- Refresh Home after Seerr bootstrap when the Seerr repository becomes available.
- Let `HomeShell` listen for `PluginSyncService.seerrAvailable` changes and refresh Home when that value changes.
- Use `PluginSyncService.seerrAvailable` as the global Seerr visibility gate for Home Sections.
- Removed legacy `SeerrPreferences.rowsConfig` checks from Home and Home Row settings visibility decisions.
- Kept Home Section activation and ordering owned by `HomeSectionConfig`, including plugin-provided defaults.

## Platform
- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [x] Linux
- [x] All / Shared code

## Testing

- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Configure Seerr Home Sections through the server plugin defaults.
2. Start the app fresh and open the Home screen without opening settings first.
3. Verify configured Seerr rows appear after Seerr availability is established.
4. Open Home Row settings and verify plugin-provided Collections are not duplicated.
5. Run targeted analyzer checks for the changed files.

## Screenshots (if applicable)

None

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced