### PR TITLE
Fix HTTP 500 on transcoded streams: emit one canonical AudioStreamIndex

### DIFF
--- a/packages/playback_core/lib/src/media_stream_resolver.dart
+++ b/packages/playback_core/lib/src/media_stream_resolver.dart
@@ -58,15 +58,22 @@ abstract class MediaStreamResolver {
       final uri = Uri.parse(url);
       final params = Map<String, String>.from(uri.queryParameters);
 
+      // Emby & Jellyfin streaming URLs use PascalCase stream indices. Emby's
+      // query-parameter binding is case-INSENSITIVE, so emitting BOTH
+      // `AudioStreamIndex` and `audioStreamIndex` makes the server merge the two
+      // values into "1,1", which fails integer parsing -> HTTP 500 on the
+      // manifest ("Failed to open" / source error, especially when resuming an
+      // audio-transcoded stream). Emit a single canonical key and strip any
+      // camelCase variant.
       if (audioStreamIndex != null) {
+        params.remove('audioStreamIndex');
         params['AudioStreamIndex'] = '$audioStreamIndex';
-        params['audioStreamIndex'] = '$audioStreamIndex';
       }
 
       if (subtitleStreamIndex != null) {
         if (subtitleStreamIndex >= 0) {
+          params.remove('subtitleStreamIndex');
           params['SubtitleStreamIndex'] = '$subtitleStreamIndex';
-          params['subtitleStreamIndex'] = '$subtitleStreamIndex';
         } else if (subtitleStreamIndex == -1) {
           params.remove('SubtitleStreamIndex');
           params.remove('subtitleStreamIndex');


### PR DESCRIPTION
Fixes #680

`applyStreamIndices()` set both `AudioStreamIndex` **and** `audioStreamIndex` (and the Subtitle pair) on the streaming URL. Emby's query binding is **case-insensitive**, so it merges the two values into `"1,1"` → `System.FormatException` in `ParseNullableInt32` → **HTTP 500** on the `.m3u8` manifest. The client shows "Failed to open" / source error — intermittently, and reliably on resume of any audio-transcoded title (EAC3/AC3 5.1).

This emits a single canonical PascalCase key (used by both Emby and Jellyfin streaming URLs) and strips any camelCase variant. One-file change; behavior is identical for the single-param case, only the duplicate is removed.