### PR TITLE
Details beta

### DIFF
--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -74,8 +74,9 @@ class AggregatedItem {
   String? get logoImageTag =>
       (rawData['ImageTags'] as Map?)?['Logo'] as String?;
 
+  // Series logo is delivered as the parent logo; servers send no SeriesLogoImageTag.
   String? get seriesLogoImageTag =>
-      rawData['SeriesLogoImageTag'] as String?;
+      rawData['ParentLogoImageTag'] as String?;
 
   Map? get _userData => rawData['UserData'] as Map?;
 

--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -74,6 +74,9 @@ class AggregatedItem {
   String? get logoImageTag =>
       (rawData['ImageTags'] as Map?)?['Logo'] as String?;
 
+  String? get seriesLogoImageTag =>
+      rawData['SeriesLogoImageTag'] as String?;
+
   Map? get _userData => rawData['UserData'] as Map?;
 
   double? get playedPercentage =>

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -540,6 +540,48 @@ class PluginSyncService extends ChangeNotifier {
     } catch (_) {}
   }
 
+  Future<List<String>?> fetchCustomCollectionOrder(
+    MediaServerClient client,
+    String collectionId,
+  ) async {
+    if (!_pluginAvailable) return null;
+    final headers = _authHeaders(client);
+    if (headers == null) return null;
+
+    try {
+      final response = await _dio.get(
+        '${client.baseUrl}/Moonfin/Collections/$collectionId/Order',
+        options: Options(headers: headers),
+      );
+      if (response.statusCode == 200 && response.data is List) {
+        return List<String>.from(response.data as List);
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Future<bool> saveCustomCollectionOrder(
+    MediaServerClient client,
+    String collectionId,
+    List<String> itemIds,
+  ) async {
+    if (!_pluginAvailable) return false;
+    final headers = _authHeaders(client);
+    if (headers == null) return false;
+
+    try {
+      final response = await _dio.post(
+        '${client.baseUrl}/Moonfin/Collections/$collectionId/Order',
+        data: itemIds,
+        options: Options(
+          headers: {...headers, 'Content-Type': 'application/json'},
+        ),
+      );
+      return response.statusCode == 200 || response.statusCode == 204;
+    } catch (_) {}
+    return false;
+  }
+
   Future<bool> pullSettingsForProfile(
     MediaServerClient client, {
     required String profile,

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -84,6 +84,9 @@ class ItemDetailViewModel extends ChangeNotifier {
   List<AggregatedItem> _collectionItems = const [];
   List<AggregatedItem> get collectionItems => _collectionItems;
 
+  List<AggregatedItem> _playlistItems = const [];
+  List<AggregatedItem> get playlistItems => _playlistItems;
+
   String? _parentCollectionName;
   String? get parentCollectionName => _parentCollectionName;
 
@@ -436,6 +439,17 @@ class ItemDetailViewModel extends ChangeNotifier {
     }
   }
 
+  Future<void> reorderCollectionPlaylistItem(int oldIndex, int newIndex) async {
+    if (oldIndex < 0 || oldIndex >= _playlistItems.length) return;
+    if (newIndex < 0 || newIndex >= _playlistItems.length) return;
+    
+    final reordered = List<AggregatedItem>.from(_playlistItems);
+    final item = reordered.removeAt(oldIndex);
+    reordered.insert(newIndex, item);
+    _playlistItems = reordered;
+    notifyListeners();
+  }
+
   Future<void> _loadCollectionItems() async {
     try {
       // No sortBy: keep the collection's native order instead of forcing alphabetical s
@@ -445,6 +459,24 @@ class ItemDetailViewModel extends ChangeNotifier {
       );
       final items = (data['Items'] as List?) ?? [];
       _collectionItems = _mapItems(items);
+      
+      // Flatten to playlist items at lowest level (movies and tv show episodes)
+      final list = <AggregatedItem>[];
+      for (final item in _collectionItems) {
+        if (item.type == 'Series') {
+          try {
+            final epData = await _client.itemsApi.getEpisodes(item.id);
+            final epItems = (epData['Items'] as List?) ?? [];
+            list.addAll(_mapItems(epItems));
+          } catch (_) {}
+        } else if (item.type == 'Movie' ||
+            item.type == 'Audio' ||
+            item.type == 'Video' ||
+            item.type == 'MusicVideo') {
+          list.add(item);
+        }
+      }
+      _playlistItems = list;
       notifyListeners();
     } catch (_) {}
   }

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -92,6 +92,58 @@ class ItemDetailViewModel extends ChangeNotifier {
   List<AggregatedItem> _collectionItems = const [];
   List<AggregatedItem> get collectionItems => _collectionItems;
 
+  // Cached BoxSet cast/crew, rebuilt only when _collectionItems changes.
+  List<AggregatedItem>? _boxSetPeopleSource;
+  List<Map<String, dynamic>> _boxSetDirectors = const [];
+  List<Map<String, dynamic>> _boxSetWriters = const [];
+  List<Map<String, dynamic>> _boxSetActors = const [];
+
+  void _ensureBoxSetPeople() {
+    if (identical(_boxSetPeopleSource, _collectionItems)) return;
+    _boxSetPeopleSource = _collectionItems;
+
+    final directors = <Map<String, dynamic>>[];
+    final writers = <Map<String, dynamic>>[];
+    final actors = <Map<String, dynamic>>[];
+    final dirNames = <String>{};
+    final writNames = <String>{};
+    final actorNames = <String>{};
+
+    for (final child in _collectionItems) {
+      final people = child.rawData['People'] as List?;
+      if (people == null) continue;
+      for (final person in people.cast<Map<String, dynamic>>()) {
+        final name = person['Name'] as String?;
+        if (name == null) continue;
+        switch (person['Type']) {
+          case 'Director':
+            if (dirNames.add(name)) directors.add(person);
+          case 'Writer':
+            if (writNames.add(name)) writers.add(person);
+        }
+      }
+    }
+    for (final child in _collectionItems) {
+      final people = child.rawData['People'] as List?;
+      if (people == null) continue;
+      for (final person in people.cast<Map<String, dynamic>>()) {
+        final type = person['Type'] as String?;
+        if (type != 'Actor' && type != 'GuestStar') continue;
+        final name = person['Name'] as String?;
+        if (name == null ||
+            dirNames.contains(name) ||
+            writNames.contains(name)) {
+          continue;
+        }
+        if (actorNames.add(name)) actors.add(person);
+      }
+    }
+
+    _boxSetDirectors = directors;
+    _boxSetWriters = writers;
+    _boxSetActors = actors;
+  }
+
   List<AggregatedItem> _playlistItems = const [];
   List<AggregatedItem> get playlistItems => _playlistItems;
 
@@ -526,21 +578,32 @@ class ItemDetailViewModel extends ChangeNotifier {
       final items = (data['Items'] as List?) ?? [];
       _collectionItems = _mapItems(items);
       
-      // Flatten to playlist items at lowest level (movies and tv show episodes)
+      // Fetch each series' episodes in parallel. The list is release sorted
+      // below, so fetch order does not affect the result.
       final list = <AggregatedItem>[];
+      final seriesChildren = <AggregatedItem>[];
       for (final item in _collectionItems) {
         if (item.type == 'Series') {
-          try {
-            final epData = await _client.itemsApi.getEpisodes(item.id);
-            final epItems = (epData['Items'] as List?) ?? [];
-            list.addAll(_mapItems(epItems));
-          } catch (_) {}
+          seriesChildren.add(item);
         } else if (item.type == 'Movie' ||
             item.type == 'Audio' ||
             item.type == 'Video' ||
             item.type == 'MusicVideo') {
           list.add(item);
         }
+      }
+      final episodeLists = await Future.wait(
+        seriesChildren.map((series) async {
+          try {
+            final epData = await _client.itemsApi.getEpisodes(series.id);
+            return _mapItems((epData['Items'] as List?) ?? []);
+          } catch (_) {
+            return const <AggregatedItem>[];
+          }
+        }),
+      );
+      for (final episodes in episodeLists) {
+        list.addAll(episodes);
       }
       
       // Default to release order (ascending) sorting
@@ -919,72 +982,24 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   List<Map<String, dynamic>> get directors {
     if (_item?.type == 'BoxSet') {
-      final list = <Map<String, dynamic>>[];
-      final seenNames = <String>{};
-      for (final child in _collectionItems) {
-        final people = child.rawData['People'] as List?;
-        if (people != null) {
-          for (final person in people.cast<Map<String, dynamic>>()) {
-            if (person['Type'] == 'Director') {
-              final name = person['Name'] as String?;
-              if (name != null && !seenNames.contains(name)) {
-                seenNames.add(name);
-                list.add(person);
-              }
-            }
-          }
-        }
-      }
-      return list;
+      _ensureBoxSetPeople();
+      return _boxSetDirectors;
     }
     return _item?.people.where((p) => p['Type'] == 'Director').toList() ?? const [];
   }
 
   List<Map<String, dynamic>> get writers {
     if (_item?.type == 'BoxSet') {
-      final list = <Map<String, dynamic>>[];
-      final seenNames = <String>{};
-      for (final child in _collectionItems) {
-        final people = child.rawData['People'] as List?;
-        if (people != null) {
-          for (final person in people.cast<Map<String, dynamic>>()) {
-            if (person['Type'] == 'Writer') {
-              final name = person['Name'] as String?;
-              if (name != null && !seenNames.contains(name)) {
-                seenNames.add(name);
-                list.add(person);
-              }
-            }
-          }
-        }
-      }
-      return list;
+      _ensureBoxSetPeople();
+      return _boxSetWriters;
     }
     return _item?.people.where((p) => p['Type'] == 'Writer').toList() ?? const [];
   }
 
   List<Map<String, dynamic>> get actors {
     if (_item?.type == 'BoxSet') {
-      final list = <Map<String, dynamic>>[];
-      final seenNames = <String>{};
-      final dirNames = directors.map((d) => d['Name'] as String?).toSet();
-      final writNames = writers.map((w) => w['Name'] as String?).toSet();
-      for (final child in _collectionItems) {
-        final people = child.rawData['People'] as List?;
-        if (people != null) {
-          for (final person in people.cast<Map<String, dynamic>>()) {
-            final type = person['Type'] as String?;
-            if (type == 'Actor' || type == 'GuestStar') {
-              final name = person['Name'] as String?;
-              if (name != null && !seenNames.contains(name) && !dirNames.contains(name) && !writNames.contains(name)) {
-                seenNames.add(name);
-                list.add(person);
-              }
-            }
-          }
-        }
-      }
-      return list;
+      _ensureBoxSetPeople();
+      return _boxSetActors;
     }
     final list = _item?.people ?? const [];
     final dirNames = directors.map((d) => d['Name'] as String?).toSet();

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -11,6 +11,13 @@ import '../repositories/tmdb_repository.dart';
 import '../utils/playlist_utils.dart';
 import '../../util/episode_playability.dart';
 
+enum CollectionSortOption {
+  alphabetical,
+  releaseAscending,
+  releaseDescending,
+  custom,
+}
+
 enum ItemDetailState { loading, ready, error }
 
 class ItemDetailViewModel extends ChangeNotifier {
@@ -86,6 +93,11 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   List<AggregatedItem> _playlistItems = const [];
   List<AggregatedItem> get playlistItems => _playlistItems;
+
+  CollectionSortOption _collectionSort = CollectionSortOption.releaseAscending;
+  CollectionSortOption get collectionSort => _collectionSort;
+
+  List<AggregatedItem> _customPlaylistItems = const [];
 
   String? _parentCollectionName;
   String? get parentCollectionName => _parentCollectionName;
@@ -439,6 +451,49 @@ class ItemDetailViewModel extends ChangeNotifier {
     }
   }
 
+  void setCollectionSort(CollectionSortOption option) {
+    _collectionSort = option;
+    _applyCollectionSort();
+  }
+
+  void _applyCollectionSort() {
+    int releaseSortAscending(AggregatedItem a, AggregatedItem b) {
+      final aDate =
+          a.premiereDate ??
+          (a.productionYear != null ? DateTime(a.productionYear!) : null);
+      final bDate =
+          b.premiereDate ??
+          (b.productionYear != null ? DateTime(b.productionYear!) : null);
+      if (aDate == null && bDate == null) {
+        return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+      }
+      if (aDate == null) return 1;
+      if (bDate == null) return -1;
+      final byDate = aDate.compareTo(bDate);
+      if (byDate != 0) return byDate;
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    }
+
+    switch (_collectionSort) {
+      case CollectionSortOption.alphabetical:
+        _playlistItems = List<AggregatedItem>.from(_playlistItems)
+          ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        break;
+      case CollectionSortOption.releaseAscending:
+        _playlistItems = List<AggregatedItem>.from(_playlistItems)
+          ..sort(releaseSortAscending);
+        break;
+      case CollectionSortOption.releaseDescending:
+        _playlistItems = List<AggregatedItem>.from(_playlistItems)
+          ..sort((a, b) => releaseSortAscending(b, a));
+        break;
+      case CollectionSortOption.custom:
+        _playlistItems = List<AggregatedItem>.from(_customPlaylistItems);
+        break;
+    }
+    notifyListeners();
+  }
+
   Future<void> reorderCollectionPlaylistItem(int oldIndex, int newIndex) async {
     if (oldIndex < 0 || oldIndex >= _playlistItems.length) return;
     if (newIndex < 0 || newIndex >= _playlistItems.length) return;
@@ -447,6 +502,8 @@ class ItemDetailViewModel extends ChangeNotifier {
     final item = reordered.removeAt(oldIndex);
     reordered.insert(newIndex, item);
     _playlistItems = reordered;
+    _customPlaylistItems = reordered;
+    _collectionSort = CollectionSortOption.custom;
     notifyListeners();
   }
 
@@ -455,7 +512,7 @@ class ItemDetailViewModel extends ChangeNotifier {
       // No sortBy: keep the collection's native order instead of forcing alphabetical s
       final data = await _client.itemsApi.getItems(
         parentId: itemId,
-        fields: 'PrimaryImageAspectRatio,BasicSyncInfo',
+        fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People',
       );
       final items = (data['Items'] as List?) ?? [];
       _collectionItems = _mapItems(items);
@@ -476,7 +533,46 @@ class ItemDetailViewModel extends ChangeNotifier {
           list.add(item);
         }
       }
+      
+      // Default to release order (ascending) sorting
+      int releaseSortAscending(AggregatedItem a, AggregatedItem b) {
+        final aDate =
+            a.premiereDate ??
+            (a.productionYear != null ? DateTime(a.productionYear!) : null);
+        final bDate =
+            b.premiereDate ??
+            (b.productionYear != null ? DateTime(b.productionYear!) : null);
+        if (aDate == null && bDate == null) {
+          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+        }
+        if (aDate == null) return 1;
+        if (bDate == null) return -1;
+        final byDate = aDate.compareTo(bDate);
+        if (byDate != 0) return byDate;
+        return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+      }
+      
+      list.sort(releaseSortAscending);
+      
       _playlistItems = list;
+      _customPlaylistItems = List<AggregatedItem>.from(list);
+      _collectionSort = CollectionSortOption.releaseAscending;
+      
+      // Resolve Next Up item
+      if (_playlistItems.isNotEmpty) {
+        final playedAll = _playlistItems.every((item) => item.rawData['UserData']?['Played'] == true);
+        if (playedAll) {
+          _nextUp = _playlistItems.first;
+        } else {
+          _nextUp = _playlistItems.firstWhere(
+            (item) => item.rawData['UserData']?['Played'] != true,
+            orElse: () => _playlistItems.first,
+          );
+        }
+      } else {
+        _nextUp = null;
+      }
+      
       notifyListeners();
     } catch (_) {}
   }
@@ -791,13 +887,75 @@ class ItemDetailViewModel extends ChangeNotifier {
     } catch (_) {}
   }
 
-  List<Map<String, dynamic>> get directors =>
-      _item?.people.where((p) => p['Type'] == 'Director').toList() ?? const [];
+  List<Map<String, dynamic>> get directors {
+    if (_item?.type == 'BoxSet') {
+      final list = <Map<String, dynamic>>[];
+      final seenNames = <String>{};
+      for (final child in _collectionItems) {
+        final people = child.rawData['People'] as List?;
+        if (people != null) {
+          for (final person in people.cast<Map<String, dynamic>>()) {
+            if (person['Type'] == 'Director') {
+              final name = person['Name'] as String?;
+              if (name != null && !seenNames.contains(name)) {
+                seenNames.add(name);
+                list.add(person);
+              }
+            }
+          }
+        }
+      }
+      return list;
+    }
+    return _item?.people.where((p) => p['Type'] == 'Director').toList() ?? const [];
+  }
 
-  List<Map<String, dynamic>> get writers =>
-      _item?.people.where((p) => p['Type'] == 'Writer').toList() ?? const [];
+  List<Map<String, dynamic>> get writers {
+    if (_item?.type == 'BoxSet') {
+      final list = <Map<String, dynamic>>[];
+      final seenNames = <String>{};
+      for (final child in _collectionItems) {
+        final people = child.rawData['People'] as List?;
+        if (people != null) {
+          for (final person in people.cast<Map<String, dynamic>>()) {
+            if (person['Type'] == 'Writer') {
+              final name = person['Name'] as String?;
+              if (name != null && !seenNames.contains(name)) {
+                seenNames.add(name);
+                list.add(person);
+              }
+            }
+          }
+        }
+      }
+      return list;
+    }
+    return _item?.people.where((p) => p['Type'] == 'Writer').toList() ?? const [];
+  }
 
   List<Map<String, dynamic>> get actors {
+    if (_item?.type == 'BoxSet') {
+      final list = <Map<String, dynamic>>[];
+      final seenNames = <String>{};
+      final dirNames = directors.map((d) => d['Name'] as String?).toSet();
+      final writNames = writers.map((w) => w['Name'] as String?).toSet();
+      for (final child in _collectionItems) {
+        final people = child.rawData['People'] as List?;
+        if (people != null) {
+          for (final person in people.cast<Map<String, dynamic>>()) {
+            final type = person['Type'] as String?;
+            if (type == 'Actor' || type == 'GuestStar') {
+              final name = person['Name'] as String?;
+              if (name != null && !seenNames.contains(name) && !dirNames.contains(name) && !writNames.contains(name)) {
+                seenNames.add(name);
+                list.add(person);
+              }
+            }
+          }
+        }
+      }
+      return list;
+    }
     final list = _item?.people ?? const [];
     final dirNames = directors.map((d) => d['Name'] as String?).toSet();
     final writNames = writers.map((w) => w['Name'] as String?).toSet();

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -577,7 +577,11 @@ class ItemDetailViewModel extends ChangeNotifier {
       );
       final items = (data['Items'] as List?) ?? [];
       _collectionItems = _mapItems(items);
-      
+      // Render the Movies/Shows/Cast tabs as soon as the top-level items are in.
+      // The per-series episode fetch below only feeds the flattened Playlist tab
+      // and Next Up, so it should not block the collection from showing.
+      notifyListeners();
+
       // Fetch each series' episodes in parallel. The list is release sorted
       // below, so fetch order does not affect the result.
       final list = <AggregatedItem>[];

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -10,6 +10,7 @@ import '../repositories/mdblist_repository.dart';
 import '../repositories/tmdb_repository.dart';
 import '../utils/playlist_utils.dart';
 import '../../util/episode_playability.dart';
+import '../services/plugin_sync_service.dart';
 
 enum CollectionSortOption {
   alphabetical,
@@ -138,7 +139,7 @@ class ItemDetailViewModel extends ChangeNotifier {
        _mdbListRepository = mdbListRepository,
        _tmdbRepository = tmdbRepository;
 
-  Future<void> load() async {
+  Future<void> load({String? mediaSourceId}) async {
     _state = ItemDetailState.loading;
     _collectionItems = const [];
     _parentCollectionItems = const [];
@@ -146,7 +147,7 @@ class ItemDetailViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final data = await _client.itemsApi.getItem(itemId);
+      final data = await _client.itemsApi.getItem(itemId, mediaSourceId: mediaSourceId);
       _item = AggregatedItem(
         id: itemId,
         serverId: _serverId ?? _client.baseUrl,
@@ -505,6 +506,14 @@ class ItemDetailViewModel extends ChangeNotifier {
     _customPlaylistItems = reordered;
     _collectionSort = CollectionSortOption.custom;
     notifyListeners();
+
+    try {
+      final syncService = GetIt.instance<PluginSyncService>();
+      if (syncService.pluginAvailable) {
+        final itemIds = reordered.map((i) => i.id).toList();
+        await syncService.saveCustomCollectionOrder(_client, itemId, itemIds);
+      }
+    } catch (_) {}
   }
 
   Future<void> _loadCollectionItems() async {
@@ -557,6 +566,27 @@ class ItemDetailViewModel extends ChangeNotifier {
       _playlistItems = list;
       _customPlaylistItems = List<AggregatedItem>.from(list);
       _collectionSort = CollectionSortOption.releaseAscending;
+
+      try {
+        final syncService = GetIt.instance<PluginSyncService>();
+        if (syncService.pluginAvailable) {
+          final customOrder = await syncService.fetchCustomCollectionOrder(_client, itemId);
+          if (customOrder != null && customOrder.isNotEmpty) {
+            final orderMap = {for (var i = 0; i < customOrder.length; i++) customOrder[i]: i};
+            list.sort((a, b) {
+              final aIndex = orderMap[a.id];
+              final bIndex = orderMap[b.id];
+              if (aIndex == null && bIndex == null) return releaseSortAscending(a, b);
+              if (aIndex == null) return 1;
+              if (bIndex == null) return -1;
+              return aIndex.compareTo(bIndex);
+            });
+            _playlistItems = list;
+            _customPlaylistItems = List<AggregatedItem>.from(list);
+            _collectionSort = CollectionSortOption.custom;
+          }
+        }
+      } catch (_) {}
       
       // Resolve Next Up item
       if (_playlistItems.isNotEmpty) {

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -7,6 +7,7 @@ import '../models/aggregated_item.dart';
 import '../models/lyrics.dart';
 import '../repositories/item_mutation_repository.dart';
 import '../repositories/mdblist_repository.dart';
+import '../repositories/tmdb_repository.dart';
 import '../utils/playlist_utils.dart';
 import '../../util/episode_playability.dart';
 
@@ -19,6 +20,7 @@ class ItemDetailViewModel extends ChangeNotifier {
   final MediaServerClient _client;
   final ItemMutationRepository _mutations;
   final MdbListRepository _mdbListRepository;
+  final TmdbRepository _tmdbRepository;
 
   final String itemId;
 
@@ -114,10 +116,12 @@ class ItemDetailViewModel extends ChangeNotifier {
     required MediaServerClient client,
     required ItemMutationRepository mutations,
     required MdbListRepository mdbListRepository,
+    required TmdbRepository tmdbRepository,
   }) : _serverId = serverId,
        _client = client,
        _mutations = mutations,
-       _mdbListRepository = mdbListRepository;
+       _mdbListRepository = mdbListRepository,
+       _tmdbRepository = tmdbRepository;
 
   Future<void> load() async {
     _state = ItemDetailState.loading;
@@ -655,6 +659,35 @@ class ItemDetailViewModel extends ChangeNotifier {
   Future<void> _loadRatings() async {
     final item = _item;
     if (item == null) return;
+
+    if (item.type == 'Episode') {
+      final enableEpisodeRatings = GetIt.instance<UserPreferences>().get(UserPreferences.enableEpisodeRatings);
+      if (!enableEpisodeRatings) return;
+
+      final seriesId = item.seriesId;
+      final season = item.parentIndexNumber;
+      final episode = item.indexNumber;
+
+      if (seriesId != null && season != null && episode != null) {
+        try {
+          final seriesData = await _client.itemsApi.getItem(seriesId);
+          final seriesTmdbId = (seriesData['ProviderIds'] as Map?)?['Tmdb']?.toString();
+          if (seriesTmdbId != null && seriesTmdbId.isNotEmpty) {
+            final rating = await _tmdbRepository.getEpisodeRating(
+              tmdbId: seriesTmdbId,
+              season: season,
+              episode: episode,
+            );
+            if (rating != null && rating > 0) {
+              _ratings = {'stars': rating};
+              notifyListeners();
+            }
+          }
+        } catch (_) {}
+      }
+      return;
+    }
+
     final tmdbId = item.tmdbId;
     if (tmdbId == null) return;
     final mediaType = item.type ?? 'Movie';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7772,5 +7772,49 @@
   "@libraryWriteAccessReactiveBody": {
     "description": "Reactive error warning message when artwork update fails"
   },
-  "externalLists": "External Home Row Lists"
+  "externalLists": "External Home Row Lists",
+  "replay": "Replay",
+  "fileInformation": "File Information",
+  "fileSizeFormat": "Size: {size}  •  Format: {format}",
+  "@fileSizeFormat": {
+    "placeholders": { "size": {}, "format": {} }
+  },
+  "showAllAudioTracks": "Show All ({count}) Audio Tracks",
+  "@showAllAudioTracks": {
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "showAllSubtitleTracks": "Show All ({count}) Subtitle Tracks",
+  "@showAllSubtitleTracks": {
+    "placeholders": { "count": { "type": "int" } }
+  },
+  "checkingDirectPlay": "Checking Direct Play capability...",
+  "directPlayCapabilityLabel": "Direct Play Capability: ",
+  "forced": "Forced",
+  "transcodeContainerNotSupported": "Container format is not supported by the player.",
+  "transcodeVideoCodecNotSupported": "Video codec is not supported.",
+  "transcodeAudioCodecNotSupported": "Audio codec is not supported.",
+  "transcodeSubtitleCodecNotSupported": "Subtitle format is not supported (requires burning).",
+  "transcodeAudioProfileNotSupported": "Audio profile is not supported.",
+  "transcodeVideoProfileNotSupported": "Video profile is not supported.",
+  "transcodeVideoLevelNotSupported": "Video level is not supported.",
+  "transcodeVideoResolutionNotSupported": "Video resolution is not supported by this device.",
+  "transcodeVideoBitDepthNotSupported": "Video bit depth is not supported.",
+  "transcodeVideoFramerateNotSupported": "Video framerate is not supported.",
+  "transcodeContainerBitrateExceedsLimit": "File bitrate exceeds player streaming limit.",
+  "transcodeVideoBitrateExceedsLimit": "Video bitrate exceeds streaming limit.",
+  "transcodeAudioBitrateExceedsLimit": "Audio bitrate exceeds streaming limit.",
+  "transcodeAudioChannelsNotSupported": "Number of audio channels is not supported.",
+  "sortAlphabetical": "Alphabetical",
+  "sortReleaseAscending": "Release Order (Ascending)",
+  "sortReleaseDescending": "Release Order (Descending)",
+  "sortCustomDragDrop": "Custom (Drag-and-Drop)",
+  "playlistSortOptions": "Playlist Sort Options",
+  "resetSort": "Reset Sort",
+  "rewatchSeasonEpisode": "Rewatch S{season}:E{episode}",
+  "@rewatchSeasonEpisode": {
+    "placeholders": { "season": { "type": "int" }, "episode": { "type": "int" } }
+  },
+  "rewatchPlaylist": "Rewatch Playlist",
+  "noSubtitlesFound": "No subtitles found.",
+  "adminControls": "Admin Controls"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15033,6 +15033,198 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'External Home Row Lists'**
   String get externalLists;
+
+  /// No description provided for @replay.
+  ///
+  /// In en, this message translates to:
+  /// **'Replay'**
+  String get replay;
+
+  /// No description provided for @fileInformation.
+  ///
+  /// In en, this message translates to:
+  /// **'File Information'**
+  String get fileInformation;
+
+  /// No description provided for @fileSizeFormat.
+  ///
+  /// In en, this message translates to:
+  /// **'Size: {size}  •  Format: {format}'**
+  String fileSizeFormat(Object size, Object format);
+
+  /// No description provided for @showAllAudioTracks.
+  ///
+  /// In en, this message translates to:
+  /// **'Show All ({count}) Audio Tracks'**
+  String showAllAudioTracks(int count);
+
+  /// No description provided for @showAllSubtitleTracks.
+  ///
+  /// In en, this message translates to:
+  /// **'Show All ({count}) Subtitle Tracks'**
+  String showAllSubtitleTracks(int count);
+
+  /// No description provided for @checkingDirectPlay.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking Direct Play capability...'**
+  String get checkingDirectPlay;
+
+  /// No description provided for @directPlayCapabilityLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Direct Play Capability: '**
+  String get directPlayCapabilityLabel;
+
+  /// No description provided for @forced.
+  ///
+  /// In en, this message translates to:
+  /// **'Forced'**
+  String get forced;
+
+  /// No description provided for @transcodeContainerNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Container format is not supported by the player.'**
+  String get transcodeContainerNotSupported;
+
+  /// No description provided for @transcodeVideoCodecNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Video codec is not supported.'**
+  String get transcodeVideoCodecNotSupported;
+
+  /// No description provided for @transcodeAudioCodecNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio codec is not supported.'**
+  String get transcodeAudioCodecNotSupported;
+
+  /// No description provided for @transcodeSubtitleCodecNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Subtitle format is not supported (requires burning).'**
+  String get transcodeSubtitleCodecNotSupported;
+
+  /// No description provided for @transcodeAudioProfileNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio profile is not supported.'**
+  String get transcodeAudioProfileNotSupported;
+
+  /// No description provided for @transcodeVideoProfileNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Video profile is not supported.'**
+  String get transcodeVideoProfileNotSupported;
+
+  /// No description provided for @transcodeVideoLevelNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Video level is not supported.'**
+  String get transcodeVideoLevelNotSupported;
+
+  /// No description provided for @transcodeVideoResolutionNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Video resolution is not supported by this device.'**
+  String get transcodeVideoResolutionNotSupported;
+
+  /// No description provided for @transcodeVideoBitDepthNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Video bit depth is not supported.'**
+  String get transcodeVideoBitDepthNotSupported;
+
+  /// No description provided for @transcodeVideoFramerateNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Video framerate is not supported.'**
+  String get transcodeVideoFramerateNotSupported;
+
+  /// No description provided for @transcodeContainerBitrateExceedsLimit.
+  ///
+  /// In en, this message translates to:
+  /// **'File bitrate exceeds player streaming limit.'**
+  String get transcodeContainerBitrateExceedsLimit;
+
+  /// No description provided for @transcodeVideoBitrateExceedsLimit.
+  ///
+  /// In en, this message translates to:
+  /// **'Video bitrate exceeds streaming limit.'**
+  String get transcodeVideoBitrateExceedsLimit;
+
+  /// No description provided for @transcodeAudioBitrateExceedsLimit.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio bitrate exceeds streaming limit.'**
+  String get transcodeAudioBitrateExceedsLimit;
+
+  /// No description provided for @transcodeAudioChannelsNotSupported.
+  ///
+  /// In en, this message translates to:
+  /// **'Number of audio channels is not supported.'**
+  String get transcodeAudioChannelsNotSupported;
+
+  /// No description provided for @sortAlphabetical.
+  ///
+  /// In en, this message translates to:
+  /// **'Alphabetical'**
+  String get sortAlphabetical;
+
+  /// No description provided for @sortReleaseAscending.
+  ///
+  /// In en, this message translates to:
+  /// **'Release Order (Ascending)'**
+  String get sortReleaseAscending;
+
+  /// No description provided for @sortReleaseDescending.
+  ///
+  /// In en, this message translates to:
+  /// **'Release Order (Descending)'**
+  String get sortReleaseDescending;
+
+  /// No description provided for @sortCustomDragDrop.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom (Drag-and-Drop)'**
+  String get sortCustomDragDrop;
+
+  /// No description provided for @playlistSortOptions.
+  ///
+  /// In en, this message translates to:
+  /// **'Playlist Sort Options'**
+  String get playlistSortOptions;
+
+  /// No description provided for @resetSort.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset Sort'**
+  String get resetSort;
+
+  /// No description provided for @rewatchSeasonEpisode.
+  ///
+  /// In en, this message translates to:
+  /// **'Rewatch S{season}:E{episode}'**
+  String rewatchSeasonEpisode(int season, int episode);
+
+  /// No description provided for @rewatchPlaylist.
+  ///
+  /// In en, this message translates to:
+  /// **'Rewatch Playlist'**
+  String get rewatchPlaylist;
+
+  /// No description provided for @noSubtitlesFound.
+  ///
+  /// In en, this message translates to:
+  /// **'No subtitles found.'**
+  String get noSubtitlesFound;
+
+  /// No description provided for @adminControls.
+  ///
+  /// In en, this message translates to:
+  /// **'Admin Controls'**
+  String get adminControls;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -8430,4 +8430,119 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -8376,4 +8376,119 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8457,4 +8457,119 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8502,4 +8502,119 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -8418,4 +8418,119 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8552,4 +8552,119 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8438,4 +8438,119 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8451,4 +8451,119 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8422,4 +8422,119 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8496,4 +8496,119 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8548,4 +8548,119 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8396,6 +8396,121 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -8414,4 +8414,119 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8504,6 +8504,121 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8439,4 +8439,119 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -8383,4 +8383,119 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8450,4 +8450,119 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8563,4 +8563,119 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8519,4 +8519,119 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -8318,4 +8318,119 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -8400,4 +8400,119 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -8444,4 +8444,119 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8487,4 +8487,119 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -8445,4 +8445,119 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8463,4 +8463,119 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -8227,4 +8227,119 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8455,4 +8455,119 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8470,4 +8470,119 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -8222,4 +8222,119 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8456,4 +8456,119 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8466,4 +8466,119 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8473,4 +8473,119 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8520,4 +8520,119 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8451,4 +8451,119 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8423,4 +8423,119 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8453,4 +8453,119 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -8403,4 +8403,119 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -8465,4 +8465,119 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8484,6 +8484,121 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8468,4 +8468,119 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8474,4 +8474,119 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -8410,4 +8410,119 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8455,4 +8455,119 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8452,4 +8452,119 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8483,4 +8483,119 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -8449,4 +8449,119 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8434,4 +8434,119 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8475,4 +8475,119 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8477,4 +8477,119 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8475,4 +8475,119 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -8369,4 +8369,119 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8502,4 +8502,119 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -8459,4 +8459,119 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -8430,4 +8430,119 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8476,4 +8476,119 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -8436,4 +8436,119 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -8179,6 +8179,121 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }
 
 /// The translations for Yue Chinese Cantonese, as used in China (`yue_CN`).

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8135,6 +8135,121 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get externalLists => 'External Home Row Lists';
+
+  @override
+  String get replay => 'Replay';
+
+  @override
+  String get fileInformation => 'File Information';
+
+  @override
+  String fileSizeFormat(Object size, Object format) {
+    return 'Size: $size  •  Format: $format';
+  }
+
+  @override
+  String showAllAudioTracks(int count) {
+    return 'Show All ($count) Audio Tracks';
+  }
+
+  @override
+  String showAllSubtitleTracks(int count) {
+    return 'Show All ($count) Subtitle Tracks';
+  }
+
+  @override
+  String get checkingDirectPlay => 'Checking Direct Play capability...';
+
+  @override
+  String get directPlayCapabilityLabel => 'Direct Play Capability: ';
+
+  @override
+  String get forced => 'Forced';
+
+  @override
+  String get transcodeContainerNotSupported =>
+      'Container format is not supported by the player.';
+
+  @override
+  String get transcodeVideoCodecNotSupported => 'Video codec is not supported.';
+
+  @override
+  String get transcodeAudioCodecNotSupported => 'Audio codec is not supported.';
+
+  @override
+  String get transcodeSubtitleCodecNotSupported =>
+      'Subtitle format is not supported (requires burning).';
+
+  @override
+  String get transcodeAudioProfileNotSupported =>
+      'Audio profile is not supported.';
+
+  @override
+  String get transcodeVideoProfileNotSupported =>
+      'Video profile is not supported.';
+
+  @override
+  String get transcodeVideoLevelNotSupported => 'Video level is not supported.';
+
+  @override
+  String get transcodeVideoResolutionNotSupported =>
+      'Video resolution is not supported by this device.';
+
+  @override
+  String get transcodeVideoBitDepthNotSupported =>
+      'Video bit depth is not supported.';
+
+  @override
+  String get transcodeVideoFramerateNotSupported =>
+      'Video framerate is not supported.';
+
+  @override
+  String get transcodeContainerBitrateExceedsLimit =>
+      'File bitrate exceeds player streaming limit.';
+
+  @override
+  String get transcodeVideoBitrateExceedsLimit =>
+      'Video bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioBitrateExceedsLimit =>
+      'Audio bitrate exceeds streaming limit.';
+
+  @override
+  String get transcodeAudioChannelsNotSupported =>
+      'Number of audio channels is not supported.';
+
+  @override
+  String get sortAlphabetical => 'Alphabetical';
+
+  @override
+  String get sortReleaseAscending => 'Release Order (Ascending)';
+
+  @override
+  String get sortReleaseDescending => 'Release Order (Descending)';
+
+  @override
+  String get sortCustomDragDrop => 'Custom (Drag-and-Drop)';
+
+  @override
+  String get playlistSortOptions => 'Playlist Sort Options';
+
+  @override
+  String get resetSort => 'Reset Sort';
+
+  @override
+  String rewatchSeasonEpisode(int season, int episode) {
+    return 'Rewatch S$season:E$episode';
+  }
+
+  @override
+  String get rewatchPlaylist => 'Rewatch Playlist';
+
+  @override
+  String get noSubtitlesFound => 'No subtitles found.';
+
+  @override
+  String get adminControls => 'Admin Controls';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).

--- a/lib/ui/mixins/focus_state_mixin.dart
+++ b/lib/ui/mixins/focus_state_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:moonfin_design/moonfin_design.dart';
 import 'package:moonfin/preference/user_preferences.dart';
 
 mixin FocusStateMixin<T extends StatefulWidget> on State<T> {
@@ -10,9 +11,15 @@ mixin FocusStateMixin<T extends StatefulWidget> on State<T> {
   bool get hovered => _hovered;
   bool get showFocusBorder => _hovered || _focused;
   
-  Color get focusColor => Color(
-    GetIt.instance<UserPreferences>().get(UserPreferences.focusColor).colorValue,
-  );
+  Color get focusColor {
+    final activeTheme = ThemeRegistry.active;
+    if (activeTheme.id == ThemeRegistry.neonPulseId) {
+      return activeTheme.borders.focusBorder.color;
+    }
+    return Color(
+      GetIt.instance<UserPreferences>().get(UserPreferences.focusColor).colorValue,
+    );
+  }
 
   bool get cardFocusExpansion =>
       GetIt.instance<UserPreferences>().get(UserPreferences.cardFocusExpansion);

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -978,6 +978,14 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   }
 
   String? _cardSubtitle(AggregatedItem item) {
+    if (item.type == 'Playlist') {
+      final count = item.childCount ?? item.recursiveItemCount;
+      if (count != null) {
+        return AppLocalizations.of(context).itemCountLabel(count);
+      }
+      return null;
+    }
+
     final parts = <String>[];
     if (item.type == 'MusicAlbum') {
       if (item.artists.isNotEmpty) return item.artists.join(', ');
@@ -1358,7 +1366,7 @@ class _MetadataRow extends StatelessWidget {
       );
     }
 
-    if (item.officialRating != null) {
+    if (item.officialRating != null && item.type != 'Playlist') {
       children.add(
         Container(
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),

--- a/lib/ui/screens/browse/library_view_screen.dart
+++ b/lib/ui/screens/browse/library_view_screen.dart
@@ -144,8 +144,10 @@ class _LibraryViewScreenState extends State<LibraryViewScreen> {
     final watchedBehavior = _prefs.get(
       UserPreferences.watchedIndicatorBehavior,
     );
-    final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
-    final focusColor = Color(_prefs.get(UserPreferences.focusColor).colorValue);
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final focusColor = isNeon
+        ? ThemeRegistry.active.borders.focusBorder.color
+        : Color(_prefs.get(UserPreferences.focusColor).colorValue);
     final cardExpansion = _prefs.get(UserPreferences.cardFocusExpansion);
     final l10n = AppLocalizations.of(context);
 
@@ -184,7 +186,7 @@ class _LibraryViewScreenState extends State<LibraryViewScreen> {
               itemType: item.type,
               focusColor: focusColor,
               cardFocusExpansion: cardExpansion,
-              suppressFocusGlow: suppressFocusGlow,
+              suppressFocusGlow: isNeon,
               onFocus: () => _onItemFocused(item),
               onHoverStart: () => _onItemFocused(item),
               onHoverEnd: () => _vm.setFocusedItem(null),

--- a/lib/ui/screens/browse/music_browse_screen.dart
+++ b/lib/ui/screens/browse/music_browse_screen.dart
@@ -467,11 +467,7 @@ class _ViewButtonState extends State<_ViewButton> with FocusStateMixin {
     final cardExpansion = GetIt.instance<UserPreferences>().get(
       UserPreferences.cardFocusExpansion,
     );
-    final focusColor = Color(
-      GetIt.instance<UserPreferences>()
-          .get(UserPreferences.focusColor)
-          .colorValue,
-    );
+    final focusColor = this.focusColor;
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       onEnter: (_) => setHovered(true),
@@ -516,7 +512,7 @@ class _ViewButtonState extends State<_ViewButton> with FocusStateMixin {
                         ),
                       )
                     : null,
-                boxShadow: showFocusBorder
+                boxShadow: showFocusBorder && ThemeRegistry.active.id != ThemeRegistry.neonPulseId
                     ? [
                         BoxShadow(
                           color: AppColorScheme.accent.withAlpha(140),
@@ -710,11 +706,18 @@ class _MusicSquareCardState extends State<_MusicSquareCard>
     final cardExpansion = GetIt.instance<UserPreferences>().get(
       UserPreferences.cardFocusExpansion,
     );
-    final focusColor = Color(
-      GetIt.instance<UserPreferences>()
-          .get(UserPreferences.focusColor)
-          .colorValue,
-    );
+    final activeTheme = ThemeRegistry.active;
+    final isNeon = activeTheme.id == ThemeRegistry.neonPulseId;
+    final focusColor = isNeon
+        ? activeTheme.borders.focusBorder.color
+        : Color(
+            GetIt.instance<UserPreferences>()
+                .get(UserPreferences.focusColor)
+                .colorValue,
+          );
+
+    final showGlow = showFocusBorder && !isNeon;
+
     return SizedBox(
       width: _cardSize,
       child: MouseRegion(
@@ -752,47 +755,73 @@ class _MusicSquareCardState extends State<_MusicSquareCard>
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    DecoratedBox(
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(6),
-                        border: showFocusBorder
-                            ? Border.fromBorderSide(
-                                ThemeRegistry.active.borders.focusBorder
-                                    .copyWith(color: focusColor, width: 2.4),
-                              )
-                            : null,
-                        boxShadow: showFocusBorder
-                            ? [
-                                BoxShadow(
-                                  color: AppColorScheme.accent.withAlpha(150),
-                                  blurRadius: 16,
-                                  spreadRadius: 1.4,
+                    Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        if (showGlow)
+                          Positioned(
+                            top: -3.5,
+                            bottom: -3.5,
+                            left: -3.5,
+                            right: -3.5,
+                            child: IgnorePointer(
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(9.5),
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: AppColorScheme.accent.withAlpha(150),
+                                      blurRadius: 16,
+                                      spreadRadius: 1.4,
+                                    ),
+                                  ],
                                 ),
-                              ]
-                            : null,
-                      ),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: Container(
-                          width: _cardSize,
-                          height: _cardSize,
-                          color: AppColorScheme.onSurface.withAlpha(
-                            focused ? 36 : 15,
+                              ),
+                            ),
                           ),
-                          child: widget.imageUrl != null
-                              ? CachedNetworkImage(
-                                  imageUrl: widget.imageUrl!,
-                                  fit: BoxFit.cover,
-                                  fadeInDuration: const Duration(
-                                    milliseconds: 200,
-                                  ),
-                                  errorWidget: (_, _, _) => _albumPlaceholder(),
-                                )
-                              : _albumPlaceholder(),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(6),
+                          child: Container(
+                            width: _cardSize,
+                            height: _cardSize,
+                            color: AppColorScheme.onSurface.withAlpha(
+                              focused ? 36 : 15,
+                            ),
+                            child: widget.imageUrl != null
+                                ? CachedNetworkImage(
+                                    imageUrl: widget.imageUrl!,
+                                    fit: BoxFit.cover,
+                                    fadeInDuration: const Duration(
+                                      milliseconds: 200,
+                                    ),
+                                    errorWidget: (_, _, _) => _albumPlaceholder(),
+                                  )
+                                : _albumPlaceholder(),
+                          ),
                         ),
-                      ),
+                        if (showFocusBorder)
+                          Positioned(
+                            top: -3.5,
+                            bottom: -3.5,
+                            left: -3.5,
+                            right: -3.5,
+                            child: IgnorePointer(
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(9.5),
+                                  border: Border.fromBorderSide(
+                                    activeTheme.borders.focusBorder.copyWith(
+                                      color: focusColor,
+                                      width: isNeon ? 3.0 : 2.4,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
                     ),
-                    const SizedBox(height: 4),
+                    const SizedBox(height: 6),
                     Text(
                       widget.title,
                       maxLines: 1,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -13108,7 +13108,7 @@ class _TrackTileState extends State<_TrackTile> with FocusStateMixin {
                   ? Border.fromBorderSide(
                       ThemeRegistry.active.borders.focusBorder.copyWith(
                         color: activeColor.withValues(alpha: 0.85),
-                        width: 1.25,
+                        width: ThemeRegistry.active.borders.focusBorder.width,
                       ),
                     )
                   : null,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -54,7 +54,6 @@ import '../../widgets/seerr_icons.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/focus/focusable_button.dart';
 import '../../widgets/focus/request_initial_focus.dart';
-import '../../widgets/focus/step_scroll.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/playback/player_loading_overlay.dart';
 import '../../../playback/offline_playback_launcher.dart';
@@ -5184,15 +5183,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     }
   }
 
-  void _focusFirstExpandedOverflowButton(BuildContext context) {
-    if (_overflowFirstExtraFocusNode.context != null &&
-        _overflowFirstExtraFocusNode.canRequestFocus) {
-      _overflowFirstExtraFocusNode.requestFocus();
-      return;
-    }
-    FocusScope.of(context).nextFocus();
-  }
-
   void _ensureOverflowButtonVisible(BuildContext context) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -5555,19 +5545,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       widget.selectedMediaSourceId,
     );
     final mediaStreams = _mediaStreamsForItem(item, selectedSource);
-    final audioStreams = mediaStreams
-        .where((s) => s['Type'] == 'Audio')
-        .toList();
     final subtitleStreams = mediaStreams
         .where((s) => s['Type'] == 'Subtitle')
         .toList();
-    final canDownloadRemoteSubtitles = _canDownloadRemoteSubtitles(item);
-    final showSubtitleButton =
-        subtitleStreams.isNotEmpty || canDownloadRemoteSubtitles;
-    final subtitleButtonIcon =
-        subtitleStreams.isEmpty && canDownloadRemoteSubtitles
-        ? Icons.download_rounded
-        : Icons.subtitles;
 
     final canShowDownloadActions =
         _isDownloadable(item.type) &&
@@ -10766,7 +10746,6 @@ class _OverviewText extends StatelessWidget {
   final TextStyle? style;
   final TextAlign? textAlign;
   final FocusNode? focusNode;
-  final FocusNode? upTarget;
   final VoidCallback? onArrowUp;
   final VoidCallback? onArrowDown;
   final VoidCallback? onArrowLeft;
@@ -10777,7 +10756,6 @@ class _OverviewText extends StatelessWidget {
     this.style,
     this.textAlign,
     this.focusNode,
-    this.upTarget,
     this.onArrowUp,
     this.onArrowDown,
     this.onArrowLeft,
@@ -10790,7 +10768,6 @@ class _OverviewText extends StatelessWidget {
     return ExpandableBiography(
       text: text,
       toggleFocusNode: focusNode,
-      upTarget: upTarget,
       onArrowUp: onArrowUp,
       onArrowDown: onArrowDown,
       onArrowLeft: onArrowLeft,
@@ -13838,6 +13815,5 @@ class _PersonDisplaySettingsDialogState
   }
 }
 
-typedef DetailActionButton = _DetailActionButton;
 typedef PersonDisplaySettingsDialog = _PersonDisplaySettingsDialog;
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -26,6 +26,7 @@ import '../../../data/services/book_reader_service.dart';
 import '../../../data/services/theme_music_service.dart';
 import '../../../data/viewmodels/item_detail_view_model.dart';
 import '../../../data/services/plugin_sync_service.dart';
+import '../../navigation/route_lifecycle_observer.dart';
 import 'modern/modern_detail_content.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
@@ -150,7 +151,7 @@ class ItemDetailScreen extends StatefulWidget {
 }
 
 class _ItemDetailScreenState extends State<ItemDetailScreen>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, RouteAware {
   late final ItemDetailViewModel _viewModel;
   final _backgroundService = GetIt.instance<BackgroundService>();
   final _themeMusicService = GetIt.instance<ThemeMusicService>();
@@ -204,6 +205,26 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    routeLifecycleObserver.subscribe(this, ModalRoute.of(context)!);
+  }
+
+  @override
+  void didPopNext() {
+    super.didPopNext();
+    final item = _viewModel.item;
+    if (item != null) {
+      _backgroundService.setBackground(item, context: BlurContext.details);
+      final nextUrl = _backgroundService.currentUrl;
+      if (nextUrl != _backdropUrl) {
+        setState(() => _backdropUrl = nextUrl);
+      }
+    }
+    _resumeThemeMusicIfEligible();
+  }
+
+  @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden ||
@@ -222,6 +243,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
 
   @override
   void dispose() {
+    routeLifecycleObserver.unsubscribe(this);
     WidgetsBinding.instance.removeObserver(this);
     _themeMusicService.unregisterDetailScreen(this);
     _backgroundSub?.cancel();
@@ -1008,7 +1030,7 @@ class _DetailContentState extends State<_DetailContent> {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 12),
-          _PersonDatesVertical(item: item),
+          PersonDatesVertical(item: item),
           if (item.productionLocations.isNotEmpty) ...[
             const SizedBox(height: 6),
             Text(
@@ -2421,7 +2443,7 @@ class _DetailContentState extends State<_DetailContent> {
 
     return [
       if (!useSplit) ...[
-        _PersonHeader(item: item, imageApi: viewModel.imageApi),
+        PersonHeader(item: item, imageApi: viewModel.imageApi),
         const SizedBox(height: 12),
       ],
       if (hasBio) ...[
@@ -2552,7 +2574,7 @@ class _DetailContentState extends State<_DetailContent> {
         const SizedBox(height: 32),
         HorizontalScrollSection(
           title: l10n.movies,
-          builder: (_, ctrl) => _FilmographyRow(
+          builder: (_, ctrl) => FilmographyRow(
             items: movies,
             imageApi: viewModel.imageApi,
             prefs: prefs,
@@ -2580,7 +2602,7 @@ class _DetailContentState extends State<_DetailContent> {
         const SizedBox(height: 32),
         HorizontalScrollSection(
           title: l10n.series,
-          builder: (_, ctrl) => _FilmographyRow(
+          builder: (_, ctrl) => FilmographyRow(
             items: series,
             imageApi: viewModel.imageApi,
             prefs: prefs,
@@ -2607,7 +2629,7 @@ class _DetailContentState extends State<_DetailContent> {
         const SizedBox(height: 32),
         HorizontalScrollSection(
           title: l10n.guestAppearances,
-          builder: (_, ctrl) => _FilmographyRow(
+          builder: (_, ctrl) => FilmographyRow(
             items: guestAppearances,
             imageApi: viewModel.imageApi,
             prefs: prefs,
@@ -2630,7 +2652,7 @@ class _DetailContentState extends State<_DetailContent> {
         const SizedBox(height: 32),
         HorizontalScrollSection(
           title: l10n.musicVideos,
-          builder: (_, ctrl) => _FilmographyRow(
+          builder: (_, ctrl) => FilmographyRow(
             items: musicVideos,
             imageApi: viewModel.imageApi,
             prefs: prefs,
@@ -2658,7 +2680,7 @@ class _DetailContentState extends State<_DetailContent> {
         const SizedBox(height: 32),
         HorizontalScrollSection(
           title: l10n.crewContributionsSeerr,
-          builder: (_, ctrl) => _SeerrCrewCreditsRow(
+          builder: (_, ctrl) => SeerrCrewCreditsRow(
             items: seerrCrewCredits,
             prefs: prefs,
             scrollController: _trackSectionScrollController(
@@ -2685,7 +2707,7 @@ class _DetailContentState extends State<_DetailContent> {
         const SizedBox(height: 32),
         HorizontalScrollSection(
           title: l10n.appearancesSeerr,
-          builder: (_, ctrl) => _SeerrAppearancesRow(
+          builder: (_, ctrl) => SeerrAppearancesRow(
             items: seerrAppearances,
             prefs: prefs,
             scrollController: _trackSectionScrollController(
@@ -5376,6 +5398,81 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   @override
   Widget build(BuildContext context) {
     final item = viewModel.item!;
+    final l10n = AppLocalizations.of(context);
+
+    if (item.type == 'Person') {
+      final hasSeerrButton = item.tmdbId != null &&
+          item.tmdbId!.isNotEmpty &&
+          GetIt.instance<PluginSyncService>().seerrAvailable;
+
+      final normalizedPrimaryButtons = [
+        _DetailActionButton(
+          label: item.isFavorite ? l10n.favorited : l10n.favorite,
+          icon: Icons.favorite,
+          isPrimary: true,
+          focusNode: widget.tvPlayFocusNode ?? _primaryFocusNode(0),
+          autofocus: PlatformDetection.isTV,
+          onPressed: viewModel.toggleFavorite,
+          isActive: item.isFavorite,
+          activeColor: const Color(0xFFFF4757),
+          onArrowUp: NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null,
+          onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
+          onArrowLeft: _focusSidebar,
+          onArrowRight: () {
+            _primaryFocusNode(1).requestFocus();
+          },
+        ),
+        _DetailActionButton(
+          label: l10n.display,
+          icon: Icons.tune,
+          focusNode: _primaryFocusNode(1),
+          onPressed: () {
+            showFocusRestoringDialog(
+              context: context,
+              useRootNavigator: false,
+              builder: (_) => PersonDisplaySettingsDialog(prefs: GetIt.instance<UserPreferences>()),
+            );
+          },
+          onArrowUp: NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null,
+          onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
+          onArrowLeft: () {
+            (widget.tvPlayFocusNode ?? _primaryFocusNode(0)).requestFocus();
+          },
+          onArrowRight: hasSeerrButton
+              ? () {
+                  _primaryFocusNode(2).requestFocus();
+                }
+              : (widget.onArrowRightAtEnd ?? () {}),
+        ),
+        if (hasSeerrButton)
+          _DetailActionButton(
+            label: l10n.seerr,
+            iconBuilder: (size, color) => SeerrIcon(size: size, color: color),
+            focusNode: _primaryFocusNode(2),
+            onPressed: () {
+              context.push(Destinations.seerrPerson(item.tmdbId!));
+            },
+            onArrowUp: NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null,
+            onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
+            onArrowLeft: () {
+              _primaryFocusNode(1).requestFocus();
+            },
+            onArrowRight: widget.onArrowRightAtEnd ?? () {},
+          ),
+      ];
+
+      return Align(
+        alignment: widget.modernStyle ? Alignment.centerLeft : Alignment.center,
+        child: Wrap(
+          spacing: widget.modernStyle ? 12.0 : 8.0,
+          runSpacing: 12.0,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          alignment: widget.modernStyle ? WrapAlignment.start : WrapAlignment.center,
+          children: normalizedPrimaryButtons,
+        ),
+      );
+    }
+
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final isPhoto = item.type == 'Photo';
     final isBook = _isReadableBookItem(item);
@@ -5443,7 +5540,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         subtitleStreams.isEmpty && canDownloadRemoteSubtitles
         ? Icons.download_rounded
         : Icons.subtitles;
-    final l10n = AppLocalizations.of(context);
+
     final canShowDownloadActions =
         _isDownloadable(item.type) &&
         _canUserDownload() &&
@@ -11304,11 +11401,11 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard> with FocusStateMix
   }
 }
 
-class _PersonHeader extends StatelessWidget {
+class PersonHeader extends StatelessWidget {
   final AggregatedItem item;
   final ImageApi imageApi;
 
-  const _PersonHeader({required this.item, required this.imageApi});
+  const PersonHeader({required this.item, required this.imageApi});
 
   @override
   Widget build(BuildContext context) {
@@ -11360,7 +11457,7 @@ class _PersonHeader extends StatelessWidget {
           textAlign: isMobile ? TextAlign.center : TextAlign.start,
         ),
         const SizedBox(height: 8),
-        _PersonDates(item: item),
+        PersonDates(item: item),
         if (item.productionLocations.isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(top: 4),
@@ -11391,10 +11488,10 @@ class _PersonHeader extends StatelessWidget {
   }
 }
 
-class _PersonDates extends StatelessWidget {
+class PersonDates extends StatelessWidget {
   final AggregatedItem item;
 
-  const _PersonDates({required this.item});
+  const PersonDates({required this.item});
 
   @override
   Widget build(BuildContext context) {
@@ -11451,10 +11548,10 @@ class _PersonDates extends StatelessWidget {
   }
 }
 
-class _PersonDatesVertical extends StatelessWidget {
+class PersonDatesVertical extends StatelessWidget {
   final AggregatedItem item;
 
-  const _PersonDatesVertical({required this.item});
+  const PersonDatesVertical({required this.item});
 
   @override
   Widget build(BuildContext context) {
@@ -11842,7 +11939,7 @@ class _ExpandableBiographyState extends State<ExpandableBiography> {
   }
 }
 
-class _FilmographyRow extends StatelessWidget {
+class FilmographyRow extends StatelessWidget {
   final List<AggregatedItem> items;
   final ImageApi imageApi;
   final UserPreferences prefs;
@@ -11851,7 +11948,7 @@ class _FilmographyRow extends StatelessWidget {
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
   final void Function(AggregatedItem item)? onItemLongPress;
 
-  const _FilmographyRow({
+  const FilmographyRow({
     required this.items,
     required this.imageApi,
     required this.prefs,
@@ -11958,14 +12055,14 @@ class _FilmographyRow extends StatelessWidget {
   }
 }
 
-class _SeerrAppearancesRow extends StatelessWidget {
+class SeerrAppearancesRow extends StatelessWidget {
   final List<SeerrDiscoverItem> items;
   final UserPreferences prefs;
   final ScrollController? scrollController;
   final FocusNode? firstFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
 
-  const _SeerrAppearancesRow({
+  const SeerrAppearancesRow({
     required this.items,
     required this.prefs,
     this.scrollController,
@@ -12041,14 +12138,14 @@ class _SeerrAppearancesRow extends StatelessWidget {
   }
 }
 
-class _SeerrCrewCreditsRow extends StatelessWidget {
+class SeerrCrewCreditsRow extends StatelessWidget {
   final List<SeerrDiscoverItem> items;
   final UserPreferences prefs;
   final ScrollController? scrollController;
   final FocusNode? firstFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
 
-  const _SeerrCrewCreditsRow({
+  const SeerrCrewCreditsRow({
     required this.items,
     required this.prefs,
     this.scrollController,
@@ -13509,3 +13606,7 @@ class _PersonDisplaySettingsDialogState
     );
   }
 }
+
+typedef DetailActionButton = _DetailActionButton;
+typedef PersonDisplaySettingsDialog = _PersonDisplaySettingsDialog;
+

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -14,6 +14,7 @@ import 'package:server_core/server_core.dart';
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/repositories/item_mutation_repository.dart';
 import '../../../data/repositories/mdblist_repository.dart';
+import '../../../data/repositories/tmdb_repository.dart';
 import '../../../data/services/background_service.dart';
 import '../../../data/services/download_service.dart';
 import '../../../data/models/download_quality.dart';
@@ -187,6 +188,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       client: client,
       mutations: GetIt.instance<ItemMutationRepository>(),
       mdbListRepository: GetIt.instance<MdbListRepository>(),
+      tmdbRepository: GetIt.instance<TmdbRepository>(),
     );
     _viewModel.addListener(_onChanged);
     _prefs.addListener(_onPrefsChanged);
@@ -327,12 +329,23 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     final useTargetNode = type != null && type != 'Photo';
     final node = useTargetNode ? _ensureInitialFocusNode() : null;
     final isAlbumOrPlaylist = type == 'MusicAlbum' || type == 'Playlist';
+    final lastCollapse = ExpandableBiography.lastCollapseTime;
+    final now = DateTime.now();
+    final wasCollapsedRecently = lastCollapse != null &&
+        now.difference(lastCollapse) < const Duration(milliseconds: 350);
+
     final showNavigationChrome =
         _viewModel.state == ItemDetailState.ready && !isAlbumOrPlaylist && _showNavbar;
+
     Widget body = NavigationLayout(
       showBackButton: true,
       showNavigationChrome: showNavigationChrome,
       child: _buildBody(context),
+    );
+
+    body = PopScope(
+      canPop: !wasCollapsedRecently,
+      child: body,
     );
     if (isAlbumOrPlaylist && !PlatformDetection.isTV) {
       body = Stack(
@@ -441,6 +454,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
                 onToggleNavbar: (show) => setState(() => _showNavbar = show),
                 actionsExpanded: _actionsExpanded,
                 onActionsExpandedChanged: (val) => setState(() => _actionsExpanded = val),
+                onCollapseBiography: () => setState(() {}),
               )
             : _DetailContent(
                 viewModel: _viewModel,
@@ -628,7 +642,7 @@ class _DetailContentState extends State<_DetailContent> {
       return true;
     }
     return target.context
-            ?.findAncestorWidgetOfExactType<_ExpandableBiography>() !=
+            ?.findAncestorWidgetOfExactType<ExpandableBiography>() !=
         null;
   }
 
@@ -1136,6 +1150,7 @@ class _DetailContentState extends State<_DetailContent> {
                         _requestSectionFocus(targetNode);
                       },
                       onArrowLeft: () => _tryFocusSidebar(),
+                      onCollapseBiography: () => setState(() {}),
                     ),
                   ),
                 SliverPadding(
@@ -1439,6 +1454,7 @@ class _DetailContentState extends State<_DetailContent> {
               ? () => _requestSectionFocus(similarFocusNode)
               : null,
           onArrowLeft: () => _tryFocusSidebar(),
+          onCollapse: () => setState(() {}),
           style: const TextStyle(
             color: Color(0xFFD7E8F6),
             fontSize: 14,
@@ -1885,6 +1901,7 @@ class _DetailContentState extends State<_DetailContent> {
               episode: ep,
               imageApi: viewModel.imageApi,
               onChanged: () => viewModel.load(),
+              isActive: viewModel.nextUp?.id == ep.id,
             ),
           ),
         ),
@@ -2409,7 +2426,7 @@ class _DetailContentState extends State<_DetailContent> {
       ],
       if (hasBio) ...[
         const SizedBox(height: 24),
-        _ExpandableBiography(
+        ExpandableBiography(
           text: item.overview!,
           toggleFocusNode: firstFocus,
           upTarget: null,
@@ -2420,6 +2437,7 @@ class _DetailContentState extends State<_DetailContent> {
           onArrowLeft: () {
             _tryFocusSidebar();
           },
+          onCollapse: () => setState(() {}),
         ),
       ],
       const SizedBox(height: 24),
@@ -2739,6 +2757,7 @@ class _DetailContentState extends State<_DetailContent> {
               ? () => _requestSectionFocus(albumsFocusNode ?? similarFocusNode)
               : null,
           onArrowLeft: () => _tryFocusSidebar(),
+          onCollapse: () => setState(() {}),
         ),
       ],
       if (viewModel.albums.isNotEmpty) ...[
@@ -3355,6 +3374,7 @@ class _HeaderSection extends StatelessWidget {
   final VoidCallback? onArrowUp;
   final VoidCallback? onArrowDown;
   final VoidCallback? onArrowLeft;
+  final VoidCallback? onCollapseBiography;
 
   const _HeaderSection({
     required this.viewModel,
@@ -3364,6 +3384,7 @@ class _HeaderSection extends StatelessWidget {
     this.onArrowUp,
     this.onArrowDown,
     this.onArrowLeft,
+    this.onCollapseBiography,
   });
 
   @override
@@ -3505,6 +3526,7 @@ class _HeaderSection extends StatelessWidget {
             onArrowUp: onArrowUp,
             onArrowDown: onArrowDown,
             onArrowLeft: onArrowLeft,
+            onCollapse: onCollapseBiography,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                   ? AppColorScheme.onSurface
@@ -4518,7 +4540,10 @@ class _BookAuthorDetailScreenState extends State<_BookAuthorDetailScreen> {
                     const SizedBox(height: 8),
                     if (data.biography != null &&
                         data.biography!.trim().isNotEmpty)
-                      _ExpandableBiography(text: data.biography!)
+                      ExpandableBiography(
+                        text: data.biography!,
+                        onCollapse: () => setState(() {}),
+                      )
                     else
                       Text(
                         AppLocalizations.of(context).noBiographyAvailable,
@@ -4949,11 +4974,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   }
 
   void _focusFirstRowButton(int index, int primaryCount) {
-    if (index == primaryCount) {
-      (widget.actionRowRightFocusNode ?? _overflowMoreFocusNode).requestFocus();
-    } else if (index >= 0 && index < primaryCount) {
-      _primaryFocusNode(index).requestFocus();
-    }
+    final targetIndex = index.clamp(0, primaryCount - 1);
+    _primaryFocusNode(targetIndex).requestFocus();
   }
   String? _tvPlayFocusAppliedForItemId;
   bool _rowHasFocus = false;
@@ -5075,7 +5097,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     if (target.canRequestFocus) {
       target.requestFocus();
       if (target.context
-              ?.findAncestorWidgetOfExactType<_ExpandableBiography>() !=
+              ?.findAncestorWidgetOfExactType<ExpandableBiography>() !=
           null) {
         return;
       }
@@ -5099,7 +5121,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   }
 
   void _focusUpTarget() {
-    if (NavigationLayout.focusNavbarNotifier.value != null) {
+    final upTarget = widget.upTarget;
+    if (upTarget != null && upTarget.context != null && upTarget.canRequestFocus) {
+      upTarget.requestFocus();
+    } else if (NavigationLayout.focusNavbarNotifier.value != null) {
       NavigationLayout.focusNavbarNotifier.value?.call();
     } else {
       _focusTarget(widget.upTarget);
@@ -5387,6 +5412,19 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       boxSetAllWatched = false;
       boxSetAllUnwatched = false;
     }
+    final isSeason = item.type == 'Season';
+    bool seasonAllWatched = false;
+    bool seasonAllUnwatched = false;
+    AggregatedItem? seasonNextUpEp;
+    if (isSeason && viewModel.episodes.isNotEmpty) {
+      seasonAllWatched = viewModel.episodes.every((e) => e.isPlayed);
+      seasonAllUnwatched = viewModel.episodes.every((e) => !e.isPlayed && (e.playedPercentage == null || e.playedPercentage == 0));
+      if (!seasonAllWatched && !seasonAllUnwatched) {
+        try {
+          seasonNextUpEp = viewModel.episodes.firstWhere((e) => !e.isPlayed);
+        } catch (_) {}
+      }
+    }
     final selectedSource = selectedMediaSourceForItem(
       item,
       widget.selectedMediaSourceId,
@@ -5416,8 +5454,33 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       playButtonLabel = l10n.view;
     } else if (isBook) {
       playButtonLabel = hasProgress ? l10n.resumeReading : l10n.read;
+    } else if (isSeason) {
+      if (seasonAllWatched) {
+        playButtonLabel = 'Replay (S${item.indexNumber}:E1)';
+      } else if (seasonAllUnwatched) {
+        playButtonLabel = l10n.play;
+      } else {
+        if (seasonNextUpEp != null) {
+          playButtonLabel = 'Resume (S${item.indexNumber}:E${seasonNextUpEp.indexNumber})';
+        } else {
+          playButtonLabel = l10n.resume;
+        }
+      }
     } else if (isSeries) {
-      if (isFullyWatched || isFullyUnwatched) {
+      if (isFullyWatched) {
+        final nextUp = viewModel.nextUp;
+        if (nextUp != null) {
+          final s = nextUp.parentIndexNumber;
+          final e = nextUp.indexNumber;
+          if (s != null && e != null) {
+            playButtonLabel = 'Replay S${s}E$e';
+          } else {
+            playButtonLabel = 'Replay S1E1';
+          }
+        } else {
+          playButtonLabel = 'Replay S1E1';
+        }
+      } else if (isFullyUnwatched) {
         playButtonLabel = l10n.play;
       } else {
         final nextUp = viewModel.nextUp;
@@ -5462,13 +5525,24 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             : Icons.play_arrow,
         focusNode: _tvPlayFocusNode,
         autofocus: PlatformDetection.isTV,
-        onPressed: () => _play(
-          context,
-          item,
-          resume: isBoxSet
-              ? (!boxSetAllWatched && !boxSetAllUnwatched)
-              : (!isPhoto && hasProgress),
-        ),
+        onPressed: () {
+          if (isSeason && viewModel.episodes.isNotEmpty) {
+            final targetEp = seasonNextUpEp ?? viewModel.episodes[0];
+            _play(
+              context,
+              targetEp,
+              resume: seasonNextUpEp != null,
+            );
+          } else {
+            _play(
+              context,
+              item,
+              resume: isBoxSet
+                  ? (!boxSetAllWatched && !boxSetAllUnwatched)
+                  : (!isPhoto && hasProgress),
+            );
+          }
+        },
         onLongPress: isVideo
             ? () => _showAdvancedPlaybackMenu(context, item)
             : null,
@@ -5585,6 +5659,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       if (canShowDownloadActions)
         _DownloadButton(item: item, viewModel: viewModel),
       if (canShowDownloadActions) _DeleteDownloadButton(item: item),
+      if (item.type == 'Episode' && item.seriesId != null)
+        _DetailActionButton(
+          label: l10n.goToSeries,
+          icon: Icons.tv,
+          onPressed: () => context.push(
+            Destinations.item(item.seriesId!, serverId: item.serverId),
+          ),
+        ),
       if (item.type == 'BoxSet'
           ? (GetIt.instance<UserRepository>().currentUser?.isAdministrator ??
                 false)
@@ -5595,14 +5677,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           onPressed: () => _confirmDeleteItem(context, item),
           isActive: true,
           activeColor: const Color(0xFFD32F2F),
-        ),
-      if (item.type == 'Episode' && item.seriesId != null)
-        _DetailActionButton(
-          label: l10n.goToSeries,
-          icon: Icons.tv,
-          onPressed: () => context.push(
-            Destinations.item(item.seriesId!, serverId: item.serverId),
-          ),
         ),
       if ((GetIt.instance<UserRepository>().currentUser?.isAdministrator ??
               false) &&
@@ -5656,7 +5730,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final List<Widget> extraButtons;
     final bool needsOverflow;
 
-    final bool isTvShow = item.type == 'Series' || item.type == 'Season' || item.type == 'Episode';
+    final bool isTvShow = item.type == 'Series' || item.type == 'Season';
     final bool isTwoColumnLayout = widget.modernStyle && isTvShow && widget.maxVisibleButtonsOverride != null;
 
     if (isTwoColumnLayout) {
@@ -5693,19 +5767,36 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         final index = entry.key;
         final button = entry.value;
         if (button is! _DetailActionButton) return button;
+        final fNode = index == 0 ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0)) : _primaryFocusNode(index);
         return _copyActionButton(
           button,
           focusNode: index == allButtons.length - 1
-              ? (widget.actionRowRightFocusNode ?? button.focusNode)
-              : button.focusNode,
+              ? (widget.actionRowRightFocusNode ?? fNode)
+              : fNode,
           onArrowUp:
               button.onArrowUp ??
               (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
-          onArrowLeft: index == 0 ? _focusSidebar : null,
+          onArrowLeft: index == 0
+              ? _focusSidebar
+              : () {
+                  if (index > 0) {
+                    final prevNode = (index - 1 == 0)
+                        ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0))
+                        : _primaryFocusNode(index - 1);
+                    prevNode.requestFocus();
+                  }
+                },
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
           onArrowRight: index == allButtons.length - 1
               ? (widget.onArrowRightAtEnd ?? () {})
-              : null,
+              : () {
+                  if (index + 1 < allButtons.length) {
+                    final nextNode = (index + 1 == allButtons.length - 1)
+                        ? (widget.actionRowRightFocusNode ?? _primaryFocusNode(index + 1))
+                        : _primaryFocusNode(index + 1);
+                    nextNode.requestFocus();
+                  }
+                },
         );
       }).toList();
       rowContent = Align(
@@ -5726,13 +5817,29 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         final index = entry.key;
         final button = entry.value;
         if (button is! _DetailActionButton) return button;
-        final fNode = _primaryFocusNode(index);
+        final fNode = index == 0 ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0)) : _primaryFocusNode(index);
         return _copyActionButton(
           button,
           focusNode: fNode,
           onFocused: () => widget.onFocusExtra?.call(false),
           onArrowUp: button.onArrowUp ?? (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
-          onArrowLeft: index == 0 ? _focusSidebar : null,
+          onArrowLeft: index == 0
+              ? _focusSidebar
+              : () {
+                  if (index > 0) {
+                    final prevNode = (index - 1 == 0)
+                        ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0))
+                        : _primaryFocusNode(index - 1);
+                    prevNode.requestFocus();
+                  }
+                },
+          onArrowRight: () {
+            if (index < primaryButtons.length - 1) {
+              _primaryFocusNode(index + 1).requestFocus();
+            } else {
+              (widget.actionRowRightFocusNode ?? _overflowMoreFocusNode).requestFocus();
+            }
+          },
           onArrowDown: isTvShow
               ? (_expanded
                   ? () => _focusSecondRowButton(index, extraButtons.length)
@@ -5760,10 +5867,20 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               ? () => _focusFirstRowButton(index, primaryButtons.length)
               : (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
-          onArrowLeft: index == 0 ? _focusSidebar : null,
+          onArrowLeft: index == 0
+              ? _focusSidebar
+              : () {
+                  if (index > 0 && index - 1 < _extraFocusNodes.length) {
+                    _extraFocusNodes[index - 1].requestFocus();
+                  }
+                },
           onArrowRight: index == extraButtons.length - 1
               ? (widget.onArrowRightAtEnd ?? () {})
-              : null,
+              : () {
+                  if (index + 1 < _extraFocusNodes.length) {
+                    _extraFocusNodes[index + 1].requestFocus();
+                  }
+                },
           suppressAutoScrollToTop: true,
         );
       }).toList();
@@ -5774,11 +5891,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         focusNode: widget.actionRowRightFocusNode ?? _overflowMoreFocusNode,
         onFocused: () => widget.onFocusExtra?.call(false),
         onArrowUp: NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null,
-        onArrowDown: isTvShow
-            ? (_expanded
-                ? () => _focusSecondRowButton(primaryButtons.length, extraButtons.length)
-                : (widget.downTarget != null ? _focusDownTarget : null))
-            : (widget.downTarget != null ? _focusDownTarget : null),
+        onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
+        onArrowLeft: () {
+          if (primaryButtons.isNotEmpty) {
+            _primaryFocusNode(primaryButtons.length - 1).requestFocus();
+          }
+        },
         onArrowRight: widget.onArrowRightAtEnd ?? () {},
         onPressed: () => setState(() => _expanded = !_expanded),
       );
@@ -8724,17 +8842,16 @@ class _DetailActionButtonState extends State<_DetailActionButton>
           false;
       // NOTE: only set `alignment` when full-width. A Container with an
       // alignment expands to fill the parent's bounded width, which would make
-      // the pill stretch even in landscape.
-      final double width = fullWidth 
+      final double? width = fullWidth 
           ? double.infinity 
-          : (isExpanded ? (isMobile ? 120.0 : 300.0) : height);
-
+          : (isExpanded ? null : height);
+ 
       final pill = AnimatedContainer(
         duration: const Duration(milliseconds: 150),
         curve: Curves.easeOut,
         height: height,
         width: fullWidth ? null : width,
-        padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 12 : 0),
+        padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 16 : 0),
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: Colors.white,
@@ -8749,7 +8866,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
           children: [
             AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: fg, size: 24),
             if (isExpanded || fullWidth) ...[
-              const SizedBox(width: 8),
+              const SizedBox(width: 6),
               Flexible(
                 child: widget.label.contains('\n')
                     ? Column(
@@ -8761,7 +8878,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                             style: Theme.of(context).textTheme.titleSmall?.copyWith(
                                   color: fg,
                                   fontWeight: FontWeight.bold,
-                                  fontSize: 12,
+                                  fontSize: 13,
                                   height: 1.1,
                                 ),
                           ),
@@ -8770,7 +8887,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                             style: Theme.of(context).textTheme.titleSmall?.copyWith(
                                   color: fg.withValues(alpha: 0.8),
                                   fontWeight: FontWeight.bold,
-                                  fontSize: 11,
+                                  fontSize: 12,
                                   height: 1.1,
                                 ),
                           ),
@@ -8783,7 +8900,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                         style: Theme.of(context).textTheme.titleSmall?.copyWith(
                               color: fg,
                               fontWeight: FontWeight.bold,
-                              fontSize: 12,
+                              fontSize: 14,
                               height: 1.1,
                             ),
                       ),
@@ -10333,6 +10450,7 @@ class _OverviewText extends StatelessWidget {
   final VoidCallback? onArrowUp;
   final VoidCallback? onArrowDown;
   final VoidCallback? onArrowLeft;
+  final VoidCallback? onCollapse;
 
   const _OverviewText({
     required this.text,
@@ -10343,18 +10461,20 @@ class _OverviewText extends StatelessWidget {
     this.onArrowUp,
     this.onArrowDown,
     this.onArrowLeft,
+    this.onCollapse,
   });
 
   @override
   Widget build(BuildContext context) {
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
-    return _ExpandableBiography(
+    return ExpandableBiography(
       text: text,
       toggleFocusNode: focusNode,
       upTarget: upTarget,
       onArrowUp: onArrowUp,
       onArrowDown: onArrowDown,
       onArrowLeft: onArrowLeft,
+      onCollapse: onCollapse,
       style:
           style ??
           Theme.of(context).textTheme.bodyLarge?.copyWith(
@@ -10948,11 +11068,18 @@ class DetailEpisodeCard extends StatefulWidget {
   final AggregatedItem episode;
   final ImageApi imageApi;
   final VoidCallback? onChanged;
+  final FocusNode? focusNode;
+  final FocusOnKeyEventCallback? onKeyEvent;
+
+  final bool isActive;
 
   const DetailEpisodeCard({
     required this.episode,
     required this.imageApi,
     this.onChanged,
+    this.focusNode,
+    this.onKeyEvent,
+    this.isActive = false,
   });
 
   @override
@@ -11000,8 +11127,13 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard> with FocusStateMix
       onEnter: (_) => setHovered(true),
       onExit: (_) => setHovered(false),
       child: Focus(
+        focusNode: widget.focusNode,
         onFocusChange: (focused) => setFocused(focused),
-        onKeyEvent: (_, event) {
+        onKeyEvent: (node, event) {
+          if (widget.onKeyEvent != null) {
+            final res = widget.onKeyEvent!(node, event);
+            if (res != KeyEventResult.ignored) return res;
+          }
           final handlerResult = _selectKeyHandler.handleKeyEvent(
             event,
             onTap: () => context.push(
@@ -11037,7 +11169,14 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard> with FocusStateMix
                           width: 1.5,
                         ),
                       )
-                    : null,
+                    : (widget.isActive
+                        ? Border.fromBorderSide(
+                            ThemeRegistry.active.borders.focusBorder.copyWith(
+                              color: isNeon ? const Color(0xFF00FFFF) : Colors.cyan.withValues(alpha: 0.7),
+                              width: 1.5,
+                            ),
+                          )
+                        : null),
               ),
               clipBehavior: Clip.antiAlias,
               child: Row(
@@ -11382,35 +11521,46 @@ class _PersonDatesVertical extends StatelessWidget {
   }
 }
 
-class _ExpandableBiography extends StatefulWidget {
+class ExpandableBiography extends StatefulWidget {
   final String text;
   final FocusNode? toggleFocusNode;
   final FocusNode? upTarget;
   final VoidCallback? onArrowUp;
   final VoidCallback? onArrowDown;
   final VoidCallback? onArrowLeft;
+  final VoidCallback? onCollapse;
   final TextStyle? style;
   final TextAlign? textAlign;
 
-  const _ExpandableBiography({
+  static DateTime? lastCollapseTime;
+
+  const ExpandableBiography({
     required this.text,
     this.toggleFocusNode,
     this.upTarget,
     this.onArrowUp,
     this.onArrowDown,
     this.onArrowLeft,
+    this.onCollapse,
     this.style,
     this.textAlign,
   });
 
   @override
-  State<_ExpandableBiography> createState() => _ExpandableBiographyState();
+  State<ExpandableBiography> createState() => _ExpandableBiographyState();
 }
 
-class _ExpandableBiographyState extends State<_ExpandableBiography> {
+class _ExpandableBiographyState extends State<ExpandableBiography> {
   bool _expanded = false;
   bool _focused = false;
   static const double _contentHorizontalPadding = 8;
+  final ScrollController _scrollbarController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollbarController.dispose();
+    super.dispose();
+  }
 
   bool _handleUpWithoutToggle() {
     if (widget.onArrowUp != null) {
@@ -11461,8 +11611,30 @@ class _ExpandableBiographyState extends State<_ExpandableBiography> {
     return tp.didExceedMaxLines;
   }
 
-  bool _stepScroll(BuildContext context, {required bool down}) {
-    return stepScrollWithinContextBounds(context, down: down);
+  bool _stepScrollDirect({required bool down}) {
+    if (!_scrollbarController.hasClients) return false;
+    final maxScroll = _scrollbarController.position.maxScrollExtent;
+    final currentScroll = _scrollbarController.offset;
+    if (down) {
+      if (currentScroll < maxScroll) {
+        _scrollbarController.animateTo(
+          (currentScroll + 40.0).clamp(0.0, maxScroll),
+          duration: const Duration(milliseconds: 80),
+          curve: Curves.easeOut,
+        );
+        return true;
+      }
+    } else {
+      if (currentScroll > 0.0) {
+        _scrollbarController.animateTo(
+          (currentScroll - 40.0).clamp(0.0, double.infinity),
+          duration: const Duration(milliseconds: 80),
+          curve: Curves.easeOut,
+        );
+        return true;
+      }
+    }
+    return false;
   }
 
   @override
@@ -11475,6 +11647,12 @@ class _ExpandableBiographyState extends State<_ExpandableBiography> {
           height: 1.5,
         );
     final l10n = AppLocalizations.of(context);
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -11493,6 +11671,20 @@ class _ExpandableBiographyState extends State<_ExpandableBiography> {
           onKeyEvent: (_, event) {
             if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
               return KeyEventResult.ignored;
+            }
+
+            final isBackKey = event.logicalKey == LogicalKeyboardKey.escape ||
+                event.logicalKey == LogicalKeyboardKey.goBack ||
+                event.logicalKey == LogicalKeyboardKey.browserBack ||
+                event.logicalKey == LogicalKeyboardKey.gameButtonB ||
+                event.logicalKey == LogicalKeyboardKey.backspace;
+            if (_expanded && isBackKey) {
+              setState(() {
+                _expanded = false;
+              });
+              ExpandableBiography.lastCollapseTime = DateTime.now();
+              widget.onCollapse?.call();
+              return KeyEventResult.handled;
             }
 
             if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
@@ -11523,22 +11715,12 @@ class _ExpandableBiographyState extends State<_ExpandableBiography> {
             }
 
             if (_expanded && event.logicalKey == LogicalKeyboardKey.arrowDown) {
-              if (_stepScroll(context, down: true)) {
-                return KeyEventResult.handled;
-              }
-              if (widget.onArrowDown != null) {
-                widget.onArrowDown!();
-                return KeyEventResult.handled;
-              }
-              return KeyEventResult.ignored;
+              _stepScrollDirect(down: true);
+              return KeyEventResult.handled;
             }
             if (_expanded && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-              if (_stepScroll(context, down: false)) {
-                return KeyEventResult.handled;
-              }
-              return _handleUpWithoutToggle()
-                  ? KeyEventResult.handled
-                  : KeyEventResult.ignored;
+              _stepScrollDirect(down: false);
+              return KeyEventResult.handled;
             }
             if (canToggle && isActivateKey(event)) {
               setState(() => _expanded = !_expanded);
@@ -11551,55 +11733,107 @@ class _ExpandableBiographyState extends State<_ExpandableBiography> {
                 ? () => setState(() => _expanded = !_expanded)
                 : null,
             child: AnimatedContainer(
-              duration: const Duration(milliseconds: 120),
-              padding: const EdgeInsets.symmetric(
-                horizontal: _contentHorizontalPadding,
-                vertical: 6,
-              ),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8),
-                border: _focused
-                    ? Border.fromBorderSide(
-                        ThemeRegistry.active.borders.focusBorder.copyWith(
-                          color: AppColorScheme.accent,
-                          width: 1.5,
-                        ),
-                      )
-                    : null,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  AnimatedCrossFade(
-                    firstChild: Text(
-                      widget.text,
-                      style: style,
-                      maxLines: 4,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: widget.textAlign,
-                    ),
-                    secondChild: Text(
-                      widget.text,
-                      style: style,
-                      textAlign: widget.textAlign,
-                    ),
-                    crossFadeState: _expanded
-                        ? CrossFadeState.showSecond
-                        : CrossFadeState.showFirst,
-                    duration: const Duration(milliseconds: 300),
-                  ),
-                  if (canToggle) ...[
-                    const SizedBox(height: 6),
-                    Text(
-                      _expanded ? l10n.showLess : l10n.readMore,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: AppColorScheme.accent,
-                        fontWeight: FontWeight.w600,
+              duration: const Duration(milliseconds: 150),
+              constraints: (canToggle && _expanded)
+                  ? const BoxConstraints(maxHeight: 220.0)
+                  : const BoxConstraints(),
+              padding: canToggle
+                  ? const EdgeInsets.all(12)
+                  : EdgeInsets.zero,
+              decoration: canToggle
+                  ? BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: _focused
+                            ? (isNeon ? AppColorScheme.accent : focusColor)
+                            : Colors.white.withValues(alpha: 0.08),
+                        width: _focused ? 1.5 : 1.0,
                       ),
+                      color: _focused
+                          ? (isNeon
+                              ? AppColorScheme.accent.withValues(alpha: 0.04)
+                              : focusColor.withValues(alpha: 0.04))
+                          : Colors.white.withValues(alpha: 0.02),
+                    )
+                  : const BoxDecoration(),
+              child: _expanded
+                  ? Scrollbar(
+                      controller: _scrollbarController,
+                      thumbVisibility: _focused,
+                      child: NotificationListener<ScrollNotification>(
+                        onNotification: (notification) => true, // Stop bubbling
+                        child: SingleChildScrollView(
+                          controller: _scrollbarController,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              AnimatedCrossFade(
+                                firstChild: Text(
+                                  widget.text,
+                                  style: style,
+                                  maxLines: 4,
+                                  overflow: TextOverflow.ellipsis,
+                                  textAlign: widget.textAlign,
+                                ),
+                                secondChild: Text(
+                                  widget.text,
+                                  style: style,
+                                  textAlign: widget.textAlign,
+                                ),
+                                crossFadeState: _expanded
+                                    ? CrossFadeState.showSecond
+                                    : CrossFadeState.showFirst,
+                                duration: const Duration(milliseconds: 300),
+                              ),
+                              if (canToggle) ...[
+                                const SizedBox(height: 8),
+                                Text(
+                                  _expanded ? l10n.showLess : l10n.readMore,
+                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: AppColorScheme.accent,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
+                    )
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        AnimatedCrossFade(
+                          firstChild: Text(
+                            widget.text,
+                            style: style,
+                            maxLines: 4,
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: widget.textAlign,
+                          ),
+                          secondChild: Text(
+                            widget.text,
+                            style: style,
+                            textAlign: widget.textAlign,
+                          ),
+                          crossFadeState: _expanded
+                              ? CrossFadeState.showSecond
+                              : CrossFadeState.showFirst,
+                          duration: const Duration(milliseconds: 300),
+                        ),
+                        if (canToggle) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            _expanded ? l10n.showLess : l10n.readMore,
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: AppColorScheme.accent,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
-                  ],
-                ],
-              ),
             ),
           ),
         );

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:cached_network_image/cached_network_image.dart';
@@ -163,6 +164,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   bool _showNavbar = true;
   bool _actionsExpanded = false;
   Timer? _focusedBackdropDebounce;
+  Timer? _backdropCycleTimer;
   String? _lastFocusedBackdropItemId;
   String? _lastDetailBackdropItemId;
   final Map<String, String> _focusedPrimaryBackdropUrlCache =
@@ -248,6 +250,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     _themeMusicService.unregisterDetailScreen(this);
     _backgroundSub?.cancel();
     _focusedBackdropDebounce?.cancel();
+    _backdropCycleTimer?.cancel();
     if (_backgroundService.currentUrl == _backdropUrl) {
       _backgroundService.clearBackgrounds();
     }
@@ -266,12 +269,26 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     setState(() {});
     final item = _viewModel.item;
     if (item != null) {
-      if (_lastDetailBackdropItemId != item.id) {
+      bool needInitialBackdrop = _lastDetailBackdropItemId != item.id;
+      if (item.type == 'Playlist' &&
+          _viewModel.tracks.isNotEmpty &&
+          _lastFocusedBackdropItemId == null) {
+        needInitialBackdrop = true;
+      }
+
+      if (needInitialBackdrop) {
         _lastDetailBackdropItemId = item.id;
         _focusedPrimaryBackdropUrlCache.clear();
-        _lastFocusedBackdropItemId = null;
-        _backgroundService.setBackground(item, context: BlurContext.details);
+
+        final target = (item.type == 'Playlist' && _viewModel.tracks.isNotEmpty)
+            ? _viewModel.tracks.first
+            : item;
+        _backgroundService.setBackground(target, context: BlurContext.details);
         _backdropUrl = _backgroundService.currentUrl;
+
+        if (item.type == 'Playlist' && _viewModel.tracks.isNotEmpty) {
+          _onBackdropItemFocused(_viewModel.tracks.first);
+        }
 
         if (item.mediaSources.isNotEmpty) {
           _selectedMediaSourceId = item.mediaSources.first['Id']?.toString();
@@ -291,9 +308,12 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
 
   void _onBackdropItemFocused(AggregatedItem focusedItem) {
     final itemId = focusedItem.id;
-    if (_lastFocusedBackdropItemId == itemId) return;
+    if (_lastFocusedBackdropItemId == itemId && _backdropCycleTimer != null) return;
     _lastFocusedBackdropItemId = itemId;
     _focusedBackdropDebounce?.cancel();
+    _backdropCycleTimer?.cancel();
+    _backdropCycleTimer = null;
+
     _focusedBackdropDebounce = Timer(const Duration(milliseconds: 80), () {
       if (!mounted || _lastFocusedBackdropItemId != itemId) return;
 
@@ -331,6 +351,31 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       final nextUrl = _backgroundService.currentUrl;
       if (nextUrl != _backdropUrl) {
         setState(() => _backdropUrl = nextUrl);
+      }
+
+      final candidates = <String>[];
+      for (final tag in focusedItem.backdropImageTags) {
+        candidates.add(_viewModel.imageApi.getBackdropImageUrl(focusedItem.id, tag: tag));
+      }
+      if (candidates.isEmpty && focusedItem.parentBackdropItemId != null) {
+        for (final tag in focusedItem.parentBackdropImageTags) {
+          candidates.add(_viewModel.imageApi.getBackdropImageUrl(focusedItem.parentBackdropItemId!, tag: tag));
+        }
+      }
+
+      if (candidates.length > 1) {
+        _backdropCycleTimer = Timer.periodic(const Duration(seconds: 4), (timer) {
+          if (!mounted || _lastFocusedBackdropItemId != itemId) {
+            timer.cancel();
+            return;
+          }
+          final remaining = candidates.where((url) => url != _backdropUrl).toList();
+          final cycleUrl = remaining.isNotEmpty
+              ? remaining[Random().nextInt(remaining.length)]
+              : candidates[Random().nextInt(candidates.length)];
+          _backgroundService.setBackgroundUrl(cycleUrl, context: BlurContext.details);
+          setState(() => _backdropUrl = cycleUrl);
+        });
       }
     });
   }
@@ -371,29 +416,6 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       canPop: !wasCollapsedRecently,
       child: body,
     );
-    if (isAlbumOrPlaylist && !PlatformDetection.isTV) {
-      body = Stack(
-        children: [
-          Positioned.fill(child: body),
-          SafeArea(
-            child: Align(
-              alignment: Alignment.topLeft,
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: IconButton(
-                  icon: const AdaptiveIcon(
-                    Icons.arrow_back,
-                    color: Colors.white,
-                    size: 24,
-                  ),
-                  onPressed: () => Navigator.of(context).maybePop(),
-                ),
-              ),
-            ),
-          ),
-        ],
-      );
-    }
     return RequestInitialFocus(
       targetNode: node,
       child: Scaffold(backgroundColor: Colors.black, body: body),
@@ -471,6 +493,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
                 initialFocusNode: _ensureInitialFocusNode(),
                 onSelectedMediaSourceChanged: (id) =>
                     setState(() => _selectedMediaSourceId = id),
+                onBackdropItemFocused: _onBackdropItemFocused,
                 autoPlay: widget.autoPlay,
                 onPlayFromChapter: (position) => unawaited(
                   _playFromChapter(context, _viewModel.item!, position, _selectedMediaSourceId),
@@ -5149,7 +5172,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     if (upTarget != null && upTarget.context != null && upTarget.canRequestFocus) {
       upTarget.requestFocus();
     } else if (NavigationLayout.focusNavbarNotifier.value != null) {
-      NavigationLayout.focusNavbarNotifier.value?.call();
+      final isAlbumOrPlaylist = widget.viewModel.item?.type == 'MusicAlbum' ||
+          widget.viewModel.item?.type == 'Playlist';
+      if (!isAlbumOrPlaylist) {
+        NavigationLayout.focusNavbarNotifier.value?.call();
+      }
     } else {
       _focusTarget(widget.upTarget);
     }
@@ -12926,8 +12953,13 @@ class _TrackTileState extends State<_TrackTile> with FocusStateMixin {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final runtime = widget.track.runtime;
+    final isAudio = widget.track.type == 'Audio';
     final runtimeText = runtime != null
-        ? '${runtime.inMinutes}:${(runtime.inSeconds % 60).toString().padLeft(2, '0')}'
+        ? (isAudio
+            ? '${runtime.inMinutes}:${(runtime.inSeconds % 60).toString().padLeft(2, '0')}'
+            : (runtime.inHours > 0
+                ? '${runtime.inHours}h ${runtime.inMinutes.remainder(60)}m'
+                : '${runtime.inMinutes}m'))
         : null;
 
     final trackNumber = widget.isPlaylist

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -8949,13 +8949,14 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         height: height,
         width: fullWidth ? null : width,
         padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 16 : 0),
-        alignment: Alignment.center,
+        alignment: fullWidth ? Alignment.center : null,
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.circular(height / 2),
-          border: showHighlight
-              ? Border.all(color: focusColor, width: 3)
-              : null,
+          border: Border.all(
+            color: showHighlight ? focusColor : Colors.transparent,
+            width: 3,
+          ),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -168,6 +168,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   final Map<String, String> _focusedPrimaryBackdropUrlCache =
       <String, String>{};
   FocusNode? _initialContentFocusNode;
+  ModalRoute<dynamic>? _observedRoute;
 
   FocusNode _ensureInitialFocusNode() => _initialContentFocusNode ??= FocusNode(
     debugLabel: 'detailInitialContent',
@@ -207,7 +208,13 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    routeLifecycleObserver.subscribe(this, ModalRoute.of(context)!);
+    final route = ModalRoute.of(context);
+    if (route == null || route == _observedRoute) return;
+    if (_observedRoute != null) {
+      routeLifecycleObserver.unsubscribe(this);
+    }
+    _observedRoute = route;
+    routeLifecycleObserver.subscribe(this, route);
   }
 
   @override
@@ -249,7 +256,10 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
 
   @override
   void dispose() {
-    routeLifecycleObserver.unsubscribe(this);
+    if (_observedRoute != null) {
+      routeLifecycleObserver.unsubscribe(this);
+      _observedRoute = null;
+    }
     WidgetsBinding.instance.removeObserver(this);
     _themeMusicService.unregisterDetailScreen(this);
     _backgroundSub?.cancel();
@@ -5721,7 +5731,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           isActive: widget.selectedMediaSourceId != null,
           activeColor: AppColorScheme.accent,
         ),
-      if (!isBook)
+      if (!isBook && !PlatformDetection.isTV)
         _DetailActionButton(
           label: l10n.cast,
           icon: Icons.cast,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -361,6 +361,38 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     );
   }
 
+  Future<void> _playFromChapter(
+    BuildContext context,
+    AggregatedItem item,
+    Duration startPosition,
+    String? mediaSourceId,
+  ) async {
+    final manager = GetIt.instance<PlaybackManager>();
+    final forceTranscode = await _shouldForceTranscodeForDolbyVisionQueue(
+      context,
+      [item],
+      mediaSourceId: mediaSourceId,
+    );
+    if (!context.mounted) return;
+    final started = await _runWithDolbyVisionStartupFallbackPrompt(
+      context,
+      manager,
+      () => manager.playItems(
+        [item],
+        startPosition: startPosition,
+        mediaSourceId: mediaSourceId,
+        enableDirectPlay: !forceTranscode,
+        enableDirectStream: !forceTranscode,
+      ),
+    );
+    if (!started || !context.mounted) return;
+
+    final destination = manager.playbackDeferredToExternalPlayer
+        ? Destinations.externalPlayer
+        : Destinations.videoPlayer;
+    unawaited(context.push(destination));
+  }
+
   Widget _buildBody(BuildContext context) {
     return switch (_viewModel.state) {
       ItemDetailState.loading => const Center(
@@ -401,6 +433,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
                 onSelectedMediaSourceChanged: (id) =>
                     setState(() => _selectedMediaSourceId = id),
                 autoPlay: widget.autoPlay,
+                onPlayFromChapter: (position) => unawaited(
+                  _playFromChapter(context, _viewModel.item!, position, _selectedMediaSourceId),
+                ),
               )
             : _DetailContent(
                 viewModel: _viewModel,
@@ -5625,37 +5660,52 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         onArrowRight: widget.onArrowRightAtEnd ?? () {},
         onPressed: () => setState(() => _expanded = !_expanded),
       );
-      final wrapAlignment =
-          widget.modernStyle ? WrapAlignment.start : WrapAlignment.center;
-      rowContent = Align(
-        alignment:
-            widget.modernStyle ? Alignment.centerLeft : Alignment.center,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: widget.modernStyle
-              ? CrossAxisAlignment.start
-              : CrossAxisAlignment.center,
-          children: [
-            Wrap(
-              spacing: buttonSpacing,
-              runSpacing: buttonRunSpacing,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              alignment: wrapAlignment,
-              children: [...normalizedPrimaryButtons, moreButton],
-            ),
-            if (_expanded) ...[
-              SizedBox(height: buttonRunSpacing),
+      if (widget.modernStyle) {
+        rowContent = Align(
+          alignment: Alignment.centerLeft,
+          child: Wrap(
+            spacing: buttonSpacing,
+            runSpacing: buttonRunSpacing,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            alignment: WrapAlignment.start,
+            children: _expanded
+                ? [...normalizedPrimaryButtons, ...normalizedExtraButtons, moreButton]
+                : [...normalizedPrimaryButtons, moreButton],
+          ),
+        );
+      } else {
+        final wrapAlignment =
+            widget.modernStyle ? WrapAlignment.start : WrapAlignment.center;
+        rowContent = Align(
+          alignment:
+              widget.modernStyle ? Alignment.centerLeft : Alignment.center,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: widget.modernStyle
+                ? CrossAxisAlignment.start
+                : CrossAxisAlignment.center,
+            children: [
               Wrap(
                 spacing: buttonSpacing,
                 runSpacing: buttonRunSpacing,
                 crossAxisAlignment: WrapCrossAlignment.center,
                 alignment: wrapAlignment,
-                children: normalizedExtraButtons,
+                children: [...normalizedPrimaryButtons, moreButton],
               ),
+              if (_expanded) ...[
+                SizedBox(height: buttonRunSpacing),
+                Wrap(
+                  spacing: buttonSpacing,
+                  runSpacing: buttonRunSpacing,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  alignment: wrapAlignment,
+                  children: normalizedExtraButtons,
+                ),
+              ],
             ],
-          ],
-        ),
-      );
+          ),
+        );
+      }
     }
 
     return Focus(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -248,7 +248,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     _themeMusicService.unregisterDetailScreen(this);
     _backgroundSub?.cancel();
     _focusedBackdropDebounce?.cancel();
-    _backgroundService.clearBackgrounds();
+    if (_backgroundService.currentUrl == _backdropUrl) {
+      _backgroundService.clearBackgrounds();
+    }
     _viewModel.removeListener(_onChanged);
     _prefs.removeListener(_onPrefsChanged);
     try {
@@ -5401,10 +5403,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final l10n = AppLocalizations.of(context);
 
     if (item.type == 'Person') {
-      final hasSeerrButton = item.tmdbId != null &&
-          item.tmdbId!.isNotEmpty &&
-          GetIt.instance<PluginSyncService>().seerrAvailable;
-
       final normalizedPrimaryButtons = [
         _DetailActionButton(
           label: item.isFavorite ? l10n.favorited : l10n.favorite,
@@ -5438,27 +5436,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           onArrowLeft: () {
             (widget.tvPlayFocusNode ?? _primaryFocusNode(0)).requestFocus();
           },
-          onArrowRight: hasSeerrButton
-              ? () {
-                  _primaryFocusNode(2).requestFocus();
-                }
-              : (widget.onArrowRightAtEnd ?? () {}),
+          onArrowRight: widget.onArrowRightAtEnd ?? () {},
         ),
-        if (hasSeerrButton)
-          _DetailActionButton(
-            label: l10n.seerr,
-            iconBuilder: (size, color) => SeerrIcon(size: size, color: color),
-            focusNode: _primaryFocusNode(2),
-            onPressed: () {
-              context.push(Destinations.seerrPerson(item.tmdbId!));
-            },
-            onArrowUp: NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null,
-            onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
-            onArrowLeft: () {
-              _primaryFocusNode(1).requestFocus();
-            },
-            onArrowRight: widget.onArrowRightAtEnd ?? () {},
-          ),
       ];
 
       return Align(
@@ -8930,7 +8909,8 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         : (isMobile ? 48.0 : 52.0);
 
     if (widget.isPrimary) {
-      const fg = Color(0xFF101417);
+      final fg = showHighlight ? AppColorScheme.onButtonFocused : Colors.white;
+      final heartColor = (widget.icon == Icons.favorite && widget.isActive) ? const Color(0xFFE50914) : fg;
       // Portrait spans the primary Play full width (circular secondary actions
       // wrap beneath); landscape keeps it content-width, inline with them.
       final fullWidth = context
@@ -8943,30 +8923,32 @@ class _DetailActionButtonState extends State<_DetailActionButton>
           ? double.infinity 
           : (isExpanded ? null : height);
  
-      final pill = AnimatedContainer(
+      final pill = AnimatedSize(
         duration: const Duration(milliseconds: 150),
         curve: Curves.easeOut,
-        height: height,
-        width: fullWidth ? null : width,
-        padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 16 : 0),
-        alignment: fullWidth ? Alignment.center : null,
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(height / 2),
-          border: Border.all(
-            color: showHighlight ? focusColor : Colors.transparent,
-            width: 3,
+        child: Container(
+          height: height,
+          width: fullWidth ? null : width,
+          padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 16 : 0),
+          alignment: fullWidth ? Alignment.center : null,
+          decoration: BoxDecoration(
+            color: showHighlight
+                ? AppColorScheme.buttonFocused
+                : Colors.white.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(height / 2),
+            border: Border.all(
+              color: showHighlight ? focusColor : Colors.transparent,
+              width: 3,
+            ),
           ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: fg, size: 24),
-            if (isExpanded || fullWidth) ...[
-              const SizedBox(width: 6),
-              Flexible(
-                child: widget.label.contains('\n')
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: heartColor, size: 24),
+              if (isExpanded || fullWidth) ...[
+                const SizedBox(width: 6),
+                widget.label.contains('\n')
                     ? Column(
                         mainAxisSize: MainAxisSize.min,
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -8994,7 +8976,6 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                     : Text(
                         widget.label,
                         maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.titleSmall?.copyWith(
                               color: fg,
                               fontWeight: FontWeight.bold,
@@ -9002,16 +8983,16 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                               height: 1.1,
                             ),
                       ),
-              ),
+              ],
             ],
-          ],
+          ),
         ),
       );
       return fullWidth ? SizedBox(width: double.infinity, child: pill) : pill;
     }
 
     final double minWidth = height;
-    final double maxWidth = isExpanded ? 180.0 : height;
+    final double maxWidth = isExpanded ? 200.0 : height;
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 150),
@@ -9021,7 +9002,10 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         minWidth: minWidth,
         maxWidth: maxWidth,
       ),
-      padding: EdgeInsets.symmetric(horizontal: isExpanded ? 14 : 0),
+      padding: EdgeInsets.only(
+        left: isExpanded ? 6 : 0,
+        right: isExpanded ? 16 : 0,
+      ),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(height / 2),
         color: showHighlight
@@ -9046,17 +9030,27 @@ class _DetailActionButtonState extends State<_DetailActionButton>
           children: [
             SizedBox(
               width: height - 4, // keep icon centered when collapsed
-              child: widget.iconBuilder != null
-                  ? widget.iconBuilder!(24, iconColor)
-                  : AdaptiveIcon(widget.icon!, color: iconColor, size: 24),
+              child: Center(
+                child: widget.iconBuilder != null
+                    ? widget.iconBuilder!(36, iconColor)
+                    : AdaptiveIcon(
+                        widget.icon!,
+                        color: (widget.icon == Icons.favorite && widget.isActive)
+                            ? const Color(0xFFE50914)
+                            : iconColor,
+                        size: 24,
+                      ),
+              ),
             ),
             if (isExpanded) ...[
               const SizedBox(width: 6),
               Text(
                 widget.label,
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
                       color: labelColor,
-                      fontWeight: FontWeight.w600,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 14,
+                      height: 1.1,
                     ),
                 textAlign: TextAlign.center,
                 maxLines: 1,
@@ -11830,63 +11824,49 @@ class _ExpandableBiographyState extends State<ExpandableBiography> {
             onTap: canToggle
                 ? () => setState(() => _expanded = !_expanded)
                 : null,
-            child: AnimatedContainer(
+            child: AnimatedSize(
               duration: const Duration(milliseconds: 150),
-              constraints: (canToggle && _expanded)
-                  ? const BoxConstraints(maxHeight: 220.0)
-                  : const BoxConstraints(),
-              padding: canToggle
-                  ? const EdgeInsets.all(12)
-                  : EdgeInsets.zero,
-              decoration: canToggle
-                  ? BoxDecoration(
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(
+              curve: Curves.easeOut,
+              child: Container(
+                constraints: (canToggle && _expanded)
+                    ? const BoxConstraints(maxHeight: 220.0)
+                    : const BoxConstraints(),
+                padding: canToggle
+                    ? const EdgeInsets.all(12)
+                    : EdgeInsets.zero,
+                decoration: canToggle
+                    ? BoxDecoration(
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(
+                          color: _focused
+                              ? (isNeon ? AppColorScheme.accent : focusColor)
+                              : Colors.white.withValues(alpha: 0.08),
+                          width: _focused ? 1.5 : 1.0,
+                        ),
                         color: _focused
-                            ? (isNeon ? AppColorScheme.accent : focusColor)
-                            : Colors.white.withValues(alpha: 0.08),
-                        width: _focused ? 1.5 : 1.0,
-                      ),
-                      color: _focused
-                          ? (isNeon
-                              ? AppColorScheme.accent.withValues(alpha: 0.04)
-                              : focusColor.withValues(alpha: 0.04))
-                          : Colors.white.withValues(alpha: 0.02),
-                    )
-                  : const BoxDecoration(),
-              child: _expanded
-                  ? Scrollbar(
-                      controller: _scrollbarController,
-                      thumbVisibility: _focused,
-                      child: NotificationListener<ScrollNotification>(
+                            ? (isNeon
+                                ? AppColorScheme.accent.withValues(alpha: 0.04)
+                                : focusColor.withValues(alpha: 0.04))
+                            : Colors.white.withValues(alpha: 0.02),
+                      )
+                    : const BoxDecoration(),
+                child: _expanded
+                    ? NotificationListener<ScrollNotification>(
                         onNotification: (notification) => true, // Stop bubbling
                         child: SingleChildScrollView(
                           controller: _scrollbarController,
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              AnimatedCrossFade(
-                                firstChild: Text(
-                                  widget.text,
-                                  style: style,
-                                  maxLines: 4,
-                                  overflow: TextOverflow.ellipsis,
-                                  textAlign: widget.textAlign,
-                                ),
-                                secondChild: Text(
-                                  widget.text,
-                                  style: style,
-                                  textAlign: widget.textAlign,
-                                ),
-                                crossFadeState: _expanded
-                                    ? CrossFadeState.showSecond
-                                    : CrossFadeState.showFirst,
-                                duration: const Duration(milliseconds: 300),
+                              Text(
+                                widget.text,
+                                style: style,
+                                textAlign: widget.textAlign,
                               ),
                               if (canToggle) ...[
                                 const SizedBox(height: 8),
                                 Text(
-                                  _expanded ? l10n.showLess : l10n.readMore,
+                                  l10n.showLess,
                                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                                     color: AppColorScheme.accent,
                                     fontWeight: FontWeight.w600,
@@ -11896,42 +11876,31 @@ class _ExpandableBiographyState extends State<ExpandableBiography> {
                             ],
                           ),
                         ),
-                      ),
-                    )
-                  : Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        AnimatedCrossFade(
-                          firstChild: Text(
+                      )
+                    : Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
                             widget.text,
                             style: style,
                             maxLines: 4,
                             overflow: TextOverflow.ellipsis,
                             textAlign: widget.textAlign,
                           ),
-                          secondChild: Text(
-                            widget.text,
-                            style: style,
-                            textAlign: widget.textAlign,
-                          ),
-                          crossFadeState: _expanded
-                              ? CrossFadeState.showSecond
-                              : CrossFadeState.showFirst,
-                          duration: const Duration(milliseconds: 300),
-                        ),
-                        if (canToggle) ...[
-                          const SizedBox(height: 8),
-                          Text(
-                            _expanded ? l10n.showLess : l10n.readMore,
-                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: AppColorScheme.accent,
-                              fontWeight: FontWeight.w600,
+                          if (canToggle) ...[
+                            const SizedBox(height: 8),
+                            Text(
+                              l10n.readMore,
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: AppColorScheme.accent,
+                                fontWeight: FontWeight.w600,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
-                      ],
-                    ),
+                      ),
+              ),
             ),
           ),
         );

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5581,7 +5581,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       playButtonLabel = hasProgress ? l10n.resumeReading : l10n.read;
     } else if (isSeason) {
       if (seasonAllWatched) {
-        playButtonLabel = 'Replay';
+        playButtonLabel = l10n.replay;
       } else if (seasonAllUnwatched) {
         playButtonLabel = l10n.play;
       } else {
@@ -5589,7 +5589,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       }
     } else if (isSeries) {
       if (isFullyWatched) {
-        playButtonLabel = 'Replay';
+        playButtonLabel = l10n.replay;
       } else if (isFullyUnwatched) {
         playButtonLabel = l10n.play;
       } else {
@@ -5617,7 +5617,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           ? l10n.play
           : l10n.resume;
     } else if (hasProgress) {
-      playButtonLabel = 'Resume (${_formatResumePosition(item.playbackPosition)})';
+      playButtonLabel = l10n.resumeFrom(_formatResumePosition(item.playbackPosition));
     } else {
       playButtonLabel = l10n.play;
     }
@@ -5712,9 +5712,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           onPressed: () {
             if (subtitleStreams.isEmpty) {
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('No subtitles found.'),
-                  duration: Duration(seconds: 2),
+                SnackBar(
+                  content: Text(l10n.noSubtitlesFound),
+                  duration: const Duration(seconds: 2),
                 ),
               );
             } else {
@@ -5791,7 +5791,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       if ((GetIt.instance<UserRepository>().currentUser?.isAdministrator ?? false) &&
           GetIt.instance<MediaServerClient>().serverType == ServerType.jellyfin)
         _DetailActionButton(
-          label: 'Admin',
+          label: l10n.admin,
           icon: Icons.settings,
           onPressed: () => _showAdminDialog(context, item),
           isActive: true,
@@ -6163,14 +6163,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   }
 
   void _showAdminDialog(BuildContext context, AggregatedItem item) {
+    final l10n = AppLocalizations.of(context);
     showDialog(
       context: context,
       builder: (context) {
         return AlertDialog(
           backgroundColor: const Color(0xFF1E1E24),
-          title: const Text(
-            'Admin Controls',
-            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          title: Text(
+            l10n.adminControls,
+            style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
           ),
           content: Column(
             mainAxisSize: MainAxisSize.min,
@@ -6205,11 +6206,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                           color: hasFocus ? Colors.white12 : Colors.transparent,
                           borderRadius: BorderRadius.circular(8),
                         ),
-                        child: const Row(
+                        child: Row(
                           children: [
-                            Icon(Icons.image, color: Colors.white70),
-                            SizedBox(width: 12),
-                            Text('Change Artwork', style: TextStyle(color: Colors.white)),
+                            const Icon(Icons.image, color: Colors.white70),
+                            const SizedBox(width: 12),
+                            Text(l10n.changeArtwork, style: const TextStyle(color: Colors.white)),
                           ],
                         ),
                       ),
@@ -6241,11 +6242,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                             color: hasFocus ? Colors.white12 : Colors.transparent,
                             borderRadius: BorderRadius.circular(8),
                           ),
-                          child: const Row(
+                          child: Row(
                             children: [
-                              Icon(Icons.edit_note, color: Colors.white70),
-                              SizedBox(width: 12),
-                              Text('Edit Metadata', style: TextStyle(color: Colors.white)),
+                              const Icon(Icons.edit_note, color: Colors.white70),
+                              const SizedBox(width: 12),
+                              Text(l10n.editMetadata, style: const TextStyle(color: Colors.white)),
                             ],
                           ),
                         ),
@@ -6276,11 +6277,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                           color: hasFocus ? Colors.white12 : Colors.transparent,
                           borderRadius: BorderRadius.circular(8),
                         ),
-                        child: const Row(
+                        child: Row(
                           children: [
-                            Icon(Icons.delete_forever, color: Colors.redAccent),
-                            SizedBox(width: 12),
-                            Text('Delete', style: TextStyle(color: Colors.redAccent)),
+                            const Icon(Icons.delete_forever, color: Colors.redAccent),
+                            const SizedBox(width: 12),
+                            Text(l10n.delete, style: const TextStyle(color: Colors.redAccent)),
                           ],
                         ),
                       ),

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -993,7 +993,7 @@ class _DetailContentState extends State<_DetailContent> {
 
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
-    final profileBorderColor = isNeon ? const Color(0xFFFF2E92) : focusColor;
+    final profileBorderColor = isNeon ? AppColorScheme.accent : focusColor;
 
     const avatarRadius = 80.0;
     final avatar = Container(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5028,6 +5028,42 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     _extraFocusNode(targetIndex).requestFocus();
   }
 
+  /// Resolves the focus node for primary-row button [index] in a full (non-
+  /// overflow) row, where the last slot shares the right-edge node.
+  FocusNode _primaryNodeAt(int index, int count) {
+    if (index == 0) return widget.tvPlayFocusNode ?? _primaryFocusNode(0);
+    if (index == count - 1) {
+      return widget.actionRowRightFocusNode ?? _primaryFocusNode(index);
+    }
+    return _primaryFocusNode(index);
+  }
+
+  /// Resolves the focus node for primary-row button [index] in an overflow row,
+  /// where the More button owns the right-edge node separately.
+  FocusNode _primaryNodePlain(int index) => index == 0
+      ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0))
+      : _primaryFocusNode(index);
+
+  /// Focuses the nearest mounted button along [nodeAt], scanning from [from] by
+  /// [step]. Skips slots that currently render nothing (unattached focus node),
+  /// e.g. the hidden delete-download action, so the d-pad chain is never
+  /// stranded on an invisible button.
+  bool _focusAdjacent(
+    FocusNode Function(int) nodeAt,
+    int from,
+    int step,
+    int count,
+  ) {
+    for (var i = from; i >= 0 && i < count; i += step) {
+      final node = nodeAt(i);
+      if (node.context != null) {
+        node.requestFocus();
+        return true;
+      }
+    }
+    return false;
+  }
+
   void _focusFirstRowButton(int index, int primaryCount) {
     final targetIndex = index.clamp(0, primaryCount - 1);
     _primaryFocusNode(targetIndex).requestFocus();
@@ -5101,6 +5137,61 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           suppressAutoScrollToTop ?? button.suppressAutoScrollToTop,
       isPrimary: button.isPrimary,
     );
+  }
+
+  /// Applies the row's per-slot focus node and arrow wiring to any action
+  /// widget, including the download/delete wrappers that are not themselves
+  /// _DetailActionButtons (without this they never join the d-pad chain).
+  Widget _wireButton(
+    Widget button, {
+    VoidCallback? onFocused,
+    VoidCallback? onArrowUp,
+    VoidCallback? onArrowDown,
+    VoidCallback? onArrowLeft,
+    VoidCallback? onArrowRight,
+    FocusNode? focusNode,
+    bool? autofocus,
+    bool? suppressAutoScrollToTop,
+  }) {
+    if (button is _DetailActionButton) {
+      return _copyActionButton(
+        button,
+        onFocused: onFocused,
+        onArrowUp: onArrowUp,
+        onArrowDown: onArrowDown,
+        onArrowLeft: onArrowLeft,
+        onArrowRight: onArrowRight,
+        focusNode: focusNode,
+        autofocus: autofocus,
+        suppressAutoScrollToTop: suppressAutoScrollToTop,
+      );
+    }
+    if (button is _DownloadButton) {
+      return _DownloadButton(
+        item: button.item,
+        viewModel: button.viewModel,
+        focusNode: focusNode,
+        onFocused: onFocused,
+        onArrowUp: onArrowUp,
+        onArrowDown: onArrowDown,
+        onArrowLeft: onArrowLeft,
+        onArrowRight: onArrowRight,
+        suppressAutoScrollToTop: suppressAutoScrollToTop ?? false,
+      );
+    }
+    if (button is _DeleteDownloadButton) {
+      return _DeleteDownloadButton(
+        item: button.item,
+        focusNode: focusNode,
+        onFocused: onFocused,
+        onArrowUp: onArrowUp,
+        onArrowDown: onArrowDown,
+        onArrowLeft: onArrowLeft,
+        onArrowRight: onArrowRight,
+        suppressAutoScrollToTop: suppressAutoScrollToTop ?? false,
+      );
+    }
+    return button;
   }
 
   bool _tryFocusSidebar() {
@@ -5591,8 +5682,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           if (s != null && e != null) {
             if (s == 1 && e == 1) {
               playButtonLabel = l10n.play;
-            } else if (_isCompact(context)) {
-              playButtonLabel = 'S${s}E$e';
             } else {
               playButtonLabel = l10n.resume;
             }
@@ -5868,7 +5957,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           isModernMobile ? allButtons.length - 1 : allButtons.length;
       final int visibleCount = isModernMobile ? maxVisible : maxVisible - 1;
       needsOverflow =
-          !isBoxSet &&
           (compact ||
               PlatformDetection.isTV ||
               widget.maxVisibleButtonsOverride != null) &&
@@ -5887,35 +5975,40 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       final normalizedButtons = allButtons.asMap().entries.map((entry) {
         final index = entry.key;
         final button = entry.value;
-        if (button is! _DetailActionButton) return button;
+        final existingUp =
+            button is _DetailActionButton ? button.onArrowUp : null;
         final fNode = index == 0 ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0)) : _primaryFocusNode(index);
-        return _copyActionButton(
+        return _wireButton(
           button,
           focusNode: index == allButtons.length - 1
               ? (widget.actionRowRightFocusNode ?? fNode)
               : fNode,
           onArrowUp:
-              button.onArrowUp ??
+              existingUp ??
               (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
           onArrowLeft: index == 0
               ? _focusSidebar
               : () {
-                  if (index > 0) {
-                    final prevNode = (index - 1 == 0)
-                        ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0))
-                        : _primaryFocusNode(index - 1);
-                    prevNode.requestFocus();
+                  if (!_focusAdjacent(
+                    (i) => _primaryNodeAt(i, allButtons.length),
+                    index - 1,
+                    -1,
+                    allButtons.length,
+                  )) {
+                    _focusSidebar();
                   }
                 },
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
           onArrowRight: index == allButtons.length - 1
               ? (widget.onArrowRightAtEnd ?? () {})
               : () {
-                  if (index + 1 < allButtons.length) {
-                    final nextNode = (index + 1 == allButtons.length - 1)
-                        ? (widget.actionRowRightFocusNode ?? _primaryFocusNode(index + 1))
-                        : _primaryFocusNode(index + 1);
-                    nextNode.requestFocus();
+                  if (!_focusAdjacent(
+                    (i) => _primaryNodeAt(i, allButtons.length),
+                    index + 1,
+                    1,
+                    allButtons.length,
+                  )) {
+                    (widget.onArrowRightAtEnd ?? () {})();
                   }
                 },
         );
@@ -5937,28 +6030,37 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       final normalizedPrimaryButtons = primaryButtons.asMap().entries.map((entry) {
         final index = entry.key;
         final button = entry.value;
-        if (button is! _DetailActionButton) return button;
+        final existingUp =
+            button is _DetailActionButton ? button.onArrowUp : null;
         final fNode = index == 0 ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0)) : _primaryFocusNode(index);
-        return _copyActionButton(
+        return _wireButton(
           button,
           focusNode: fNode,
           onFocused: () => widget.onFocusExtra?.call(false),
-          onArrowUp: button.onArrowUp ?? (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
+          onArrowUp: existingUp ?? (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
           onArrowLeft: index == 0
               ? _focusSidebar
               : () {
-                  if (index > 0) {
-                    final prevNode = (index - 1 == 0)
-                        ? (widget.tvPlayFocusNode ?? _primaryFocusNode(0))
-                        : _primaryFocusNode(index - 1);
-                    prevNode.requestFocus();
+                  if (!_focusAdjacent(
+                    _primaryNodePlain,
+                    index - 1,
+                    -1,
+                    primaryButtons.length,
+                  )) {
+                    _focusSidebar();
                   }
                 },
           onArrowRight: () {
-            if (index < primaryButtons.length - 1) {
-              _primaryFocusNode(index + 1).requestFocus();
-            } else {
-              (widget.actionRowRightFocusNode ?? _overflowMoreFocusNode).requestFocus();
+            // Skip any unmounted slot (e.g. hidden delete-download) and fall
+            // through to the More button so it is always reachable.
+            if (!_focusAdjacent(
+              _primaryNodePlain,
+              index + 1,
+              1,
+              primaryButtons.length,
+            )) {
+              (widget.actionRowRightFocusNode ?? _overflowMoreFocusNode)
+                  .requestFocus();
             }
           },
           onArrowDown: isTvShow
@@ -5972,7 +6074,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       final normalizedExtraButtons = extraButtons.asMap().entries.map((entry) {
         final index = entry.key;
         final button = entry.value;
-        if (button is! _DetailActionButton) return button;
         final fNode = (index == 0 && widget.extraFirstFocusNode != null)
             ? widget.extraFirstFocusNode!
             : (() {
@@ -5981,7 +6082,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 }
                 return _extraFocusNodes[index];
               })();
-        return _copyActionButton(
+        return _wireButton(
           button,
           focusNode: fNode,
           onFocused: () {
@@ -6003,13 +6104,25 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           onArrowLeft: index == 0
               ? _focusSidebar
               : () {
-                  _extraFocusNode(index - 1).requestFocus();
+                  if (!_focusAdjacent(
+                    _extraFocusNode,
+                    index - 1,
+                    -1,
+                    extraButtons.length,
+                  )) {
+                    _focusSidebar();
+                  }
                 },
-          onArrowRight: index == extraButtons.length - 1
-              ? (widget.onArrowRightAtEnd ?? () {})
-              : () {
-                  _extraFocusNode(index + 1).requestFocus();
-                },
+          onArrowRight: () {
+            if (!_focusAdjacent(
+              _extraFocusNode,
+              index + 1,
+              1,
+              extraButtons.length,
+            )) {
+              (widget.onArrowRightAtEnd ?? () {})();
+            }
+          },
           suppressAutoScrollToTop: true,
         );
       }).toList();
@@ -6026,9 +6139,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               }
             : (widget.downTarget != null ? _focusDownTarget : null),
         onArrowLeft: () {
-          if (primaryButtons.isNotEmpty) {
-            _primaryFocusNode(primaryButtons.length - 1).requestFocus();
-          }
+          // Scan back from the last primary slot, skipping any unmounted button
+          // (e.g. hidden delete-download) so More can always return to the row.
+          _focusAdjacent(
+            _primaryNodePlain,
+            primaryButtons.length - 1,
+            -1,
+            primaryButtons.length,
+          );
         },
         onArrowRight: widget.onArrowRightAtEnd ?? () {},
         onPressed: () => setState(() => _expanded = !_expanded),
@@ -6095,17 +6213,31 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                   spacing: buttonSpacing,
                   runSpacing: buttonRunSpacing,
                   crossAxisAlignment: WrapCrossAlignment.center,
-                  alignment: WrapAlignment.start,
+                  // On mobile the collapsed row is full (overflow is active), so
+                  // justify the tiles edge to edge with the full-width Play pill
+                  // above instead of piling leftover space on the right.
+                  alignment: compact
+                      ? WrapAlignment.spaceBetween
+                      : WrapAlignment.start,
                   children: [...normalizedPrimaryButtons, moreButton],
                 ),
                 if (_expanded) ...[
                   SizedBox(height: buttonRunSpacing),
-                  Wrap(
-                    spacing: buttonSpacing,
-                    runSpacing: buttonRunSpacing,
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    alignment: WrapAlignment.start,
-                    children: normalizedExtraButtons,
+                  // Force full width so spaceBetween has room to justify; unlike
+                  // the collapsed row it has no full-width Play pill to stretch it.
+                  SizedBox(
+                    width: double.infinity,
+                    child: Wrap(
+                      spacing: buttonSpacing,
+                      runSpacing: buttonRunSpacing,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      // Match the collapsed row: justify the revealed tiles edge
+                      // to edge on mobile instead of piling space on the right.
+                      alignment: compact
+                          ? WrapAlignment.spaceBetween
+                          : WrapAlignment.start,
+                      children: normalizedExtraButtons,
+                    ),
                   ),
                 ],
               ],
@@ -8559,8 +8691,25 @@ bool _canUserDownload() {
 class _DownloadButton extends StatefulWidget {
   final AggregatedItem item;
   final ItemDetailViewModel viewModel;
+  final FocusNode? focusNode;
+  final VoidCallback? onFocused;
+  final VoidCallback? onArrowUp;
+  final VoidCallback? onArrowDown;
+  final VoidCallback? onArrowLeft;
+  final VoidCallback? onArrowRight;
+  final bool suppressAutoScrollToTop;
 
-  const _DownloadButton({required this.item, required this.viewModel});
+  const _DownloadButton({
+    required this.item,
+    required this.viewModel,
+    this.focusNode,
+    this.onFocused,
+    this.onArrowUp,
+    this.onArrowDown,
+    this.onArrowLeft,
+    this.onArrowRight,
+    this.suppressAutoScrollToTop = false,
+  });
 
   @override
   State<_DownloadButton> createState() => _DownloadButtonState();
@@ -8723,13 +8872,38 @@ class _DownloadButtonState extends State<_DownloadButton> {
         final downloadError = progress?.error;
         final isBatch = downloadService.isBatchDownloading;
 
+        // Forward the focus node and arrow wiring the action row assigns to this
+        // slot so the button is reachable by d-pad in every download state.
+        _DetailActionButton wire({
+          required String label,
+          required IconData icon,
+          required VoidCallback onPressed,
+          bool isActive = false,
+          Color? activeColor,
+        }) {
+          return _DetailActionButton(
+            label: label,
+            icon: icon,
+            onPressed: onPressed,
+            isActive: isActive,
+            activeColor: activeColor,
+            focusNode: widget.focusNode,
+            onFocused: widget.onFocused,
+            onArrowUp: widget.onArrowUp,
+            onArrowDown: widget.onArrowDown,
+            onArrowLeft: widget.onArrowLeft,
+            onArrowRight: widget.onArrowRight,
+            suppressAutoScrollToTop: widget.suppressAutoScrollToTop,
+          );
+        }
+
         if (progress != null &&
             !progress.isComplete &&
             progress.error == null) {
           final label = progress.progress >= 0
               ? '${(progress.progress * 100).toInt()}%'
               : '${(progress.bytesReceived / 1048576).toStringAsFixed(1)} MB';
-          return _DetailActionButton(
+          return wire(
             label: label,
             icon: Icons.close,
             onPressed: () => downloadService.cancelDownload(item.id),
@@ -8750,7 +8924,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
               break;
             }
           }
-          return _DetailActionButton(
+          return wire(
             label: '${done + 1}/$total${pct.isNotEmpty ? ' · $pct' : ''}',
             icon: Icons.close,
             onPressed: () => downloadService.cancelAll(),
@@ -8760,7 +8934,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
         }
 
         if (_isOffline || (progress != null && progress.isComplete)) {
-          return _DetailActionButton(
+          return wire(
             label: AppLocalizations.of(context).downloaded,
             icon: Icons.download_done,
             isActive: true,
@@ -8770,7 +8944,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
         }
 
         if (downloadError != null) {
-          return _DetailActionButton(
+          return wire(
             label: AppLocalizations.of(context).retry,
             icon: Icons.error_outline,
             isActive: true,
@@ -8786,7 +8960,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
           );
         }
 
-        return _DetailActionButton(
+        return wire(
           label: AppLocalizations.of(context).download,
           icon: Icons.download,
           onPressed: () => _showQualityPicker(context, downloadService),
@@ -8934,8 +9108,24 @@ class _DownloadButtonState extends State<_DownloadButton> {
 
 class _DeleteDownloadButton extends StatefulWidget {
   final AggregatedItem item;
+  final FocusNode? focusNode;
+  final VoidCallback? onFocused;
+  final VoidCallback? onArrowUp;
+  final VoidCallback? onArrowDown;
+  final VoidCallback? onArrowLeft;
+  final VoidCallback? onArrowRight;
+  final bool suppressAutoScrollToTop;
 
-  const _DeleteDownloadButton({required this.item});
+  const _DeleteDownloadButton({
+    required this.item,
+    this.focusNode,
+    this.onFocused,
+    this.onArrowUp,
+    this.onArrowDown,
+    this.onArrowLeft,
+    this.onArrowRight,
+    this.suppressAutoScrollToTop = false,
+  });
 
   @override
   State<_DeleteDownloadButton> createState() => _DeleteDownloadButtonState();
@@ -8985,6 +9175,13 @@ class _DeleteDownloadButtonState extends State<_DeleteDownloadButton> {
       onPressed: () => _confirmDelete(context),
       isActive: true,
       activeColor: const Color(0xFFFF4757),
+      focusNode: widget.focusNode,
+      onFocused: widget.onFocused,
+      onArrowUp: widget.onArrowUp,
+      onArrowDown: widget.onArrowDown,
+      onArrowLeft: widget.onArrowLeft,
+      onArrowRight: widget.onArrowRight,
+      suppressAutoScrollToTop: widget.suppressAutoScrollToTop,
     );
   }
 
@@ -9271,16 +9468,21 @@ class _DetailActionButtonState extends State<_DetailActionButton>
               child: Center(child: iconWidget),
             ),
             const SizedBox(height: 6),
-            Text(
-              widget.label,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: labelColor,
-                    fontWeight: FontWeight.w600,
-                    height: 1.1,
-                  ),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
+            // Shrink long labels (e.g. "Unwatched") to fit the tile on one line
+            // instead of wrapping a lone letter into the row below.
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                widget.label,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: labelColor,
+                      fontWeight: FontWeight.w600,
+                      height: 1.1,
+                    ),
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                softWrap: false,
+              ),
             ),
           ],
         ),

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -491,8 +491,10 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
                 backdropUrl: _backdropUrl,
                 selectedMediaSourceId: _selectedMediaSourceId,
                 initialFocusNode: _ensureInitialFocusNode(),
-                onSelectedMediaSourceChanged: (id) =>
-                    setState(() => _selectedMediaSourceId = id),
+                onSelectedMediaSourceChanged: (id) {
+                  setState(() => _selectedMediaSourceId = id);
+                  _viewModel.load(mediaSourceId: id);
+                },
                 onBackdropItemFocused: _onBackdropItemFocused,
                 autoPlay: widget.autoPlay,
                 onPlayFromChapter: (position) => unawaited(
@@ -509,8 +511,10 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
                 backdropUrl: _backdropUrl,
                 selectedMediaSourceId: _selectedMediaSourceId,
                 initialFocusNode: _ensureInitialFocusNode(),
-                onSelectedMediaSourceChanged: (id) =>
-                    setState(() => _selectedMediaSourceId = id),
+                onSelectedMediaSourceChanged: (id) {
+                  setState(() => _selectedMediaSourceId = id);
+                  _viewModel.load(mediaSourceId: id);
+                },
                 onBackdropItemFocused: _onBackdropItemFocused,
                 autoPlay: widget.autoPlay,
               ),
@@ -4212,6 +4216,7 @@ class DetailActionButtons extends StatefulWidget {
   /// circular buttons (landscape).
   final bool fullWidthPrimary;
   final FocusNode? actionRowRightFocusNode;
+  final FocusNode? extraFirstFocusNode;
   final ValueChanged<bool>? onFocusExtra;
   final bool? actionsExpanded;
   final ValueChanged<bool>? onActionsExpandedChanged;
@@ -4231,6 +4236,7 @@ class DetailActionButtons extends StatefulWidget {
     this.modernStyle = false,
     this.fullWidthPrimary = false,
     this.actionRowRightFocusNode,
+    this.extraFirstFocusNode,
     this.onFocusExtra,
     this.actionsExpanded,
     this.onActionsExpandedChanged,
@@ -5011,13 +5017,23 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     return _primaryFocusNodes[listIndex];
   }
 
+  /// Returns the focus node for extra-row button [index], matching the same
+  /// logic used when assigning focus nodes during build so index 0 always
+  /// resolves to [widget.extraFirstFocusNode] when provided.
+  FocusNode _extraFocusNode(int index) {
+    if (index == 0 && widget.extraFirstFocusNode != null) {
+      return widget.extraFirstFocusNode!;
+    }
+    while (_extraFocusNodes.length <= index) {
+      _extraFocusNodes.add(FocusNode(debugLabel: 'extra_btn_${_extraFocusNodes.length}'));
+    }
+    return _extraFocusNodes[index];
+  }
+
   void _focusSecondRowButton(int index, int extraCount) {
     if (extraCount <= 0) return;
     final targetIndex = index.clamp(0, extraCount - 1);
-    while (_extraFocusNodes.length <= targetIndex) {
-      _extraFocusNodes.add(FocusNode(debugLabel: 'extra_btn_${_extraFocusNodes.length}'));
-    }
-    _extraFocusNodes[targetIndex].requestFocus();
+    _extraFocusNode(targetIndex).requestFocus();
   }
 
   void _focusFirstRowButton(int index, int primaryCount) {
@@ -5421,7 +5437,25 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
            button.icon == Icons.check_circle_outline ||
            button.icon == Icons.favorite ||
            button.icon == Icons.playlist_add ||
-           button.icon == Icons.delete_outline;
+           button.icon == Icons.delete_outline ||
+           button.icon == Icons.movie_outlined;
+  }
+
+  bool _isSeasonManagementButton(_DetailActionButton button) {
+    return button.icon == Icons.check_circle ||
+           button.icon == Icons.check_circle_outline ||
+           button.icon == Icons.favorite ||
+           button.icon == Icons.playlist_add ||
+           button.icon == Icons.settings;
+  }
+
+  bool _isSeriesManagementButton(_DetailActionButton button) {
+    return button.icon == Icons.check_circle ||
+           button.icon == Icons.check_circle_outline ||
+           button.icon == Icons.favorite ||
+           button.icon == Icons.playlist_add ||
+           button.icon == Icons.settings ||
+           button.icon == Icons.movie_outlined;
   }
 
   @override
@@ -5490,6 +5524,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         item.type == 'AudioBook' ||
         mediaType == 'Audio';
     final isVideo = !isPhoto && !isBook && !isAudio;
+    final isPlayableVideo = item.type == 'Movie' || item.type == 'Episode' || item.type == 'Video' || item.type == 'MusicVideo';
+    final isPlayableMedia = isPlayableVideo || item.type == 'Audio' || item.type == 'AudioBook';
     final ws = _computeWatchState(item);
     final isFullyWatched = ws.isFullyWatched;
     final isFullyUnwatched = ws.isFullyUnwatched;
@@ -5559,30 +5595,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       playButtonLabel = hasProgress ? l10n.resumeReading : l10n.read;
     } else if (isSeason) {
       if (seasonAllWatched) {
-        playButtonLabel = 'Replay (S${item.indexNumber}:E1)';
+        playButtonLabel = 'Replay';
       } else if (seasonAllUnwatched) {
         playButtonLabel = l10n.play;
       } else {
-        if (seasonNextUpEp != null) {
-          playButtonLabel = 'Resume (S${item.indexNumber}:E${seasonNextUpEp.indexNumber})';
-        } else {
-          playButtonLabel = l10n.resume;
-        }
+        playButtonLabel = l10n.resume;
       }
     } else if (isSeries) {
       if (isFullyWatched) {
-        final nextUp = viewModel.nextUp;
-        if (nextUp != null) {
-          final s = nextUp.parentIndexNumber;
-          final e = nextUp.indexNumber;
-          if (s != null && e != null) {
-            playButtonLabel = 'Replay S${s}E$e';
-          } else {
-            playButtonLabel = 'Replay S1E1';
-          }
-        } else {
-          playButtonLabel = 'Replay S1E1';
-        }
+        playButtonLabel = 'Replay';
       } else if (isFullyUnwatched) {
         playButtonLabel = l10n.play;
       } else {
@@ -5596,13 +5617,13 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             } else if (_isCompact(context)) {
               playButtonLabel = 'S${s}E$e';
             } else {
-              playButtonLabel = 'Resume S${s}E$e';
+              playButtonLabel = l10n.resume;
             }
           } else {
-            playButtonLabel = 'Resume';
+            playButtonLabel = l10n.resume;
           }
         } else {
-          playButtonLabel = 'Resume';
+          playButtonLabel = l10n.resume;
         }
       }
     } else if (isBoxSet) {
@@ -5656,9 +5677,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           icon: Icons.shuffle_rounded,
           onPressed: () => _shuffle(context, item),
         ),
-      if (isBoxSet
+      if (item.type == 'Series' || (isBoxSet
           ? !(boxSetAllWatched || boxSetAllUnwatched)
-          : (hasProgress && !isPhoto))
+          : (hasProgress && !isPhoto)))
         _DetailActionButton(
           label: isBook ? l10n.startOver : l10n.restart,
           icon: Icons.restart_alt,
@@ -5693,19 +5714,30 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           isActive: true,
           activeColor: const Color(0xFF4CAF50),
         ),
-      if (audioStreams.length > 1)
+      if (isPlayableVideo) ...[
         _DetailActionButton(
           label: l10n.audio,
           icon: Icons.audiotrack,
           onPressed: () => _openAudioSelector(context, item),
         ),
-      if (showSubtitleButton)
         _DetailActionButton(
           label: l10n.subtitles,
-          icon: subtitleButtonIcon,
-          onPressed: () => _openSubtitleSelector(context, item),
+          icon: Icons.subtitles,
+          onPressed: () {
+            if (subtitleStreams.isEmpty) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('No subtitles found.'),
+                  duration: Duration(seconds: 2),
+                ),
+              );
+            } else {
+              _openSubtitleSelector(context, item);
+            }
+          },
         ),
-      if (item.mediaSources.length > 1)
+      ],
+      if (isPlayableMedia && item.mediaSources.length > 1)
         _DetailActionButton(
           label: l10n.version,
           icon: Icons.video_file,
@@ -5713,13 +5745,13 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           isActive: widget.selectedMediaSourceId != null,
           activeColor: AppColorScheme.accent,
         ),
-      if (!isBook && !PlatformDetection.isTV)
+      if (!isBook)
         _DetailActionButton(
           label: l10n.cast,
           icon: Icons.cast,
           onPressed: () => _castToDevice(context, item),
         ),
-      if (_hasTrailer(item))
+      if (item.type == 'Series' || _hasTrailer(item))
         _DetailActionButton(
           label: l10n.trailer,
           icon: Icons.movie_outlined,
@@ -5770,26 +5802,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             Destinations.item(item.seriesId!, serverId: item.serverId),
           ),
         ),
-      if (item.type == 'BoxSet'
-          ? (GetIt.instance<UserRepository>().currentUser?.isAdministrator ??
-                false)
-          : item.canDelete)
+      if ((GetIt.instance<UserRepository>().currentUser?.isAdministrator ?? false) &&
+          GetIt.instance<MediaServerClient>().serverType == ServerType.jellyfin)
         _DetailActionButton(
-          label: l10n.delete,
-          icon: Icons.delete_outline,
-          onPressed: () => _confirmDeleteItem(context, item),
+          label: 'Admin',
+          icon: Icons.settings,
+          onPressed: () => _showAdminDialog(context, item),
           isActive: true,
           activeColor: const Color(0xFFD32F2F),
-        ),
-      if ((GetIt.instance<UserRepository>().currentUser?.isAdministrator ??
-              false) &&
-          GetIt.instance<MediaServerClient>().serverType ==
-              ServerType.jellyfin &&
-          !PlatformDetection.isTV)
-        _DetailActionButton(
-          label: l10n.editMetadata,
-          icon: Icons.edit_note,
-          onPressed: () => context.push(Destinations.adminMetadata(item.id)),
         ),
     ];
 
@@ -5825,8 +5845,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
     final compact = !_useDesktopDetailLayout(context);
     final desktopScale = _desktopUiScale();
-    final buttonSpacing = compact ? 8.0 : 10.0 * desktopScale;
-    final buttonRunSpacing = compact ? 12.0 : 14.0 * desktopScale;
+    final buttonSpacing = compact ? 6.0 : 8.0 * desktopScale;
+    final buttonRunSpacing = compact ? 10.0 : 12.0 * desktopScale;
     final maxVisible = _calculateMaxVisibleButtons(context);
 
     final List<Widget> primaryButtons;
@@ -5834,14 +5854,23 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final bool needsOverflow;
 
     final bool isTvShow = item.type == 'Series' || item.type == 'Season';
-    final bool isTwoColumnLayout = widget.modernStyle && isTvShow && widget.maxVisibleButtonsOverride != null;
+    final bool isTvSeries = item.type == 'Series';
+    final bool isTvSeason = item.type == 'Season';
+    final bool isTwoColumnLayout = (widget.modernStyle && isTvShow && widget.maxVisibleButtonsOverride != null) || isTvSeries;
 
     if (isTwoColumnLayout) {
       final List<Widget> prim = [];
       final List<Widget> ext = [];
       for (final btn in allButtons) {
-        if (btn is _DetailActionButton && _isManagementButton(btn)) {
-          ext.add(btn);
+        if (btn is _DetailActionButton) {
+          final isManagement = isTvSeries
+              ? _isSeriesManagementButton(btn)
+              : (isTvSeason ? _isSeasonManagementButton(btn) : _isManagementButton(btn));
+          if (isManagement) {
+            ext.add(btn);
+          } else {
+            prim.add(btn);
+          }
         } else {
           prim.add(btn);
         }
@@ -5851,6 +5880,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       needsOverflow = extraButtons.isNotEmpty;
     } else {
       needsOverflow =
+          !isBoxSet &&
           (compact ||
               PlatformDetection.isTV ||
               widget.maxVisibleButtonsOverride != null) &&
@@ -5955,10 +5985,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         final index = entry.key;
         final button = entry.value;
         if (button is! _DetailActionButton) return button;
-        while (_extraFocusNodes.length <= index) {
-          _extraFocusNodes.add(FocusNode(debugLabel: 'extra_btn_${_extraFocusNodes.length}'));
-        }
-        final fNode = _extraFocusNodes[index];
+        final fNode = (index == 0 && widget.extraFirstFocusNode != null)
+            ? widget.extraFirstFocusNode!
+            : (() {
+                while (_extraFocusNodes.length <= index) {
+                  _extraFocusNodes.add(FocusNode(debugLabel: 'extra_btn_${_extraFocusNodes.length}'));
+                }
+                return _extraFocusNodes[index];
+              })();
         return _copyActionButton(
           button,
           focusNode: fNode,
@@ -5967,22 +6001,26 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             widget.onFocusExtra?.call(true);
           },
           onArrowUp: isTvShow
-              ? () => _focusFirstRowButton(index, primaryButtons.length)
+              ? () {
+                  // For both Series and Season: last extra button (Admin) goes up to More button
+                  // All other extra buttons navigate up to the corresponding primary button
+                  if (index == extraButtons.length - 1) {
+                    (widget.actionRowRightFocusNode ?? _overflowMoreFocusNode).requestFocus();
+                  } else {
+                    _focusFirstRowButton(index, primaryButtons.length);
+                  }
+                }
               : (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
           onArrowLeft: index == 0
               ? _focusSidebar
               : () {
-                  if (index > 0 && index - 1 < _extraFocusNodes.length) {
-                    _extraFocusNodes[index - 1].requestFocus();
-                  }
+                  _extraFocusNode(index - 1).requestFocus();
                 },
           onArrowRight: index == extraButtons.length - 1
               ? (widget.onArrowRightAtEnd ?? () {})
               : () {
-                  if (index + 1 < _extraFocusNodes.length) {
-                    _extraFocusNodes[index + 1].requestFocus();
-                  }
+                  _extraFocusNode(index + 1).requestFocus();
                 },
           suppressAutoScrollToTop: true,
         );
@@ -5994,7 +6032,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         focusNode: widget.actionRowRightFocusNode ?? _overflowMoreFocusNode,
         onFocused: () => widget.onFocusExtra?.call(false),
         onArrowUp: NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null,
-        onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
+        onArrowDown: isTvShow && _expanded && extraButtons.isNotEmpty
+            ? () {
+                _extraFocusNode(extraButtons.length - 1).requestFocus();
+              }
+            : (widget.downTarget != null ? _focusDownTarget : null),
         onArrowLeft: () {
           if (primaryButtons.isNotEmpty) {
             _primaryFocusNode(primaryButtons.length - 1).requestFocus();
@@ -6006,19 +6048,33 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
       if (widget.modernStyle) {
         if (isTvShow) {
+          // Build a Row so the play pill (first button) can grow via Flexible
+          // to fill available space — avoids text truncation for long labels.
+          final pillButton = normalizedPrimaryButtons.isNotEmpty
+              ? normalizedPrimaryButtons.first
+              : null;
+          final circleButtons = normalizedPrimaryButtons.skip(1).toList();
+
+          Widget primaryRow = Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (pillButton != null)
+                Flexible(fit: FlexFit.loose, child: pillButton),
+              for (final btn in circleButtons) ...[SizedBox(width: buttonSpacing), btn],
+              SizedBox(width: buttonSpacing),
+              moreButton,
+            ],
+          );
+
           if (_expanded) {
             rowContent = Align(
               alignment: Alignment.centerLeft,
               child: Column(
+                mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Wrap(
-                    spacing: buttonSpacing,
-                    runSpacing: buttonRunSpacing,
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    alignment: WrapAlignment.start,
-                    children: [...normalizedPrimaryButtons, moreButton],
-                  ),
+                  primaryRow,
                   Padding(
                     padding: EdgeInsets.only(top: buttonRunSpacing),
                     child: Wrap(
@@ -6035,13 +6091,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           } else {
             rowContent = Align(
               alignment: Alignment.centerLeft,
-              child: Wrap(
-                spacing: buttonSpacing,
-                runSpacing: buttonRunSpacing,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                alignment: WrapAlignment.start,
-                children: [...normalizedPrimaryButtons, moreButton],
-              ),
+              child: primaryRow,
             );
           }
         } else {
@@ -6124,6 +6174,139 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final m = position.inMinutes.remainder(60);
     if (h > 0) return '${h}h ${m}m';
     return '${m}m';
+  }
+
+  void _showAdminDialog(BuildContext context, AggregatedItem item) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          backgroundColor: const Color(0xFF1E1E24),
+          title: const Text(
+            'Admin Controls',
+            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Focus(
+                onKeyEvent: (_, event) {
+                  if (isActivateKey(event)) {
+                    Navigator.of(context).pop();
+                    ChangeArtworkDialog.show(context, item: item).then((changed) {
+                      if (changed == true) {
+                        viewModel.load();
+                      }
+                    });
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: Builder(
+                  builder: (context) {
+                    final hasFocus = Focus.of(context).hasFocus;
+                    return InkWell(
+                      onTap: () async {
+                        Navigator.of(context).pop();
+                        final changed = await ChangeArtworkDialog.show(context, item: item);
+                        if (changed == true) {
+                          viewModel.load();
+                        }
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                        decoration: BoxDecoration(
+                          color: hasFocus ? Colors.white12 : Colors.transparent,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: const Row(
+                          children: [
+                            Icon(Icons.image, color: Colors.white70),
+                            SizedBox(width: 12),
+                            Text('Change Artwork', style: TextStyle(color: Colors.white)),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              if (!PlatformDetection.isTV)
+                Focus(
+                  onKeyEvent: (_, event) {
+                    if (isActivateKey(event)) {
+                      Navigator.of(context).pop();
+                      context.push(Destinations.adminMetadata(item.id));
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  child: Builder(
+                    builder: (context) {
+                      final hasFocus = Focus.of(context).hasFocus;
+                      return InkWell(
+                        onTap: () {
+                          Navigator.of(context).pop();
+                          context.push(Destinations.adminMetadata(item.id));
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                          decoration: BoxDecoration(
+                            color: hasFocus ? Colors.white12 : Colors.transparent,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Row(
+                            children: [
+                              Icon(Icons.edit_note, color: Colors.white70),
+                              SizedBox(width: 12),
+                              Text('Edit Metadata', style: TextStyle(color: Colors.white)),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              Focus(
+                onKeyEvent: (_, event) {
+                  if (isActivateKey(event)) {
+                    Navigator.of(context).pop();
+                    _confirmDeleteItem(context, item);
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: Builder(
+                  builder: (context) {
+                    final hasFocus = Focus.of(context).hasFocus;
+                    return InkWell(
+                      onTap: () {
+                        Navigator.of(context).pop();
+                        _confirmDeleteItem(context, item);
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                        decoration: BoxDecoration(
+                          color: hasFocus ? Colors.white12 : Colors.transparent,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: const Row(
+                          children: [
+                            Icon(Icons.delete_forever, color: Colors.redAccent),
+                            SizedBox(width: 12),
+                            Text('Delete', style: TextStyle(color: Colors.redAccent)),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   Future<void> _confirmDeleteItem(
@@ -8944,19 +9127,19 @@ class _DetailActionButtonState extends State<_DetailActionButton>
               .findAncestorWidgetOfExactType<DetailActionButtons>()
               ?.fullWidthPrimary ??
           false;
-      // NOTE: only set `alignment` when full-width. A Container with an
-      // alignment expands to fill the parent's bounded width, which would make
-      final double? width = fullWidth 
-          ? double.infinity 
-          : (isExpanded ? null : height);
- 
-      final pill = AnimatedSize(
-        duration: const Duration(milliseconds: 150),
-        curve: Curves.easeOut,
-        child: Container(
+
+      // When expanded (focused): use ConstrainedBox with a minWidth floor
+      // so the pill always has enough room for labels like "Resume S12:E24".
+      // Flexible in the parent Row lets the pill grow beyond the minimum.
+      final Widget pill;
+      if (isExpanded || fullWidth) {
+        final pillInner = Container(
           height: height,
-          width: fullWidth ? null : width,
-          padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 16 : 0),
+          width: fullWidth ? double.infinity : null,
+          padding: EdgeInsets.only(
+            left: fullWidth ? 10 : 10,
+            right: fullWidth ? 10 : 14,
+          ),
           alignment: fullWidth ? Alignment.center : null,
           decoration: BoxDecoration(
             color: showHighlight
@@ -8973,8 +9156,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: heartColor, size: 24),
-              if (isExpanded || fullWidth) ...[
-                const SizedBox(width: 6),
+              const SizedBox(width: 2),
                 widget.label.contains('\n')
                     ? Column(
                         mainAxisSize: MainAxisSize.min,
@@ -9003,18 +9185,50 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                     : Text(
                         widget.label,
                         maxLines: 1,
+                        softWrap: false,
                         style: Theme.of(context).textTheme.titleSmall?.copyWith(
                               color: fg,
                               fontWeight: FontWeight.bold,
-                              fontSize: 14,
+                              fontSize: 13,
                               height: 1.1,
                             ),
                       ),
               ],
-            ],
+            ),
+        );
+        // Landscape: wrap with a minWidth so text always has room.
+        // Flexible in the parent Row allows growing beyond minWidth.
+        pill = fullWidth
+            ? pillInner
+            : ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 200),
+                child: pillInner,
+              );
+      } else {
+        // Collapsed: animate from/to a circle
+        pill = AnimatedSize(
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOut,
+          child: SizedBox.square(
+            dimension: height,
+            child: Container(
+              height: height,
+              width: height,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(height / 2),
+                border: Border.all(
+                  color: Colors.transparent,
+                  width: 3,
+                ),
+              ),
+              child: Center(
+                child: AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: Colors.white, size: 24),
+              ),
+            ),
           ),
-        ),
-      );
+        );
+      }
       return fullWidth ? SizedBox(width: double.infinity, child: pill) : pill;
     }
 
@@ -11297,8 +11511,10 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard> with FocusStateMix
                           )
                         : null),
               ),
-              clipBehavior: Clip.antiAlias,
-              child: Row(
+              clipBehavior: Clip.none,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Row(
                 children: [
                   SizedBox(
                     width: isMobile ? 160.0 : 196.0 * desktopScale,
@@ -11416,6 +11632,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard> with FocusStateMix
                 ],
               ),
             ),
+          ),
           ),
         ),
       ),
@@ -11647,6 +11864,7 @@ class ExpandableBiography extends StatefulWidget {
   final VoidCallback? onArrowUp;
   final VoidCallback? onArrowDown;
   final VoidCallback? onArrowLeft;
+  final VoidCallback? onArrowRight;
   final VoidCallback? onCollapse;
   final TextStyle? style;
   final TextAlign? textAlign;
@@ -11660,6 +11878,7 @@ class ExpandableBiography extends StatefulWidget {
     this.onArrowUp,
     this.onArrowDown,
     this.onArrowLeft,
+    this.onArrowRight,
     this.onCollapse,
     this.style,
     this.textAlign,
@@ -11722,9 +11941,15 @@ class _ExpandableBiographyState extends State<ExpandableBiography> {
     if (maxWidth <= 0) {
       return false;
     }
+    final limit = (GetIt.instance<UserPreferences>()
+                .get(UserPreferences.desktopUiScale)
+                .scaleFactor >=
+            1.2)
+        ? 2
+        : 4;
     final tp = TextPainter(
       text: TextSpan(text: widget.text, style: style),
-      maxLines: 4,
+      maxLines: limit,
       textDirection: TextDirection.ltr,
     )..layout(maxWidth: maxWidth);
     return tp.didExceedMaxLines;
@@ -11815,6 +12040,10 @@ class _ExpandableBiographyState extends State<ExpandableBiography> {
             }
 
             if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+              if (widget.onArrowRight != null) {
+                widget.onArrowRight!();
+                return KeyEventResult.handled;
+              }
               return KeyEventResult.handled;
             }
 
@@ -11911,7 +12140,12 @@ class _ExpandableBiographyState extends State<ExpandableBiography> {
                           Text(
                             widget.text,
                             style: style,
-                            maxLines: 4,
+                            maxLines: (GetIt.instance<UserPreferences>()
+                                        .get(UserPreferences.desktopUiScale)
+                                        .scaleFactor >=
+                                    1.2)
+                                ? 2
+                                : 4,
                             overflow: TextOverflow.ellipsis,
                             textAlign: widget.textAlign,
                           ),
@@ -13159,18 +13393,26 @@ class _TrackTileState extends State<_TrackTile> with FocusStateMixin {
                     ],
                   ),
                 ),
-                if (runtimeText != null)
-                  Padding(
+                () {
+                  final releaseYear = widget.track.productionYear ??
+                      (widget.track.premiereDate != null ? widget.track.premiereDate!.year : null);
+                  final parts = [
+                    if (releaseYear != null) '$releaseYear',
+                    if (runtimeText != null) runtimeText,
+                  ];
+                  if (parts.isEmpty) return const SizedBox.shrink();
+                  return Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     child: Text(
-                      runtimeText,
+                      parts.join('  •  '),
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: showFocusBorder
                             ? Colors.white.withValues(alpha: 0.82)
                             : Colors.white.withValues(alpha: 0.5),
                       ),
                     ),
-                  ),
+                  );
+                }(),
                 if (PlatformDetection.isTV) ...[
                   if (widget.reorderable) ...[
                     IconButton(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -221,6 +221,12 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
         setState(() => _backdropUrl = nextUrl);
       }
     }
+    // A pushed child screen (e.g. a similar item) clears the shared play-button
+    // notifier on its way out; reclaim it so focus restoration finds this screen.
+    if (PlatformDetection.isTV && _initialContentFocusNode != null) {
+      NavigationLayout.focusDetailsPlayButtonNotifier.value =
+          _initialContentFocusNode;
+    }
     _resumeThemeMusicIfEligible();
   }
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 import 'dart:ui';
 
 import 'package:cached_network_image/cached_network_image.dart';
@@ -164,7 +163,6 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   bool _showNavbar = true;
   bool _actionsExpanded = false;
   Timer? _focusedBackdropDebounce;
-  Timer? _backdropCycleTimer;
   String? _lastFocusedBackdropItemId;
   String? _lastDetailBackdropItemId;
   final Map<String, String> _focusedPrimaryBackdropUrlCache =
@@ -250,7 +248,6 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     _themeMusicService.unregisterDetailScreen(this);
     _backgroundSub?.cancel();
     _focusedBackdropDebounce?.cancel();
-    _backdropCycleTimer?.cancel();
     if (_backgroundService.currentUrl == _backdropUrl) {
       _backgroundService.clearBackgrounds();
     }
@@ -308,11 +305,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
 
   void _onBackdropItemFocused(AggregatedItem focusedItem) {
     final itemId = focusedItem.id;
-    if (_lastFocusedBackdropItemId == itemId && _backdropCycleTimer != null) return;
+    if (_lastFocusedBackdropItemId == itemId) return;
     _lastFocusedBackdropItemId = itemId;
     _focusedBackdropDebounce?.cancel();
-    _backdropCycleTimer?.cancel();
-    _backdropCycleTimer = null;
 
     _focusedBackdropDebounce = Timer(const Duration(milliseconds: 80), () {
       if (!mounted || _lastFocusedBackdropItemId != itemId) return;
@@ -351,31 +346,6 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       final nextUrl = _backgroundService.currentUrl;
       if (nextUrl != _backdropUrl) {
         setState(() => _backdropUrl = nextUrl);
-      }
-
-      final candidates = <String>[];
-      for (final tag in focusedItem.backdropImageTags) {
-        candidates.add(_viewModel.imageApi.getBackdropImageUrl(focusedItem.id, tag: tag));
-      }
-      if (candidates.isEmpty && focusedItem.parentBackdropItemId != null) {
-        for (final tag in focusedItem.parentBackdropImageTags) {
-          candidates.add(_viewModel.imageApi.getBackdropImageUrl(focusedItem.parentBackdropItemId!, tag: tag));
-        }
-      }
-
-      if (candidates.length > 1) {
-        _backdropCycleTimer = Timer.periodic(const Duration(seconds: 4), (timer) {
-          if (!mounted || _lastFocusedBackdropItemId != itemId) {
-            timer.cancel();
-            return;
-          }
-          final remaining = candidates.where((url) => url != _backdropUrl).toList();
-          final cycleUrl = remaining.isNotEmpty
-              ? remaining[Random().nextInt(remaining.length)]
-              : candidates[Random().nextInt(candidates.length)];
-          _backgroundService.setBackgroundUrl(cycleUrl, context: BlurContext.details);
-          setState(() => _backdropUrl = cycleUrl);
-        });
       }
     });
   }

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4927,6 +4927,34 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   final FocusNode _overflowFirstExtraFocusNode = FocusNode(
     debugLabel: 'detail_overflow_first_extra',
   );
+  final List<FocusNode> _primaryFocusNodes = [];
+  final List<FocusNode> _extraFocusNodes = [];
+
+  FocusNode _primaryFocusNode(int index) {
+    if (index == 0) return _tvPlayFocusNode;
+    final listIndex = index - 1;
+    while (_primaryFocusNodes.length <= listIndex) {
+      _primaryFocusNodes.add(FocusNode(debugLabel: 'primary_btn_${_primaryFocusNodes.length + 1}'));
+    }
+    return _primaryFocusNodes[listIndex];
+  }
+
+  void _focusSecondRowButton(int index, int extraCount) {
+    if (extraCount <= 0) return;
+    final targetIndex = index.clamp(0, extraCount - 1);
+    while (_extraFocusNodes.length <= targetIndex) {
+      _extraFocusNodes.add(FocusNode(debugLabel: 'extra_btn_${_extraFocusNodes.length}'));
+    }
+    _extraFocusNodes[targetIndex].requestFocus();
+  }
+
+  void _focusFirstRowButton(int index, int primaryCount) {
+    if (index == primaryCount) {
+      (widget.actionRowRightFocusNode ?? _overflowMoreFocusNode).requestFocus();
+    } else if (index >= 0 && index < primaryCount) {
+      _primaryFocusNode(index).requestFocus();
+    }
+  }
   String? _tvPlayFocusAppliedForItemId;
   bool _rowHasFocus = false;
 
@@ -4957,6 +4985,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     _localTvPlayFocusNode.dispose();
     _overflowMoreFocusNode.dispose();
     _overflowFirstExtraFocusNode.dispose();
+    for (final node in _primaryFocusNodes) {
+      node.dispose();
+    }
+    for (final node in _extraFocusNodes) {
+      node.dispose();
+    }
     super.dispose();
   }
 
@@ -5065,7 +5099,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   }
 
   void _focusUpTarget() {
-    _focusTarget(widget.upTarget);
+    if (NavigationLayout.focusNavbarNotifier.value != null) {
+      NavigationLayout.focusNavbarNotifier.value?.call();
+    } else {
+      _focusTarget(widget.upTarget);
+    }
   }
 
   void _focusFirstExpandedOverflowButton(BuildContext context) {
@@ -5392,7 +5430,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             } else if (_isCompact(context)) {
               playButtonLabel = 'S${s}E$e';
             } else {
-              playButtonLabel = 'Resume from\nS$s:E$e';
+              playButtonLabel = 'Resume S${s}E$e';
             }
           } else {
             playButtonLabel = 'Resume';
@@ -5406,7 +5444,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           ? l10n.play
           : l10n.resume;
     } else if (hasProgress) {
-      playButtonLabel = 'Resume from\n${_formatResumePosition(item.playbackPosition)}';
+      playButtonLabel = 'Resume (${_formatResumePosition(item.playbackPosition)})';
     } else {
       playButtonLabel = l10n.play;
     }
@@ -5618,7 +5656,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final List<Widget> extraButtons;
     final bool needsOverflow;
 
-    final bool isTwoColumnLayout = widget.modernStyle && widget.maxVisibleButtonsOverride != null;
+    final bool isTvShow = item.type == 'Series' || item.type == 'Season' || item.type == 'Episode';
+    final bool isTwoColumnLayout = widget.modernStyle && isTvShow && widget.maxVisibleButtonsOverride != null;
 
     if (isTwoColumnLayout) {
       final List<Widget> prim = [];
@@ -5661,7 +5700,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               : button.focusNode,
           onArrowUp:
               button.onArrowUp ??
-              (widget.upTarget != null ? _focusUpTarget : null),
+              (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
           onArrowLeft: index == 0 ? _focusSidebar : null,
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
           onArrowRight: index == allButtons.length - 1
@@ -5683,39 +5722,43 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         ),
       );
     } else {
-      final normalizedPrimaryButtons = primaryButtons.asMap().entries.map((
-        entry,
-      ) {
+      final normalizedPrimaryButtons = primaryButtons.asMap().entries.map((entry) {
         final index = entry.key;
         final button = entry.value;
         if (button is! _DetailActionButton) return button;
+        final fNode = _primaryFocusNode(index);
         return _copyActionButton(
           button,
+          focusNode: fNode,
           onFocused: () => widget.onFocusExtra?.call(false),
-          onArrowUp: button.onArrowUp ?? _focusUpTarget,
+          onArrowUp: button.onArrowUp ?? (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
           onArrowLeft: index == 0 ? _focusSidebar : null,
-          onArrowDown: _expanded
-              ? () => _focusFirstExpandedOverflowButton(context)
+          onArrowDown: isTvShow
+              ? (_expanded
+                  ? () => _focusSecondRowButton(index, extraButtons.length)
+                  : (widget.downTarget != null ? _focusDownTarget : null))
               : (widget.downTarget != null ? _focusDownTarget : null),
         );
       }).toList();
+
       final normalizedExtraButtons = extraButtons.asMap().entries.map((entry) {
         final index = entry.key;
         final button = entry.value;
         if (button is! _DetailActionButton) return button;
+        while (_extraFocusNodes.length <= index) {
+          _extraFocusNodes.add(FocusNode(debugLabel: 'extra_btn_${_extraFocusNodes.length}'));
+        }
+        final fNode = _extraFocusNodes[index];
         return _copyActionButton(
           button,
-          focusNode: index == 0 ? _overflowFirstExtraFocusNode : null,
+          focusNode: fNode,
           onFocused: () {
             _ensureOverflowButtonVisible(context);
             widget.onFocusExtra?.call(true);
           },
-          onArrowUp: widget.modernStyle ? null : () {
-            if (_overflowMoreFocusNode.context != null &&
-                _overflowMoreFocusNode.canRequestFocus) {
-              _overflowMoreFocusNode.requestFocus();
-            }
-          },
+          onArrowUp: isTvShow
+              ? () => _focusFirstRowButton(index, primaryButtons.length)
+              : (NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null),
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
           onArrowLeft: index == 0 ? _focusSidebar : null,
           onArrowRight: index == extraButtons.length - 1
@@ -5724,46 +5767,64 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           suppressAutoScrollToTop: true,
         );
       }).toList();
+
       final moreButton = _DetailActionButton(
         label: _expanded ? l10n.less : l10n.more,
         icon: _expanded ? Icons.expand_less : Icons.expand_more,
         focusNode: widget.actionRowRightFocusNode ?? _overflowMoreFocusNode,
         onFocused: () => widget.onFocusExtra?.call(false),
-        onArrowUp: _focusUpTarget,
-        onArrowDown: _expanded
-            ? () => _focusFirstExpandedOverflowButton(context)
-            : null,
+        onArrowUp: NavigationLayout.focusNavbarNotifier.value != null || widget.upTarget != null ? _focusUpTarget : null,
+        onArrowDown: isTvShow
+            ? (_expanded
+                ? () => _focusSecondRowButton(primaryButtons.length, extraButtons.length)
+                : (widget.downTarget != null ? _focusDownTarget : null))
+            : (widget.downTarget != null ? _focusDownTarget : null),
         onArrowRight: widget.onArrowRightAtEnd ?? () {},
         onPressed: () => setState(() => _expanded = !_expanded),
       );
+
       if (widget.modernStyle) {
-        if (_expanded) {
-          rowContent = Align(
-            alignment: Alignment.centerLeft,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Wrap(
-                  spacing: buttonSpacing,
-                  runSpacing: buttonRunSpacing,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  alignment: WrapAlignment.start,
-                  children: [...normalizedPrimaryButtons, moreButton],
-                ),
-                Padding(
-                  padding: EdgeInsets.only(top: buttonRunSpacing),
-                  child: Wrap(
+        if (isTvShow) {
+          if (_expanded) {
+            rowContent = Align(
+              alignment: Alignment.centerLeft,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Wrap(
                     spacing: buttonSpacing,
                     runSpacing: buttonRunSpacing,
                     crossAxisAlignment: WrapCrossAlignment.center,
                     alignment: WrapAlignment.start,
-                    children: normalizedExtraButtons,
+                    children: [...normalizedPrimaryButtons, moreButton],
                   ),
-                ),
-              ],
-            ),
-          );
+                  Padding(
+                    padding: EdgeInsets.only(top: buttonRunSpacing),
+                    child: Wrap(
+                      spacing: buttonSpacing,
+                      runSpacing: buttonRunSpacing,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      alignment: WrapAlignment.start,
+                      children: normalizedExtraButtons,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          } else {
+            rowContent = Align(
+              alignment: Alignment.centerLeft,
+              child: Wrap(
+                spacing: buttonSpacing,
+                runSpacing: buttonRunSpacing,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                alignment: WrapAlignment.start,
+                children: [...normalizedPrimaryButtons, moreButton],
+              ),
+            );
+          }
         } else {
+          // Movie page: single row!
           rowContent = Align(
             alignment: Alignment.centerLeft,
             child: Wrap(
@@ -5771,7 +5832,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               runSpacing: buttonRunSpacing,
               crossAxisAlignment: WrapCrossAlignment.center,
               alignment: WrapAlignment.start,
-              children: [...normalizedPrimaryButtons, moreButton],
+              children: _expanded
+                  ? [...normalizedPrimaryButtons, ...normalizedExtraButtons, moreButton]
+                  : [...normalizedPrimaryButtons, moreButton],
             ),
           );
         }
@@ -9102,12 +9165,12 @@ class DetailCastRow extends StatelessWidget {
     final avatarRadius = isMobile ? 35.0 : 45.0 * desktopScale;
 
     return SizedBox(
-      height: isMobile ? 158 : 178 * desktopScale,
+      height: isMobile ? 172 : 196 * desktopScale,
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,
         clipBehavior: Clip.none,
-        padding: const EdgeInsets.fromLTRB(4, 10, 4, 4),
+        padding: const EdgeInsets.fromLTRB(4, 12, 4, 12),
         itemCount: people.length,
         separatorBuilder: (_, _) =>
             SizedBox(width: isMobile ? 12 : 16 * desktopScale),
@@ -9236,16 +9299,14 @@ class _CastPersonCardState extends State<_CastPersonCard> with FocusStateMixin {
                     padding: const EdgeInsets.all(2),
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      border: showFocusBorder
-                          ? Border.fromBorderSide(
-                              ThemeRegistry.active.borders.focusBorder.copyWith(
-                                color: isNeon
-                                    ? AppColorScheme.accent
-                                    : focusColor,
-                                width: 1.5,
-                              ),
-                            )
-                          : null,
+                      border: Border.fromBorderSide(
+                        ThemeRegistry.active.borders.focusBorder.copyWith(
+                          color: showFocusBorder
+                              ? (isNeon ? AppColorScheme.accent : focusColor)
+                              : Colors.transparent,
+                          width: 1.5,
+                        ),
+                      ),
                     ),
                     child: CircleAvatar(
                       radius: widget.avatarRadius,
@@ -9262,7 +9323,7 @@ class _CastPersonCardState extends State<_CastPersonCard> with FocusStateMixin {
                           : null,
                     ),
                   ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: 12),
                   Text(
                     widget.name,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -9566,6 +9627,50 @@ class _ChapterListCard extends StatefulWidget {
 
 class _ChapterListCardState extends State<_ChapterListCard>
     with FocusStateMixin {
+  String _normalizeTimeString(String s) {
+    s = s.trim();
+    final parts = s.split(':');
+    if (parts.length == 2) {
+      final m = int.tryParse(parts[0]);
+      final sec = parts[1];
+      if (m != null) return '$m:$sec';
+    } else if (parts.length == 3) {
+      final h = int.tryParse(parts[0]);
+      final m = int.tryParse(parts[1]);
+      final sec = parts[2];
+      if (h != null && m != null) {
+        if (h == 0) return '$m:$sec';
+        return '$h:${m.toString().padLeft(2, '0')}:$sec';
+      }
+    }
+    return s;
+  }
+
+  String _cleanChapterDisplay(String rawName, Duration position, String Function(Duration) formatDuration) {
+    final lDuration = formatDuration(position);
+    final normDuration = _normalizeTimeString(lDuration);
+
+    final parts = rawName.split(RegExp(r'\s*-\s*'));
+    final normalizedParts = parts.map(_normalizeTimeString).toList();
+
+    final uniqueParts = <String>[];
+    for (final part in normalizedParts) {
+      if (part.isEmpty) continue;
+      if (!uniqueParts.contains(part)) {
+        uniqueParts.add(part);
+      }
+    }
+
+    if (uniqueParts.isNotEmpty && uniqueParts.last == normDuration) {
+      uniqueParts.removeLast();
+    }
+
+    if (uniqueParts.isEmpty) {
+      return normDuration;
+    }
+    return '${uniqueParts.join(' - ')} - $normDuration';
+  }
+
   @override
   Widget build(BuildContext context) {
     final focusColor = Color(
@@ -9647,7 +9752,7 @@ class _ChapterListCardState extends State<_ChapterListCard>
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  '${widget.chapterName} - ${widget.formatDuration(widget.position)}',
+                  _cleanChapterDisplay(widget.chapterName, widget.position, widget.formatDuration),
                   textAlign: TextAlign.center,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -158,6 +158,8 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   StreamSubscription<String?>? _backgroundSub;
   bool _themeMusicStarted = false;
   String? _selectedMediaSourceId;
+  bool _showNavbar = true;
+  bool _actionsExpanded = false;
   Timer? _focusedBackdropDebounce;
   String? _lastFocusedBackdropItemId;
   String? _lastDetailBackdropItemId;
@@ -326,7 +328,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     final node = useTargetNode ? _ensureInitialFocusNode() : null;
     final isAlbumOrPlaylist = type == 'MusicAlbum' || type == 'Playlist';
     final showNavigationChrome =
-        _viewModel.state == ItemDetailState.ready && !isAlbumOrPlaylist;
+        _viewModel.state == ItemDetailState.ready && !isAlbumOrPlaylist && _showNavbar;
     Widget body = NavigationLayout(
       showBackButton: true,
       showNavigationChrome: showNavigationChrome,
@@ -436,6 +438,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
                 onPlayFromChapter: (position) => unawaited(
                   _playFromChapter(context, _viewModel.item!, position, _selectedMediaSourceId),
                 ),
+                onToggleNavbar: (show) => setState(() => _showNavbar = show),
+                actionsExpanded: _actionsExpanded,
+                onActionsExpandedChanged: (val) => setState(() => _actionsExpanded = val),
               )
             : _DetailContent(
                 viewModel: _viewModel,
@@ -4137,6 +4142,10 @@ class DetailActionButtons extends StatefulWidget {
   /// When false the pill is content-width and sits inline with the secondary
   /// circular buttons (landscape).
   final bool fullWidthPrimary;
+  final FocusNode? actionRowRightFocusNode;
+  final ValueChanged<bool>? onFocusExtra;
+  final bool? actionsExpanded;
+  final ValueChanged<bool>? onActionsExpandedChanged;
 
   const DetailActionButtons({
     required this.viewModel,
@@ -4152,6 +4161,10 @@ class DetailActionButtons extends StatefulWidget {
     this.onArrowRightAtEnd,
     this.modernStyle = false,
     this.fullWidthPrimary = false,
+    this.actionRowRightFocusNode,
+    this.onFocusExtra,
+    this.actionsExpanded,
+    this.onActionsExpandedChanged,
   });
 
   @override
@@ -4890,7 +4903,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   set _selectedSubtitleIndex(int? value) =>
       viewModel.selectedSubtitleIndex = value;
 
-  bool _expanded = false;
+  bool _localExpanded = false;
+  bool get _expanded => widget.actionsExpanded ?? _localExpanded;
+  set _expanded(bool val) {
+    if (widget.onActionsExpandedChanged != null) {
+      widget.onActionsExpandedChanged!(val);
+    } else {
+      setState(() => _localExpanded = val);
+    }
+  }
   bool _playLaunchInFlight = false;
   bool _autoPlayTriggered = false;
   DownloadedItem? _offlineRow;
@@ -5204,6 +5225,20 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   })
   _computeWatchState(AggregatedItem item) {
     final isSeries = item.type == 'Series';
+    final isContainer = item.type == 'Series' ||
+                        item.type == 'Season' ||
+                        item.type == 'BoxSet' ||
+                        item.type == 'MusicAlbum';
+    if (!isContainer) {
+      final hasProgress = (item.playedPercentage ?? 0) > 0 ||
+                          (item.playbackPosition?.inMilliseconds ?? 0) > 0;
+      return (
+        isFullyWatched: item.isPlayed,
+        isFullyUnwatched: !item.isPlayed && !hasProgress,
+        isPartiallyWatched: hasProgress,
+        hasProgress: hasProgress,
+      );
+    }
     final totalEpisodes = isSeries
         ? (item.recursiveItemCount ?? 0)
         : (item.childCount ?? item.recursiveItemCount ?? 0);
@@ -5265,6 +5300,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         .where((s) => s['Type'] == 'Audio')
         .toList();
     _showSubtitleSelector(context, item, subtitleStreams, audioStreams);
+  }
+
+  bool _isManagementButton(_DetailActionButton button) {
+    return button.icon == Icons.check_circle ||
+           button.icon == Icons.check_circle_outline ||
+           button.icon == Icons.favorite ||
+           button.icon == Icons.playlist_add ||
+           button.icon == Icons.delete_outline;
   }
 
   @override
@@ -5349,7 +5392,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             } else if (_isCompact(context)) {
               playButtonLabel = 'S${s}E$e';
             } else {
-              playButtonLabel = 'Resume from S$s:E$e';
+              playButtonLabel = 'Resume from\nS$s:E$e';
             }
           } else {
             playButtonLabel = 'Resume';
@@ -5363,9 +5406,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           ? l10n.play
           : l10n.resume;
     } else if (hasProgress) {
-      playButtonLabel = l10n.resumeFrom(
-        _formatResumePosition(item.playbackPosition),
-      );
+      playButtonLabel = 'Resume from\n${_formatResumePosition(item.playbackPosition)}';
     } else {
       playButtonLabel = l10n.play;
     }
@@ -5572,11 +5613,40 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final buttonSpacing = compact ? 8.0 : 10.0 * desktopScale;
     final buttonRunSpacing = compact ? 12.0 : 14.0 * desktopScale;
     final maxVisible = _calculateMaxVisibleButtons(context);
-    final needsOverflow =
-        (compact ||
-            PlatformDetection.isTV ||
-            widget.maxVisibleButtonsOverride != null) &&
-        allButtons.length > maxVisible;
+
+    final List<Widget> primaryButtons;
+    final List<Widget> extraButtons;
+    final bool needsOverflow;
+
+    final bool isTwoColumnLayout = widget.modernStyle && widget.maxVisibleButtonsOverride != null;
+
+    if (isTwoColumnLayout) {
+      final List<Widget> prim = [];
+      final List<Widget> ext = [];
+      for (final btn in allButtons) {
+        if (btn is _DetailActionButton && _isManagementButton(btn)) {
+          ext.add(btn);
+        } else {
+          prim.add(btn);
+        }
+      }
+      primaryButtons = prim;
+      extraButtons = ext;
+      needsOverflow = extraButtons.isNotEmpty;
+    } else {
+      needsOverflow =
+          (compact ||
+              PlatformDetection.isTV ||
+              widget.maxVisibleButtonsOverride != null) &&
+          allButtons.length > maxVisible;
+      if (needsOverflow) {
+        primaryButtons = allButtons.take(maxVisible - 1).toList();
+        extraButtons = allButtons.skip(maxVisible - 1).toList();
+      } else {
+        primaryButtons = allButtons;
+        extraButtons = const [];
+      }
+    }
 
     final Widget rowContent;
     if (!needsOverflow) {
@@ -5586,6 +5656,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         if (button is! _DetailActionButton) return button;
         return _copyActionButton(
           button,
+          focusNode: index == allButtons.length - 1
+              ? (widget.actionRowRightFocusNode ?? button.focusNode)
+              : button.focusNode,
           onArrowUp:
               button.onArrowUp ??
               (widget.upTarget != null ? _focusUpTarget : null),
@@ -5610,8 +5683,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         ),
       );
     } else {
-      final primaryButtons = allButtons.take(maxVisible - 1).toList();
-      final extraButtons = allButtons.skip(maxVisible - 1).toList();
       final normalizedPrimaryButtons = primaryButtons.asMap().entries.map((
         entry,
       ) {
@@ -5620,6 +5691,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         if (button is! _DetailActionButton) return button;
         return _copyActionButton(
           button,
+          onFocused: () => widget.onFocusExtra?.call(false),
           onArrowUp: button.onArrowUp ?? _focusUpTarget,
           onArrowLeft: index == 0 ? _focusSidebar : null,
           onArrowDown: _expanded
@@ -5634,8 +5706,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         return _copyActionButton(
           button,
           focusNode: index == 0 ? _overflowFirstExtraFocusNode : null,
-          onFocused: () => _ensureOverflowButtonVisible(context),
-          onArrowUp: () {
+          onFocused: () {
+            _ensureOverflowButtonVisible(context);
+            widget.onFocusExtra?.call(true);
+          },
+          onArrowUp: widget.modernStyle ? null : () {
             if (_overflowMoreFocusNode.context != null &&
                 _overflowMoreFocusNode.canRequestFocus) {
               _overflowMoreFocusNode.requestFocus();
@@ -5652,7 +5727,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       final moreButton = _DetailActionButton(
         label: _expanded ? l10n.less : l10n.more,
         icon: _expanded ? Icons.expand_less : Icons.expand_more,
-        focusNode: _overflowMoreFocusNode,
+        focusNode: widget.actionRowRightFocusNode ?? _overflowMoreFocusNode,
+        onFocused: () => widget.onFocusExtra?.call(false),
         onArrowUp: _focusUpTarget,
         onArrowDown: _expanded
             ? () => _focusFirstExpandedOverflowButton(context)
@@ -5661,18 +5737,44 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         onPressed: () => setState(() => _expanded = !_expanded),
       );
       if (widget.modernStyle) {
-        rowContent = Align(
-          alignment: Alignment.centerLeft,
-          child: Wrap(
-            spacing: buttonSpacing,
-            runSpacing: buttonRunSpacing,
-            crossAxisAlignment: WrapCrossAlignment.center,
-            alignment: WrapAlignment.start,
-            children: _expanded
-                ? [...normalizedPrimaryButtons, ...normalizedExtraButtons, moreButton]
-                : [...normalizedPrimaryButtons, moreButton],
-          ),
-        );
+        if (_expanded) {
+          rowContent = Align(
+            alignment: Alignment.centerLeft,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: buttonSpacing,
+                  runSpacing: buttonRunSpacing,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  alignment: WrapAlignment.start,
+                  children: [...normalizedPrimaryButtons, moreButton],
+                ),
+                Padding(
+                  padding: EdgeInsets.only(top: buttonRunSpacing),
+                  child: Wrap(
+                    spacing: buttonSpacing,
+                    runSpacing: buttonRunSpacing,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    alignment: WrapAlignment.start,
+                    children: normalizedExtraButtons,
+                  ),
+                ),
+              ],
+            ),
+          );
+        } else {
+          rowContent = Align(
+            alignment: Alignment.centerLeft,
+            child: Wrap(
+              spacing: buttonSpacing,
+              runSpacing: buttonRunSpacing,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              alignment: WrapAlignment.start,
+              children: [...normalizedPrimaryButtons, moreButton],
+            ),
+          );
+        }
       } else {
         final wrapAlignment =
             widget.modernStyle ? WrapAlignment.start : WrapAlignment.center;
@@ -8544,7 +8646,10 @@ class _DetailActionButtonState extends State<_DetailActionButton>
     required Color labelColor,
   }) {
     final isExpanded = showHighlight;
-    final double height = widget.isPrimary ? (isMobile ? 50.0 : 54.0) : (isMobile ? 48.0 : 52.0);
+    final hasNewline = widget.label.contains('\n');
+    final double height = widget.isPrimary
+        ? (isMobile ? (hasNewline ? 56.0 : 50.0) : (hasNewline ? 64.0 : 54.0))
+        : (isMobile ? 48.0 : 52.0);
 
     if (widget.isPrimary) {
       const fg = Color(0xFF101417);
@@ -8559,14 +8664,14 @@ class _DetailActionButtonState extends State<_DetailActionButton>
       // the pill stretch even in landscape.
       final double width = fullWidth 
           ? double.infinity 
-          : (isExpanded ? (isMobile ? 120.0 : 140.0) : height);
+          : (isExpanded ? (isMobile ? 120.0 : 300.0) : height);
 
       final pill = AnimatedContainer(
         duration: const Duration(milliseconds: 150),
         curve: Curves.easeOut,
         height: height,
         width: fullWidth ? null : width,
-        padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 16 : 0),
+        padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 12 : 0),
         alignment: Alignment.center,
         decoration: BoxDecoration(
           color: Colors.white,
@@ -8575,26 +8680,53 @@ class _DetailActionButtonState extends State<_DetailActionButton>
               ? Border.all(color: focusColor, width: 3)
               : null,
         ),
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          physics: const NeverScrollableScrollPhysics(),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: fg, size: 24),
-              if (isExpanded || fullWidth) ...[
-                const SizedBox(width: 8),
-                Text(
-                  widget.label,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: fg,
-                        fontWeight: FontWeight.w600,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: fg, size: 24),
+            if (isExpanded || fullWidth) ...[
+              const SizedBox(width: 8),
+              Flexible(
+                child: widget.label.contains('\n')
+                    ? Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            widget.label.split('\n')[0],
+                            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                                  color: fg,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 12,
+                                  height: 1.1,
+                                ),
+                          ),
+                          Text(
+                            widget.label.split('\n')[1],
+                            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                                  color: fg.withValues(alpha: 0.8),
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 11,
+                                  height: 1.1,
+                                ),
+                          ),
+                        ],
+                      )
+                    : Text(
+                        widget.label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                              color: fg,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 12,
+                              height: 1.1,
+                            ),
                       ),
-                ),
-              ],
+              ),
             ],
-          ),
+          ],
         ),
       );
       return fullWidth ? SizedBox(width: double.infinity, child: pill) : pill;
@@ -8950,6 +9082,7 @@ class DetailCastRow extends StatelessWidget {
   final ScrollController? scrollController;
   final FocusNode? firstItemFocusNode;
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
+  final VoidCallback? onNavigateUp;
 
   const DetailCastRow({
     required this.people,
@@ -8958,6 +9091,7 @@ class DetailCastRow extends StatelessWidget {
     this.scrollController,
     this.firstItemFocusNode,
     this.onItemKeyEvent,
+    this.onNavigateUp,
   });
 
   @override
@@ -9001,6 +9135,7 @@ class DetailCastRow extends StatelessWidget {
             imageUrl: imageUrl,
             isMobile: isMobile,
             focusNode: index == 0 ? firstItemFocusNode : null,
+            onNavigateUp: onNavigateUp,
             onKeyEvent: onItemKeyEvent == null
                 ? null
                 : (event) => onItemKeyEvent!(index, event),
@@ -9026,6 +9161,7 @@ class _CastPersonCard extends StatefulWidget {
   final FocusNode? focusNode;
   final KeyEventResult Function(KeyEvent event)? onKeyEvent;
   final VoidCallback? onTap;
+  final VoidCallback? onNavigateUp;
 
   const _CastPersonCard({
     required this.cardWidth,
@@ -9037,6 +9173,7 @@ class _CastPersonCard extends StatefulWidget {
     this.focusNode,
     this.onKeyEvent,
     this.onTap,
+    this.onNavigateUp,
   });
 
   @override
@@ -9066,6 +9203,14 @@ class _CastPersonCardState extends State<_CastPersonCard> with FocusStateMixin {
         focusNode: widget.focusNode,
         onFocusChange: (focused) => setFocused(focused),
         onKeyEvent: (_, event) {
+          final isNavigationEvent =
+              event is KeyDownEvent || event is KeyRepeatEvent;
+          if (isNavigationEvent &&
+              event.logicalKey == LogicalKeyboardKey.arrowUp &&
+              widget.onNavigateUp != null) {
+            widget.onNavigateUp!();
+            return KeyEventResult.handled;
+          }
           final customResult = widget.onKeyEvent?.call(event);
           if (customResult != null && customResult != KeyEventResult.ignored) {
             return customResult;
@@ -9139,7 +9284,7 @@ class _CastPersonCardState extends State<_CastPersonCard> with FocusStateMixin {
                         fontSize: widget.isMobile ? 10 : 11,
                       ),
                       textAlign: TextAlign.center,
-                      maxLines: 1,
+                      maxLines: 3,
                       overflow: TextOverflow.ellipsis,
                     ),
                 ],

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -8491,7 +8491,11 @@ class _DetailActionButtonState extends State<_DetailActionButton>
     required bool showHighlight,
     required Color focusColor,
     required Color iconColor,
+    required Color labelColor,
   }) {
+    final isExpanded = showHighlight;
+    final double height = widget.isPrimary ? (isMobile ? 50.0 : 54.0) : (isMobile ? 48.0 : 52.0);
+
     if (widget.isPrimary) {
       const fg = Color(0xFF101417);
       // Portrait spans the primary Play full width (circular secondary actions
@@ -8503,42 +8507,63 @@ class _DetailActionButtonState extends State<_DetailActionButton>
       // NOTE: only set `alignment` when full-width. A Container with an
       // alignment expands to fill the parent's bounded width, which would make
       // the pill stretch even in landscape.
-      final pill = Container(
-        height: isMobile ? 50 : 54,
-        alignment: fullWidth ? Alignment.center : null,
-        padding: const EdgeInsets.symmetric(horizontal: 22),
+      final double width = fullWidth 
+          ? double.infinity 
+          : (isExpanded ? (isMobile ? 120.0 : 140.0) : height);
+
+      final pill = AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeOut,
+        height: height,
+        width: fullWidth ? null : width,
+        padding: EdgeInsets.symmetric(horizontal: isExpanded || fullWidth ? 16 : 0),
+        alignment: Alignment.center,
         decoration: BoxDecoration(
           color: Colors.white,
-          borderRadius: BorderRadius.circular(28),
+          borderRadius: BorderRadius.circular(height / 2),
           border: showHighlight
               ? Border.all(color: focusColor, width: 3)
               : null,
         ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: fg, size: 24),
-            const SizedBox(width: 10),
-            Text(
-              widget.label,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color: fg,
-                    fontWeight: FontWeight.w600,
-                  ),
-            ),
-          ],
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          physics: const NeverScrollableScrollPhysics(),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              AdaptiveIcon(widget.icon ?? Icons.play_arrow, color: fg, size: 24),
+              if (isExpanded || fullWidth) ...[
+                const SizedBox(width: 8),
+                Text(
+                  widget.label,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: fg,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ],
+            ],
+          ),
         ),
       );
       return fullWidth ? SizedBox(width: double.infinity, child: pill) : pill;
     }
 
-    final diameter = isMobile ? 48.0 : 52.0;
-    final circle = Container(
-      width: diameter,
-      height: diameter,
+    final double minWidth = height;
+    final double maxWidth = isExpanded ? 180.0 : height;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 150),
+      curve: Curves.easeOut,
+      height: height,
+      constraints: BoxConstraints(
+        minWidth: minWidth,
+        maxWidth: maxWidth,
+      ),
+      padding: EdgeInsets.symmetric(horizontal: isExpanded ? 14 : 0),
       decoration: BoxDecoration(
-        shape: BoxShape.circle,
+        borderRadius: BorderRadius.circular(height / 2),
         color: showHighlight
             ? AppColorScheme.buttonFocused
             : (widget.isActive
@@ -8552,29 +8577,34 @@ class _DetailActionButtonState extends State<_DetailActionButton>
           width: showHighlight ? 2.5 : 1.5,
         ),
       ),
-      child: widget.iconBuilder != null
-          ? widget.iconBuilder!(24, iconColor)
-          : AdaptiveIcon(widget.icon!, color: iconColor, size: 24),
-    );
-    if (!isMobile) return circle;
-    return SizedBox(
-      width: 76,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          circle,
-          const SizedBox(height: 6),
-          Text(
-            widget.label,
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
-                  fontWeight: FontWeight.w600,
-                ),
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        physics: const NeverScrollableScrollPhysics(),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: height - 4, // keep icon centered when collapsed
+              child: widget.iconBuilder != null
+                  ? widget.iconBuilder!(24, iconColor)
+                  : AdaptiveIcon(widget.icon!, color: iconColor, size: 24),
+            ),
+            if (isExpanded) ...[
+              const SizedBox(width: 6),
+              Text(
+                widget.label,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: labelColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }
@@ -8773,6 +8803,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                   showHighlight: showHighlight,
                   focusColor: focusColor,
                   iconColor: iconColor,
+                  labelColor: labelColor,
                 )
               : SizedBox(
                   width: isMobile ? 80 : 108 * desktopScale,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -198,7 +198,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
 
     _backdropUrl = _backgroundService.currentUrl;
     _backgroundSub = _backgroundService.backgroundStream.listen((url) {
-      if (mounted) {
+      // Ignore null: a child screen clearing the shared service on its way out
+      // must not blank this screen's backdrop after it has been restored.
+      if (mounted && url != null) {
         setState(() => _backdropUrl = url);
       }
     });
@@ -223,7 +225,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     if (item != null) {
       _backgroundService.setBackground(item, context: BlurContext.details);
       final nextUrl = _backgroundService.currentUrl;
-      if (nextUrl != _backdropUrl) {
+      // Keep the last good backdrop if the service has none to give (e.g. after
+      // returning from a child with no backdrop that cleared the shared service).
+      if (nextUrl != null && nextUrl != _backdropUrl) {
         setState(() => _backdropUrl = nextUrl);
       }
     }
@@ -382,14 +386,17 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     final type = _viewModel.item?.type;
     final useTargetNode = type != null && type != 'Photo';
     final node = useTargetNode ? _ensureInitialFocusNode() : null;
-    final isAlbumOrPlaylist = type == 'MusicAlbum' || type == 'Playlist';
     final lastCollapse = ExpandableBiography.lastCollapseTime;
     final now = DateTime.now();
     final wasCollapsedRecently = lastCollapse != null &&
         now.difference(lastCollapse) < const Duration(milliseconds: 350);
 
-    final showNavigationChrome =
-        _viewModel.state == ItemDetailState.ready && !isAlbumOrPlaylist && _showNavbar;
+    // Albums/playlists hide the chrome on TV/desktop (their split hero owns the
+    // top area); on mobile they need the back arrow like every other screen.
+    final isAlbumOrPlaylist = type == 'MusicAlbum' || type == 'Playlist';
+    final showNavigationChrome = _viewModel.state == ItemDetailState.ready &&
+        _showNavbar &&
+        (!isAlbumOrPlaylist || _isCompact(context));
 
     Widget body = NavigationLayout(
       showBackButton: true,
@@ -5232,11 +5239,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       return maxTVButtons > 2 ? maxTVButtons : 2;
     }
     final screenWidth = MediaQuery.sizeOf(context).width;
-    final compact = !_useDesktopDetailLayout(context);
+    final compact = (widget.modernStyle && _isCompact(context)) ||
+        !_useDesktopDetailLayout(context);
     final desktopScale = _desktopUiScale();
-    final buttonWidth = compact ? 80.0 : 108.0 * desktopScale;
-    const spacing = 8.0;
-    const horizontalPadding = 64.0;
+    // On mobile, secondary buttons are labelled vertical tiles 66 wide; the
+    // spacing and content padding below mirror the real layout exactly so the
+    // row packs as many tiles as physically fit before the rest fold into More.
+    final buttonWidth = compact ? 66.0 : 108.0 * desktopScale;
+    final spacing = compact ? 4.0 : 8.0 * desktopScale;
+    final horizontalPadding = compact ? 40.0 : 64.0;
 
     final availableWidth = screenWidth - horizontalPadding;
     final maxButtons = ((availableWidth + spacing) / (buttonWidth + spacing))
@@ -5809,9 +5820,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       }).toList();
     }
 
-    final compact = !_useDesktopDetailLayout(context);
+    final compact = (widget.modernStyle && _isCompact(context)) ||
+        !_useDesktopDetailLayout(context);
     final desktopScale = _desktopUiScale();
-    final buttonSpacing = compact ? 6.0 : 8.0 * desktopScale;
+    final buttonSpacing = compact ? 4.0 : 8.0 * desktopScale;
     final buttonRunSpacing = compact ? 10.0 : 12.0 * desktopScale;
     final maxVisible = _calculateMaxVisibleButtons(context);
 
@@ -5822,7 +5834,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final bool isTvShow = item.type == 'Series' || item.type == 'Season';
     final bool isTvSeries = item.type == 'Series';
     final bool isTvSeason = item.type == 'Season';
-    final bool isTwoColumnLayout = (widget.modernStyle && isTvShow && widget.maxVisibleButtonsOverride != null) || isTvSeries;
+    // Series uses the two-column (inline-Play) layout on TV/desktop, but on the
+    // modern mobile layout it should match movies: full-width primary + overflow.
+    final bool isModernMobile = widget.modernStyle && _isCompact(context);
+    // Series/Season keep the two-column inline-Play layout on TV/desktop; on the
+    // compact (mobile) layout every type uses the full-width primary + overflow.
+    final bool isTwoColumnLayout = !isModernMobile && isTvShow;
 
     if (isTwoColumnLayout) {
       final List<Widget> prim = [];
@@ -5845,15 +5862,20 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       extraButtons = ext;
       needsOverflow = extraButtons.isNotEmpty;
     } else {
+      // On mobile the full-width primary sits on its own row, so it does not
+      // occupy a slot in the secondary row: exclude it from the count and split.
+      final int secondaryCount =
+          isModernMobile ? allButtons.length - 1 : allButtons.length;
+      final int visibleCount = isModernMobile ? maxVisible : maxVisible - 1;
       needsOverflow =
           !isBoxSet &&
           (compact ||
               PlatformDetection.isTV ||
               widget.maxVisibleButtonsOverride != null) &&
-          allButtons.length > maxVisible;
+          secondaryCount > maxVisible;
       if (needsOverflow) {
-        primaryButtons = allButtons.take(maxVisible - 1).toList();
-        extraButtons = allButtons.skip(maxVisible - 1).toList();
+        primaryButtons = allButtons.take(visibleCount).toList();
+        extraButtons = allButtons.skip(visibleCount).toList();
       } else {
         primaryButtons = allButtons;
         extraButtons = const [];
@@ -6013,7 +6035,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       );
 
       if (widget.modernStyle) {
-        if (isTvShow) {
+        if (isTwoColumnLayout) {
           // Build a Row so the play pill (first button) can grow via Flexible
           // to fill available space — avoids text truncation for long labels.
           final pillButton = normalizedPrimaryButtons.isNotEmpty
@@ -6061,17 +6083,32 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             );
           }
         } else {
-          // Movie page: single row!
+          // Primary row keeps the More/Less button pinned at its end; the extra
+          // buttons reveal in a second wrap below, so More/Less never moves.
           rowContent = Align(
             alignment: Alignment.centerLeft,
-            child: Wrap(
-              spacing: buttonSpacing,
-              runSpacing: buttonRunSpacing,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              alignment: WrapAlignment.start,
-              children: _expanded
-                  ? [...normalizedPrimaryButtons, ...normalizedExtraButtons, moreButton]
-                  : [...normalizedPrimaryButtons, moreButton],
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Wrap(
+                  spacing: buttonSpacing,
+                  runSpacing: buttonRunSpacing,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  alignment: WrapAlignment.start,
+                  children: [...normalizedPrimaryButtons, moreButton],
+                ),
+                if (_expanded) ...[
+                  SizedBox(height: buttonRunSpacing),
+                  Wrap(
+                    spacing: buttonSpacing,
+                    runSpacing: buttonRunSpacing,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    alignment: WrapAlignment.start,
+                    children: normalizedExtraButtons,
+                  ),
+                ],
+              ],
             ),
           );
         }
@@ -8750,9 +8787,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
         }
 
         return _DetailActionButton(
-          label: isMulti
-              ? AppLocalizations.of(context).downloadAll
-              : AppLocalizations.of(context).download,
+          label: AppLocalizations.of(context).download,
           icon: Icons.download,
           onPressed: () => _showQualityPicker(context, downloadService),
         );
@@ -9197,6 +9232,59 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         );
       }
       return fullWidth ? SizedBox(width: double.infinity, child: pill) : pill;
+    }
+
+    if (isMobile) {
+      // Vertical tile: circular icon with its label always shown underneath.
+      final iconWidget = widget.iconBuilder != null
+          ? widget.iconBuilder!(36, iconColor)
+          : AdaptiveIcon(
+              widget.icon!,
+              color: (widget.icon == Icons.favorite && widget.isActive)
+                  ? const Color(0xFFE50914)
+                  : iconColor,
+              size: 24,
+            );
+      return SizedBox(
+        width: 66,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: height,
+              height: height,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: showHighlight
+                    ? AppColorScheme.buttonFocused
+                    : (widget.isActive
+                        ? (widget.activeColor ?? AppColorScheme.accent)
+                            .withValues(alpha: 0.18)
+                        : Colors.white.withValues(alpha: 0.06)),
+                border: Border.all(
+                  color: showHighlight
+                      ? focusColor
+                      : AppColorScheme.onSurface.withValues(alpha: 0.35),
+                  width: showHighlight ? 2.5 : 1.5,
+                ),
+              ),
+              child: Center(child: iconWidget),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              widget.label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: labelColor,
+                    fontWeight: FontWeight.w600,
+                    height: 1.1,
+                  ),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      );
     }
 
     final double minWidth = height;
@@ -12045,6 +12133,7 @@ class _ExpandableBiographyState extends State<ExpandableBiography> {
                 ? () => setState(() => _expanded = !_expanded)
                 : null,
             child: AnimatedSize(
+              alignment: Alignment.topCenter,
               duration: const Duration(milliseconds: 150),
               curve: Curves.easeOut,
               child: Container(
@@ -12752,7 +12841,7 @@ class _AlbumActions extends StatelessWidget {
       ),
       if (onDownloadAll != null)
         _DetailActionButton(
-          label: l10n.downloadAll,
+          label: l10n.download,
           icon: Icons.download,
           onArrowDown: onPlayDown,
           onPressed: onDownloadAll!,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -21,7 +21,7 @@ import '../item_detail_screen.dart'
     show
         DetailActionButtons,
         DetailCastRow,
-        DetailMetadataSection,
+        DetailChaptersRow,
         DetailFeaturesRow,
         DetailEpisodeCard,
         DetailTrackList,
@@ -47,6 +47,7 @@ class ModernDetailContent extends StatefulWidget {
   final ValueChanged<String?> onSelectedMediaSourceChanged;
   final FocusNode? initialFocusNode;
   final bool autoPlay;
+  final void Function(Duration position)? onPlayFromChapter;
 
   const ModernDetailContent({
     super.key,
@@ -57,6 +58,7 @@ class ModernDetailContent extends StatefulWidget {
     required this.onSelectedMediaSourceChanged,
     this.initialFocusNode,
     this.autoPlay = false,
+    this.onPlayFromChapter,
   });
 
   @override
@@ -194,6 +196,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final cast = _ModernTab(l10n.cast, _castTab);
     final crew = _ModernTab(l10n.crewSection, _crewTab);
     final studios = _ModernTab(l10n.studios, _studiosTab);
+    final chapters = _ModernTab(l10n.chapters, _chaptersTab);
     final details = _ModernTab(l10n.details, _detailsTab);
     final similar = _ModernTab(l10n.similar, (_, _) => _itemGrid(_vm.similar));
 
@@ -205,6 +208,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
+          if (item.chapters.isNotEmpty) chapters,
           details,
           if (hasSimilar) similar,
         ];
@@ -215,6 +219,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
+          if (item.chapters.isNotEmpty) chapters,
           details,
         ];
       case 'Episode':
@@ -224,6 +229,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
+          if (item.chapters.isNotEmpty) chapters,
           details,
           if (hasSimilar) similar,
         ];
@@ -255,6 +261,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
+          if (item.chapters.isNotEmpty) chapters,
           details,
         ];
       default:
@@ -262,6 +269,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
+          if (item.chapters.isNotEmpty) chapters,
           details,
           if (hasFeatures) _ModernTab(l10n.extras, _extrasTab),
           if (hasSimilar) similar,
@@ -402,15 +410,35 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   Widget _crewTab(BuildContext context, AggregatedItem item) {
     final l10n = AppLocalizations.of(context);
-    final directors = _vm.directors.map((d) => {
-      ...d,
-      'Role': d['Role'] ?? l10n.director,
+    final Map<String, Map<String, dynamic>> merged = {};
+    for (final d in _vm.directors) {
+      final id = d['Id']?.toString() ?? d['Name']?.toString() ?? '';
+      if (id.isEmpty) continue;
+      merged[id] = {
+        ...d,
+        'Roles': <String>{d['Role'] as String? ?? l10n.director},
+      };
+    }
+    for (final w in _vm.writers) {
+      final id = w['Id']?.toString() ?? w['Name']?.toString() ?? '';
+      if (id.isEmpty) continue;
+      if (merged.containsKey(id)) {
+        final roles = merged[id]!['Roles'] as Set<String>;
+        roles.add(w['Role'] as String? ?? l10n.writer);
+      } else {
+        merged[id] = {
+          ...w,
+          'Roles': <String>{w['Role'] as String? ?? l10n.writer},
+        };
+      }
+    }
+    final crew = merged.values.map((person) {
+      final roles = person['Roles'] as Set<String>;
+      return {
+        ...person,
+        'Role': roles.join(', '),
+      };
     }).toList();
-    final writers = _vm.writers.map((w) => {
-      ...w,
-      'Role': w['Role'] ?? l10n.writer,
-    }).toList();
-    final crew = [...directors, ...writers];
 
     return SizedBox(
       height: 200,
@@ -418,6 +446,40 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         people: crew,
         imageApi: _vm.imageApi,
         serverId: item.serverId,
+      ),
+    );
+  }
+
+  Widget _buildStudioFallback(BuildContext context, String name) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.25),
+            Theme.of(context).colorScheme.secondary.withValues(alpha: 0.05),
+            Colors.transparent,
+          ],
+          stops: const [0.0, 0.5, 1.0],
+        ),
+      ),
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(
+            name.toUpperCase(),
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 1.5,
+              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -462,7 +524,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               height: cardHeight,
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(12),
-                color: Colors.white.withValues(alpha: 0.05),
                 border: Border.all(
                   color: Colors.white.withValues(alpha: 0.15),
                   width: 1,
@@ -470,51 +531,30 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               ),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(12),
-                child: Center(
-                  child: imageUrl != null
-                      ? CachedNetworkImage(
-                          imageUrl: imageUrl,
-                          fit: BoxFit.contain,
-                          placeholder: (context, url) => Padding(
-                            padding: const EdgeInsets.all(8.0),
-                            child: Text(
-                              name,
-                              textAlign: TextAlign.center,
-                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                    color: Colors.white70,
-                                  ),
-                            ),
-                          ),
-                          errorWidget: (context, url, error) => Padding(
-                            padding: const EdgeInsets.all(8.0),
-                            child: Text(
-                              name,
-                              textAlign: TextAlign.center,
-                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                    color: Colors.white70,
-                                  ),
-                            ),
-                          ),
-                        )
-                      : Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Text(
-                            name,
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                  color: Colors.white70,
-                                ),
-                          ),
-                        ),
-                ),
+                child: imageUrl != null
+                    ? CachedNetworkImage(
+                        imageUrl: imageUrl,
+                        fit: BoxFit.contain,
+                        placeholder: (context, url) => _buildStudioFallback(context, name),
+                        errorWidget: (context, url, error) => _buildStudioFallback(context, name),
+                      )
+                    : _buildStudioFallback(context, name),
               ),
             ),
           );
         },
       ),
+    );
+  }
+
+  Widget _chaptersTab(BuildContext context, AggregatedItem item) {
+    if (item.chapters.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return DetailChaptersRow(
+      item: item,
+      imageApi: _vm.imageApi,
+      onPlayFromChapter: widget.onPlayFromChapter ?? (_) {},
     );
   }
 
@@ -534,11 +574,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (isPlayable && mediaSource != null) ...[
+        if (isPlayable && mediaSource != null)
           _buildFileInformation(context, item, mediaSource),
-          const Divider(color: Colors.white10, height: 40, thickness: 1),
-        ],
-        DetailMetadataSection(viewModel: _vm),
       ],
     );
   }
@@ -911,15 +948,17 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   /// circular button is ~62 wide.
   int? _actionButtonCap(BuildContext context, AggregatedItem item) {
     if (!_landscape) return null;
-    final heroWidth =
-        (MediaQuery.sizeOf(context).width * 0.45).clamp(360.0, 620.0);
+    final hasUpNext = _buildUpNext(context, item) != null;
+    final heroWidth = hasUpNext
+        ? (MediaQuery.sizeOf(context).width * 0.45).clamp(360.0, 620.0)
+        : (MediaQuery.sizeOf(context).width * 0.75).clamp(450.0, 960.0);
     final pillWidth = switch (item.type) {
       'Series' || 'Season' || 'Episode' => 300.0,
       'MusicAlbum' || 'Playlist' || 'AudioBook' || 'MusicArtist' => 160.0,
       _ => 220.0,
     };
     final circles = ((heroWidth - pillWidth - 62) / 62).floor();
-    return (circles + 2).clamp(2, 8);
+    return (circles + 2).clamp(2, 12);
   }
 
   Widget _buildHero(BuildContext context, AggregatedItem item) {
@@ -967,6 +1006,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           enableAdditionalRatings:
               widget.prefs.get(UserPreferences.enableAdditionalRatings),
           enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
+          showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
+          showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
         ),
         if (item.tagline != null && item.tagline!.trim().isNotEmpty) ...[
           const SizedBox(height: 14),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -23,6 +23,7 @@ import '../../../widgets/logo_view.dart';
 import '../../../widgets/media_card.dart';
 import '../../../widgets/rating_display.dart';
 import '../../../widgets/focus/focusable_wrapper.dart';
+import '../../../widgets/focus/focusable_toolbar_button.dart';
 import '../../../widgets/navigation_layout.dart';
 import '../../../widgets/top_toolbar.dart';
 import '../../../../data/repositories/seerr_repository.dart';

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -113,6 +113,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _chaptersFirstFocusNode = FocusNode(debugLabel: 'chaptersFirst');
   final FocusNode _similarFirstFocusNode = FocusNode(debugLabel: 'similarFirst');
   final FocusNode _gridFirstFocusNode = FocusNode(debugLabel: 'gridFirst');
+  final FocusNode _collectionSortFocusNode = FocusNode(debugLabel: 'collectionSort');
   final FocusNode _seasonsFirstFocusNode = FocusNode(debugLabel: 'seasonsFirst');
   final FocusNode _episodesFirstFocusNode = FocusNode(debugLabel: 'episodesFirst');
   final FocusNode _overviewFocusNode = FocusNode(debugLabel: 'overview');
@@ -428,6 +429,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _personSeerrAppearancesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _personSeerrCrewCreditsFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _gridFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _collectionSortFocusNode.onKeyEvent = (node, event) {
+      if (event is KeyDownEvent) {
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+          if (_vm.playlistItems.isNotEmpty) {
+            final firstTrackId = _vm.playlistItems.first.id;
+            final firstNode = _trackFocusNodes.putIfAbsent(firstTrackId, () => FocusNode());
+            if (firstNode.canRequestFocus) {
+              firstNode.requestFocus();
+              return KeyEventResult.handled;
+            }
+          }
+        } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          _focusSelectedTab();
+          return KeyEventResult.handled;
+        }
+      }
+      return leftToSidebarHandler(node, event);
+    };
 
     _vm.addListener(_onViewModelChanged);
     _scrollController.addListener(_onScroll);
@@ -511,6 +530,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _chaptersFirstFocusNode.dispose();
     _similarFirstFocusNode.dispose();
     _gridFirstFocusNode.dispose();
+    _collectionSortFocusNode.dispose();
     _seasonsFirstFocusNode.dispose();
     _episodesFirstFocusNode.dispose();
     _overviewFocusNode.dispose();
@@ -594,10 +614,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
       } else if (label == l10n.playlist) {
         if (_vm.item?.type == 'BoxSet' && _vm.playlistItems.isNotEmpty) {
-          final firstTrackId = _vm.playlistItems.first.id;
-          final firstTrackNode = _trackFocusNodes.putIfAbsent(firstTrackId, () => FocusNode());
-          if (firstTrackNode.canRequestFocus) {
-            firstTrackNode.requestFocus();
+          if (_collectionSortFocusNode.canRequestFocus) {
+            _collectionSortFocusNode.requestFocus();
           }
         }
       } else if (label == l10n.movies) {
@@ -723,7 +741,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   getFocusNode: (id) =>
                       _trackFocusNodes.putIfAbsent(id, () => FocusNode()),
                   onPlayTrack: (index) => _playPlaylistTrack(context, index),
-                  reorderable: true,
+                  reorderable: _vm.collectionSort == CollectionSortOption.custom,
                   onReorder: (oldIndex, newIndex) {
                     var target = newIndex;
                     if (target > oldIndex) {
@@ -733,7 +751,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   },
                   onMoveUp: (index) => _vm.reorderCollectionPlaylistItem(index, index - 1),
                   onMoveDown: (index) => _vm.reorderCollectionPlaylistItem(index, index + 1),
-                  onFirstTrackUp: () => widget.initialFocusNode?.requestFocus(),
+                  onFirstTrackUp: () => _collectionSortFocusNode.requestFocus(),
                   onTrackFocused: widget.onBackdropItemFocused,
                 );
 
@@ -753,7 +771,33 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                     alignment: Alignment.topLeft,
                     child: ConstrainedBox(
                       constraints: const BoxConstraints(maxWidth: 800),
-                      child: listWidget,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 12.0),
+                            child: Row(
+                              children: [
+                                FocusableToolbarButton(
+                                  icon: Icons.sort_rounded,
+                                  focusNode: _collectionSortFocusNode,
+                                  tooltip: 'Reset Sort',
+                                  onTap: () => _showCollectionSortDialog(context),
+                                ),
+                                const SizedBox(width: 12),
+                                Text(
+                                  'Sort: ${_getCollectionSortLabel(_vm.collectionSort)}',
+                                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                        color: Colors.white70,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          listWidget,
+                        ],
+                      ),
                     ),
                   ),
                 );
@@ -2147,6 +2191,99 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     context.push(isAudio ? Destinations.audioPlayer : Destinations.videoPlayer);
   }
 
+  String _getCollectionSortLabel(CollectionSortOption option) {
+    return switch (option) {
+      CollectionSortOption.alphabetical => 'Alphabetical',
+      CollectionSortOption.releaseAscending => 'Release Order (Ascending)',
+      CollectionSortOption.releaseDescending => 'Release Order (Descending)',
+      CollectionSortOption.custom => 'Custom (Drag-and-Drop)',
+    };
+  }
+
+  void _showCollectionSortDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          backgroundColor: const Color(0xFF1E1E24),
+          title: Text(
+            'Playlist Sort Options',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: CollectionSortOption.values.map((option) {
+              final active = _vm.collectionSort == option;
+              return Focus(
+                onKeyEvent: (_, event) {
+                  if (isActivateKey(event)) {
+                    _vm.setCollectionSort(option);
+                    Navigator.of(context).pop();
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: Builder(
+                  builder: (context) {
+                    final focused = Focus.of(context).hasFocus;
+                    return InkWell(
+                      onTap: () {
+                        _vm.setCollectionSort(option);
+                        Navigator.of(context).pop();
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 12.0,
+                          horizontal: 16.0,
+                        ),
+                        decoration: BoxDecoration(
+                          color: focused
+                              ? Colors.white12
+                              : Colors.transparent,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          children: [
+                            Icon(
+                              active
+                                  ? Icons.radio_button_checked
+                                  : Icons.radio_button_off,
+                              color: active
+                                  ? AppColorScheme.accent
+                                  : Colors.white54,
+                            ),
+                            const SizedBox(width: 16),
+                            Text(
+                              _getCollectionSortLabel(option),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyLarge
+                                  ?.copyWith(
+                                    color: active
+                                        ? AppColorScheme.accent
+                                        : Colors.white,
+                                    fontWeight: active
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              );
+            }).toList(),
+          ),
+        );
+      },
+    );
+  }
+
   /// In landscape the hero column is ~45% of the width. Size the visible action
   /// count so the Play pill, the circular buttons and the "More" toggle all stay
   /// on a single row (extras expand to a second row beneath). Reserves room for
@@ -2823,7 +2960,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget? _buildUpNext(BuildContext context, AggregatedItem item) {
-    const supported = {'Series', 'Season'};
+    const supported = {'Series', 'Season', 'BoxSet'};
     if (!supported.contains(item.type)) return null;
 
     final l10n = AppLocalizations.of(context);
@@ -2841,6 +2978,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         try {
           episode = _vm.episodes.firstWhere((e) => !e.isPlayed);
         } catch (_) {}
+      }
+    } else if (item.type == 'BoxSet') {
+      episode = _vm.nextUp;
+      if (episode != null) {
+        final playedAll = _vm.playlistItems.every((item) => item.rawData['UserData']?['Played'] == true);
+        if (playedAll) {
+          customLabel = 'Rewatch Playlist';
+        }
       }
     } else {
       episode = _vm.nextUp;

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -22,6 +22,9 @@ import '../../../widgets/rating_display.dart';
 import '../../../widgets/focus/focusable_wrapper.dart';
 import '../../../widgets/navigation_layout.dart';
 import '../../../widgets/top_toolbar.dart';
+import '../../../../data/repositories/seerr_repository.dart';
+import '../../../../data/services/seerr/seerr_api_models.dart';
+import '../../../../data/services/plugin_sync_service.dart';
 import '../item_detail_screen.dart'
     show
         DetailActionButtons,
@@ -31,7 +34,11 @@ import '../item_detail_screen.dart'
         DetailEpisodeCard,
         DetailTrackList,
         ExpandableBiography,
-        selectedMediaSourceForItem;
+        selectedMediaSourceForItem,
+        PersonDates,
+        FilmographyRow,
+        SeerrAppearancesRow,
+        SeerrCrewCreditsRow;
 import 'modern_landscape_layout.dart';
 import 'modern_portrait_layout.dart';
 import 'widgets/details_tab_bar.dart';
@@ -102,6 +109,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _seasonsFirstFocusNode = FocusNode(debugLabel: 'seasonsFirst');
   final FocusNode _episodesFirstFocusNode = FocusNode(debugLabel: 'episodesFirst');
   final FocusNode _overviewFocusNode = FocusNode(debugLabel: 'overview');
+  final FocusNode _personMoviesFirstFocusNode = FocusNode(debugLabel: 'personMoviesFirst');
+  final FocusNode _personSeriesFirstFocusNode = FocusNode(debugLabel: 'personSeriesFirst');
+  final FocusNode _personSeerrAppearancesFirstFocusNode = FocusNode(debugLabel: 'personSeerrAppearancesFirst');
+  final FocusNode _personSeerrCrewCreditsFirstFocusNode = FocusNode(debugLabel: 'personSeerrCrewCreditsFirst');
   late final ScrollController _scrollController = ScrollController();
   String? _seriesLogoTag;
   String? _seriesLogoId;
@@ -110,6 +121,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   bool _subtitlesExpanded = false;
   int? _loadedAudioIndex;
   int? _loadedSubtitleIndex;
+  List<SeerrDiscoverItem>? _seerrAppearances;
+  List<SeerrDiscoverItem>? _seerrCrewCredits;
 
   PlaybackInfoResult? _playbackInfo;
   bool _loadingPlaybackInfo = false;
@@ -179,6 +192,177 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
   }
 
+  Future<void> _loadSeerrAppearances() async {
+    final item = _vm.item;
+    if (item == null || item.type != 'Person') return;
+    final tmdbId = item.tmdbId;
+    if (tmdbId == null || tmdbId.isEmpty) return;
+    if (!GetIt.instance<PluginSyncService>().seerrAvailable) {
+      return;
+    }
+
+    try {
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      await repo.ensureInitialized();
+      final personId = int.tryParse(tmdbId);
+      if (personId != null) {
+        final credits = await repo.getPersonCombinedCredits(personId);
+        const excludedJobs = {'thanks', 'special thanks'};
+        final castWithPosters =
+            credits.cast.where((i) => i.posterPath != null).toList()
+              ..sort((a, b) => a.displayTitle.compareTo(b.displayTitle));
+        final crewWithPosters = credits.crew
+            .where(
+              (i) =>
+                  i.posterPath != null &&
+                  !excludedJobs.contains(i.job?.toLowerCase()),
+            )
+            .toList()
+          ..sort((a, b) => a.displayTitle.compareTo(b.displayTitle));
+        if (mounted) {
+          setState(() {
+            _seerrAppearances = castWithPosters;
+            _seerrCrewCredits = crewWithPosters;
+          });
+        }
+      }
+    } catch (e) {
+      debugPrint('Error loading Seerr appearances: $e');
+    }
+  }
+
+  List<AggregatedItem> _sortJellyfinItems(List<AggregatedItem> list) {
+    final sortOpt = widget.prefs.get(UserPreferences.personPageSortOption);
+    final sorted = List<AggregatedItem>.from(list);
+    if (sortOpt == 'alphabetical') {
+      sorted.sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    } else {
+      final asc = sortOpt == 'releaseDateAsc';
+      sorted.sort((a, b) {
+        final dateA = a.premiereDate ?? (a.productionYear != null ? DateTime(a.productionYear!) : null);
+        final dateB = b.premiereDate ?? (b.productionYear != null ? DateTime(b.productionYear!) : null);
+        if (dateA == null && dateB == null) {
+          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+        }
+        if (dateA == null) return 1;
+        if (dateB == null) return -1;
+        final comp = dateA.compareTo(dateB);
+        return asc ? comp : -comp;
+      });
+    }
+    return sorted;
+  }
+
+  List<SeerrDiscoverItem> _groupSeerrItems(List<SeerrDiscoverItem> list, bool isCrew) {
+    final groupOpt = widget.prefs.get(UserPreferences.personPageGroupItems);
+    if (!groupOpt) return list;
+    final grouped = <int, List<SeerrDiscoverItem>>{};
+    for (final item in list) {
+      grouped.putIfAbsent(item.id, () => []).add(item);
+    }
+
+    final result = <SeerrDiscoverItem>[];
+    for (final entries in grouped.values) {
+      final first = entries.first;
+      if (entries.length == 1) {
+        result.add(first);
+        continue;
+      }
+
+      if (isCrew) {
+        final jobs = entries
+            .map((e) => e.job ?? e.department)
+            .where((j) => j != null && j.isNotEmpty)
+            .map((j) => j!)
+            .toSet();
+        final combinedJobs = jobs.join(', ');
+        result.add(SeerrDiscoverItem(
+          id: first.id,
+          mediaType: first.mediaType,
+          title: first.title,
+          name: first.name,
+          originalTitle: first.originalTitle,
+          originalName: first.originalName,
+          posterPath: first.posterPath,
+          backdropPath: first.backdropPath,
+          overview: first.overview,
+          releaseDate: first.releaseDate,
+          firstAirDate: first.firstAirDate,
+          originalLanguage: first.originalLanguage,
+          genreIds: first.genreIds,
+          voteAverage: first.voteAverage,
+          voteCount: first.voteCount,
+          popularity: first.popularity,
+          adult: first.adult,
+          mediaInfo: first.mediaInfo,
+          character: first.character,
+          job: combinedJobs.isNotEmpty ? combinedJobs : null,
+          department: first.department,
+        ));
+      } else {
+        final characters = entries
+            .map((e) => e.character)
+            .where((c) => c != null && c.isNotEmpty)
+            .map((c) => c!)
+            .toSet();
+        final combinedCharacters = characters.join(', ');
+        result.add(SeerrDiscoverItem(
+          id: first.id,
+          mediaType: first.mediaType,
+          title: first.title,
+          name: first.name,
+          originalTitle: first.originalTitle,
+          originalName: first.originalName,
+          posterPath: first.posterPath,
+          backdropPath: first.backdropPath,
+          overview: first.overview,
+          releaseDate: first.releaseDate,
+          firstAirDate: first.firstAirDate,
+          originalLanguage: first.originalLanguage,
+          genreIds: first.genreIds,
+          voteAverage: first.voteAverage,
+          voteCount: first.voteCount,
+          popularity: first.popularity,
+          adult: first.adult,
+          mediaInfo: first.mediaInfo,
+          character: combinedCharacters.isNotEmpty ? combinedCharacters : null,
+          job: first.job,
+          department: first.department,
+        ));
+      }
+    }
+    return result;
+  }
+
+  List<SeerrDiscoverItem> _sortSeerrItems(List<SeerrDiscoverItem> list) {
+    final sortOpt = widget.prefs.get(UserPreferences.personPageSortOption);
+    final sorted = List<SeerrDiscoverItem>.from(list);
+    if (sortOpt == 'alphabetical') {
+      sorted.sort((a, b) => a.displayTitle.toLowerCase().compareTo(b.displayTitle.toLowerCase()));
+    } else {
+      final asc = sortOpt == 'releaseDateAsc';
+      sorted.sort((a, b) {
+        final dateStrA = a.releaseDate ?? a.firstAirDate;
+        final dateStrB = b.releaseDate ?? b.firstAirDate;
+        if (dateStrA == null && dateStrB == null) {
+          return a.displayTitle.toLowerCase().compareTo(b.displayTitle.toLowerCase());
+        }
+        if (dateStrA == null) return 1;
+        if (dateStrB == null) return -1;
+        final dateA = DateTime.tryParse(dateStrA);
+        final dateB = DateTime.tryParse(dateStrB);
+        if (dateA == null && dateB == null) {
+          return dateStrA.compareTo(dateStrB);
+        }
+        if (dateA == null) return 1;
+        if (dateB == null) return -1;
+        final comp = dateA.compareTo(dateB);
+        return asc ? comp : -comp;
+      });
+    }
+    return sorted;
+  }
+
   ItemDetailViewModel get _vm => widget.viewModel;
 
   @override
@@ -206,6 +390,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _similarFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _seasonsFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _episodesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _personMoviesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _personSeriesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _personSeerrAppearancesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _personSeerrCrewCreditsFirstFocusNode.onKeyEvent = leftToSidebarHandler;
 
     _vm.addListener(_onViewModelChanged);
     _scrollController.addListener(_onScroll);
@@ -221,6 +409,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
     _loadSeriesLogo();
+    _loadSeerrAppearances();
   }
 
   @override
@@ -232,6 +421,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       });
       NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
+    _loadSeerrAppearances();
   }
 
   void _onScroll() {
@@ -251,6 +441,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (mounted) {
       setState(() {});
       _loadSeriesLogo();
+      _loadSeerrAppearances();
     }
   }
 
@@ -281,6 +472,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _seasonsFirstFocusNode.dispose();
     _episodesFirstFocusNode.dispose();
     _overviewFocusNode.dispose();
+    _personMoviesFirstFocusNode.dispose();
+    _personSeriesFirstFocusNode.dispose();
+    _personSeerrAppearancesFirstFocusNode.dispose();
+    _personSeerrCrewCreditsFirstFocusNode.dispose();
     super.dispose();
   }
 
@@ -345,6 +540,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         if (_seasonsFirstFocusNode.canRequestFocus) _seasonsFirstFocusNode.requestFocus();
       } else if (label == l10n.episodes) {
         if (_episodesFirstFocusNode.canRequestFocus) _episodesFirstFocusNode.requestFocus();
+      } else if (label == l10n.movies) {
+        if (_personMoviesFirstFocusNode.canRequestFocus) _personMoviesFirstFocusNode.requestFocus();
+      } else if (label == l10n.series) {
+        if (_personSeriesFirstFocusNode.canRequestFocus) _personSeriesFirstFocusNode.requestFocus();
+      } else if (label == l10n.appearancesSeerr) {
+        if (_personSeerrAppearancesFirstFocusNode.canRequestFocus) _personSeerrAppearancesFirstFocusNode.requestFocus();
+      } else if (label == l10n.crewContributionsSeerr) {
+        if (_personSeerrCrewCreditsFirstFocusNode.canRequestFocus) _personSeerrCrewCreditsFirstFocusNode.requestFocus();
       }
     }
   }
@@ -423,10 +626,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasSimilar) similar,
         ];
       case 'Person':
+        final movies = _sortJellyfinItems(_vm.filmographyMovies);
+        final series = _sortJellyfinItems(_vm.filmographySeries);
+        final hasSeerrAppearances = _seerrAppearances != null && _seerrAppearances!.isNotEmpty;
+        final hasSeerrCrewCredits = _seerrCrewCredits != null && _seerrCrewCredits!.isNotEmpty;
+        final sortedSeerrAppearances = hasSeerrAppearances ? _sortSeerrItems(_groupSeerrItems(_seerrAppearances!, false)) : const <SeerrDiscoverItem>[];
+        final sortedSeerrCrewCredits = hasSeerrCrewCredits ? _sortSeerrItems(_groupSeerrItems(_seerrCrewCredits!, true)) : const <SeerrDiscoverItem>[];
+
         return [
-          if (_vm.filmography.isNotEmpty)
-            _ModernTab(l10n.appearances, (_, _) => _itemGrid(_vm.filmography)),
-          details,
+          if (movies.isNotEmpty)
+            _ModernTab(l10n.movies, (context, item) => _moviesTab(context, movies)),
+          if (series.isNotEmpty)
+            _ModernTab(l10n.series, (context, item) => _seriesTab(context, series)),
+          if (sortedSeerrAppearances.isNotEmpty)
+            _ModernTab(l10n.appearancesSeerr, (context, item) => _seerrAppearancesTab(context, sortedSeerrAppearances)),
+          if (sortedSeerrCrewCredits.isNotEmpty)
+            _ModernTab(l10n.crewContributionsSeerr, (context, item) => _seerrCrewCreditsTab(context, sortedSeerrCrewCredits)),
+          if (movies.isEmpty && series.isEmpty && sortedSeerrAppearances.isEmpty && sortedSeerrCrewCredits.isEmpty && _vm.filmography.isNotEmpty)
+            _ModernTab(l10n.appearances, (_, _) => _itemGrid(_sortJellyfinItems(_vm.filmography))),
         ];
       case 'BoxSet':
         return [
@@ -668,6 +885,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               });
             },
             borderRadius: 8,
+            suppressFocusGlow: true,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               child: Row(
@@ -975,6 +1193,108 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             },
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _moviesTab(BuildContext context, List<AggregatedItem> movies) {
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: FilmographyRow(
+        items: movies,
+        imageApi: _vm.imageApi,
+        prefs: widget.prefs,
+        firstFocusNode: _personMoviesFirstFocusNode,
+        onItemKeyEvent: (index, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+      ),
+    );
+  }
+
+  Widget _seriesTab(BuildContext context, List<AggregatedItem> series) {
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: FilmographyRow(
+        items: series,
+        imageApi: _vm.imageApi,
+        prefs: widget.prefs,
+        firstFocusNode: _personSeriesFirstFocusNode,
+        onItemKeyEvent: (index, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+      ),
+    );
+  }
+
+  Widget _seerrAppearancesTab(BuildContext context, List<SeerrDiscoverItem> items) {
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: SeerrAppearancesRow(
+        items: items,
+        prefs: widget.prefs,
+        firstFocusNode: _personSeerrAppearancesFirstFocusNode,
+        onItemKeyEvent: (index, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+      ),
+    );
+  }
+
+  Widget _seerrCrewCreditsTab(BuildContext context, List<SeerrDiscoverItem> items) {
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: SeerrCrewCreditsRow(
+        items: items,
+        prefs: widget.prefs,
+        firstFocusNode: _personSeerrCrewCreditsFirstFocusNode,
+        onItemKeyEvent: (index, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
       ),
     );
   }
@@ -1713,6 +2033,133 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final desktopScale = _desktopUiScale(prefs: widget.prefs);
     final logoScaleFactor = desktopScale > 1.1 ? 0.70 : 1.0;
 
+    if (item.type == 'Person') {
+      final profileUrl = _imageUrl(item);
+      final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+      final focusColor = Color(widget.prefs.get(UserPreferences.focusColor).colorValue);
+      final profileBorderColor = isNeon ? const Color(0xFFFF2E92) : focusColor;
+
+
+      final avatar = Container(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: profileBorderColor, width: 3.0),
+        ),
+        child: CircleAvatar(
+          radius: 60.0,
+          backgroundColor: Colors.white.withValues(alpha: 0.1),
+          backgroundImage: profileUrl != null
+              ? CachedNetworkImageProvider(profileUrl)
+              : null,
+          child: profileUrl == null
+              ? const Icon(Icons.person, color: Colors.white54, size: 48)
+              : null,
+        ),
+      );
+
+      final personInfo = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            item.name,
+            style: textTheme.displaySmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 8),
+          PersonDates(item: item),
+          if (item.productionLocations.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              item.productionLocations.first,
+              style: textTheme.bodyMedium?.copyWith(
+                color: Colors.white.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ],
+      );
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: hasUpNext ? MainAxisSize.max : MainAxisSize.min,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              avatar,
+              const SizedBox(width: 24),
+              Expanded(child: personInfo),
+            ],
+          ),
+          if (overview != null && overview.isNotEmpty) ...[
+            const SizedBox(height: 24),
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: _landscape ? 580 : double.infinity,
+              ),
+              child: ExpandableBiography(
+                text: overview,
+                toggleFocusNode: _overviewFocusNode,
+                onArrowDown: () {
+                  widget.initialFocusNode?.requestFocus();
+                },
+                onArrowUp: () {
+                  NavigationLayout.focusNavbarNotifier.value?.call();
+                },
+                onArrowLeft: () {
+                  final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+                  if (navbarPosition == NavbarPosition.left) {
+                    NavigationLayout.focusNavbarNotifier.value?.call();
+                  }
+                },
+                onCollapse: widget.onCollapseBiography,
+                style: textTheme.bodyMedium?.copyWith(
+                  height: 1.45,
+                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: 24),
+          Focus(
+            canRequestFocus: false,
+            skipTraversal: true,
+            onFocusChange: (focused) {
+              if (focused) {
+                widget.onToggleNavbar?.call(true);
+                if (_scrollController.hasClients) {
+                  _scrollController.animateTo(
+                    0.0,
+                    duration: const Duration(milliseconds: 250),
+                    curve: Curves.easeInOut,
+                  );
+                }
+              }
+            },
+            child: DetailActionButtons(
+              viewModel: _vm,
+              itemId: item.id,
+              selectedMediaSourceId: widget.selectedMediaSourceId,
+              onSelectedMediaSourceChanged: widget.onSelectedMediaSourceChanged,
+              tvPlayFocusNode: widget.initialFocusNode,
+              downTarget: _tabNode(_selectedTab >= 0 ? _selectedTab : 0),
+              upTarget: _overviewFocusNode,
+              autoPlay: widget.autoPlay,
+              modernStyle: true,
+              fullWidthPrimary: !_landscape,
+              maxVisibleButtonsOverride: _actionButtonCap(context, item),
+              onArrowRightAtEnd: _landscape ? _focusRightOfActions : null,
+              actionRowRightFocusNode: _actionRowRightFocusNode,
+              onFocusExtra: (_) {},
+            ),
+          ),
+        ],
+      );
+    }
+
     final Column childrenCol = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: hasUpNext ? MainAxisSize.max : MainAxisSize.min,
@@ -2104,7 +2551,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   /// subtle edge vignette. In portrait it fades from the top into the content.
   Widget _buildBackdrop(bool landscape) {
     final base = AppColorScheme.background;
-    final url = widget.backdropUrl;
+    final item = _vm.item;
+    final url = widget.backdropUrl ?? (item?.type == 'Person' ? _imageUrl(item!) : null);
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -2226,6 +2674,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               _crewFirstFocusNode.requestFocus();
             } else if (label == l10n.studios) {
               _studiosFirstFocusNode.requestFocus();
+            } else if (label == l10n.movies) {
+              _personMoviesFirstFocusNode.requestFocus();
+            } else if (label == l10n.series) {
+              _personSeriesFirstFocusNode.requestFocus();
+            } else if (label == l10n.appearancesSeerr) {
+              _personSeerrAppearancesFirstFocusNode.requestFocus();
+            } else if (label == l10n.crewContributionsSeerr) {
+              _personSeerrCrewCreditsFirstFocusNode.requestFocus();
             }
           }
         }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -17,6 +17,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../../preference/user_preferences.dart';
 import '../../../../preference/preference_constants.dart';
 import '../../../../util/platform_detection.dart';
+import '../../../../util/focus/dpad_keys.dart';
 import '../../../navigation/destinations.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/media_card.dart';
@@ -102,6 +103,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final List<FocusNode> _tabFocusNodes = [];
   final FocusNode _upNextFocusNode = FocusNode(debugLabel: 'modernUpNext');
   final FocusNode _actionRowRightFocusNode = FocusNode(debugLabel: 'actionRowRight');
+  final FocusNode _artistFocusNode = FocusNode(debugLabel: 'albumArtist');
   final FocusNode _audioShowAllFocusNode = FocusNode(debugLabel: 'audioShowAll');
   final FocusNode _subtitleShowAllFocusNode = FocusNode(debugLabel: 'subtitleShowAll');
   final FocusNode _detailsTabFocusNode = FocusNode(debugLabel: 'detailsTabContent');
@@ -110,6 +112,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _studiosFirstFocusNode = FocusNode(debugLabel: 'studiosFirst');
   final FocusNode _chaptersFirstFocusNode = FocusNode(debugLabel: 'chaptersFirst');
   final FocusNode _similarFirstFocusNode = FocusNode(debugLabel: 'similarFirst');
+  final FocusNode _gridFirstFocusNode = FocusNode(debugLabel: 'gridFirst');
   final FocusNode _seasonsFirstFocusNode = FocusNode(debugLabel: 'seasonsFirst');
   final FocusNode _episodesFirstFocusNode = FocusNode(debugLabel: 'episodesFirst');
   final FocusNode _overviewFocusNode = FocusNode(debugLabel: 'overview');
@@ -424,6 +427,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _personSeriesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _personSeerrAppearancesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _personSeerrCrewCreditsFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _gridFirstFocusNode.onKeyEvent = leftToSidebarHandler;
 
     _vm.addListener(_onViewModelChanged);
     _scrollController.addListener(_onScroll);
@@ -497,6 +501,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
     _upNextFocusNode.dispose();
     _actionRowRightFocusNode.dispose();
+    _artistFocusNode.dispose();
     _audioShowAllFocusNode.dispose();
     _subtitleShowAllFocusNode.dispose();
     _detailsTabFocusNode.dispose();
@@ -505,6 +510,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _studiosFirstFocusNode.dispose();
     _chaptersFirstFocusNode.dispose();
     _similarFirstFocusNode.dispose();
+    _gridFirstFocusNode.dispose();
     _seasonsFirstFocusNode.dispose();
     _episodesFirstFocusNode.dispose();
     _overviewFocusNode.dispose();
@@ -584,6 +590,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         if (_personSeerrAppearancesFirstFocusNode.canRequestFocus) _personSeerrAppearancesFirstFocusNode.requestFocus();
       } else if (label == l10n.crewContributionsSeerr) {
         if (_personSeerrCrewCreditsFirstFocusNode.canRequestFocus) _personSeerrCrewCreditsFirstFocusNode.requestFocus();
+      } else if (label == l10n.albums || label == l10n.items || label == l10n.appearances) {
+        if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
       }
     }
   }
@@ -657,8 +665,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       case 'MusicArtist':
         return [
           if (_vm.albums.isNotEmpty)
-            _ModernTab(l10n.albums, (_, _) => _itemGrid(_vm.albums)),
-          details,
+            _ModernTab(l10n.albums, (_, _) => _itemGrid(_vm.albums, aspectRatio: 1.0)),
           if (hasSimilar) similar,
         ];
       case 'Person':
@@ -1860,7 +1867,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     };
   }
 
-  Widget _itemGrid(List<AggregatedItem> items) {
+  Widget _itemGrid(List<AggregatedItem> items, {double aspectRatio = 2 / 3}) {
     return LayoutBuilder(
       builder: (context, constraints) {
         const spacing = 12.0;
@@ -1872,7 +1879,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         final cellWidth =
             (constraints.maxWidth - (crossAxisCount - 1) * spacing) /
                 crossAxisCount;
-        const cardRatio = 2 / 3;
+        final cardRatio = aspectRatio;
         const textHeight = 44.0;
         final childAspectRatio =
             cellWidth / (cellWidth / cardRatio + textHeight);
@@ -1907,6 +1914,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               final entry = items[i];
               return MediaCard(
                 title: entry.name,
+                focusNode: i == 0 ? _gridFirstFocusNode : null,
                 imageUrl: _imageUrl(entry),
                 width: double.infinity,
                 aspectRatio: cardRatio,
@@ -2294,31 +2302,76 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ),
           if (item.type == 'MusicAlbum' && artistName != null) ...[
             const SizedBox(height: 4),
-            GestureDetector(
-              onTap: () {
-                final artistId = item.albumArtists.isNotEmpty
-                    ? item.albumArtists.first['Id']?.toString()
-                    : null;
-                if (artistId != null) {
-                  context.push(
-                    Destinations.item(artistId, serverId: item.serverId),
-                  );
+            Focus(
+              focusNode: _artistFocusNode,
+              onKeyEvent: (node, event) {
+                if (event is KeyDownEvent) {
+                  if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                    widget.initialFocusNode?.requestFocus();
+                    return KeyEventResult.handled;
+                  }
+                  if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                    return KeyEventResult.handled;
+                  }
                 }
+                if (isActivateKey(event)) {
+                  final artistId = item.albumArtists.isNotEmpty
+                      ? item.albumArtists.first['Id']?.toString()
+                      : null;
+                  if (artistId != null) {
+                    context.push(
+                      Destinations.item(artistId, serverId: item.serverId),
+                    );
+                  }
+                  return KeyEventResult.handled;
+                }
+                return KeyEventResult.ignored;
               },
-              child: Text(
-                artistName,
-                style: textTheme.titleMedium?.copyWith(
-                  color: AppColorScheme.accent,
-                  fontWeight: FontWeight.bold,
-                  shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                      ? [
-                          const Shadow(
-                            color: Color(0xFFFF2E92),
-                            blurRadius: 8,
-                          ),
-                        ]
-                      : null,
-                ),
+              child: Builder(
+                builder: (context) {
+                  final focused = Focus.of(context).hasFocus;
+                  return GestureDetector(
+                    onTap: () {
+                      final artistId = item.albumArtists.isNotEmpty
+                          ? item.albumArtists.first['Id']?.toString()
+                          : null;
+                      if (artistId != null) {
+                        context.push(
+                          Destinations.item(artistId, serverId: item.serverId),
+                        );
+                      }
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(4),
+                        border: focused
+                            ? Border.fromBorderSide(
+                                ThemeRegistry.active.borders.focusBorder.copyWith(
+                                  color: AppColorScheme.accent,
+                                  width: 1.5,
+                                ),
+                              )
+                            : null,
+                      ),
+                      child: Text(
+                        artistName,
+                        style: textTheme.titleMedium?.copyWith(
+                          color: AppColorScheme.accent,
+                          fontWeight: FontWeight.bold,
+                          shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                              ? [
+                                  const Shadow(
+                                    color: Color(0xFFFF2E92),
+                                    blurRadius: 8,
+                                  ),
+                                ]
+                              : null,
+                        ),
+                      ),
+                    ),
+                  );
+                },
               ),
             ),
           ],
@@ -2367,7 +2420,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               downTarget: _vm.tracks.isNotEmpty
                   ? _trackFocusNodes.putIfAbsent(_vm.tracks.first.id, () => FocusNode())
                   : null,
-              upTarget: null,
+              upTarget: item.type == 'MusicAlbum' && artistName != null
+                  ? _artistFocusNode
+                  : null,
               autoPlay: widget.autoPlay,
               modernStyle: true,
               fullWidthPrimary: false,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -2033,7 +2033,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         }
       },
       onKeyEvent: (node, event) {
-        if (item.type == 'Playlist') {
+        if (item.type == 'Playlist' || item.type == 'MusicAlbum') {
           return KeyEventResult.ignored;
         }
         if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
@@ -2042,7 +2042,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         }
         return KeyEventResult.ignored;
       },
-      child: item.type == 'Playlist'
+      child: (item.type == 'Playlist' || item.type == 'MusicAlbum')
           ? Align(
               alignment: Alignment.topLeft,
               child: ConstrainedBox(
@@ -2232,7 +2232,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       );
     }
 
-    if (item.type == 'Playlist') {
+    final isMusicAlbumOrPlaylist = item.type == 'Playlist' || item.type == 'MusicAlbum';
+    if (isMusicAlbumOrPlaylist) {
       final l10n = AppLocalizations.of(context);
       final coverUrl = _imageUrl(item);
       final coverImage = Container(
@@ -2261,14 +2262,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 )
               : Container(
                   color: Colors.white.withValues(alpha: 0.05),
-                  child: const Icon(
-                    Icons.playlist_play,
+                  child: Icon(
+                    item.type == 'MusicAlbum' ? Icons.album : Icons.playlist_play,
                     color: Colors.white24,
                     size: 64,
                   ),
                 ),
         ),
       );
+
+      final artistName = item.albumArtist;
 
       final playlistInfo = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -2289,13 +2292,51 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   : null,
             ),
           ),
+          if (item.type == 'MusicAlbum' && artistName != null) ...[
+            const SizedBox(height: 4),
+            GestureDetector(
+              onTap: () {
+                final artistId = item.albumArtists.isNotEmpty
+                    ? item.albumArtists.first['Id']?.toString()
+                    : null;
+                if (artistId != null) {
+                  context.push(
+                    Destinations.item(artistId, serverId: item.serverId),
+                  );
+                }
+              },
+              child: Text(
+                artistName,
+                style: textTheme.titleMedium?.copyWith(
+                  color: AppColorScheme.accent,
+                  fontWeight: FontWeight.bold,
+                  shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                      ? [
+                          const Shadow(
+                            color: Color(0xFFFF2E92),
+                            blurRadius: 8,
+                          ),
+                        ]
+                      : null,
+                ),
+              ),
+            ),
+          ],
           const SizedBox(height: 8),
           Text(
             () {
               final count = _vm.tracks.length;
               final trackText = l10n.trackCount(count);
-              final genresText = item.genres.join(', ');
-              return genresText.isNotEmpty ? '$trackText • $genresText' : trackText;
+              final parts = <String>[];
+              if (item.type == 'MusicAlbum' && item.productionYear != null) {
+                parts.add(item.productionYear.toString());
+              }
+              parts.add(trackText);
+              if (item.genres.isNotEmpty) {
+                final genresList = item.type == 'Playlist' ? item.genres : item.genres.take(2);
+                parts.add(genresList.join(', '));
+              }
+              return parts.join(' • ');
             }(),
             style: textTheme.bodyMedium?.copyWith(
               color: Colors.white.withValues(alpha: 0.7),
@@ -2911,7 +2952,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         MediaQuery.orientationOf(context) == Orientation.landscape;
 
     final tabs = _tabsFor(item, l10n);
-    if (item.type == 'Playlist') {
+    final isMusicAlbumOrPlaylist = item.type == 'Playlist' || item.type == 'MusicAlbum';
+    if (isMusicAlbumOrPlaylist) {
       _selectedTab = 0;
     } else if (_selectedTab >= tabs.length) {
       _selectedTab = PlatformDetection.isTV ? -1 : 0;
@@ -2950,11 +2992,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
 
     final Widget tabBarWidget;
-    if (item.type == 'Playlist') {
+    if (isMusicAlbumOrPlaylist) {
       tabBarWidget = Padding(
         padding: const EdgeInsets.only(bottom: 12),
         child: Text(
-          l10n.playlist,
+          item.type == 'Playlist' ? l10n.playlist : l10n.trackList,
           style: textTheme.titleLarge?.copyWith(
             fontWeight: FontWeight.bold,
             color: Colors.white,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -30,12 +30,18 @@ import '../item_detail_screen.dart'
         DetailFeaturesRow,
         DetailEpisodeCard,
         DetailTrackList,
+        ExpandableBiography,
         selectedMediaSourceForItem;
 import 'modern_landscape_layout.dart';
 import 'modern_portrait_layout.dart';
 import 'widgets/details_tab_bar.dart';
 import 'widgets/season_card.dart';
 import 'widgets/up_next_card.dart';
+
+double _desktopUiScale({UserPreferences? prefs}) {
+  final effectivePrefs = prefs ?? GetIt.instance<UserPreferences>();
+  return effectivePrefs.get(UserPreferences.desktopUiScale).scaleFactor;
+}
 
 /// "Modern" detail-screen style: one responsive screen that chooses a landscape
 /// (TV / desktop / any landscape device) or portrait (phone / tablet portrait)
@@ -56,6 +62,7 @@ class ModernDetailContent extends StatefulWidget {
   final ValueChanged<bool>? onToggleNavbar;
   final bool actionsExpanded;
   final ValueChanged<bool> onActionsExpandedChanged;
+  final VoidCallback? onCollapseBiography;
 
   const ModernDetailContent({
     super.key,
@@ -70,6 +77,7 @@ class ModernDetailContent extends StatefulWidget {
     this.onToggleNavbar,
     required this.actionsExpanded,
     required this.onActionsExpandedChanged,
+    this.onCollapseBiography,
   });
 
   @override
@@ -93,7 +101,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _similarFirstFocusNode = FocusNode(debugLabel: 'similarFirst');
   final FocusNode _seasonsFirstFocusNode = FocusNode(debugLabel: 'seasonsFirst');
   final FocusNode _episodesFirstFocusNode = FocusNode(debugLabel: 'episodesFirst');
+  final FocusNode _overviewFocusNode = FocusNode(debugLabel: 'overview');
   late final ScrollController _scrollController = ScrollController();
+  String? _seriesLogoTag;
+  String? _seriesLogoId;
   bool _showNavbarState = true;
   bool _audioExpanded = false;
   bool _subtitlesExpanded = false;
@@ -209,6 +220,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       });
       NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
+    _loadSeriesLogo();
   }
 
   @override
@@ -236,7 +248,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   void _onViewModelChanged() {
-    if (mounted) setState(() {});
+    if (mounted) {
+      setState(() {});
+      _loadSeriesLogo();
+    }
   }
 
   @override
@@ -265,7 +280,27 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _similarFirstFocusNode.dispose();
     _seasonsFirstFocusNode.dispose();
     _episodesFirstFocusNode.dispose();
+    _overviewFocusNode.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadSeriesLogo() async {
+    final item = _vm.item;
+    if (item == null) return;
+    final seriesId = item.seriesId;
+    if (seriesId == null || _seriesLogoId == seriesId) return;
+
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      final seriesData = await client.itemsApi.getItem(seriesId);
+      final logoTag = (seriesData['ImageTags'] as Map?)?['Logo'] as String?;
+      if (mounted) {
+        setState(() {
+          _seriesLogoTag = logoTag;
+          _seriesLogoId = seriesId;
+        });
+      }
+    } catch (_) {}
   }
 
   /// Right of the action buttons goes to the Up Next card when it's present,
@@ -418,6 +453,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   Widget _seasonsTab(BuildContext context, AggregatedItem item) {
     final l10n = AppLocalizations.of(context);
+    final textTheme = Theme.of(context).textTheme;
     final counts = _episodeCountsBySeason();
     final showPosterUrl = _imageUrl(item);
     final cards = [
@@ -431,6 +467,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           isFallbackImage: _imageUrl(_vm.seasons[i]) == null,
           landscape: _landscape,
           onNavigateUp: _focusSelectedTab,
+          onNavigateRight: i == _vm.seasons.length - 1 ? () {} : null,
           focusNode: i == 0 ? _seasonsFirstFocusNode : null,
           onTap: () => context.push(
             Destinations.item(_vm.seasons[i].id, serverId: _vm.seasons[i].serverId),
@@ -443,20 +480,59 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                for (final card in cards)
+                for (var i = 0; i < cards.length; i++)
                   Padding(
                     padding: const EdgeInsets.only(right: 12),
-                    child: card,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text(
+                          _vm.seasons[i].name.toUpperCase(),
+                          style: textTheme.labelMedium?.copyWith(
+                            color: Colors.white70,
+                            fontWeight: FontWeight.bold,
+                            letterSpacing: 1.0,
+                            fontSize: 10,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 6),
+                        cards[i],
+                      ],
+                    ),
                   ),
               ],
             ),
           )
         : Column(
             children: [
-              for (final card in cards)
+              for (var i = 0; i < cards.length; i++)
                 Padding(
                   padding: const EdgeInsets.only(bottom: 12),
-                  child: card,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Text(
+                            _vm.seasons[i].name.toUpperCase(),
+                            style: textTheme.labelMedium?.copyWith(
+                              color: Colors.white70,
+                              fontWeight: FontWeight.bold,
+                              letterSpacing: 1.0,
+                              fontSize: 10,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 6),
+                          cards[i],
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
             ],
           );
@@ -477,7 +553,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         }
         return KeyEventResult.ignored;
       },
-      child: child,
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 32),
+        child: child,
+      ),
     );
   }
 
@@ -497,27 +576,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           for (var i = 0; i < _vm.episodes.length; i++)
             Padding(
               padding: const EdgeInsets.only(bottom: 8),
-              child: i == 0
-                  ? Focus(
-                      focusNode: _episodesFirstFocusNode,
-                      onKeyEvent: (node, event) {
+              child: DetailEpisodeCard(
+                episode: _vm.episodes[i],
+                imageApi: _vm.imageApi,
+                onChanged: () => _vm.load(),
+                isActive: _vm.episodes[i].id == _vm.nextUp?.id,
+                focusNode: i == 0 ? _episodesFirstFocusNode : null,
+                onKeyEvent: i == 0
+                    ? (node, event) {
                         if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
                           _focusSelectedTab();
                           return KeyEventResult.handled;
                         }
                         return KeyEventResult.ignored;
-                      },
-                      child: DetailEpisodeCard(
-                        episode: _vm.episodes[i],
-                        imageApi: _vm.imageApi,
-                        onChanged: () => _vm.load(),
-                      ),
-                    )
-                  : DetailEpisodeCard(
-                      episode: _vm.episodes[i],
-                      imageApi: _vm.imageApi,
-                      onChanged: () => _vm.load(),
-                    ),
+                      }
+                    : null,
+              ),
             ),
         ],
       ),
@@ -638,6 +712,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                     episode: episode,
                     imageApi: _vm.imageApi,
                     onChanged: () => _vm.load(),
+                    isActive: episode.id == _vm.nextUp?.id,
                   ),
                 );
               }).toList(),
@@ -687,6 +762,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             serverId: item.serverId,
             firstItemFocusNode: _castFirstFocusNode,
             onNavigateUp: _focusSelectedTab,
+            onItemKeyEvent: (index, event) {
+              if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowRight && index == _vm.actors.length - 1) {
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
           ),
         ),
       );
@@ -766,6 +847,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           serverId: item.serverId,
           firstItemFocusNode: _crewFirstFocusNode,
           onNavigateUp: _focusSelectedTab,
+          onItemKeyEvent: (index, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowRight && index == crew.length - 1) {
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
         ),
       ),
     );
@@ -861,6 +948,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 borderRadius: 12,
                 suppressFocusGlow: true,
                 onNavigateUp: _focusSelectedTab,
+                onNavigateRight: index == studios.length - 1 ? () {} : null,
                 child: Container(
                   width: cardWidth,
                   height: cardHeight,
@@ -1612,27 +1700,56 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _buildHero(BuildContext context, AggregatedItem item) {
     final textTheme = Theme.of(context).textTheme;
     final isEpisode = item.type == 'Episode';
+    final isSeason = item.type == 'Season';
     final logoTag = item.logoImageTag ?? (isEpisode ? item.seriesLogoImageTag : null);
     final logoId = logoTag != null ? (item.logoImageTag != null ? item.id : item.seriesId) : null;
     final overview = item.overview?.trim();
     final hideTitleAndLogo = _landscape && _vm.nextUp != null;
-    return Column(
+    final hasUpNext = _landscape && _vm.nextUp != null;
+    final showRatings = isEpisode
+        ? false
+        : (_vm.ratings.isNotEmpty || item.communityRating != null || item.criticRating != null);
+
+    final desktopScale = _desktopUiScale(prefs: widget.prefs);
+    final logoScaleFactor = desktopScale > 1.1 ? 0.70 : 1.0;
+
+    final Column childrenCol = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
+      mainAxisSize: hasUpNext ? MainAxisSize.max : MainAxisSize.min,
       children: [
         if (!hideTitleAndLogo) ...[
-          if (logoTag != null && logoId != null)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 4),
-              child: LogoView(
-                imageUrl: _vm.imageApi
-                    .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
-                maxHeight: _landscape ? 90 : 64,
-                maxWidth: _landscape ? 360 : 260,
+          if (isSeason && _seriesLogoTag != null && _seriesLogoId != null) ...[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                LogoView(
+                  imageUrl: _vm.imageApi
+                      .getLogoImageUrl(_seriesLogoId!, maxWidth: 200, tag: _seriesLogoTag),
+                  maxHeight: 50 * logoScaleFactor,
+                  maxWidth: 150 * logoScaleFactor,
+                ),
+                const SizedBox(width: 16),
+                Text(
+                  item.name,
+                  style: (_landscape
+                          ? textTheme.displaySmall
+                          : textTheme.headlineMedium)
+                      ?.copyWith(fontWeight: FontWeight.w700),
+                ),
+              ],
+            ),
+          ] else if (isEpisode) ...[
+            if (_seriesLogoTag != null && _seriesLogoId != null) ...[
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: LogoView(
+                  imageUrl: _vm.imageApi
+                      .getLogoImageUrl(_seriesLogoId!, maxWidth: 350, tag: _seriesLogoTag),
+                  maxHeight: (_landscape ? 90 : 64) * logoScaleFactor,
+                  maxWidth: (_landscape ? 360 : 260) * logoScaleFactor,
+                ),
               ),
-            )
-          else ...[
-            if (isEpisode && item.seriesName != null)
+            ] else if (item.seriesName != null) ...[
               Padding(
                 padding: const EdgeInsets.only(bottom: 4),
                 child: Text(
@@ -1643,6 +1760,25 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   ),
                 ),
               ),
+            ],
+            Text(
+              item.name,
+              style: (_landscape
+                      ? textTheme.displaySmall
+                      : textTheme.headlineMedium)
+                  ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ] else if (logoTag != null && logoId != null) ...[
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: LogoView(
+                imageUrl: _vm.imageApi
+                    .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
+                maxHeight: (_landscape ? 90 : 64) * logoScaleFactor,
+                maxWidth: (_landscape ? 360 : 260) * logoScaleFactor,
+              ),
+            ),
+          ] else ...[
             Text(
               item.name,
               style: (_landscape
@@ -1651,69 +1787,66 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   ?.copyWith(fontWeight: FontWeight.w700),
             ),
           ],
-        ],
-        if (isEpisode && logoTag != null) ...[
-          const SizedBox(height: 4),
-          Text(
-            item.name,
-            style: (_landscape
-                    ? textTheme.headlineMedium
-                    : textTheme.titleLarge)
-                ?.copyWith(fontWeight: FontWeight.w700),
-          ),
-        ],
-        const SizedBox(height: 6),
-        if (hideTitleAndLogo) ...[
-          RatingsRow(
-            ratings: _vm.ratings,
-            communityRating: item.communityRating,
-            criticRating: item.criticRating,
-            enableAdditionalRatings:
-                widget.prefs.get(UserPreferences.enableAdditionalRatings),
-            enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
-            showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
-            showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
-          ),
-        ] else ...[
+          const SizedBox(height: 6),
           _metadataRow(context, item),
-        ],
-        const SizedBox(height: 6),
-        if (!_landscape || _vm.nextUp == null) ...[
-          RatingsRow(
-            ratings: _vm.ratings,
-            communityRating: item.communityRating,
-            criticRating: item.criticRating,
-            enableAdditionalRatings:
-                widget.prefs.get(UserPreferences.enableAdditionalRatings),
-            enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
-            showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
-            showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
-          ),
+          if (showRatings) ...[
+            const SizedBox(height: 6),
+            RatingsRow(
+              ratings: _vm.ratings,
+              communityRating: item.communityRating,
+              criticRating: item.criticRating,
+              enableAdditionalRatings:
+                  widget.prefs.get(UserPreferences.enableAdditionalRatings),
+              enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
+              showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
+              showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
+            ),
+          ],
           const SizedBox(height: 6),
         ],
         if (item.tagline != null && item.tagline!.trim().isNotEmpty) ...[
           const SizedBox(height: 8),
-          Text(
-            item.tagline!.trim(),
-            style: textTheme.titleSmall?.copyWith(
-              fontStyle: FontStyle.italic,
-              color: AppColorScheme.onSurface.withValues(alpha: 0.9),
+          ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: _landscape ? 580 : double.infinity),
+            child: Text(
+              item.tagline!.trim(),
+              style: textTheme.titleSmall?.copyWith(
+                fontStyle: FontStyle.italic,
+                color: AppColorScheme.onSurface.withValues(alpha: 0.9),
+              ),
             ),
           ),
         ],
         if (overview != null && overview.isNotEmpty) ...[
           const SizedBox(height: 8),
-          Text(
-            overview,
-            maxLines: _landscape ? 4 : 6,
-            overflow: TextOverflow.ellipsis,
-            style: textTheme.bodyMedium?.copyWith(
-              height: 1.45,
-              color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: _landscape ? 580 : double.infinity,
+            ),
+            child: ExpandableBiography(
+              text: overview,
+              toggleFocusNode: _overviewFocusNode,
+              onArrowDown: () {
+                widget.initialFocusNode?.requestFocus();
+              },
+              onArrowUp: () {
+                NavigationLayout.focusNavbarNotifier.value?.call();
+              },
+              onArrowLeft: () {
+                final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+                if (navbarPosition == NavbarPosition.left) {
+                  NavigationLayout.focusNavbarNotifier.value?.call();
+                }
+              },
+              onCollapse: widget.onCollapseBiography,
+              style: textTheme.bodyMedium?.copyWith(
+                height: 1.45,
+                color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+              ),
             ),
           ),
         ],
-        const SizedBox(height: 10),
+        const SizedBox(height: 24),
         Focus(
           canRequestFocus: false,
           skipTraversal: true,
@@ -1736,27 +1869,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             onSelectedMediaSourceChanged: widget.onSelectedMediaSourceChanged,
             tvPlayFocusNode: widget.initialFocusNode,
             downTarget: _tabNode(_selectedTab >= 0 ? _selectedTab : 0),
+            upTarget: _overviewFocusNode,
             autoPlay: widget.autoPlay,
             modernStyle: true,
             fullWidthPrimary: !_landscape,
             maxVisibleButtonsOverride: _actionButtonCap(context, item),
             onArrowRightAtEnd: _landscape ? _focusRightOfActions : null,
             actionRowRightFocusNode: _actionRowRightFocusNode,
-            onFocusExtra: (isFocused) {
-              if (isFocused) {
-                widget.onToggleNavbar?.call(false);
-              } else {
-                if (_scrollController.hasClients && _scrollController.offset <= 140) {
-                  widget.onToggleNavbar?.call(true);
-                }
-              }
-            },
+            onFocusExtra: (_) {},
             actionsExpanded: widget.actionsExpanded,
             onActionsExpandedChanged: widget.onActionsExpandedChanged,
           ),
         ),
       ],
     );
+
+    return childrenCol;
   }
 
   Widget _metadataRow(BuildContext context, AggregatedItem item) {
@@ -1776,11 +1904,55 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (item.type == 'Series' && item.childCount != null) {
       addText(l10n.seasonCount(item.childCount!));
     }
+    if (item.type == 'Season') {
+      final epCount = _vm.episodes.length > 0 ? _vm.episodes.length : (item.childCount ?? 0);
+      if (epCount > 0) {
+        addText(l10n.episodeCount(epCount));
+      }
+    }
+    if (item.type == 'Episode') {
+      final s = item.parentIndexNumber;
+      final e = item.indexNumber;
+      if (s != null && e != null) {
+        addText('S${s}:E$e');
+      }
+      final enableEpisodeRatings = widget.prefs.get(UserPreferences.enableEpisodeRatings);
+      if (enableEpisodeRatings) {
+        final ratingVal = _vm.ratings['stars'] ?? item.communityRating;
+        if (ratingVal != null && ratingVal > 0) {
+          final displayVal = ratingVal <= 10.0 ? ratingVal * 10 : ratingVal;
+          final ratingText = '${displayVal.toInt()}%';
+          pieces.add(
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Image.asset(
+                  'assets/icons/ratings/tmdb.png',
+                  height: 14,
+                  filterQuality: FilterQuality.medium,
+                ),
+                const SizedBox(width: 4),
+                Text(ratingText, style: style),
+              ],
+            ),
+          );
+        }
+      }
+    }
     final status = item.status;
     if (item.type == 'Series' && status != null && status.isNotEmpty) {
       pieces.add(_statusBadge(context, status));
     }
-    final runtime = item.runtime;
+    var runtime = item.runtime;
+    if (runtime == null && item.type == 'Season' && _vm.episodes.isNotEmpty) {
+      var totalMs = 0;
+      for (final ep in _vm.episodes) {
+        totalMs += ep.runtime?.inMilliseconds ?? 0;
+      }
+      if (totalMs > 0) {
+        runtime = Duration(milliseconds: totalMs);
+      }
+    }
     if (runtime != null && item.type != 'Series') {
       pieces.add(
         Row(
@@ -1842,18 +2014,38 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget? _buildUpNext(BuildContext context, AggregatedItem item) {
-    const supported = {'Series', 'Season', 'Episode'};
+    const supported = {'Series', 'Season'};
     if (!supported.contains(item.type)) return null;
-    final episode = _vm.nextUp;
-    if (episode == null) return null;
+
     final l10n = AppLocalizations.of(context);
+    AggregatedItem? episode;
+    String? customLabel;
+
+    if (item.type == 'Season') {
+      if (_vm.episodes.isEmpty) return null;
+      final seasonAllWatched = _vm.episodes.every((e) => e.isPlayed);
+      final seasonAllUnwatched = _vm.episodes.every((e) => !e.isPlayed && (e.playedPercentage == null || e.playedPercentage == 0));
+      if (seasonAllWatched) {
+        episode = _vm.episodes[0];
+        customLabel = 'Rewatch S${item.indexNumber}:E1';
+      } else if (!seasonAllUnwatched) {
+        try {
+          episode = _vm.episodes.firstWhere((e) => !e.isPlayed);
+        } catch (_) {}
+      }
+    } else {
+      episode = _vm.nextUp;
+    }
+
+    if (episode == null) return null;
+
     final s = episode.parentIndexNumber;
     final e = episode.indexNumber;
     final code = (s != null && e != null) ? 'S$s:E$e' : null;
     final title = code != null ? '$code - ${episode.name}' : episode.name;
     final progress = (episode.playedPercentage ?? 0) / 100.0;
     return UpNextCard(
-      label: l10n.nextUp,
+      label: customLabel ?? l10n.nextUp,
       title: title,
       description: episode.overview?.trim(),
       imageUrl: _imageUrl(episode),
@@ -1870,7 +2062,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       onNavigateDown: _focusSelectedTab,
       onTap: () async {
         final manager = GetIt.instance<PlaybackManager>();
-        final hasProgress = (episode.playbackPosition?.inMilliseconds ?? 0) > 0 ||
+        final hasProgress = (episode!.playbackPosition?.inMilliseconds ?? 0) > 0 ||
                             (episode.playedPercentage ?? 0) > 0;
         await manager.playItems(
           [episode],
@@ -2052,6 +2244,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
+    final desktopScale = _desktopUiScale(prefs: widget.prefs);
+    final logoScaleFactor = desktopScale > 1.1 ? 0.70 : 1.0;
+
     _landscape = PlatformDetection.isTV ||
         PlatformDetection.useDesktopUi ||
         MediaQuery.orientationOf(context) == Orientation.landscape;
@@ -2102,17 +2297,21 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final logoTag = item.logoImageTag ?? (isEpisode ? item.seriesLogoImageTag : null);
     final logoId = logoTag != null ? (item.logoImageTag != null ? item.id : item.seriesId) : null;
 
-    final Widget? aboveHeroWidget = (_vm.nextUp != null)
+    final showRatings = isEpisode
+        ? false
+        : (_vm.ratings.isNotEmpty || item.communityRating != null || item.criticRating != null);
+    final Widget? aboveHeroWidget = (_landscape && _vm.nextUp != null)
         ? Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
+              const SizedBox(height: 24),
               if (logoTag != null && logoId != null) ...[
                 LogoView(
                   imageUrl: _vm.imageApi
                       .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
-                  maxHeight: 90,
-                  maxWidth: 360,
+                  maxHeight: 90 * logoScaleFactor,
+                  maxWidth: 360 * logoScaleFactor,
                 ),
                 const SizedBox(height: 6),
               ] else ...[
@@ -2123,6 +2322,19 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 const SizedBox(height: 6),
               ],
               _metadataRow(context, item),
+              if (showRatings) ...[
+                const SizedBox(height: 6),
+                RatingsRow(
+                  ratings: _vm.ratings,
+                  communityRating: item.communityRating,
+                  criticRating: item.criticRating,
+                  enableAdditionalRatings:
+                      widget.prefs.get(UserPreferences.enableAdditionalRatings),
+                  enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
+                  showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
+                  showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
+                ),
+              ],
             ],
           )
         : null;

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -13,12 +13,14 @@ import '../../../../data/models/aggregated_item.dart';
 import '../../../../data/viewmodels/item_detail_view_model.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../preference/user_preferences.dart';
+import '../../../../preference/preference_constants.dart';
 import '../../../../util/platform_detection.dart';
 import '../../../navigation/destinations.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/media_card.dart';
 import '../../../widgets/rating_display.dart';
 import '../../../widgets/focus/focusable_wrapper.dart';
+import '../../../widgets/navigation_layout.dart';
 import '../../../widgets/top_toolbar.dart';
 import '../item_detail_screen.dart'
     show
@@ -87,6 +89,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _castFirstFocusNode = FocusNode(debugLabel: 'castFirst');
   final FocusNode _crewFirstFocusNode = FocusNode(debugLabel: 'crewFirst');
   final FocusNode _studiosFirstFocusNode = FocusNode(debugLabel: 'studiosFirst');
+  final FocusNode _chaptersFirstFocusNode = FocusNode(debugLabel: 'chaptersFirst');
+  final FocusNode _similarFirstFocusNode = FocusNode(debugLabel: 'similarFirst');
+  final FocusNode _seasonsFirstFocusNode = FocusNode(debugLabel: 'seasonsFirst');
+  final FocusNode _episodesFirstFocusNode = FocusNode(debugLabel: 'episodesFirst');
   late final ScrollController _scrollController = ScrollController();
   bool _showNavbarState = true;
   bool _audioExpanded = false;
@@ -167,6 +173,29 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   @override
   void initState() {
     super.initState();
+    
+    final FocusOnKeyEventCallback leftToSidebarHandler = (node, event) {
+      if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+        final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+        if (navbarPosition == NavbarPosition.left) {
+          final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+          if (focusNavbar != null) {
+            focusNavbar();
+            return KeyEventResult.handled;
+          }
+        }
+      }
+      return KeyEventResult.ignored;
+    };
+
+    _castFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _crewFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _studiosFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _chaptersFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _similarFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _seasonsFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _episodesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+
     _vm.addListener(_onViewModelChanged);
     _scrollController.addListener(_onScroll);
     if (PlatformDetection.isTV) {
@@ -178,6 +207,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) widget.initialFocusNode?.requestFocus();
       });
+      NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
   }
 
@@ -188,6 +218,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) widget.initialFocusNode?.requestFocus();
       });
+      NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
   }
 
@@ -210,6 +241,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   @override
   void dispose() {
+    if (NavigationLayout.focusDetailsPlayButtonNotifier.value == widget.initialFocusNode) {
+      NavigationLayout.focusDetailsPlayButtonNotifier.value = null;
+    }
     _vm.removeListener(_onViewModelChanged);
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
@@ -227,6 +261,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _castFirstFocusNode.dispose();
     _crewFirstFocusNode.dispose();
     _studiosFirstFocusNode.dispose();
+    _chaptersFirstFocusNode.dispose();
+    _similarFirstFocusNode.dispose();
+    _seasonsFirstFocusNode.dispose();
+    _episodesFirstFocusNode.dispose();
     super.dispose();
   }
 
@@ -243,11 +281,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   FocusNode _tabNode(int index) {
     while (_tabFocusNodes.length <= index) {
       final node = FocusNode(debugLabel: 'tab_$index');
-      node.addListener(() {
-        if (node.hasFocus && mounted) {
-          widget.onToggleNavbar?.call(false);
-        }
-      });
       _tabFocusNodes.add(node);
     }
     return _tabFocusNodes[index];
@@ -256,8 +289,28 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   void _focusSelectedTab() => _tabNode(_selectedTab).requestFocus();
 
   void _onTabBarNavigateDown() {
-    if (_detailsTabFocusNode.context != null && _detailsTabFocusNode.canRequestFocus) {
-      _detailsTabFocusNode.requestFocus();
+    if (_vm.item == null) return;
+    final l10n = AppLocalizations.of(context);
+    final tabs = _tabsFor(_vm.item!, l10n);
+    if (_selectedTab >= 0 && _selectedTab < tabs.length) {
+      final label = tabs[_selectedTab].label;
+      if (label == l10n.cast) {
+        if (_castFirstFocusNode.canRequestFocus) _castFirstFocusNode.requestFocus();
+      } else if (label == l10n.crewSection) {
+        if (_crewFirstFocusNode.canRequestFocus) _crewFirstFocusNode.requestFocus();
+      } else if (label == l10n.studios) {
+        if (_studiosFirstFocusNode.canRequestFocus) _studiosFirstFocusNode.requestFocus();
+      } else if (label == l10n.chapters) {
+        if (_chaptersFirstFocusNode.canRequestFocus) _chaptersFirstFocusNode.requestFocus();
+      } else if (label == l10n.details) {
+        if (_detailsTabFocusNode.canRequestFocus) _detailsTabFocusNode.requestFocus();
+      } else if (label == l10n.similar) {
+        if (_similarFirstFocusNode.canRequestFocus) _similarFirstFocusNode.requestFocus();
+      } else if (label == l10n.seasons) {
+        if (_seasonsFirstFocusNode.canRequestFocus) _seasonsFirstFocusNode.requestFocus();
+      } else if (label == l10n.episodes) {
+        if (_episodesFirstFocusNode.canRequestFocus) _episodesFirstFocusNode.requestFocus();
+      }
     }
   }
 
@@ -284,7 +337,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final studios = _ModernTab(l10n.studios, _studiosTab);
     final chapters = _ModernTab(l10n.chapters, _chaptersTab);
     final details = _ModernTab(l10n.details, _detailsTab);
-    final similar = _ModernTab(l10n.similar, (_, _) => _itemGrid(_vm.similar));
+    final similar = _ModernTab(l10n.similar, (_, _) => _similarTab(context, _vm.similar));
 
     switch (item.type) {
       case 'Series':
@@ -368,85 +421,106 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final counts = _episodeCountsBySeason();
     final showPosterUrl = _imageUrl(item);
     final cards = [
-      for (final season in _vm.seasons)
+      for (var i = 0; i < _vm.seasons.length; i++)
         SeasonCard(
-          title: season.name,
+          title: _vm.seasons[i].name,
           subtitle: l10n.episodeCount(
-            counts[season.id] ?? season.childCount ?? 0,
+            counts[_vm.seasons[i].id] ?? _vm.seasons[i].childCount ?? 0,
           ),
-          imageUrl: _imageUrl(season) ?? showPosterUrl,
-          isFallbackImage: _imageUrl(season) == null,
+          imageUrl: _imageUrl(_vm.seasons[i]) ?? showPosterUrl,
+          isFallbackImage: _imageUrl(_vm.seasons[i]) == null,
           landscape: _landscape,
           onNavigateUp: _focusSelectedTab,
+          focusNode: i == 0 ? _seasonsFirstFocusNode : null,
           onTap: () => context.push(
-            Destinations.item(season.id, serverId: season.serverId),
+            Destinations.item(_vm.seasons[i].id, serverId: _vm.seasons[i].serverId),
           ),
         ),
     ];
-    if (_landscape) {
-      return Focus(
-        onKeyEvent: (node, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    final child = _landscape
+        ? SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final card in cards)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 12),
+                    child: card,
+                  ),
+              ],
+            ),
+          )
+        : Column(
             children: [
               for (final card in cards)
                 Padding(
-                  padding: const EdgeInsets.only(right: 12),
+                  padding: const EdgeInsets.only(bottom: 12),
                   child: card,
                 ),
             ],
-          ),
-        ),
-      );
-    }
-    return Column(
-      children: [
-        for (final card in cards)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 12),
-            child: card,
-          ),
-      ],
+          );
+
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          _focusSelectedTab();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: child,
     );
   }
 
   Widget _episodeListTab(BuildContext context, AggregatedItem item) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        for (var i = 0; i < _vm.episodes.length; i++)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: i == 0
-                ? Focus(
-                    onKeyEvent: (node, event) {
-                      if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                        _focusSelectedTab();
-                        return KeyEventResult.handled;
-                      }
-                      return KeyEventResult.ignored;
-                    },
-                    child: DetailEpisodeCard(
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var i = 0; i < _vm.episodes.length; i++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: i == 0
+                  ? Focus(
+                      focusNode: _episodesFirstFocusNode,
+                      onKeyEvent: (node, event) {
+                        if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                          _focusSelectedTab();
+                          return KeyEventResult.handled;
+                        }
+                        return KeyEventResult.ignored;
+                      },
+                      child: DetailEpisodeCard(
+                        episode: _vm.episodes[i],
+                        imageApi: _vm.imageApi,
+                        onChanged: () => _vm.load(),
+                      ),
+                    )
+                  : DetailEpisodeCard(
                       episode: _vm.episodes[i],
                       imageApi: _vm.imageApi,
                       onChanged: () => _vm.load(),
                     ),
-                  )
-                : DetailEpisodeCard(
-                    episode: _vm.episodes[i],
-                    imageApi: _vm.imageApi,
-                    onChanged: () => _vm.load(),
-                  ),
-          ),
-      ],
+            ),
+        ],
+      ),
     );
   }
 
@@ -509,6 +583,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           padding: const EdgeInsets.only(bottom: 6),
           child: FocusableWrapper(
             onNavigateUp: isFirst ? _focusSelectedTab : null,
+            focusNode: isFirst ? _episodesFirstFocusNode : null,
             onSelect: () {
               setState(() {
                 if (_expandedSeasons.contains(season)) {
@@ -572,15 +647,33 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       }
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: children,
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: children,
+      ),
     );
   }
 
   Widget _castTab(BuildContext context, AggregatedItem item) => SizedBox(
         height: 200,
         child: Focus(
+          canRequestFocus: false,
+          onFocusChange: (focused) {
+            if (focused && mounted) {
+              widget.onToggleNavbar?.call(false);
+            } else if (!focused && mounted) {
+              widget.onToggleNavbar?.call(true);
+            }
+          },
           onKeyEvent: (node, event) {
             if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
               _focusSelectedTab();
@@ -652,6 +745,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return SizedBox(
       height: 200,
       child: Focus(
+        canRequestFocus: false,
+        onFocusChange: (focused) {
+          if (focused && mounted) {
+            widget.onToggleNavbar?.call(false);
+          } else if (!focused && mounted) {
+            widget.onToggleNavbar?.call(true);
+          }
+        },
         onKeyEvent: (node, event) {
           if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
             _focusSelectedTab();
@@ -720,6 +821,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       child: SizedBox(
         height: cardHeight + 20,
         child: Focus(
+          canRequestFocus: false,
+          onFocusChange: (focused) {
+            if (focused && mounted) {
+              widget.onToggleNavbar?.call(false);
+            } else if (!focused && mounted) {
+              widget.onToggleNavbar?.call(true);
+            }
+          },
           onKeyEvent: (node, event) {
             if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
               _focusSelectedTab();
@@ -787,6 +896,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       return const SizedBox.shrink();
     }
     return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
       onKeyEvent: (node, event) {
         if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
           _focusSelectedTab();
@@ -798,6 +915,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         item: item,
         imageApi: _vm.imageApi,
         onPlayFromChapter: widget.onPlayFromChapter ?? (_) {},
+        firstItemFocusNode: _chaptersFirstFocusNode,
       ),
     );
   }
@@ -805,6 +923,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _extrasTab(BuildContext context, AggregatedItem item) => SizedBox(
         height: 200,
         child: Focus(
+          canRequestFocus: false,
+          onFocusChange: (focused) {
+            if (focused && mounted) {
+              widget.onToggleNavbar?.call(false);
+            } else if (!focused && mounted) {
+              widget.onToggleNavbar?.call(true);
+            }
+          },
           onKeyEvent: (node, event) {
             if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
               _focusSelectedTab();
@@ -852,11 +978,31 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final subtitleStreams = rawStreams.where((s) => s['Type'] == 'Subtitle').toList();
       
       final hasButtons = audioStreams.length > 2 || subtitleStreams.length > 2;
-      return _DetailsContainer(
-        isScrollable: true,
-        canRequestFocus: true,
-        focusNode: _detailsTabFocusNode,
-        child: _buildFileInformation(context, targetItem, mediaSource),
+      return Focus(
+        canRequestFocus: false,
+        onFocusChange: (focused) {
+          if (focused && mounted) {
+            widget.onToggleNavbar?.call(false);
+          } else if (!focused && mounted) {
+            widget.onToggleNavbar?.call(true);
+          }
+        },
+        child: _DetailsContainer(
+          isScrollable: hasButtons,
+          canRequestFocus: true,
+          focusNode: _detailsTabFocusNode,
+          onNavigateUp: _focusSelectedTab,
+          onSelect: hasButtons
+              ? () {
+                  if (audioStreams.length > 2) {
+                    _audioShowAllFocusNode.requestFocus();
+                  } else if (subtitleStreams.length > 2) {
+                    _subtitleShowAllFocusNode.requestFocus();
+                  }
+                }
+              : null,
+          child: _buildFileInformation(context, targetItem, mediaSource),
+        ),
       );
     }
     return const SizedBox.shrink();
@@ -1052,6 +1198,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   onNavigateUp: _focusSelectedTab,
                   onSelect: () => setState(() => _audioExpanded = !_audioExpanded),
                   borderRadius: 6,
+                  suppressFocusGlow: true,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                     child: Text(
@@ -1123,6 +1270,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   onNavigateUp: _focusSelectedTab,
                   onSelect: () => setState(() => _subtitlesExpanded = !_subtitlesExpanded),
                   borderRadius: 6,
+                  suppressFocusGlow: true,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                     child: Text(
@@ -1285,6 +1433,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         final childAspectRatio =
             cellWidth / (cellWidth / cardRatio + textHeight);
         return Focus(
+          canRequestFocus: false,
+          onFocusChange: (focused) {
+            if (focused && mounted) {
+              widget.onToggleNavbar?.call(false);
+            } else if (!focused && mounted) {
+              widget.onToggleNavbar?.call(true);
+            }
+          },
           onKeyEvent: (node, event) {
             if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
               _focusSelectedTab();
@@ -1326,8 +1482,78 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
+  Widget _similarTab(BuildContext context, List<AggregatedItem> items) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    final isMobile = _landscape == false;
+    final desktopScale = widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final cardWidth = isMobile ? 90.0 : 120.0 * desktopScale;
+    const cardRatio = 2 / 3;
+    final cardHeight = cardWidth / cardRatio + 48.0;
+
+    return SizedBox(
+      height: cardHeight + 24.0,
+      child: Focus(
+        canRequestFocus: false,
+        onFocusChange: (focused) {
+          if (focused && mounted) {
+            widget.onToggleNavbar?.call(false);
+          } else if (!focused && mounted) {
+            widget.onToggleNavbar?.call(true);
+          }
+        },
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          clipBehavior: Clip.none,
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 12),
+          itemCount: items.length,
+          separatorBuilder: (_, __) => SizedBox(width: isMobile ? 8.0 : 12.0 * desktopScale),
+          itemBuilder: (context, i) {
+            final entry = items[i];
+            return MediaCard(
+              title: entry.name,
+              imageUrl: _imageUrl(entry),
+              width: cardWidth,
+              aspectRatio: cardRatio,
+              isPlayed: entry.isPlayed,
+              isFavorite: entry.isFavorite,
+              itemType: entry.type,
+              focusNode: i == 0 ? _similarFirstFocusNode : null,
+              onKeyEvent: (node, event) {
+                if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                  _focusSelectedTab();
+                  return KeyEventResult.handled;
+                }
+                return KeyEventResult.ignored;
+              },
+              watchedBehavior:
+                  widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
+              onTap: () => context.push(
+                Destinations.item(entry.id, serverId: entry.serverId),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
   Widget _tracksTab(BuildContext context, AggregatedItem item) {
     return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
       onKeyEvent: (node, event) {
         if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
           _focusSelectedTab();
@@ -1437,7 +1663,20 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ),
         ],
         const SizedBox(height: 6),
-        _metadataRow(context, item),
+        if (hideTitleAndLogo) ...[
+          RatingsRow(
+            ratings: _vm.ratings,
+            communityRating: item.communityRating,
+            criticRating: item.criticRating,
+            enableAdditionalRatings:
+                widget.prefs.get(UserPreferences.enableAdditionalRatings),
+            enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
+            showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
+            showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
+          ),
+        ] else ...[
+          _metadataRow(context, item),
+        ],
         const SizedBox(height: 6),
         if (!_landscape || _vm.nextUp == null) ...[
           RatingsRow(
@@ -1479,12 +1718,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           canRequestFocus: false,
           skipTraversal: true,
           onFocusChange: (focused) {
-            if (focused && _scrollController.hasClients) {
-              _scrollController.animateTo(
-                0.0,
-                duration: const Duration(milliseconds: 250),
-                curve: Curves.easeInOut,
-              );
+            if (focused) {
+              widget.onToggleNavbar?.call(true);
+              if (_scrollController.hasClients) {
+                _scrollController.animateTo(
+                  0.0,
+                  duration: const Duration(milliseconds: 250),
+                  curve: Curves.easeInOut,
+                );
+              }
             }
           },
           child: DetailActionButtons(
@@ -1836,10 +2078,19 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       selectedIndex: _selectedTab,
       onSelect: _selectTab,
       focusNodeFor: _tabNode,
-      onExitLeft: () => widget.initialFocusNode?.requestFocus(),
-      onNavigateDown: (_selectedTab >= 0 && _selectedTab < tabs.length && tabs[_selectedTab].label == l10n.details)
-          ? _onTabBarNavigateDown
-          : null,
+      onExitLeft: () {
+        final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+        if (navbarPosition == NavbarPosition.left) {
+          final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+          if (focusNavbar != null) {
+            focusNavbar();
+            return;
+          }
+        }
+        widget.initialFocusNode?.requestFocus();
+      },
+      onExitUp: () => widget.initialFocusNode?.requestFocus(),
+      onNavigateDown: _onTabBarNavigateDown,
     );
 
     final hero = _buildHero(context, item);
@@ -1863,24 +2114,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   maxHeight: 90,
                   maxWidth: 360,
                 ),
-                const SizedBox(height: 12),
+                const SizedBox(height: 6),
               ] else ...[
                 Text(
                   item.name,
                   style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700),
                 ),
-                const SizedBox(height: 8),
+                const SizedBox(height: 6),
               ],
-              RatingsRow(
-                ratings: _vm.ratings,
-                communityRating: item.communityRating,
-                criticRating: item.criticRating,
-                enableAdditionalRatings:
-                    widget.prefs.get(UserPreferences.enableAdditionalRatings),
-                enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
-                showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
-                showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
-              ),
+              _metadataRow(context, item),
             ],
           )
         : null;
@@ -1918,12 +2160,16 @@ class _DetailsContainer extends StatefulWidget {
   final bool isScrollable;
   final bool canRequestFocus;
   final FocusNode? focusNode;
+  final VoidCallback? onNavigateUp;
+  final VoidCallback? onSelect;
 
   const _DetailsContainer({
     required this.child,
     required this.isScrollable,
     required this.canRequestFocus,
     this.focusNode,
+    this.onNavigateUp,
+    this.onSelect,
   });
 
   @override
@@ -1960,44 +2206,61 @@ class _DetailsContainerState extends State<_DetailsContainer> with FocusStateMix
                 context,
                 duration: const Duration(milliseconds: 250),
                 curve: Curves.easeInOut,
-                alignment: 0.5,
+                alignment: 0.0,
               );
             }
           });
         }
       },
-      onKeyEvent: widget.isScrollable
-          ? (node, event) {
-              if (event is KeyDownEvent || event is KeyRepeatEvent) {
-                if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-                  final maxScroll = _scrollController.position.maxScrollExtent;
-                  final currentScroll = _scrollController.offset;
-                  if (currentScroll < maxScroll) {
-                    _scrollController.animateTo(
-                      (currentScroll + 60.0).clamp(0.0, maxScroll),
-                      duration: const Duration(milliseconds: 100),
-                      curve: Curves.easeOut,
-                    );
-                    return KeyEventResult.handled;
-                  }
-                } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                  final currentScroll = _scrollController.offset;
-                  if (currentScroll > 0.0) {
-                    _scrollController.animateTo(
-                      (currentScroll - 60.0).clamp(0.0, double.infinity),
-                      duration: const Duration(milliseconds: 100),
-                      curve: Curves.easeOut,
-                    );
-                    return KeyEventResult.handled;
-                  }
-                }
-              }
-              return KeyEventResult.ignored;
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent) {
+          if (event.logicalKey == LogicalKeyboardKey.enter ||
+              event.logicalKey == LogicalKeyboardKey.select) {
+            if (widget.onSelect != null) {
+              widget.onSelect!();
+              return KeyEventResult.handled;
             }
-          : null,
+          }
+        }
+        if (widget.isScrollable) {
+          if (event is KeyDownEvent || event is KeyRepeatEvent) {
+            if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+              final maxScroll = _scrollController.position.maxScrollExtent;
+              final currentScroll = _scrollController.offset;
+              if (currentScroll < maxScroll) {
+                _scrollController.animateTo(
+                  (currentScroll + 60.0).clamp(0.0, maxScroll),
+                  duration: const Duration(milliseconds: 100),
+                  curve: Curves.easeOut,
+                );
+                return KeyEventResult.handled;
+              }
+            } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              final currentScroll = _scrollController.offset;
+              if (currentScroll > 0.0) {
+                _scrollController.animateTo(
+                  (currentScroll - 60.0).clamp(0.0, double.infinity),
+                  duration: const Duration(milliseconds: 100),
+                  curve: Curves.easeOut,
+                );
+                return KeyEventResult.handled;
+              } else {
+                widget.onNavigateUp?.call();
+                return KeyEventResult.handled;
+              }
+            }
+          }
+        } else {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            widget.onNavigateUp?.call();
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
-        height: widget.isScrollable ? 320 : null,
+        height: 460,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(12),
           border: Border.all(

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -849,9 +849,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               },
             ),
           if (moviesList.isNotEmpty)
-            _ModernTab(l10n.movies, (context, item) => _moviesTab(context, moviesList, focusNode: _moviesFirstFocusNode)),
+            _ModernTab(l10n.movies, (context, item) => _mediaGrid(context, moviesList, firstFocusNode: _moviesFirstFocusNode)),
           if (seriesList.isNotEmpty)
-            _ModernTab(l10n.series, (context, item) => _seriesTab(context, seriesList, focusNode: _seriesFirstFocusNode)),
+            _ModernTab(l10n.series, (context, item) => _mediaGrid(context, seriesList, firstFocusNode: _seriesFirstFocusNode)),
           if (hasCast) _ModernTab(l10n.cast, _boxSetCastTab),
           if (hasCrew) _ModernTab(l10n.crewSection, _boxSetCrewTab),
           if (hasStudios) studios,
@@ -879,7 +879,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     // unplayed episode's seasonId so the cyan border always renders correctly.
     final nextUpSeasonId = _vm.nextUp?.seasonId ??
         _vm.seriesEpisodes.firstWhereOrNull((e) => !e.isPlayed)?.seasonId;
-    SeasonCard buildSeasonCard(int i, {double? width, double? height}) =>
+    SeasonCard buildSeasonCard(
+      int i, {
+      double? width,
+      double? height,
+      bool topRow = true,
+    }) =>
         SeasonCard(
           title: _vm.seasons[i].name,
           subtitle: l10n.episodeCount(
@@ -889,11 +894,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           isFallbackImage: _imageUrl(_vm.seasons[i]) == null,
           landscape: _landscape,
           isNextUp: _vm.seasons[i].id == nextUpSeasonId,
-          onNavigateUp: _focusSelectedTab,
-          onNavigateRight: i == _vm.seasons.length - 1 ? () {} : null,
+          onNavigateUp: topRow ? _focusSelectedTab : null,
           focusNode: i == 0 ? _seasonsFirstFocusNode : null,
           width: width,
           height: height,
+          autoScroll: true,
           onTap: () => context.push(
             Destinations.item(_vm.seasons[i].id, serverId: _vm.seasons[i].serverId),
           ),
@@ -904,64 +909,56 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       letterSpacing: 1.0,
       fontSize: 10,
     );
-    final child = _landscape
-        ? SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                for (var i = 0; i < _vm.seasons.length; i++)
-                  Padding(
-                    padding: const EdgeInsets.only(right: 12),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Text(
-                          _vm.seasons[i].name.toUpperCase(),
-                          style: seasonLabelStyle,
-                          textAlign: TextAlign.center,
-                        ),
-                        const SizedBox(height: 6),
-                        buildSeasonCard(i),
-                      ],
-                    ),
-                  ),
-              ],
+    // Centered when it fits, horizontally scrollable when the name is longer
+    // than the card, so a long season name never wraps to a second line.
+    Widget seasonLabel(int i, double viewportWidth) => SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minWidth: viewportWidth),
+            child: Text(
+              _vm.seasons[i].name.toUpperCase(),
+              maxLines: 1,
+              softWrap: false,
+              style: seasonLabelStyle,
+              textAlign: TextAlign.center,
             ),
-          )
-        : LayoutBuilder(
-            builder: (context, constraints) {
-              const spacing = 12.0;
-              final columns = (constraints.maxWidth / 130).floor().clamp(3, 6);
-              final cardWidth =
-                  ((constraints.maxWidth - spacing * (columns - 1)) / columns)
-                      .floorToDouble();
-              final cardHeight = cardWidth * 1.5;
-              return Wrap(
-                spacing: spacing,
-                runSpacing: 16,
-                children: [
-                  for (var i = 0; i < _vm.seasons.length; i++)
-                    SizedBox(
+          ),
+        );
+    final child = LayoutBuilder(
+      builder: (context, constraints) {
+        const spacing = 12.0;
+        final columns = (constraints.maxWidth / (_landscape ? 160.0 : 130.0))
+            .floor()
+            .clamp(3, _landscape ? 8 : 6);
+        final cardWidth =
+            ((constraints.maxWidth - spacing * (columns - 1)) / columns)
+                .floorToDouble();
+        final cardHeight = cardWidth * 1.5;
+        return Wrap(
+          spacing: spacing,
+          runSpacing: 16,
+          children: [
+            for (var i = 0; i < _vm.seasons.length; i++)
+              SizedBox(
+                width: cardWidth,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    seasonLabel(i, cardWidth),
+                    const SizedBox(height: 6),
+                    buildSeasonCard(
+                      i,
                       width: cardWidth,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            _vm.seasons[i].name.toUpperCase(),
-                            style: seasonLabelStyle,
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(height: 6),
-                          buildSeasonCard(i, width: cardWidth, height: cardHeight),
-                        ],
-                      ),
+                      height: cardHeight,
+                      topRow: i < columns,
                     ),
-                ],
-              );
-            },
-          );
+                  ],
+                ),
+              ),
+          ],
+        );
+      },
+    );
 
     return Focus(
       canRequestFocus: false,
@@ -971,13 +968,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         } else if (!focused && mounted) {
           widget.onToggleNavbar?.call(true);
         }
-      },
-      onKeyEvent: (node, event) {
-        if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          _focusSelectedTab();
-          return KeyEventResult.handled;
-        }
-        return KeyEventResult.ignored;
       },
       child: Padding(
         padding: const EdgeInsets.only(bottom: 32),
@@ -2570,99 +2560,89 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  Widget _similarTab(BuildContext context, List<AggregatedItem> items) {
+  Widget _similarTab(BuildContext context, List<AggregatedItem> items) =>
+      _mediaGrid(context, items, firstFocusNode: _similarFirstFocusNode);
+
+  /// Responsive poster grid shared by the Similar tab and the collection
+  /// Movies/Shows tabs. Columns scale to width; d-pad uses default geometric
+  /// traversal, the top row escapes up to the tab bar, and cards scroll into
+  /// view on focus so rows below the fold stay reachable.
+  Widget _mediaGrid(
+    BuildContext context,
+    List<AggregatedItem> items, {
+    FocusNode? firstFocusNode,
+  }) {
     if (items.isEmpty) return const SizedBox.shrink();
-    final isMobile = _landscape == false;
     const cardRatio = 2 / 3;
 
-    if (isMobile) {
-      return LayoutBuilder(
-        builder: (context, constraints) {
-          const spacing = 12.0;
-          final columns = (constraints.maxWidth / 130).floor().clamp(3, 6);
-          final cardWidth =
-              ((constraints.maxWidth - spacing * (columns - 1)) / columns)
-                  .floorToDouble();
-          return Wrap(
-            spacing: spacing,
-            runSpacing: 16,
-            children: [
-              for (final entry in items)
-                MediaCard(
-                  title: entry.name,
-                  imageUrl: _imageUrl(entry),
-                  width: cardWidth,
-                  aspectRatio: cardRatio,
-                  isPlayed: entry.isPlayed,
-                  isFavorite: entry.isFavorite,
-                  itemType: entry.type,
-                  watchedBehavior:
-                      widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
-                  onTap: () => context.push(
-                    Destinations.item(entry.id, serverId: entry.serverId),
-                  ),
-                ),
-            ],
-          );
-        },
-      );
-    }
-
-    final desktopScale =
-        widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
-    final cardWidth = 120.0 * desktopScale;
-    final cardHeight = cardWidth / cardRatio + 48.0;
-
-    return SizedBox(
-      height: cardHeight + 24.0,
-      child: Focus(
-        canRequestFocus: false,
-        onFocusChange: (focused) {
-          if (focused && mounted) {
-            widget.onToggleNavbar?.call(false);
-          } else if (!focused && mounted) {
-            widget.onToggleNavbar?.call(true);
-          }
-        },
-        onKeyEvent: (node, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
-        child: ListView.separated(
-          scrollDirection: Axis.horizontal,
-          clipBehavior: Clip.none,
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 12),
-          itemCount: items.length,
-          separatorBuilder: (_, __) => SizedBox(width: isMobile ? 8.0 : 12.0 * desktopScale),
-          itemBuilder: (context, i) {
-            final entry = items[i];
-            return MediaCard(
-              title: entry.name,
-              imageUrl: _imageUrl(entry),
-              width: cardWidth,
-              aspectRatio: cardRatio,
-              isPlayed: entry.isPlayed,
-              isFavorite: entry.isFavorite,
-              itemType: entry.type,
-              focusNode: i == 0 ? _similarFirstFocusNode : null,
-              onKeyEvent: (node, event) {
-                if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                  _focusSelectedTab();
-                  return KeyEventResult.handled;
-                }
-                return KeyEventResult.ignored;
-              },
-              watchedBehavior:
-                  widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
-              onTap: () => context.push(
-                Destinations.item(entry.id, serverId: entry.serverId),
+    final grid = LayoutBuilder(
+      builder: (context, constraints) {
+        const spacing = 12.0;
+        final columns = (constraints.maxWidth / (_landscape ? 150.0 : 130.0))
+            .floor()
+            .clamp(3, _landscape ? 8 : 6);
+        final cardWidth =
+            ((constraints.maxWidth - spacing * (columns - 1)) / columns)
+                .floorToDouble();
+        return Wrap(
+          spacing: spacing,
+          runSpacing: 16,
+          children: [
+            for (var i = 0; i < items.length; i++)
+              Builder(
+                builder: (cellContext) {
+                  final entry = items[i];
+                  final topRow = i < columns;
+                  return MediaCard(
+                    title: entry.name,
+                    imageUrl: _imageUrl(entry),
+                    width: cardWidth,
+                    aspectRatio: cardRatio,
+                    isPlayed: entry.isPlayed,
+                    isFavorite: entry.isFavorite,
+                    itemType: entry.type,
+                    focusNode: i == 0 ? firstFocusNode : null,
+                    onFocus: () => Scrollable.ensureVisible(
+                      cellContext,
+                      alignment: 0.5,
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeOut,
+                    ),
+                    onKeyEvent: topRow
+                        ? (node, event) {
+                            if (event is KeyDownEvent &&
+                                event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                              _focusSelectedTab();
+                              return KeyEventResult.handled;
+                            }
+                            return KeyEventResult.ignored;
+                          }
+                        : null,
+                    watchedBehavior: widget.prefs
+                        .get(UserPreferences.watchedIndicatorBehavior),
+                    onTap: () => context.push(
+                      Destinations.item(entry.id, serverId: entry.serverId),
+                    ),
+                  );
+                },
               ),
-            );
-          },
-        ),
+          ],
+        );
+      },
+    );
+
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 32),
+        child: grid,
       ),
     );
   }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' show Random;
 import 'dart:ui' show ImageFilter;
+import 'package:collection/collection.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -104,6 +105,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final List<FocusNode> _tabFocusNodes = [];
   final FocusNode _upNextFocusNode = FocusNode(debugLabel: 'modernUpNext');
   final FocusNode _actionRowRightFocusNode = FocusNode(debugLabel: 'actionRowRight');
+  final FocusNode _extraFirstFocusNode = FocusNode(debugLabel: 'extraFirstBtn');
   final FocusNode _artistFocusNode = FocusNode(debugLabel: 'albumArtist');
   final FocusNode _audioShowAllFocusNode = FocusNode(debugLabel: 'audioShowAll');
   final FocusNode _subtitleShowAllFocusNode = FocusNode(debugLabel: 'subtitleShowAll');
@@ -115,6 +117,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _similarFirstFocusNode = FocusNode(debugLabel: 'similarFirst');
   final FocusNode _gridFirstFocusNode = FocusNode(debugLabel: 'gridFirst');
   final FocusNode _collectionSortFocusNode = FocusNode(debugLabel: 'collectionSort');
+  final FocusNode _moviesFirstFocusNode = FocusNode(debugLabel: 'moviesFirst');
+  final FocusNode _seriesFirstFocusNode = FocusNode(debugLabel: 'seriesFirst');
   final FocusNode _seasonsFirstFocusNode = FocusNode(debugLabel: 'seasonsFirst');
   final FocusNode _episodesFirstFocusNode = FocusNode(debugLabel: 'episodesFirst');
   final FocusNode _overviewFocusNode = FocusNode(debugLabel: 'overview');
@@ -430,6 +434,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _personSeerrAppearancesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _personSeerrCrewCreditsFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _gridFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _moviesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+    _seriesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _collectionSortFocusNode.onKeyEvent = (node, event) {
       if (event is KeyDownEvent) {
         if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
@@ -521,6 +527,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
     _upNextFocusNode.dispose();
     _actionRowRightFocusNode.dispose();
+    _extraFirstFocusNode.dispose();
     _artistFocusNode.dispose();
     _audioShowAllFocusNode.dispose();
     _subtitleShowAllFocusNode.dispose();
@@ -532,6 +539,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _similarFirstFocusNode.dispose();
     _gridFirstFocusNode.dispose();
     _collectionSortFocusNode.dispose();
+    _moviesFirstFocusNode.dispose();
+    _seriesFirstFocusNode.dispose();
     _seasonsFirstFocusNode.dispose();
     _episodesFirstFocusNode.dispose();
     _overviewFocusNode.dispose();
@@ -581,58 +590,60 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   void _focusSelectedTab() => _tabNode(_selectedTab).requestFocus();
 
-  void _onTabBarNavigateDown() {
+  void _onTabBarNavigateDown(int tabIndex) {
     if (_vm.item == null) return;
-    final l10n = AppLocalizations.of(context);
-    final tabs = _tabsFor(_vm.item!, l10n);
-    if (_selectedTab >= 0 && _selectedTab < tabs.length) {
-      final label = tabs[_selectedTab].label;
-      if (label == l10n.cast) {
-        if (_castFirstFocusNode.canRequestFocus) _castFirstFocusNode.requestFocus();
-      } else if (label == l10n.crewSection) {
-        if (_crewFirstFocusNode.canRequestFocus) _crewFirstFocusNode.requestFocus();
-      } else if (label == l10n.studios) {
-        if (_studiosFirstFocusNode.canRequestFocus) _studiosFirstFocusNode.requestFocus();
-      } else if (label == l10n.chapters) {
-        if (_chaptersFirstFocusNode.canRequestFocus) _chaptersFirstFocusNode.requestFocus();
-      } else if (label == l10n.details) {
-        if (_detailsTabFocusNode.canRequestFocus) _detailsTabFocusNode.requestFocus();
-      } else if (label == l10n.similar) {
-        if (_similarFirstFocusNode.canRequestFocus) _similarFirstFocusNode.requestFocus();
-      } else if (label == l10n.seasons) {
-        if (_seasonsFirstFocusNode.canRequestFocus) _seasonsFirstFocusNode.requestFocus();
-      } else if (label == l10n.episodes) {
-        if (_episodesFirstFocusNode.canRequestFocus) _episodesFirstFocusNode.requestFocus();
-      } else if (label == l10n.movies) {
-        if (_personMoviesFirstFocusNode.canRequestFocus) _personMoviesFirstFocusNode.requestFocus();
-      } else if (label == l10n.series) {
-        if (_personSeriesFirstFocusNode.canRequestFocus) _personSeriesFirstFocusNode.requestFocus();
-      } else if (label == l10n.appearancesSeerr) {
-        if (_personSeerrAppearancesFirstFocusNode.canRequestFocus) _personSeerrAppearancesFirstFocusNode.requestFocus();
-      } else if (label == l10n.crewContributionsSeerr) {
-        if (_personSeerrCrewCreditsFirstFocusNode.canRequestFocus) _personSeerrCrewCreditsFirstFocusNode.requestFocus();
-      } else if (label == l10n.albums || label == l10n.items || label == l10n.appearances) {
-        if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
-      } else if (label == l10n.playlist) {
-        if (_vm.item?.type == 'BoxSet' && _vm.playlistItems.isNotEmpty) {
-          if (_collectionSortFocusNode.canRequestFocus) {
-            _collectionSortFocusNode.requestFocus();
+    if (_selectedTab != tabIndex) {
+      _selectTab(tabIndex);
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context);
+      final tabs = _tabsFor(_vm.item!, l10n);
+      if (tabIndex >= 0 && tabIndex < tabs.length) {
+        final label = tabs[tabIndex].label;
+        if (label == l10n.cast) {
+          if (_castFirstFocusNode.canRequestFocus) _castFirstFocusNode.requestFocus();
+        } else if (label == l10n.crewSection) {
+          if (_crewFirstFocusNode.canRequestFocus) _crewFirstFocusNode.requestFocus();
+        } else if (label == l10n.studios) {
+          if (_studiosFirstFocusNode.canRequestFocus) _studiosFirstFocusNode.requestFocus();
+        } else if (label == l10n.chapters) {
+          if (_chaptersFirstFocusNode.canRequestFocus) _chaptersFirstFocusNode.requestFocus();
+        } else if (label == l10n.details) {
+          if (_detailsTabFocusNode.canRequestFocus) _detailsTabFocusNode.requestFocus();
+        } else if (label == l10n.similar) {
+          if (_similarFirstFocusNode.canRequestFocus) _similarFirstFocusNode.requestFocus();
+        } else if (label == l10n.seasons) {
+          if (_seasonsFirstFocusNode.canRequestFocus) _seasonsFirstFocusNode.requestFocus();
+        } else if (label == l10n.episodes) {
+          if (_episodesFirstFocusNode.canRequestFocus) _episodesFirstFocusNode.requestFocus();
+        } else if (label == l10n.movies) {
+          if (_vm.item?.type == 'BoxSet') {
+            if (_moviesFirstFocusNode.canRequestFocus) _moviesFirstFocusNode.requestFocus();
+          } else {
+            if (_personMoviesFirstFocusNode.canRequestFocus) _personMoviesFirstFocusNode.requestFocus();
+          }
+        } else if (label == l10n.series) {
+          if (_vm.item?.type == 'BoxSet') {
+            if (_seriesFirstFocusNode.canRequestFocus) _seriesFirstFocusNode.requestFocus();
+          } else {
+            if (_personSeriesFirstFocusNode.canRequestFocus) _personSeriesFirstFocusNode.requestFocus();
+          }
+        } else if (label == l10n.appearancesSeerr) {
+          if (_personSeerrAppearancesFirstFocusNode.canRequestFocus) _personSeerrAppearancesFirstFocusNode.requestFocus();
+        } else if (label == l10n.crewContributionsSeerr) {
+          if (_personSeerrCrewCreditsFirstFocusNode.canRequestFocus) _personSeerrCrewCreditsFirstFocusNode.requestFocus();
+        } else if (label == l10n.albums || label == l10n.items || label == l10n.appearances) {
+          if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
+        } else if (label == l10n.playlist) {
+          if (_vm.item?.type == 'BoxSet' && _vm.playlistItems.isNotEmpty) {
+            if (_collectionSortFocusNode.canRequestFocus) {
+              _collectionSortFocusNode.requestFocus();
+            }
           }
         }
-      } else if (label == l10n.movies) {
-        if (_vm.item?.type == 'BoxSet') {
-          if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
-        } else {
-          if (_personMoviesFirstFocusNode.canRequestFocus) _personMoviesFirstFocusNode.requestFocus();
-        }
-      } else if (label == l10n.series) {
-        if (_vm.item?.type == 'BoxSet') {
-          if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
-        } else {
-          if (_personSeriesFirstFocusNode.canRequestFocus) _personSeriesFirstFocusNode.requestFocus();
-        }
       }
-    }
+    });
   }
 
   bool _isAudioItem(AggregatedItem item) {
@@ -729,7 +740,25 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ];
       case 'BoxSet':
         final moviesList = _vm.collectionItems.where((i) => i.type == 'Movie').toList();
+        moviesList.sort((a, b) {
+          final aIndex = _vm.playlistItems.indexWhere((p) => p.id == a.id);
+          final bIndex = _vm.playlistItems.indexWhere((p) => p.id == b.id);
+          if (aIndex == -1 && bIndex == -1) return 0;
+          if (aIndex == -1) return 1;
+          if (bIndex == -1) return -1;
+          return aIndex.compareTo(bIndex);
+        });
+
         final seriesList = _vm.collectionItems.where((i) => i.type == 'Series').toList();
+        seriesList.sort((a, b) {
+          final aIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == a.id || p.id == a.id);
+          final bIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == b.id || p.id == b.id);
+          if (aIndex == -1 && bIndex == -1) return 0;
+          if (aIndex == -1) return 1;
+          if (bIndex == -1) return -1;
+          return aIndex.compareTo(bIndex);
+        });
+
         return [
           if (_vm.playlistItems.isNotEmpty)
             _ModernTab(
@@ -805,11 +834,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               },
             ),
           if (moviesList.isNotEmpty)
-            _ModernTab(l10n.movies, (_, _) => _itemGrid(moviesList)),
+            _ModernTab(l10n.movies, (context, item) => _moviesTab(context, moviesList, focusNode: _moviesFirstFocusNode)),
           if (seriesList.isNotEmpty)
-            _ModernTab(l10n.series, (_, _) => _itemGrid(seriesList)),
-          if (hasCast) cast,
-          if (hasCrew) crew,
+            _ModernTab(l10n.series, (context, item) => _seriesTab(context, seriesList, focusNode: _seriesFirstFocusNode)),
+          if (hasCast) _ModernTab(l10n.cast, _boxSetCastTab),
+          if (hasCrew) _ModernTab(l10n.crewSection, _boxSetCrewTab),
           if (hasStudios) studios,
         ];
       default:
@@ -830,6 +859,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final textTheme = Theme.of(context).textTheme;
     final counts = _episodeCountsBySeason();
     final showPosterUrl = _imageUrl(item);
+    // Determine which season contains the "next up" episode, mirroring the
+    // episode-card logic: prefer _vm.nextUp.seasonId, fall back to the first
+    // unplayed episode's seasonId so the cyan border always renders correctly.
+    final nextUpSeasonId = _vm.nextUp?.seasonId ??
+        _vm.seriesEpisodes.firstWhereOrNull((e) => !e.isPlayed)?.seasonId;
     final cards = [
       for (var i = 0; i < _vm.seasons.length; i++)
         SeasonCard(
@@ -840,6 +874,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           imageUrl: _imageUrl(_vm.seasons[i]) ?? showPosterUrl,
           isFallbackImage: _imageUrl(_vm.seasons[i]) == null,
           landscape: _landscape,
+          isNextUp: _vm.seasons[i].id == nextUpSeasonId,
           onNavigateUp: _focusSelectedTab,
           onNavigateRight: i == _vm.seasons.length - 1 ? () {} : null,
           focusNode: i == 0 ? _seasonsFirstFocusNode : null,
@@ -935,6 +970,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget _episodeListTab(BuildContext context, AggregatedItem item) {
+    // For Season pages _vm.nextUp is null (the API call uses seriesId which
+    // on a Season item resolves to nothing). Fall back to the first unplayed
+    // episode so the cyan "next up" border still renders correctly.
+    final nextUpId = _vm.nextUp?.id ??
+        _vm.episodes.firstWhereOrNull((e) => !e.isPlayed)?.id;
+
     return Focus(
       canRequestFocus: false,
       onFocusChange: (focused) {
@@ -954,7 +995,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 episode: _vm.episodes[i],
                 imageApi: _vm.imageApi,
                 onChanged: () => _vm.load(),
-                isActive: _vm.episodes[i].id == _vm.nextUp?.id,
+                isActive: _vm.episodes[i].id == nextUpId,
                 focusNode: i == 0 ? _episodesFirstFocusNode : null,
                 onKeyEvent: i == 0
                     ? (node, event) {
@@ -1233,6 +1274,282 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
+  bool _initializedBoxSetCastExpanded = false;
+  bool _initializedBoxSetCrewExpanded = false;
+  final Set<String> _expandedCollectionCastItems = {};
+  final Set<String> _expandedCollectionCrewItems = {};
+
+  Widget _boxSetCastTab(BuildContext context, AggregatedItem item) {
+    final sortedItems = [..._vm.collectionItems];
+    // Sort items by their order in playlistItems (playlist order)
+    sortedItems.sort((a, b) {
+      final aIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == a.id || p.id == a.id);
+      final bIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == b.id || p.id == b.id);
+      if (aIndex == -1 && bIndex == -1) return 0;
+      if (aIndex == -1) return 1;
+      if (bIndex == -1) return -1;
+      return aIndex.compareTo(bIndex);
+    });
+
+    if (!_initializedBoxSetCastExpanded && sortedItems.isNotEmpty) {
+      _initializedBoxSetCastExpanded = true;
+      _expandedCollectionCastItems.add(sortedItems.first.id);
+    }
+
+    final children = <Widget>[];
+    for (var i = 0; i < sortedItems.length; i++) {
+      final childItem = sortedItems[i];
+      final people = childItem.rawData['People'] as List?;
+      if (people == null || people.isEmpty) continue;
+      final childActors = people.cast<Map<String, dynamic>>().where((p) {
+        final type = p['Type'] as String?;
+        return type == 'Actor' || type == 'GuestStar';
+      }).toList();
+      if (childActors.isEmpty) continue;
+
+      final isExpanded = _expandedCollectionCastItems.contains(childItem.id);
+      final isFirst = children.isEmpty;
+
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: FocusableWrapper(
+            onNavigateUp: isFirst ? _focusSelectedTab : null,
+            focusNode: isFirst ? _castFirstFocusNode : null,
+            onSelect: () {
+              setState(() {
+                if (_expandedCollectionCastItems.contains(childItem.id)) {
+                  _expandedCollectionCastItems.remove(childItem.id);
+                } else {
+                  _expandedCollectionCastItems.add(childItem.id);
+                }
+              });
+            },
+            borderRadius: 8,
+            suppressFocusGlow: true,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Row(
+                children: [
+                  Icon(
+                    isExpanded ? Icons.expand_more : Icons.chevron_right,
+                    color: Colors.white70,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    childItem.name,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                        ),
+                  ),
+                  const SizedBox(width: 10),
+                  Text(
+                    '(${childActors.length})',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.white38,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      if (isExpanded) {
+        children.add(
+          Padding(
+            padding: const EdgeInsets.only(left: 12, bottom: 12),
+            child: SizedBox(
+              height: 200,
+              child: DetailCastRow(
+                people: childActors,
+                imageApi: _vm.imageApi,
+                serverId: childItem.serverId,
+                onNavigateUp: _focusSelectedTab,
+              ),
+            ),
+          ),
+        );
+      }
+    }
+
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: children,
+      ),
+    );
+  }
+
+  Widget _boxSetCrewTab(BuildContext context, AggregatedItem item) {
+    final l10n = AppLocalizations.of(context);
+    final sortedItems = [..._vm.collectionItems];
+    // Sort items by their order in playlistItems (playlist order)
+    sortedItems.sort((a, b) {
+      final aIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == a.id || p.id == a.id);
+      final bIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == b.id || p.id == b.id);
+      if (aIndex == -1 && bIndex == -1) return 0;
+      if (aIndex == -1) return 1;
+      if (bIndex == -1) return -1;
+      return aIndex.compareTo(bIndex);
+    });
+
+    if (!_initializedBoxSetCrewExpanded && sortedItems.isNotEmpty) {
+      _initializedBoxSetCrewExpanded = true;
+      _expandedCollectionCrewItems.add(sortedItems.first.id);
+    }
+
+    final children = <Widget>[];
+    for (var i = 0; i < sortedItems.length; i++) {
+      final childItem = sortedItems[i];
+      final people = childItem.rawData['People'] as List?;
+      if (people == null || people.isEmpty) continue;
+      final childCrewRaw = people.cast<Map<String, dynamic>>().where((p) {
+        final type = p['Type'] as String?;
+        return type == 'Director' || type == 'Writer';
+      }).toList();
+      if (childCrewRaw.isEmpty) continue;
+
+      final Map<String, Map<String, dynamic>> merged = {};
+      for (final person in childCrewRaw) {
+        final id = person['Id']?.toString() ?? person['Name']?.toString() ?? '';
+        if (id.isEmpty) continue;
+        final type = person['Type'] as String?;
+        final roleStr = person['Role']?.toString().trim();
+        final role = (roleStr != null && roleStr.isNotEmpty)
+            ? roleStr
+            : (type == 'Director' ? l10n.director : l10n.writer);
+        if (merged.containsKey(id)) {
+          final roles = merged[id]!['Roles'] as Set<String>;
+          roles.add(role);
+        } else {
+          merged[id] = {
+            ...person,
+            'Roles': <String>{role},
+          };
+        }
+      }
+      final childCrew = merged.values.map((person) {
+        final roles = person['Roles'] as Set<String>;
+        final normalizedRoles = roles.map((r) {
+          final trimmed = r.trim();
+          if (trimmed.isEmpty) return '';
+          return trimmed.split(RegExp(r'[;,]'))
+              .map((s) => s.trim())
+              .where((s) => s.isNotEmpty)
+              .map((s) {
+                if (s == s.toUpperCase() && s.length > 1) {
+                  return s[0] + s.substring(1).toLowerCase();
+                }
+                return s;
+              })
+              .join('\n');
+        }).expand((r) => r.split('\n')).where((r) => r.isNotEmpty).toSet();
+
+        return {
+          ...person,
+          'Role': normalizedRoles.join('\n'),
+        };
+      }).toList();
+
+      if (childCrew.isEmpty) continue;
+
+      final isExpanded = _expandedCollectionCrewItems.contains(childItem.id);
+      final isFirst = children.isEmpty;
+
+      children.add(
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: FocusableWrapper(
+            onNavigateUp: isFirst ? _focusSelectedTab : null,
+            focusNode: isFirst ? _crewFirstFocusNode : null,
+            onSelect: () {
+              setState(() {
+                if (_expandedCollectionCrewItems.contains(childItem.id)) {
+                  _expandedCollectionCrewItems.remove(childItem.id);
+                } else {
+                  _expandedCollectionCrewItems.add(childItem.id);
+                }
+              });
+            },
+            borderRadius: 8,
+            suppressFocusGlow: true,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Row(
+                children: [
+                  Icon(
+                    isExpanded ? Icons.expand_more : Icons.chevron_right,
+                    color: Colors.white70,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    childItem.name,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                        ),
+                  ),
+                  const SizedBox(width: 10),
+                  Text(
+                    '(${childCrew.length})',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.white38,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      if (isExpanded) {
+        children.add(
+          Padding(
+            padding: const EdgeInsets.only(left: 12, bottom: 12),
+            child: SizedBox(
+              height: 200,
+              child: DetailCastRow(
+                people: childCrew,
+                imageApi: _vm.imageApi,
+                serverId: childItem.serverId,
+                onNavigateUp: _focusSelectedTab,
+              ),
+            ),
+          ),
+        );
+      }
+    }
+
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: children,
+      ),
+    );
+  }
+
   Widget _buildStudioFallback(BuildContext context, String name) {
     return Container(
       decoration: BoxDecoration(
@@ -1354,7 +1671,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  Widget _moviesTab(BuildContext context, List<AggregatedItem> movies) {
+  Widget _moviesTab(BuildContext context, List<AggregatedItem> movies, {FocusNode? focusNode}) {
     return Focus(
       canRequestFocus: false,
       onFocusChange: (focused) {
@@ -1368,7 +1685,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         items: movies,
         imageApi: _vm.imageApi,
         prefs: widget.prefs,
-        firstFocusNode: _personMoviesFirstFocusNode,
+        firstFocusNode: focusNode ?? _personMoviesFirstFocusNode,
         onItemKeyEvent: (index, event) {
           if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
             _focusSelectedTab();
@@ -1380,7 +1697,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  Widget _seriesTab(BuildContext context, List<AggregatedItem> series) {
+  Widget _seriesTab(BuildContext context, List<AggregatedItem> series, {FocusNode? focusNode}) {
     return Focus(
       canRequestFocus: false,
       onFocusChange: (focused) {
@@ -1394,7 +1711,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         items: series,
         imageApi: _vm.imageApi,
         prefs: widget.prefs,
-        firstFocusNode: _personSeriesFirstFocusNode,
+        firstFocusNode: focusNode ?? _personSeriesFirstFocusNode,
         onItemKeyEvent: (index, event) {
           if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
             _focusSelectedTab();
@@ -1981,7 +2298,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     };
   }
 
-  Widget _itemGrid(List<AggregatedItem> items, {double aspectRatio = 2 / 3}) {
+  Widget _itemGrid(List<AggregatedItem> items, {double aspectRatio = 2 / 3, FocusNode? focusNode}) {
     return LayoutBuilder(
       builder: (context, constraints) {
         const spacing = 12.0;
@@ -2028,7 +2345,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               final entry = items[i];
               return MediaCard(
                 title: entry.name,
-                focusNode: i == 0 ? _gridFirstFocusNode : null,
+                focusNode: i == 0 ? (focusNode ?? _gridFirstFocusNode) : null,
                 imageUrl: _imageUrl(entry),
                 width: double.infinity,
                 aspectRatio: cardRatio,
@@ -2291,17 +2608,27 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   /// the Play pill (wider for "Resume from S#:E#" labels) plus More (~62); each
   /// circular button is ~62 wide.
   int? _actionButtonCap(BuildContext context, AggregatedItem item) {
-    if (item.type == 'Series' || item.type == 'Season' || item.type == 'Episode') {
+    if (item.type == 'Movie' || item.type == 'Episode') {
+      return 15;
+    }
+    if (item.type == 'Series') {
       final hasUpNext = _vm.nextUp != null;
       if (_landscape && hasUpNext) {
         return 4;
       }
       return null;
     }
+    if (item.type == 'Season') {
+      // Always use two-column layout for Seasons so Favorite folds into More
+      return 5;
+    }
+    if (item.type == 'BoxSet') {
+      return null;
+    }
     if (!_landscape) return null;
     final hasUpNext = _buildUpNext(context, item) != null;
     final heroWidth = hasUpNext
-        ? (MediaQuery.sizeOf(context).width * 0.45).clamp(360.0, 620.0)
+        ? (MediaQuery.sizeOf(context).width * 0.65).clamp(450.0, 900.0)
         : (MediaQuery.sizeOf(context).width * 0.75).clamp(450.0, 960.0);
     final pillWidth = switch (item.type) {
       'Series' || 'Season' || 'Episode' => 300.0,
@@ -2319,8 +2646,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final logoTag = item.logoImageTag ?? (isEpisode ? item.seriesLogoImageTag : null);
     final logoId = logoTag != null ? (item.logoImageTag != null ? item.id : item.seriesId) : null;
     final overview = item.overview?.trim();
-    final hideTitleAndLogo = _landscape && _vm.nextUp != null;
-    final hasUpNext = _landscape && _vm.nextUp != null;
+    final hideTitleAndLogo = _landscape && _buildUpNext(context, item) != null;
+    final hasUpNext = _landscape && _buildUpNext(context, item) != null;
     final showRatings = isEpisode
         ? false
         : (_vm.ratings.isNotEmpty || item.communityRating != null || item.criticRating != null);
@@ -2393,7 +2720,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             const SizedBox(height: 24),
             ConstrainedBox(
               constraints: BoxConstraints(
-                maxWidth: _landscape ? 670.0 : double.infinity,
+                maxWidth: _landscape ? 850.0 : double.infinity,
               ),
               child: ExpandableBiography(
                 text: overview,
@@ -2718,20 +3045,82 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ] else if (logoTag != null && logoId != null) ...[
             Padding(
               padding: const EdgeInsets.only(bottom: 4),
-              child: LogoView(
-                imageUrl: _vm.imageApi
-                    .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
-                maxHeight: (_landscape ? 90 : 64) * logoScaleFactor,
-                maxWidth: (_landscape ? 360 : 260) * logoScaleFactor,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  LogoView(
+                    imageUrl: _vm.imageApi
+                        .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
+                    maxHeight: (_landscape ? 75 : 64) * logoScaleFactor,
+                    maxWidth: (_landscape ? 300 : 260) * logoScaleFactor,
+                  ),
+                  if (item.mediaSources.length > 1) ...[
+                    const SizedBox(width: 16),
+                    () {
+                      final selectedSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
+                      final versionName = selectedSource?['Name'] as String? ?? 'Default';
+                      return Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: AppColorScheme.accent.withValues(alpha: 0.15),
+                          borderRadius: BorderRadius.circular(4),
+                          border: Border.all(
+                            color: AppColorScheme.accent.withValues(alpha: 0.4),
+                            width: 1,
+                          ),
+                        ),
+                        child: Text(
+                          versionName,
+                          style: textTheme.bodySmall?.copyWith(
+                            color: AppColorScheme.accent,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      );
+                    }(),
+                  ],
+                ],
               ),
             ),
           ] else ...[
-            Text(
-              item.name,
-              style: (_landscape
-                      ? textTheme.displaySmall
-                      : textTheme.headlineMedium)
-                  ?.copyWith(fontWeight: FontWeight.w700),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  item.name,
+                  style: (_landscape
+                          ? textTheme.displaySmall
+                          : textTheme.headlineMedium)
+                      ?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                if (item.mediaSources.length > 1) ...[
+                  const SizedBox(width: 16),
+                  () {
+                    final selectedSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
+                    final versionName = selectedSource?['Name'] as String? ?? 'Default';
+                    return Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: AppColorScheme.accent.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(4),
+                        border: Border.all(
+                          color: AppColorScheme.accent.withValues(alpha: 0.4),
+                          width: 1,
+                        ),
+                      ),
+                      child: Text(
+                        versionName,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: AppColorScheme.accent,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    );
+                  }(),
+                ],
+              ],
             ),
           ],
           const SizedBox(height: 6),
@@ -2752,9 +3141,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           const SizedBox(height: 6),
         ],
         if (item.tagline != null && item.tagline!.trim().isNotEmpty) ...[
-          const SizedBox(height: 8),
+          if (!hideTitleAndLogo)
+            const SizedBox(height: 8),
           ConstrainedBox(
-            constraints: BoxConstraints(maxWidth: _landscape ? 580 : double.infinity),
+            constraints: BoxConstraints(maxWidth: _landscape ? 800 : double.infinity),
             child: Text(
               item.tagline!.trim(),
               style: textTheme.titleSmall?.copyWith(
@@ -2765,10 +3155,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ),
         ],
         if (overview != null && overview.isNotEmpty) ...[
-          const SizedBox(height: 8),
+          if (!hideTitleAndLogo || (item.tagline != null && item.tagline!.trim().isNotEmpty))
+            const SizedBox(height: 8),
           ConstrainedBox(
             constraints: BoxConstraints(
-              maxWidth: _landscape ? 580 : double.infinity,
+              maxWidth: _landscape ? 800 : double.infinity,
             ),
             child: ExpandableBiography(
               text: overview,
@@ -2785,6 +3176,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   NavigationLayout.focusNavbarNotifier.value?.call();
                 }
               },
+              onArrowRight: hasUpNext
+                  ? () => _upNextFocusNode.requestFocus()
+                  : null,
               onCollapse: widget.onCollapseBiography,
               style: textTheme.bodyMedium?.copyWith(
                 height: 1.45,
@@ -2823,6 +3217,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             maxVisibleButtonsOverride: _actionButtonCap(context, item),
             onArrowRightAtEnd: _landscape ? _focusRightOfActions : null,
             actionRowRightFocusNode: _actionRowRightFocusNode,
+            extraFirstFocusNode: _extraFirstFocusNode,
             onFocusExtra: (_) {},
             actionsExpanded: widget.actionsExpanded,
             onActionsExpandedChanged: widget.onActionsExpandedChanged,
@@ -2963,6 +3358,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget? _buildUpNext(BuildContext context, AggregatedItem item) {
     const supported = {'Series', 'Season', 'BoxSet'};
     if (!supported.contains(item.type)) return null;
+    final isBoxSet = item.type == 'BoxSet';
 
     final l10n = AppLocalizations.of(context);
     AggregatedItem? episode;
@@ -2990,6 +3386,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       }
     } else {
       episode = _vm.nextUp;
+      if (episode == null && _vm.seriesEpisodes.isNotEmpty) {
+        try {
+          episode = _vm.seriesEpisodes.firstWhere((e) => !e.isPlayed);
+        } catch (_) {
+          episode = _vm.seriesEpisodes.first;
+          final s = episode.parentIndexNumber ?? 1;
+          final e = episode.indexNumber ?? 1;
+          customLabel = 'Rewatch S$s:E$e';
+        }
+      }
     }
 
     if (episode == null) return null;
@@ -2998,17 +3404,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final e = episode.indexNumber;
     final code = (s != null && e != null) ? 'S$s:E$e' : null;
     final title = code != null ? '$code - ${episode.name}' : episode.name;
+    final combinedLabel = customLabel != null
+        ? '$customLabel - ${episode.name}'
+        : '${l10n.nextUp} - $title';
     final progress = (episode.playedPercentage ?? 0) / 100.0;
     return UpNextCard(
-      label: customLabel ?? l10n.nextUp,
-      title: title,
+      label: combinedLabel,
+      title: '',
       description: episode.overview?.trim(),
       imageUrl: _imageUrl(episode),
       progress: progress,
       remainingLabel: _remainingLabel(episode, l10n),
       focusNode: _upNextFocusNode,
+      minimal: isBoxSet,
+      width: isBoxSet ? 200.0 : double.infinity,
       onNavigateLeft: () {
-        if (_actionRowRightFocusNode.context != null && _actionRowRightFocusNode.canRequestFocus) {
+        if (_overviewFocusNode.context != null && _overviewFocusNode.canRequestFocus) {
+          _overviewFocusNode.requestFocus();
+        } else if (_actionRowRightFocusNode.context != null && _actionRowRightFocusNode.canRequestFocus) {
           _actionRowRightFocusNode.requestFocus();
         } else {
           widget.initialFocusNode?.requestFocus();
@@ -3255,6 +3668,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       onSelect: _selectTab,
       focusNodeFor: _tabNode,
       onExitLeft: () {
+        final isTvSection = item.type == 'Season' || item.type == 'Series';
+        if (isTvSection && widget.actionsExpanded) {
+          // If More row is open, go to first extra button (Watched/Unwatched)
+          _extraFirstFocusNode.requestFocus();
+          return;
+        }
         final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
         if (navbarPosition == NavbarPosition.left) {
           final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
@@ -3263,6 +3682,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             return;
           }
         }
+        // Default: focus Play/Resume button
         widget.initialFocusNode?.requestFocus();
       },
       onExitUp: () => widget.initialFocusNode?.requestFocus(),
@@ -3305,24 +3725,87 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final showRatings = isEpisode
         ? false
         : (_vm.ratings.isNotEmpty || item.communityRating != null || item.criticRating != null);
-    final Widget? aboveHeroWidget = (_landscape && _vm.nextUp != null)
+
+    final Widget? aboveHeroWidget = (_landscape && upNext != null)
         ? Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
               const SizedBox(height: 24),
               if (logoTag != null && logoId != null) ...[
-                LogoView(
-                  imageUrl: _vm.imageApi
-                      .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
-                  maxHeight: 90 * logoScaleFactor,
-                  maxWidth: 360 * logoScaleFactor,
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    LogoView(
+                      imageUrl: _vm.imageApi
+                          .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
+                      maxHeight: 75 * logoScaleFactor,
+                      maxWidth: 300 * logoScaleFactor,
+                    ),
+                    if (item.mediaSources.length > 1) ...[
+                      const SizedBox(width: 16),
+                      () {
+                        final selectedSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
+                        final versionName = selectedSource?['Name'] as String? ?? 'Default';
+                        return Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: AppColorScheme.accent.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(4),
+                            border: Border.all(
+                              color: AppColorScheme.accent.withValues(alpha: 0.4),
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            versionName,
+                            style: textTheme.bodySmall?.copyWith(
+                              color: AppColorScheme.accent,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        );
+                      }(),
+                    ],
+                  ],
                 ),
                 const SizedBox(height: 6),
               ] else ...[
-                Text(
-                  item.name,
-                  style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      item.name,
+                      style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    if (item.mediaSources.length > 1) ...[
+                      const SizedBox(width: 16),
+                      () {
+                        final selectedSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
+                        final versionName = selectedSource?['Name'] as String? ?? 'Default';
+                        return Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: AppColorScheme.accent.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(4),
+                            border: Border.all(
+                              color: AppColorScheme.accent.withValues(alpha: 0.4),
+                              width: 1,
+                            ),
+                          ),
+                          child: Text(
+                            versionName,
+                            style: textTheme.bodySmall?.copyWith(
+                              color: AppColorScheme.accent,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        );
+                      }(),
+                    ],
+                  ],
                 ),
                 const SizedBox(height: 6),
               ],
@@ -3354,6 +3837,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             topInset: topInset,
             scrollController: _scrollController,
             aboveHero: aboveHeroWidget,
+            isBoxSet: item.type == 'BoxSet',
           )
         : ModernPortraitLayout(
             backdrop: backdrop,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -827,12 +827,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                                 FocusableToolbarButton(
                                   icon: Icons.sort_rounded,
                                   focusNode: _collectionSortFocusNode,
-                                  tooltip: 'Reset Sort',
+                                  tooltip: l10n.resetSort,
                                   onTap: () => _showCollectionSortDialog(context),
                                 ),
                                 const SizedBox(width: 12),
                                 Text(
-                                  'Sort: ${_getCollectionSortLabel(_vm.collectionSort)}',
+                                  'Sort: ${_getCollectionSortLabel(_vm.collectionSort, l10n)}',
                                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                         color: Colors.white70,
                                         fontWeight: FontWeight.bold,
@@ -2098,6 +2098,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     Map<String, dynamic> mediaSource,
   ) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final textTheme = theme.textTheme;
 
     // File name and Size
@@ -2179,7 +2180,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'File Information',
+          l10n.fileInformation,
           style: textTheme.titleMedium?.copyWith(
             color: Colors.white,
             fontWeight: FontWeight.bold,
@@ -2208,7 +2209,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               ),
               const SizedBox(height: 4),
               Text(
-                'Size: $formattedSize  •  Format: $container',
+                l10n.fileSizeFormat(formattedSize, container),
                 style: textTheme.bodySmall?.copyWith(color: Colors.white70),
               ),
             ],
@@ -2232,7 +2233,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
         if (audioStreams.isNotEmpty) ...[
           _buildInfoRow(
-            'Audio',
+            l10n.audio,
             Text.rich(
               TextSpan(
                 children: [
@@ -2249,7 +2250,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                         audioStreams.firstWhere((s) => s['IsDefault'] == true, orElse: () => audioStreams.first)['Index'] as int?;
                     final title = a['DisplayTitle'] ?? a['Codec']?.toString().toUpperCase();
                     final lang = formatLang(a['Language']);
-                    final isDefault = a['IsDefault'] == true ? ' [Default]' : '';
+                    final isDefault = a['IsDefault'] == true ? ' [${l10n.defaultLabel}]' : '';
                     final isSelected = a['Index'] == activeAudioIndex;
 
                     return [
@@ -2286,7 +2287,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                     child: Text(
-                      _audioExpanded ? 'Show Less' : 'Show All (${audioStreams.length}) Audio Tracks',
+                      _audioExpanded ? l10n.showLess : l10n.showAllAudioTracks(audioStreams.length),
                       style: TextStyle(
                         color: AppColorScheme.accent,
                         fontWeight: FontWeight.bold,
@@ -2303,7 +2304,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
         if (subtitleStreams.isNotEmpty) ...[
           _buildInfoRow(
-            'Subtitles',
+            l10n.subtitles,
             Text.rich(
               TextSpan(
                 children: [
@@ -2320,8 +2321,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                         subtitleStreams.firstWhere((s) => s['IsDefault'] == true, orElse: () => subtitleStreams.first)['Index'] as int?;
                     final title = s['DisplayTitle'] ?? s['Codec']?.toString().toUpperCase();
                     final lang = formatLang(s['Language']);
-                    final isDefault = s['IsDefault'] == true ? ' [Default]' : '';
-                    final isForced = s['IsForced'] == true ? ' [Forced]' : '';
+                    final isDefault = s['IsDefault'] == true ? ' [${l10n.defaultLabel}]' : '';
+                    final isForced = s['IsForced'] == true ? ' [${l10n.forced}]' : '';
                     final isSelected = s['Index'] == activeSubtitleIndex;
 
                     return [
@@ -2358,7 +2359,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                     child: Text(
-                      _subtitlesExpanded ? 'Show Less' : 'Show All (${subtitleStreams.length}) Subtitle Tracks',
+                      _subtitlesExpanded ? l10n.showLess : l10n.showAllSubtitleTracks(subtitleStreams.length),
                       style: TextStyle(
                         color: AppColorScheme.accent,
                         fontWeight: FontWeight.bold,
@@ -2401,6 +2402,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget _buildDirectPlaySection(BuildContext context, AggregatedItem item, TextTheme textTheme) {
+    final l10n = AppLocalizations.of(context);
     if (_loadingPlaybackInfo) {
       return Row(
         children: [
@@ -2411,7 +2413,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ),
           const SizedBox(width: 8),
           Text(
-            'Checking Direct Play capability...',
+            l10n.checkingDirectPlay,
             style: textTheme.bodySmall?.copyWith(color: Colors.white54),
           ),
         ],
@@ -2440,14 +2442,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         Row(
           children: [
             Text(
-              'Direct Play Capability: ',
+              l10n.directPlayCapabilityLabel,
               style: textTheme.bodyMedium?.copyWith(
                 color: Colors.white54,
                 fontWeight: FontWeight.w600,
               ),
             ),
             Text(
-              canDirectPlay ? 'Yes' : 'No',
+              canDirectPlay ? l10n.yes : l10n.no,
               style: textTheme.bodyMedium?.copyWith(
                 color: canDirectPlay ? const Color(0xFF2E7D32) : const Color(0xFFD32F2F),
                 fontWeight: FontWeight.bold,
@@ -2462,7 +2464,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: reasons.map((r) {
-                final readable = _formatTranscodeReason(r);
+                final readable = _formatTranscodeReason(r, l10n);
                 return Padding(
                   padding: const EdgeInsets.only(top: 2),
                   child: Text(
@@ -2480,22 +2482,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  String _formatTranscodeReason(String reason) {
+  String _formatTranscodeReason(String reason, AppLocalizations l10n) {
     return switch (reason) {
-      'ContainerNotSupported' => 'Container format is not supported by the player.',
-      'VideoCodecNotSupported' => 'Video codec is not supported.',
-      'AudioCodecNotSupported' => 'Audio codec is not supported.',
-      'SubtitleCodecNotSupported' => 'Subtitle format is not supported (requires burning).',
-      'AudioProfileNotSupported' => 'Audio profile is not supported.',
-      'VideoProfileNotSupported' => 'Video profile is not supported.',
-      'VideoLevelNotSupported' => 'Video level is not supported.',
-      'VideoResolutionNotSupported' => 'Video resolution is not supported by this device.',
-      'VideoBitDepthNotSupported' => 'Video bit depth is not supported.',
-      'VideoFramerateNotSupported' => 'Video framerate is not supported.',
-      'ContainerBitrateExceedsLimit' => 'File bitrate exceeds player streaming limit.',
-      'VideoBitrateExceedsLimit' => 'Video bitrate exceeds streaming limit.',
-      'AudioBitrateExceedsLimit' => 'Audio bitrate exceeds streaming limit.',
-      'AudioChannelsNotSupported' => 'Number of audio channels is not supported.',
+      'ContainerNotSupported' => l10n.transcodeContainerNotSupported,
+      'VideoCodecNotSupported' => l10n.transcodeVideoCodecNotSupported,
+      'AudioCodecNotSupported' => l10n.transcodeAudioCodecNotSupported,
+      'SubtitleCodecNotSupported' => l10n.transcodeSubtitleCodecNotSupported,
+      'AudioProfileNotSupported' => l10n.transcodeAudioProfileNotSupported,
+      'VideoProfileNotSupported' => l10n.transcodeVideoProfileNotSupported,
+      'VideoLevelNotSupported' => l10n.transcodeVideoLevelNotSupported,
+      'VideoResolutionNotSupported' => l10n.transcodeVideoResolutionNotSupported,
+      'VideoBitDepthNotSupported' => l10n.transcodeVideoBitDepthNotSupported,
+      'VideoFramerateNotSupported' => l10n.transcodeVideoFramerateNotSupported,
+      'ContainerBitrateExceedsLimit' => l10n.transcodeContainerBitrateExceedsLimit,
+      'VideoBitrateExceedsLimit' => l10n.transcodeVideoBitrateExceedsLimit,
+      'AudioBitrateExceedsLimit' => l10n.transcodeAudioBitrateExceedsLimit,
+      'AudioChannelsNotSupported' => l10n.transcodeAudioChannelsNotSupported,
       _ => reason,
     };
   }
@@ -2711,23 +2713,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     context.push(isAudio ? Destinations.audioPlayer : Destinations.videoPlayer);
   }
 
-  String _getCollectionSortLabel(CollectionSortOption option) {
+  String _getCollectionSortLabel(CollectionSortOption option, AppLocalizations l10n) {
     return switch (option) {
-      CollectionSortOption.alphabetical => 'Alphabetical',
-      CollectionSortOption.releaseAscending => 'Release Order (Ascending)',
-      CollectionSortOption.releaseDescending => 'Release Order (Descending)',
-      CollectionSortOption.custom => 'Custom (Drag-and-Drop)',
+      CollectionSortOption.alphabetical => l10n.sortAlphabetical,
+      CollectionSortOption.releaseAscending => l10n.sortReleaseAscending,
+      CollectionSortOption.releaseDescending => l10n.sortReleaseDescending,
+      CollectionSortOption.custom => l10n.sortCustomDragDrop,
     };
   }
 
   void _showCollectionSortDialog(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     showDialog(
       context: context,
       builder: (context) {
         return AlertDialog(
           backgroundColor: const Color(0xFF1E1E24),
           title: Text(
-            'Playlist Sort Options',
+            l10n.playlistSortOptions,
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
                   color: Colors.white,
                   fontWeight: FontWeight.bold,
@@ -2777,7 +2780,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                             ),
                             const SizedBox(width: 16),
                             Text(
-                              _getCollectionSortLabel(option),
+                              _getCollectionSortLabel(option, l10n),
                               style: Theme.of(context)
                                   .textTheme
                                   .bodyLarge
@@ -3572,7 +3575,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final seasonAllUnwatched = _vm.episodes.every((e) => !e.isPlayed && (e.playedPercentage == null || e.playedPercentage == 0));
       if (seasonAllWatched) {
         episode = _vm.episodes[0];
-        customLabel = 'Rewatch S${item.indexNumber}:E1';
+        customLabel = l10n.rewatchSeasonEpisode(item.indexNumber ?? 0, 1);
       } else if (!seasonAllUnwatched) {
         try {
           episode = _vm.episodes.firstWhere((e) => !e.isPlayed);
@@ -3583,7 +3586,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       if (episode != null) {
         final playedAll = _vm.playlistItems.every((item) => item.rawData['UserData']?['Played'] == true);
         if (playedAll) {
-          customLabel = 'Rewatch Playlist';
+          customLabel = l10n.rewatchPlaylist;
         }
       }
     } else {
@@ -3595,7 +3598,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           episode = _vm.seriesEpisodes.first;
           final s = episode.parentIndexNumber ?? 1;
           final e = episode.indexNumber ?? 1;
-          customLabel = 'Rewatch S$s:E$e';
+          customLabel = l10n.rewatchSeasonEpisode(s, e);
         }
       }
     }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -602,44 +602,42 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       if (tabIndex >= 0 && tabIndex < tabs.length) {
         final label = tabs[tabIndex].label;
         if (label == l10n.cast) {
-          if (_castFirstFocusNode.canRequestFocus) _castFirstFocusNode.requestFocus();
+          _castFirstFocusNode.requestFocus();
         } else if (label == l10n.crewSection) {
-          if (_crewFirstFocusNode.canRequestFocus) _crewFirstFocusNode.requestFocus();
+          _crewFirstFocusNode.requestFocus();
         } else if (label == l10n.studios) {
-          if (_studiosFirstFocusNode.canRequestFocus) _studiosFirstFocusNode.requestFocus();
+          _studiosFirstFocusNode.requestFocus();
         } else if (label == l10n.chapters) {
-          if (_chaptersFirstFocusNode.canRequestFocus) _chaptersFirstFocusNode.requestFocus();
+          _chaptersFirstFocusNode.requestFocus();
         } else if (label == l10n.details) {
-          if (_detailsTabFocusNode.canRequestFocus) _detailsTabFocusNode.requestFocus();
+          _detailsTabFocusNode.requestFocus();
         } else if (label == l10n.similar) {
-          if (_similarFirstFocusNode.canRequestFocus) _similarFirstFocusNode.requestFocus();
+          _similarFirstFocusNode.requestFocus();
         } else if (label == l10n.seasons) {
-          if (_seasonsFirstFocusNode.canRequestFocus) _seasonsFirstFocusNode.requestFocus();
+          _seasonsFirstFocusNode.requestFocus();
         } else if (label == l10n.episodes) {
-          if (_episodesFirstFocusNode.canRequestFocus) _episodesFirstFocusNode.requestFocus();
+          _episodesFirstFocusNode.requestFocus();
         } else if (label == l10n.movies) {
           if (_vm.item?.type == 'BoxSet') {
-            if (_moviesFirstFocusNode.canRequestFocus) _moviesFirstFocusNode.requestFocus();
+            _moviesFirstFocusNode.requestFocus();
           } else {
-            if (_personMoviesFirstFocusNode.canRequestFocus) _personMoviesFirstFocusNode.requestFocus();
+            _personMoviesFirstFocusNode.requestFocus();
           }
         } else if (label == l10n.series) {
           if (_vm.item?.type == 'BoxSet') {
-            if (_seriesFirstFocusNode.canRequestFocus) _seriesFirstFocusNode.requestFocus();
+            _seriesFirstFocusNode.requestFocus();
           } else {
-            if (_personSeriesFirstFocusNode.canRequestFocus) _personSeriesFirstFocusNode.requestFocus();
+            _personSeriesFirstFocusNode.requestFocus();
           }
         } else if (label == l10n.appearancesSeerr) {
-          if (_personSeerrAppearancesFirstFocusNode.canRequestFocus) _personSeerrAppearancesFirstFocusNode.requestFocus();
+          _personSeerrAppearancesFirstFocusNode.requestFocus();
         } else if (label == l10n.crewContributionsSeerr) {
-          if (_personSeerrCrewCreditsFirstFocusNode.canRequestFocus) _personSeerrCrewCreditsFirstFocusNode.requestFocus();
+          _personSeerrCrewCreditsFirstFocusNode.requestFocus();
         } else if (label == l10n.albums || label == l10n.items || label == l10n.appearances) {
-          if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
+          _gridFirstFocusNode.requestFocus();
         } else if (label == l10n.playlist) {
           if (_vm.item?.type == 'BoxSet' && _vm.playlistItems.isNotEmpty) {
-            if (_collectionSortFocusNode.canRequestFocus) {
-              _collectionSortFocusNode.requestFocus();
-            }
+            _collectionSortFocusNode.requestFocus();
           }
         }
       }
@@ -1834,8 +1832,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       if (_vm.nextUp != null) {
         return _vm.nextUp;
       }
-      if (_vm.episodes.isNotEmpty) {
-        return _vm.episodes.first;
+      if (_vm.seriesEpisodes.isNotEmpty) {
+        try {
+          return _vm.seriesEpisodes.firstWhere((e) => !e.isPlayed);
+        } catch (_) {
+          return _vm.seriesEpisodes.first;
+        }
       }
     } else if (item.type == 'Season') {
       if (_vm.episodes.isNotEmpty) {
@@ -3961,7 +3963,7 @@ class _DetailsContainerState extends State<_DetailsContainer> with FocusStateMix
       },
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
-        height: 460,
+        constraints: const BoxConstraints(maxHeight: 400),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(12),
           border: Border.all(

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -71,6 +71,7 @@ class ModernDetailContent extends StatefulWidget {
   final ValueChanged<bool>? onToggleNavbar;
   final bool actionsExpanded;
   final ValueChanged<bool> onActionsExpandedChanged;
+  final ValueChanged<AggregatedItem>? onBackdropItemFocused;
   final VoidCallback? onCollapseBiography;
 
   const ModernDetailContent({
@@ -80,6 +81,7 @@ class ModernDetailContent extends StatefulWidget {
     this.backdropUrl,
     this.selectedMediaSourceId,
     required this.onSelectedMediaSourceChanged,
+    this.onBackdropItemFocused,
     this.initialFocusNode,
     this.autoPlay = false,
     this.onPlayFromChapter,
@@ -1987,6 +1989,40 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget _tracksTab(BuildContext context, AggregatedItem item) {
+    final canManagePlaylistTracks = item.type == 'Playlist' && _vm.canManagePlaylistTracks;
+
+    final listWidget = DetailTrackList(
+      tracks: _vm.tracks,
+      imageApi: _vm.imageApi,
+      isAudiobook: _isAudiobook(item),
+      isPlaylist: item.type == 'Playlist',
+      groupByDisc: item.type == 'MusicAlbum',
+      getFocusNode: (id) =>
+          _trackFocusNodes.putIfAbsent(id, () => FocusNode()),
+      onPlayTrack: (index) => _playTrack(context, index),
+      reorderable: canManagePlaylistTracks,
+      onReorder: canManagePlaylistTracks
+          ? (oldIndex, newIndex) {
+              var target = newIndex;
+              if (target > oldIndex) {
+                target -= 1;
+              }
+              _vm.reorderPlaylistTrack(oldIndex, target);
+            }
+          : null,
+      onRemoveFromPlaylist: canManagePlaylistTracks
+          ? (track) => _vm.removeTrackFromPlaylist(track)
+          : null,
+      onMoveUp: canManagePlaylistTracks
+          ? (index) => _vm.reorderPlaylistTrack(index, index - 1)
+          : null,
+      onMoveDown: canManagePlaylistTracks
+          ? (index) => _vm.reorderPlaylistTrack(index, index + 1)
+          : null,
+      onFirstTrackUp: () => widget.initialFocusNode?.requestFocus(),
+      onTrackFocused: widget.onBackdropItemFocused,
+    );
+
     return Focus(
       canRequestFocus: false,
       onFocusChange: (focused) {
@@ -1997,22 +2033,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         }
       },
       onKeyEvent: (node, event) {
+        if (item.type == 'Playlist') {
+          return KeyEventResult.ignored;
+        }
         if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
           _focusSelectedTab();
           return KeyEventResult.handled;
         }
         return KeyEventResult.ignored;
       },
-      child: DetailTrackList(
-        tracks: _vm.tracks,
-        imageApi: _vm.imageApi,
-        isAudiobook: _isAudiobook(item),
-        isPlaylist: item.type == 'Playlist',
-        groupByDisc: item.type == 'MusicAlbum',
-        getFocusNode: (id) =>
-            _trackFocusNodes.putIfAbsent(id, () => FocusNode()),
-        onPlayTrack: (index) => _playTrack(context, index),
-      ),
+      child: item.type == 'Playlist'
+          ? Align(
+              alignment: Alignment.topLeft,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 800),
+                child: listWidget,
+              ),
+            )
+          : listWidget,
     );
   }
 
@@ -2190,6 +2228,123 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               onFocusExtra: (_) {},
             ),
           ),
+        ],
+      );
+    }
+
+    if (item.type == 'Playlist') {
+      final l10n = AppLocalizations.of(context);
+      final coverUrl = _imageUrl(item);
+      final coverImage = Container(
+        width: 180,
+        height: 180,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: const Color(0xFFE8DCCA).withValues(alpha: 0.8),
+            width: 2.0,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.4),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(10),
+          child: coverUrl != null
+              ? CachedNetworkImage(
+                  imageUrl: coverUrl,
+                  fit: BoxFit.cover,
+                )
+              : Container(
+                  color: Colors.white.withValues(alpha: 0.05),
+                  child: const Icon(
+                    Icons.playlist_play,
+                    color: Colors.white24,
+                    size: 64,
+                  ),
+                ),
+        ),
+      );
+
+      final playlistInfo = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            item.name,
+            style: textTheme.displaySmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+              shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                  ? [
+                      const Shadow(
+                        color: Color(0xFFFF2E92),
+                        blurRadius: 12,
+                      ),
+                    ]
+                  : null,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            () {
+              final count = _vm.tracks.length;
+              final trackText = l10n.trackCount(count);
+              final genresText = item.genres.join(', ');
+              return genresText.isNotEmpty ? '$trackText • $genresText' : trackText;
+            }(),
+            style: textTheme.bodyMedium?.copyWith(
+              color: Colors.white.withValues(alpha: 0.7),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Focus(
+            canRequestFocus: false,
+            skipTraversal: true,
+            onFocusChange: (focused) {
+              if (focused) {
+                widget.onToggleNavbar?.call(true);
+                if (_scrollController.hasClients) {
+                  _scrollController.animateTo(
+                    0.0,
+                    duration: const Duration(milliseconds: 250),
+                    curve: Curves.easeInOut,
+                  );
+                }
+              }
+            },
+            child: DetailActionButtons(
+              viewModel: _vm,
+              itemId: item.id,
+              selectedMediaSourceId: widget.selectedMediaSourceId,
+              onSelectedMediaSourceChanged: widget.onSelectedMediaSourceChanged,
+              tvPlayFocusNode: widget.initialFocusNode,
+              downTarget: _vm.tracks.isNotEmpty
+                  ? _trackFocusNodes.putIfAbsent(_vm.tracks.first.id, () => FocusNode())
+                  : null,
+              upTarget: null,
+              autoPlay: widget.autoPlay,
+              modernStyle: true,
+              fullWidthPrimary: false,
+              maxVisibleButtonsOverride: 10,
+              onArrowRightAtEnd: null,
+              actionRowRightFocusNode: _actionRowRightFocusNode,
+              onFocusExtra: (_) {},
+            ),
+          ),
+        ],
+      );
+
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          coverImage,
+          const SizedBox(width: 28),
+          Expanded(child: playlistInfo),
         ],
       );
     }
@@ -2756,7 +2911,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         MediaQuery.orientationOf(context) == Orientation.landscape;
 
     final tabs = _tabsFor(item, l10n);
-    if (_selectedTab >= tabs.length) {
+    if (item.type == 'Playlist') {
+      _selectedTab = 0;
+    } else if (_selectedTab >= tabs.length) {
       _selectedTab = PlatformDetection.isTV ? -1 : 0;
     }
 
@@ -2791,6 +2948,30 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       onExitUp: () => widget.initialFocusNode?.requestFocus(),
       onNavigateDown: _onTabBarNavigateDown,
     );
+
+    final Widget tabBarWidget;
+    if (item.type == 'Playlist') {
+      tabBarWidget = Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: Text(
+          l10n.playlist,
+          style: textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+            shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                ? [
+                    const Shadow(
+                      color: Color(0xFFFF2E92),
+                      blurRadius: 10,
+                    ),
+                  ]
+                : null,
+          ),
+        ),
+      );
+    } else {
+      tabBarWidget = tabBar;
+    }
 
     final hero = _buildHero(context, item);
     final upNext = _buildUpNext(context, item);
@@ -2848,7 +3029,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             backdrop: backdrop,
             hero: hero,
             upNext: upNext,
-            tabBar: tabBar,
+            tabBar: tabBarWidget,
             tabContent: tabContent,
             topInset: topInset,
             scrollController: _scrollController,
@@ -2858,7 +3039,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             backdrop: backdrop,
             hero: hero,
             upNext: upNext,
-            tabBar: tabBar,
+            tabBar: tabBarWidget,
             tabContent: tabContent,
             topInset: topInset,
           );

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -592,6 +592,26 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         if (_personSeerrCrewCreditsFirstFocusNode.canRequestFocus) _personSeerrCrewCreditsFirstFocusNode.requestFocus();
       } else if (label == l10n.albums || label == l10n.items || label == l10n.appearances) {
         if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
+      } else if (label == l10n.playlist) {
+        if (_vm.item?.type == 'BoxSet' && _vm.playlistItems.isNotEmpty) {
+          final firstTrackId = _vm.playlistItems.first.id;
+          final firstTrackNode = _trackFocusNodes.putIfAbsent(firstTrackId, () => FocusNode());
+          if (firstTrackNode.canRequestFocus) {
+            firstTrackNode.requestFocus();
+          }
+        }
+      } else if (label == l10n.movies) {
+        if (_vm.item?.type == 'BoxSet') {
+          if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
+        } else {
+          if (_personMoviesFirstFocusNode.canRequestFocus) _personMoviesFirstFocusNode.requestFocus();
+        }
+      } else if (label == l10n.series) {
+        if (_vm.item?.type == 'BoxSet') {
+          if (_gridFirstFocusNode.canRequestFocus) _gridFirstFocusNode.requestFocus();
+        } else {
+          if (_personSeriesFirstFocusNode.canRequestFocus) _personSeriesFirstFocusNode.requestFocus();
+        }
       }
     }
   }
@@ -689,14 +709,63 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             _ModernTab(l10n.appearances, (_, _) => _itemGrid(_sortJellyfinItems(_vm.filmography))),
         ];
       case 'BoxSet':
+        final moviesList = _vm.collectionItems.where((i) => i.type == 'Movie').toList();
+        final seriesList = _vm.collectionItems.where((i) => i.type == 'Series').toList();
         return [
-          if (_vm.collectionItems.isNotEmpty)
-            _ModernTab(l10n.items, (_, _) => _itemGrid(_vm.collectionItems)),
+          if (_vm.playlistItems.isNotEmpty)
+            _ModernTab(
+              l10n.playlist,
+              (context, item) {
+                final listWidget = DetailTrackList(
+                  tracks: _vm.playlistItems,
+                  imageApi: _vm.imageApi,
+                  isPlaylist: true,
+                  getFocusNode: (id) =>
+                      _trackFocusNodes.putIfAbsent(id, () => FocusNode()),
+                  onPlayTrack: (index) => _playPlaylistTrack(context, index),
+                  reorderable: true,
+                  onReorder: (oldIndex, newIndex) {
+                    var target = newIndex;
+                    if (target > oldIndex) {
+                      target -= 1;
+                    }
+                    _vm.reorderCollectionPlaylistItem(oldIndex, target);
+                  },
+                  onMoveUp: (index) => _vm.reorderCollectionPlaylistItem(index, index - 1),
+                  onMoveDown: (index) => _vm.reorderCollectionPlaylistItem(index, index + 1),
+                  onFirstTrackUp: () => widget.initialFocusNode?.requestFocus(),
+                  onTrackFocused: widget.onBackdropItemFocused,
+                );
+
+                return Focus(
+                  canRequestFocus: false,
+                  onFocusChange: (focused) {
+                    if (focused && mounted) {
+                      widget.onToggleNavbar?.call(false);
+                    } else if (!focused && mounted) {
+                      widget.onToggleNavbar?.call(true);
+                    }
+                  },
+                  onKeyEvent: (node, event) {
+                    return KeyEventResult.ignored;
+                  },
+                  child: Align(
+                    alignment: Alignment.topLeft,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 800),
+                      child: listWidget,
+                    ),
+                  ),
+                );
+              },
+            ),
+          if (moviesList.isNotEmpty)
+            _ModernTab(l10n.movies, (_, _) => _itemGrid(moviesList)),
+          if (seriesList.isNotEmpty)
+            _ModernTab(l10n.series, (_, _) => _itemGrid(seriesList)),
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
-          if (item.chapters.isNotEmpty) chapters,
-          details,
         ];
       default:
         return [
@@ -2067,6 +2136,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     await manager.playItems(_vm.tracks, startIndex: index);
     if (!context.mounted) return;
     final isAudio = _vm.tracks.every(_isAudioItem);
+    context.push(isAudio ? Destinations.audioPlayer : Destinations.videoPlayer);
+  }
+
+  Future<void> _playPlaylistTrack(BuildContext context, int index) async {
+    final manager = GetIt.instance<PlaybackManager>();
+    await manager.playItems(_vm.playlistItems, startIndex: index);
+    if (!context.mounted) return;
+    final isAudio = _vm.playlistItems.every(_isAudioItem);
     context.push(isAudio ? Destinations.audioPlayer : Destinations.videoPlayer);
   }
 

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:playback_core/playback_core.dart';
+import 'package:server_core/server_core.dart';
 
 import '../../../../data/models/aggregated_item.dart';
 import '../../../../data/viewmodels/item_detail_view_model.dart';
@@ -14,12 +15,12 @@ import '../../../navigation/destinations.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/media_card.dart';
 import '../../../widgets/rating_display.dart';
+import '../../../widgets/focus/focusable_wrapper.dart';
 import '../../../widgets/top_toolbar.dart';
 import '../item_detail_screen.dart'
     show
         DetailActionButtons,
         DetailCastRow,
-        DetailMetadataRow,
         DetailMetadataSection,
         DetailFeaturesRow,
         DetailEpisodeCard,
@@ -68,6 +69,65 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final Map<String, FocusNode> _trackFocusNodes = {};
   final List<FocusNode> _tabFocusNodes = [];
   final FocusNode _upNextFocusNode = FocusNode(debugLabel: 'modernUpNext');
+
+  PlaybackInfoResult? _playbackInfo;
+  bool _loadingPlaybackInfo = false;
+  String? _loadedPlaybackInfoItemId;
+
+  Future<void> _loadPlaybackInfo(AggregatedItem item) async {
+    if (_loadingPlaybackInfo) return;
+    if (_playbackInfo != null && _loadedPlaybackInfoItemId == item.id) return;
+    
+    _loadingPlaybackInfo = true;
+    _loadedPlaybackInfoItemId = item.id;
+    // Delay state change slightly to prevent setstate during build
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() {});
+    });
+
+    try {
+      final client = GetIt.instance<MediaServerClient>();
+      final manager = GetIt.instance<PlaybackManager>();
+      
+      final backend = manager.backend;
+      final profile = backend?.getDeviceProfile() ?? {};
+      final bitrate = profile['MaxStreamingBitrate'] as int?;
+
+      final mediaSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
+      final mediaSourceId = mediaSource?['Id']?.toString();
+
+      final request = PlaybackInfoRequest(
+        itemId: item.id,
+        mediaSourceId: mediaSourceId,
+        deviceProfile: profile,
+        maxStreamingBitrate: bitrate,
+        enableDirectPlay: true,
+        enableDirectStream: true,
+        enableTranscoding: true,
+      );
+
+      final rawInfo = await client.playbackApi.getPlaybackInfo(
+        item.id,
+        requestBody: request.toJson(),
+        userId: client.userId,
+      );
+
+      final parsed = PlaybackInfoResult.fromJson(rawInfo);
+      if (mounted) {
+        setState(() {
+          _playbackInfo = parsed;
+          _loadingPlaybackInfo = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _loadingPlaybackInfo = false;
+          _playbackInfo = null;
+        });
+      }
+    }
+  }
 
   ItemDetailViewModel get _vm => widget.viewModel;
 
@@ -126,9 +186,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   List<_ModernTab> _tabsFor(AggregatedItem item, AppLocalizations l10n) {
     final hasCast = _vm.actors.isNotEmpty;
+    final hasCrew = _vm.directors.isNotEmpty || _vm.writers.isNotEmpty;
+    final hasStudios = item.studios.isNotEmpty;
     final hasSimilar = _vm.similar.isNotEmpty;
     final hasFeatures = _vm.features.isNotEmpty;
+
     final cast = _ModernTab(l10n.cast, _castTab);
+    final crew = _ModernTab(l10n.crewSection, _crewTab);
+    final studios = _ModernTab(l10n.studios, _studiosTab);
     final details = _ModernTab(l10n.details, _detailsTab);
     final similar = _ModernTab(l10n.similar, (_, _) => _itemGrid(_vm.similar));
 
@@ -138,6 +203,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (_vm.seasons.isNotEmpty) _ModernTab(l10n.seasons, _seasonsTab),
           _ModernTab(l10n.episodes, _seriesEpisodesTab),
           if (hasCast) cast,
+          if (hasCrew) crew,
+          if (hasStudios) studios,
           details,
           if (hasSimilar) similar,
         ];
@@ -146,6 +213,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (_vm.episodes.isNotEmpty)
             _ModernTab(l10n.episodes, _episodeListTab),
           if (hasCast) cast,
+          if (hasCrew) crew,
+          if (hasStudios) studios,
           details,
         ];
       case 'Episode':
@@ -153,6 +222,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (_vm.episodes.isNotEmpty)
             _ModernTab(l10n.episodes, _episodeListTab),
           if (hasCast) cast,
+          if (hasCrew) crew,
+          if (hasStudios) studios,
           details,
           if (hasSimilar) similar,
         ];
@@ -182,11 +253,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (_vm.collectionItems.isNotEmpty)
             _ModernTab(l10n.items, (_, _) => _itemGrid(_vm.collectionItems)),
           if (hasCast) cast,
+          if (hasCrew) crew,
+          if (hasStudios) studios,
           details,
         ];
       default:
         return [
           if (hasCast) cast,
+          if (hasCrew) crew,
+          if (hasStudios) studios,
           details,
           if (hasFeatures) _ModernTab(l10n.extras, _extrasTab),
           if (hasSimilar) similar,
@@ -325,6 +400,124 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ),
       );
 
+  Widget _crewTab(BuildContext context, AggregatedItem item) {
+    final l10n = AppLocalizations.of(context);
+    final directors = _vm.directors.map((d) => {
+      ...d,
+      'Role': d['Role'] ?? l10n.director,
+    }).toList();
+    final writers = _vm.writers.map((w) => {
+      ...w,
+      'Role': w['Role'] ?? l10n.writer,
+    }).toList();
+    final crew = [...directors, ...writers];
+
+    return SizedBox(
+      height: 200,
+      child: DetailCastRow(
+        people: crew,
+        imageApi: _vm.imageApi,
+        serverId: item.serverId,
+      ),
+    );
+  }
+
+  Widget _studiosTab(BuildContext context, AggregatedItem item) {
+    final studios = item.studios;
+    if (studios.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final isMobile = _landscape == false;
+    final desktopScale = widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final cardWidth = isMobile ? 120.0 : 160.0 * desktopScale;
+    final cardHeight = isMobile ? 80.0 : 100.0 * desktopScale;
+
+    return SizedBox(
+      height: cardHeight + 20,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        clipBehavior: Clip.none,
+        itemCount: studios.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 16),
+        itemBuilder: (context, index) {
+          final studio = studios[index];
+          final name = studio['Name']?.toString() ?? '';
+          final studioId = studio['Id']?.toString();
+
+          final imageUrl = studioId != null
+              ? _vm.imageApi.getPrimaryImageUrl(
+                  studioId,
+                  maxHeight: isMobile ? 100 : (160 * desktopScale).round(),
+                )
+              : null;
+
+          return FocusableWrapper(
+            onSelect: name.isNotEmpty
+                ? () => context.push(Destinations.searchWith('studio:$name'))
+                : null,
+            borderRadius: 12,
+            child: Container(
+              width: cardWidth,
+              height: cardHeight,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                color: Colors.white.withValues(alpha: 0.05),
+                border: Border.all(
+                  color: Colors.white.withValues(alpha: 0.15),
+                  width: 1,
+                ),
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: Center(
+                  child: imageUrl != null
+                      ? CachedNetworkImage(
+                          imageUrl: imageUrl,
+                          fit: BoxFit.contain,
+                          placeholder: (context, url) => Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Text(
+                              name,
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                    color: Colors.white70,
+                                  ),
+                            ),
+                          ),
+                          errorWidget: (context, url, error) => Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Text(
+                              name,
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                    color: Colors.white70,
+                                  ),
+                            ),
+                          ),
+                        )
+                      : Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Text(
+                            name,
+                            textAlign: TextAlign.center,
+                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                  color: Colors.white70,
+                                ),
+                          ),
+                        ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
   Widget _extrasTab(BuildContext context, AggregatedItem item) => SizedBox(
         height: 200,
         child: DetailFeaturesRow(
@@ -335,19 +528,310 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       );
 
   Widget _detailsTab(BuildContext context, AggregatedItem item) {
+    final mediaSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
+    final isPlayable = item.type != 'Series' && item.type != 'Season' && item.type != 'Person';
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        DetailMetadataRow(
-          item: item,
-          selectedMediaSource:
-              selectedMediaSourceForItem(item, widget.selectedMediaSourceId),
-          technicalOnly: true,
-        ),
-        const SizedBox(height: 20),
+        if (isPlayable && mediaSource != null) ...[
+          _buildFileInformation(context, item, mediaSource),
+          const Divider(color: Colors.white10, height: 40, thickness: 1),
+        ],
         DetailMetadataSection(viewModel: _vm),
       ],
     );
+  }
+
+  Widget _buildFileInformation(
+    BuildContext context,
+    AggregatedItem item,
+    Map<String, dynamic> mediaSource,
+  ) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    // File name and Size
+    final sizeBytes = mediaSource['Size'] as int? ?? 0;
+    final String formattedSize;
+    if (sizeBytes > 0) {
+      final double mb = sizeBytes / (1024 * 1024);
+      if (mb > 999) {
+        formattedSize = '${(mb / 1024).toStringAsFixed(2)} GB';
+      } else {
+        formattedSize = '${mb.toStringAsFixed(0)} MB';
+      }
+    } else {
+      formattedSize = 'Unknown Size';
+    }
+
+    final String path = mediaSource['Path'] as String? ?? '';
+    final String fileName = path.split('/').last.split('\\').last;
+    final String container = mediaSource['Container']?.toString().toUpperCase() ?? 'Unknown';
+
+    // Parse streams
+    final List<Map<String, dynamic>> rawStreams = (mediaSource['MediaStreams'] as List?)
+            ?.whereType<Map>()
+            .map((e) => e.cast<String, dynamic>())
+            .toList() ??
+        [];
+
+    final videoStreams = rawStreams.where((s) => s['Type'] == 'Video').toList();
+    final audioStreams = rawStreams.where((s) => s['Type'] == 'Audio').toList();
+    final subtitleStreams = rawStreams.where((s) => s['Type'] == 'Subtitle').toList();
+
+    // Video "Greatest Hits"
+    final List<String> videoDetails = [];
+    if (videoStreams.isNotEmpty) {
+      final v = videoStreams.first;
+      final codec = v['Codec']?.toString().toUpperCase() ?? 'Unknown Codec';
+      final profile = v['Profile']?.toString();
+      final width = v['Width']?.toString();
+      final height = v['Height']?.toString();
+      final frameRate = v['RealFrameRate'] ?? v['AverageFrameRate'];
+      final bitDepth = v['BitDepth'] as int?;
+      final videoRange = v['VideoRange']?.toString();
+      final videoRangeType = v['VideoRangeType']?.toString();
+
+      var videoStr = codec;
+      if (profile != null && profile.isNotEmpty) videoStr += ' ($profile)';
+      videoDetails.add(videoStr);
+
+      if (width != null && height != null) {
+        videoDetails.add('$width x $height');
+      }
+
+      if (frameRate != null) {
+        final fr = double.tryParse(frameRate.toString());
+        if (fr != null) {
+          videoDetails.add('${fr.toStringAsFixed(3)} fps');
+        }
+      }
+
+      if (bitDepth != null) {
+        videoDetails.add('$bitDepth-bit');
+      }
+
+      if (videoRange != null && videoRange.isNotEmpty) {
+        var rangeStr = videoRange;
+        if (videoRangeType != null && videoRangeType.isNotEmpty) {
+          rangeStr += ' ($videoRangeType)';
+        }
+        videoDetails.add(rangeStr);
+      }
+    }
+
+    String formatLang(String? code) {
+      if (code == null || code.isEmpty) return 'Unknown';
+      return code.toUpperCase();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'File Information',
+          style: textTheme.titleMedium?.copyWith(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 12),
+
+        // File name details card
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.04),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: Colors.white10),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                fileName,
+                style: textTheme.bodyLarge?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Size: $formattedSize  •  Format: $container',
+                style: textTheme.bodySmall?.copyWith(color: Colors.white70),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        if (videoDetails.isNotEmpty) ...[
+          _buildInfoRow('Video', videoDetails.join('  •  '), textTheme),
+          const SizedBox(height: 10),
+        ],
+
+        if (audioStreams.isNotEmpty) ...[
+          _buildInfoRow(
+            'Audio',
+            audioStreams.map((a) {
+              final title = a['DisplayTitle'] ?? a['Codec']?.toString().toUpperCase();
+              final lang = formatLang(a['Language']);
+              final isDefault = a['IsDefault'] == true ? ' [Default]' : '';
+              return '$title ($lang)$isDefault';
+            }).join('\n'),
+            textTheme,
+          ),
+          const SizedBox(height: 10),
+        ],
+
+        if (subtitleStreams.isNotEmpty) ...[
+          _buildInfoRow(
+            'Subtitles',
+            subtitleStreams.map((s) {
+              final title = s['DisplayTitle'] ?? s['Codec']?.toString().toUpperCase();
+              final lang = formatLang(s['Language']);
+              final isDefault = s['IsDefault'] == true ? ' [Default]' : '';
+              final isForced = s['IsForced'] == true ? ' [Forced]' : '';
+              return '$title ($lang)$isDefault$isForced';
+            }).join('\n'),
+            textTheme,
+          ),
+          const SizedBox(height: 10),
+        ],
+
+        const SizedBox(height: 12),
+        _buildDirectPlaySection(context, item, textTheme),
+      ],
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value, TextTheme textTheme) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 90,
+          child: Text(
+            label,
+            style: textTheme.bodyMedium?.copyWith(
+              color: Colors.white54,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: textTheme.bodyMedium?.copyWith(
+              color: Colors.white.withValues(alpha: 0.9),
+              height: 1.3,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDirectPlaySection(BuildContext context, AggregatedItem item, TextTheme textTheme) {
+    if (_loadingPlaybackInfo) {
+      return Row(
+        children: [
+          const SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white70),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            'Checking Direct Play capability...',
+            style: textTheme.bodySmall?.copyWith(color: Colors.white54),
+          ),
+        ],
+      );
+    }
+
+    if (_playbackInfo == null) {
+      return const SizedBox.shrink();
+    }
+
+    if (_playbackInfo!.mediaSources.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final source = _playbackInfo!.mediaSources.firstWhere(
+      (s) => s.id == widget.selectedMediaSourceId || widget.selectedMediaSourceId == null,
+      orElse: () => _playbackInfo!.mediaSources.first,
+    );
+
+    final canDirectPlay = source.supportsDirectPlay;
+    final reasons = source.transcodingReasons;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              'Direct Play Capability: ',
+              style: textTheme.bodyMedium?.copyWith(
+                color: Colors.white54,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            Text(
+              canDirectPlay ? 'Yes' : 'No',
+              style: textTheme.bodyMedium?.copyWith(
+                color: canDirectPlay ? const Color(0xFF2E7D32) : const Color(0xFFD32F2F),
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        if (!canDirectPlay && reasons.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: reasons.map((r) {
+                final readable = _formatTranscodeReason(r);
+                return Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    '• $readable',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: Colors.white70,
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  String _formatTranscodeReason(String reason) {
+    return switch (reason) {
+      'ContainerNotSupported' => 'Container format is not supported by the player.',
+      'VideoCodecNotSupported' => 'Video codec is not supported.',
+      'AudioCodecNotSupported' => 'Audio codec is not supported.',
+      'SubtitleCodecNotSupported' => 'Subtitle format is not supported (requires burning).',
+      'AudioProfileNotSupported' => 'Audio profile is not supported.',
+      'VideoProfileNotSupported' => 'Video profile is not supported.',
+      'VideoLevelNotSupported' => 'Video level is not supported.',
+      'VideoResolutionNotSupported' => 'Video resolution is not supported by this device.',
+      'VideoBitDepthNotSupported' => 'Video bit depth is not supported.',
+      'VideoFramerateNotSupported' => 'Video framerate is not supported.',
+      'ContainerBitrateExceedsLimit' => 'File bitrate exceeds player streaming limit.',
+      'VideoBitrateExceedsLimit' => 'Video bitrate exceeds streaming limit.',
+      'AudioBitrateExceedsLimit' => 'Audio bitrate exceeds streaming limit.',
+      'AudioChannelsNotSupported' => 'Number of audio channels is not supported.',
+      _ => reason,
+    };
   }
 
   Widget _itemGrid(List<AggregatedItem> items) {
@@ -754,6 +1238,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     final tabs = _tabsFor(item, l10n);
     if (_selectedTab >= tabs.length) _selectedTab = 0;
+
+    if (tabs.isNotEmpty && _selectedTab < tabs.length && tabs[_selectedTab].label == l10n.details) {
+      final isPlayable = item.type != 'Series' && item.type != 'Season' && item.type != 'Person';
+      if (isPlayable) {
+        _loadPlaybackInfo(item);
+      }
+    }
+
     final tabContent = tabs.isEmpty
         ? const SizedBox.shrink()
         : tabs[_selectedTab].builder(context, item);

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -707,7 +707,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCrew) crew,
           if (hasStudios) studios,
           if (item.chapters.isNotEmpty) chapters,
-          details,
         ];
       case 'Episode':
         return [
@@ -880,8 +879,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     // unplayed episode's seasonId so the cyan border always renders correctly.
     final nextUpSeasonId = _vm.nextUp?.seasonId ??
         _vm.seriesEpisodes.firstWhereOrNull((e) => !e.isPlayed)?.seasonId;
-    final cards = [
-      for (var i = 0; i < _vm.seasons.length; i++)
+    SeasonCard buildSeasonCard(int i, {double? width, double? height}) =>
         SeasonCard(
           title: _vm.seasons[i].name,
           subtitle: l10n.episodeCount(
@@ -894,18 +892,25 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           onNavigateUp: _focusSelectedTab,
           onNavigateRight: i == _vm.seasons.length - 1 ? () {} : null,
           focusNode: i == 0 ? _seasonsFirstFocusNode : null,
+          width: width,
+          height: height,
           onTap: () => context.push(
             Destinations.item(_vm.seasons[i].id, serverId: _vm.seasons[i].serverId),
           ),
-        ),
-    ];
+        );
+    final seasonLabelStyle = textTheme.labelMedium?.copyWith(
+      color: Colors.white70,
+      fontWeight: FontWeight.bold,
+      letterSpacing: 1.0,
+      fontSize: 10,
+    );
     final child = _landscape
         ? SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                for (var i = 0; i < cards.length; i++)
+                for (var i = 0; i < _vm.seasons.length; i++)
                   Padding(
                     padding: const EdgeInsets.only(right: 12),
                     child: Column(
@@ -914,52 +919,48 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                       children: [
                         Text(
                           _vm.seasons[i].name.toUpperCase(),
-                          style: textTheme.labelMedium?.copyWith(
-                            color: Colors.white70,
-                            fontWeight: FontWeight.bold,
-                            letterSpacing: 1.0,
-                            fontSize: 10,
-                          ),
+                          style: seasonLabelStyle,
                           textAlign: TextAlign.center,
                         ),
                         const SizedBox(height: 6),
-                        cards[i],
+                        buildSeasonCard(i),
                       ],
                     ),
                   ),
               ],
             ),
           )
-        : Column(
-            children: [
-              for (var i = 0; i < cards.length; i++)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 12),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Column(
+        : LayoutBuilder(
+            builder: (context, constraints) {
+              const spacing = 12.0;
+              final columns = (constraints.maxWidth / 130).floor().clamp(3, 6);
+              final cardWidth =
+                  ((constraints.maxWidth - spacing * (columns - 1)) / columns)
+                      .floorToDouble();
+              final cardHeight = cardWidth * 1.5;
+              return Wrap(
+                spacing: spacing,
+                runSpacing: 16,
+                children: [
+                  for (var i = 0; i < _vm.seasons.length; i++)
+                    SizedBox(
+                      width: cardWidth,
+                      child: Column(
                         mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           Text(
                             _vm.seasons[i].name.toUpperCase(),
-                            style: textTheme.labelMedium?.copyWith(
-                              color: Colors.white70,
-                              fontWeight: FontWeight.bold,
-                              letterSpacing: 1.0,
-                              fontSize: 10,
-                            ),
+                            style: seasonLabelStyle,
                             textAlign: TextAlign.center,
                           ),
                           const SizedBox(height: 6),
-                          cards[i],
+                          buildSeasonCard(i, width: cardWidth, height: cardHeight),
                         ],
                       ),
-                    ],
-                  ),
-                ),
-            ],
+                    ),
+                ],
+              );
+            },
           );
 
     return Focus(
@@ -2572,9 +2573,44 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _similarTab(BuildContext context, List<AggregatedItem> items) {
     if (items.isEmpty) return const SizedBox.shrink();
     final isMobile = _landscape == false;
-    final desktopScale = widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
-    final cardWidth = isMobile ? 90.0 : 120.0 * desktopScale;
     const cardRatio = 2 / 3;
+
+    if (isMobile) {
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          const spacing = 12.0;
+          final columns = (constraints.maxWidth / 130).floor().clamp(3, 6);
+          final cardWidth =
+              ((constraints.maxWidth - spacing * (columns - 1)) / columns)
+                  .floorToDouble();
+          return Wrap(
+            spacing: spacing,
+            runSpacing: 16,
+            children: [
+              for (final entry in items)
+                MediaCard(
+                  title: entry.name,
+                  imageUrl: _imageUrl(entry),
+                  width: cardWidth,
+                  aspectRatio: cardRatio,
+                  isPlayed: entry.isPlayed,
+                  isFavorite: entry.isFavorite,
+                  itemType: entry.type,
+                  watchedBehavior:
+                      widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
+                  onTap: () => context.push(
+                    Destinations.item(entry.id, serverId: entry.serverId),
+                  ),
+                ),
+            ],
+          );
+        },
+      );
+    }
+
+    final desktopScale =
+        widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final cardWidth = 120.0 * desktopScale;
     final cardHeight = cardWidth / cardRatio + 48.0;
 
     return SizedBox(
@@ -2807,43 +2843,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  /// In landscape the hero column is ~45% of the width. Size the visible action
-  /// count so the Play pill, the circular buttons and the "More" toggle all stay
-  /// on a single row (extras expand to a second row beneath). Reserves room for
-  /// the Play pill (wider for "Resume from S#:E#" labels) plus More (~62); each
-  /// circular button is ~62 wide.
-  int? _actionButtonCap(BuildContext context, AggregatedItem item) {
-    if (item.type == 'Movie' || item.type == 'Episode') {
-      return 15;
-    }
-    if (item.type == 'Series') {
-      final hasUpNext = _vm.nextUp != null;
-      if (_landscape && hasUpNext) {
-        return 4;
-      }
-      return null;
-    }
-    if (item.type == 'Season') {
-      // Always use two-column layout for Seasons so Favorite folds into More
-      return 5;
-    }
-    if (item.type == 'BoxSet') {
-      return null;
-    }
-    if (!_landscape) return null;
-    final hasUpNext = _buildUpNext(context, item) != null;
-    final heroWidth = hasUpNext
-        ? (MediaQuery.sizeOf(context).width * 0.65).clamp(450.0, 900.0)
-        : (MediaQuery.sizeOf(context).width * 0.75).clamp(450.0, 960.0);
-    final pillWidth = switch (item.type) {
-      'Series' || 'Season' || 'Episode' => 300.0,
-      'MusicAlbum' || 'Playlist' || 'AudioBook' || 'MusicArtist' => 160.0,
-      _ => 220.0,
-    };
-    final circles = ((heroWidth - pillWidth - 62) / 62).floor();
-    return (circles + 2).clamp(2, 12);
-  }
-
   List<Shadow>? _neonTextGlow(double blurRadius) =>
       ThemeRegistry.active.id == ThemeRegistry.neonPulseId
           ? [Shadow(color: AppColorScheme.accent, blurRadius: blurRadius)]
@@ -2982,7 +2981,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               autoPlay: widget.autoPlay,
               modernStyle: true,
               fullWidthPrimary: !_landscape,
-              maxVisibleButtonsOverride: _actionButtonCap(context, item),
+              maxVisibleButtonsOverride: null,
               onArrowRightAtEnd: _landscape ? _focusRightOfActions : null,
               actionRowRightFocusNode: _actionRowRightFocusNode,
               onFocusExtra: (_) {},
@@ -3163,8 +3162,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   : null,
               autoPlay: widget.autoPlay,
               modernStyle: true,
-              fullWidthPrimary: false,
-              maxVisibleButtonsOverride: 10,
+              fullWidthPrimary: !_landscape,
+              maxVisibleButtonsOverride: _landscape ? 10 : null,
               onArrowRightAtEnd: null,
               actionRowRightFocusNode: _actionRowRightFocusNode,
               onFocusExtra: (_) {},
@@ -3173,12 +3172,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ],
       );
 
-      return Row(
+      if (_landscape) {
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            coverImage,
+            const SizedBox(width: 28),
+            Expanded(child: playlistInfo),
+          ],
+        );
+      }
+      return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          coverImage,
-          const SizedBox(width: 28),
-          Expanded(child: playlistInfo),
+          Center(child: coverImage),
+          const SizedBox(height: 20),
+          playlistInfo,
         ],
       );
     }
@@ -3410,7 +3419,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             autoPlay: widget.autoPlay,
             modernStyle: true,
             fullWidthPrimary: !_landscape,
-            maxVisibleButtonsOverride: _actionButtonCap(context, item),
+            maxVisibleButtonsOverride: null,
             onArrowRightAtEnd: _landscape ? _focusRightOfActions : null,
             actionRowRightFocusNode: _actionRowRightFocusNode,
             extraFirstFocusNode: _extraFirstFocusNode,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -126,6 +126,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _personSeriesFirstFocusNode = FocusNode(debugLabel: 'personSeriesFirst');
   final FocusNode _personSeerrAppearancesFirstFocusNode = FocusNode(debugLabel: 'personSeerrAppearancesFirst');
   final FocusNode _personSeerrCrewCreditsFirstFocusNode = FocusNode(debugLabel: 'personSeerrCrewCreditsFirst');
+  final Map<String, FocusNode> _boxSetHeadingFocusNodes = {};
+  final Map<String, FocusNode> _boxSetRowFirstFocusNodes = {};
   late final ScrollController _scrollController = ScrollController();
   String? _seriesLogoTag;
   String? _seriesLogoId;
@@ -548,6 +550,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _personSeriesFirstFocusNode.dispose();
     _personSeerrAppearancesFirstFocusNode.dispose();
     _personSeerrCrewCreditsFirstFocusNode.dispose();
+    for (final node in _boxSetHeadingFocusNodes.values) {
+      node.dispose();
+    }
+    for (final node in _boxSetRowFirstFocusNodes.values) {
+      node.dispose();
+    }
     super.dispose();
   }
 
@@ -1306,14 +1314,53 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       if (childActors.isEmpty) continue;
 
       final isExpanded = _expandedCollectionCastItems.contains(childItem.id);
-      final isFirst = children.isEmpty;
+      
+      final headingNode = i == 0
+          ? _castFirstFocusNode
+          : _boxSetHeadingFocusNodes.putIfAbsent(childItem.id, () => FocusNode(debugLabel: 'heading_cast_${childItem.name}'));
+      final rowFirstNode = _boxSetRowFirstFocusNodes.putIfAbsent(childItem.id, () => FocusNode(debugLabel: 'row_first_cast_${childItem.name}'));
 
       children.add(
         Padding(
           padding: const EdgeInsets.only(bottom: 6),
           child: FocusableWrapper(
-            onNavigateUp: isFirst ? _focusSelectedTab : null,
-            focusNode: isFirst ? _castFirstFocusNode : null,
+            focusNode: headingNode,
+            onNavigateLeft: () {
+              final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+              if (navbarPosition == NavbarPosition.left) {
+                final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+                if (focusNavbar != null) {
+                  focusNavbar();
+                }
+              }
+            },
+            onNavigateRight: () {}, // Cap on right
+            onNavigateUp: () {
+              if (i == 0) {
+                _focusSelectedTab();
+              } else {
+                final prevItem = sortedItems[i - 1];
+                final prevExpanded = _expandedCollectionCastItems.contains(prevItem.id);
+                if (prevExpanded) {
+                  _boxSetRowFirstFocusNodes[prevItem.id]?.requestFocus();
+                } else {
+                  if (i - 1 == 0) {
+                    _castFirstFocusNode.requestFocus();
+                  } else {
+                    _boxSetHeadingFocusNodes[prevItem.id]?.requestFocus();
+                  }
+                }
+              }
+            },
+            onNavigateDown: () {
+              if (isExpanded) {
+                rowFirstNode.requestFocus();
+              } else if (i < sortedItems.length - 1) {
+                final nextItem = sortedItems[i + 1];
+                final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_cast_${nextItem.name}'));
+                nextNode.requestFocus();
+              }
+            },
             onSelect: () {
               setState(() {
                 if (_expandedCollectionCastItems.contains(childItem.id)) {
@@ -1366,7 +1413,38 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 people: childActors,
                 imageApi: _vm.imageApi,
                 serverId: childItem.serverId,
-                onNavigateUp: _focusSelectedTab,
+                firstItemFocusNode: rowFirstNode,
+                onNavigateUp: () {
+                  headingNode.requestFocus();
+                },
+                onItemKeyEvent: (index, event) {
+                  if (event is KeyDownEvent || event is KeyRepeatEvent) {
+                    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                      if (i < sortedItems.length - 1) {
+                        final nextItem = sortedItems[i + 1];
+                        final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_cast_${nextItem.name}'));
+                        nextNode.requestFocus();
+                      }
+                      return KeyEventResult.handled;
+                    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                      headingNode.requestFocus();
+                      return KeyEventResult.handled;
+                    } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft && index == 0) {
+                      final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+                      if (navbarPosition == NavbarPosition.left) {
+                        final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+                        if (focusNavbar != null) {
+                          focusNavbar();
+                          return KeyEventResult.handled;
+                        }
+                      }
+                      return KeyEventResult.handled; // Cap on left
+                    } else if (event.logicalKey == LogicalKeyboardKey.arrowRight && index == childActors.length - 1) {
+                      return KeyEventResult.handled; // Cap on right
+                    }
+                  }
+                  return KeyEventResult.ignored;
+                },
               ),
             ),
           ),
@@ -1464,14 +1542,53 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       if (childCrew.isEmpty) continue;
 
       final isExpanded = _expandedCollectionCrewItems.contains(childItem.id);
-      final isFirst = children.isEmpty;
+      
+      final headingNode = i == 0
+          ? _crewFirstFocusNode
+          : _boxSetHeadingFocusNodes.putIfAbsent(childItem.id, () => FocusNode(debugLabel: 'heading_crew_${childItem.name}'));
+      final rowFirstNode = _boxSetRowFirstFocusNodes.putIfAbsent(childItem.id, () => FocusNode(debugLabel: 'row_first_crew_${childItem.name}'));
 
       children.add(
         Padding(
           padding: const EdgeInsets.only(bottom: 6),
           child: FocusableWrapper(
-            onNavigateUp: isFirst ? _focusSelectedTab : null,
-            focusNode: isFirst ? _crewFirstFocusNode : null,
+            focusNode: headingNode,
+            onNavigateLeft: () {
+              final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+              if (navbarPosition == NavbarPosition.left) {
+                final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+                if (focusNavbar != null) {
+                  focusNavbar();
+                }
+              }
+            },
+            onNavigateRight: () {}, // Cap on right
+            onNavigateUp: () {
+              if (i == 0) {
+                _focusSelectedTab();
+              } else {
+                final prevItem = sortedItems[i - 1];
+                final prevExpanded = _expandedCollectionCrewItems.contains(prevItem.id);
+                if (prevExpanded) {
+                  _boxSetRowFirstFocusNodes[prevItem.id]?.requestFocus();
+                } else {
+                  if (i - 1 == 0) {
+                    _crewFirstFocusNode.requestFocus();
+                  } else {
+                    _boxSetHeadingFocusNodes[prevItem.id]?.requestFocus();
+                  }
+                }
+              }
+            },
+            onNavigateDown: () {
+              if (isExpanded) {
+                rowFirstNode.requestFocus();
+              } else if (i < sortedItems.length - 1) {
+                final nextItem = sortedItems[i + 1];
+                final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_crew_${nextItem.name}'));
+                nextNode.requestFocus();
+              }
+            },
             onSelect: () {
               setState(() {
                 if (_expandedCollectionCrewItems.contains(childItem.id)) {
@@ -1524,7 +1641,38 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 people: childCrew,
                 imageApi: _vm.imageApi,
                 serverId: childItem.serverId,
-                onNavigateUp: _focusSelectedTab,
+                firstItemFocusNode: rowFirstNode,
+                onNavigateUp: () {
+                  headingNode.requestFocus();
+                },
+                onItemKeyEvent: (index, event) {
+                  if (event is KeyDownEvent || event is KeyRepeatEvent) {
+                    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                      if (i < sortedItems.length - 1) {
+                        final nextItem = sortedItems[i + 1];
+                        final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_crew_${nextItem.name}'));
+                        nextNode.requestFocus();
+                      }
+                      return KeyEventResult.handled;
+                    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                      headingNode.requestFocus();
+                      return KeyEventResult.handled;
+                    } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft && index == 0) {
+                      final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+                      if (navbarPosition == NavbarPosition.left) {
+                        final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+                        if (focusNavbar != null) {
+                          focusNavbar();
+                          return KeyEventResult.handled;
+                        }
+                      }
+                      return KeyEventResult.handled; // Cap on left
+                    } else if (event.logicalKey == LogicalKeyboardKey.arrowRight && index == childCrew.length - 1) {
+                      return KeyEventResult.handled; // Cap on right
+                    }
+                  }
+                  return KeyEventResult.ignored;
+                },
               ),
             ),
           ),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -193,9 +193,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
       final parsed = PlaybackInfoResult.fromJson(rawInfo);
       if (mounted) {
+        // Drop the result if the track selection changed mid-request.
+        final stillCurrent = _loadedAudioIndex == _vm.selectedAudioIndex &&
+            _loadedSubtitleIndex == _vm.selectedSubtitleIndex;
         setState(() {
-          _playbackInfo = parsed;
           _loadingPlaybackInfo = false;
+          if (stillCurrent) _playbackInfo = parsed;
         });
       }
     } catch (_) {

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -595,7 +595,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (_selectedTab != tabIndex) {
       _selectTab(tabIndex);
     }
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    Future.delayed(const Duration(milliseconds: 50), () {
       if (!mounted) return;
       final l10n = AppLocalizations.of(context);
       final tabs = _tabsFor(_vm.item!, l10n);

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3599,29 +3599,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             curve: Curves.easeInOut,
           );
         }
-
-        if (PlatformDetection.isTV && _vm.item != null) {
-          final l10n = AppLocalizations.of(context);
-          final tabs = _tabsFor(_vm.item!, l10n);
-          if (index < tabs.length) {
-            final label = tabs[index].label;
-            if (label == l10n.cast) {
-              _castFirstFocusNode.requestFocus();
-            } else if (label == l10n.crewSection) {
-              _crewFirstFocusNode.requestFocus();
-            } else if (label == l10n.studios) {
-              _studiosFirstFocusNode.requestFocus();
-            } else if (label == l10n.movies) {
-              _personMoviesFirstFocusNode.requestFocus();
-            } else if (label == l10n.series) {
-              _personSeriesFirstFocusNode.requestFocus();
-            } else if (label == l10n.appearancesSeerr) {
-              _personSeerrAppearancesFirstFocusNode.requestFocus();
-            } else if (label == l10n.crewContributionsSeerr) {
-              _personSeerrCrewCreditsFirstFocusNode.requestFocus();
-            }
-          }
-        }
       });
     }
   }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:math' show Random;
+import 'dart:ui' show ImageFilter;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -123,6 +125,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   int? _loadedSubtitleIndex;
   List<SeerrDiscoverItem>? _seerrAppearances;
   List<SeerrDiscoverItem>? _seerrCrewCredits;
+  String? _randomBackdropUrl;
 
   PlaybackInfoResult? _playbackInfo;
   bool _loadingPlaybackInfo = false;
@@ -189,6 +192,31 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           _playbackInfo = null;
         });
       }
+    }
+  }
+
+  void _selectRandomBackdrop() {
+    final item = _vm.item;
+    if (item == null || item.type != 'Person') return;
+    final candidates = <String>[];
+
+    // 1. Local Jellyfin items
+    for (final f in _vm.filmographyMovies) {
+      if (f.backdropImageTags.isNotEmpty) {
+        candidates.add(_vm.imageApi.getBackdropImageUrl(f.id, tag: f.backdropImageTags.first));
+      }
+    }
+    for (final f in _vm.filmographySeries) {
+      if (f.backdropImageTags.isNotEmpty) {
+        candidates.add(_vm.imageApi.getBackdropImageUrl(f.id, tag: f.backdropImageTags.first));
+      }
+    }
+
+    if (candidates.isNotEmpty) {
+      final randIndex = Random().nextInt(candidates.length);
+      setState(() {
+        _randomBackdropUrl = candidates[randIndex];
+      });
     }
   }
 
@@ -409,7 +437,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
     _loadSeriesLogo();
-    _loadSeerrAppearances();
+    _loadSeerrAppearances().then((_) {
+      if (mounted) _selectRandomBackdrop();
+    });
   }
 
   @override
@@ -421,7 +451,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       });
       NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
-    _loadSeerrAppearances();
+    _loadSeerrAppearances().then((_) {
+      if (mounted) _selectRandomBackdrop();
+    });
   }
 
   void _onScroll() {
@@ -441,7 +473,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (mounted) {
       setState(() {});
       _loadSeriesLogo();
-      _loadSeerrAppearances();
+      _loadSeerrAppearances().then((_) {
+        if (mounted) _selectRandomBackdrop();
+      });
     }
   }
 
@@ -2098,7 +2132,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             const SizedBox(height: 24),
             ConstrainedBox(
               constraints: BoxConstraints(
-                maxWidth: _landscape ? 580 : double.infinity,
+                maxWidth: _landscape ? 670.0 : double.infinity,
               ),
               child: ExpandableBiography(
                 text: overview,
@@ -2552,7 +2586,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _buildBackdrop(bool landscape) {
     final base = AppColorScheme.background;
     final item = _vm.item;
-    final url = widget.backdropUrl ?? (item?.type == 'Person' ? _imageUrl(item!) : null);
+    final url = widget.backdropUrl ?? (item?.type == 'Person' ? (_randomBackdropUrl ?? _imageUrl(item!)) : null);
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -2566,7 +2600,20 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             fadeInDuration: const Duration(milliseconds: 250),
             errorWidget: (context, url, error) => const SizedBox.shrink(),
           ),
-          ColoredBox(color: Colors.black.withValues(alpha: 0.40)),
+          if (item?.type == 'Person' && _randomBackdropUrl == null)
+            Positioned.fill(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                child: Container(
+                  color: Colors.black.withValues(alpha: 0.2),
+                ),
+              ),
+            ),
+          ColoredBox(
+            color: Colors.black.withValues(
+              alpha: item?.type == 'Person' ? 0.20 : 0.40,
+            ),
+          ),
         ],
         if (landscape) ...[
           DecoratedBox(
@@ -2656,8 +2703,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (index >= 0) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (_scrollController.hasClients) {
+          final desktopScale = _desktopUiScale(prefs: widget.prefs);
           _scrollController.animateTo(
-            220.0,
+            260.0 * desktopScale,
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
           );
@@ -2941,13 +2989,9 @@ class _DetailsContainerState extends State<_DetailsContainer> with FocusStateMix
         ),
         padding: const EdgeInsets.all(16),
         child: widget.isScrollable
-            ? Scrollbar(
+            ? SingleChildScrollView(
                 controller: _scrollController,
-                thumbVisibility: showFocusBorder,
-                child: SingleChildScrollView(
-                  controller: _scrollController,
-                  child: widget.child,
-                ),
+                child: widget.child,
               )
             : widget.child,
       ),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -50,6 +51,9 @@ class ModernDetailContent extends StatefulWidget {
   final FocusNode? initialFocusNode;
   final bool autoPlay;
   final void Function(Duration position)? onPlayFromChapter;
+  final ValueChanged<bool>? onToggleNavbar;
+  final bool actionsExpanded;
+  final ValueChanged<bool> onActionsExpandedChanged;
 
   const ModernDetailContent({
     super.key,
@@ -61,6 +65,9 @@ class ModernDetailContent extends StatefulWidget {
     this.initialFocusNode,
     this.autoPlay = false,
     this.onPlayFromChapter,
+    this.onToggleNavbar,
+    required this.actionsExpanded,
+    required this.onActionsExpandedChanged,
   });
 
   @override
@@ -68,11 +75,24 @@ class ModernDetailContent extends StatefulWidget {
 }
 
 class _ModernDetailContentState extends State<ModernDetailContent> {
-  int _selectedTab = 0;
+  int _selectedTab = PlatformDetection.isTV ? -1 : 0;
   bool _landscape = true;
   final Map<String, FocusNode> _trackFocusNodes = {};
   final List<FocusNode> _tabFocusNodes = [];
   final FocusNode _upNextFocusNode = FocusNode(debugLabel: 'modernUpNext');
+  final FocusNode _actionRowRightFocusNode = FocusNode(debugLabel: 'actionRowRight');
+  final FocusNode _audioShowAllFocusNode = FocusNode(debugLabel: 'audioShowAll');
+  final FocusNode _subtitleShowAllFocusNode = FocusNode(debugLabel: 'subtitleShowAll');
+  final FocusNode _detailsTabFocusNode = FocusNode(debugLabel: 'detailsTabContent');
+  final FocusNode _castFirstFocusNode = FocusNode(debugLabel: 'castFirst');
+  final FocusNode _crewFirstFocusNode = FocusNode(debugLabel: 'crewFirst');
+  final FocusNode _studiosFirstFocusNode = FocusNode(debugLabel: 'studiosFirst');
+  late final ScrollController _scrollController = ScrollController();
+  bool _showNavbarState = true;
+  bool _audioExpanded = false;
+  bool _subtitlesExpanded = false;
+  int? _loadedAudioIndex;
+  int? _loadedSubtitleIndex;
 
   PlaybackInfoResult? _playbackInfo;
   bool _loadingPlaybackInfo = false;
@@ -80,10 +100,17 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   Future<void> _loadPlaybackInfo(AggregatedItem item) async {
     if (_loadingPlaybackInfo) return;
-    if (_playbackInfo != null && _loadedPlaybackInfoItemId == item.id) return;
+    if (_playbackInfo != null &&
+        _loadedPlaybackInfoItemId == item.id &&
+        _loadedAudioIndex == _vm.selectedAudioIndex &&
+        _loadedSubtitleIndex == _vm.selectedSubtitleIndex) {
+      return;
+    }
     
     _loadingPlaybackInfo = true;
     _loadedPlaybackInfoItemId = item.id;
+    _loadedAudioIndex = _vm.selectedAudioIndex;
+    _loadedSubtitleIndex = _vm.selectedSubtitleIndex;
     // Delay state change slightly to prevent setstate during build
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) setState(() {});
@@ -103,6 +130,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final request = PlaybackInfoRequest(
         itemId: item.id,
         mediaSourceId: mediaSourceId,
+        audioStreamIndex: _vm.selectedAudioIndex,
+        subtitleStreamIndex: _vm.selectedSubtitleIndex,
         deviceProfile: profile,
         maxStreamingBitrate: bitrate,
         enableDirectPlay: true,
@@ -139,6 +168,40 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   void initState() {
     super.initState();
     _vm.addListener(_onViewModelChanged);
+    _scrollController.addListener(_onScroll);
+    if (PlatformDetection.isTV) {
+      if (_vm.item?.type == 'Season') {
+        _selectedTab = 0;
+      } else {
+        _selectedTab = -1;
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.initialFocusNode?.requestFocus();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(ModernDetailContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialFocusNode != oldWidget.initialFocusNode && PlatformDetection.isTV) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.initialFocusNode?.requestFocus();
+      });
+    }
+  }
+
+  void _onScroll() {
+    if (!mounted) return;
+    if (PlatformDetection.isTV) return;
+    final scrolledDown = _scrollController.offset > 50.0;
+    if (scrolledDown && _showNavbarState) {
+      _showNavbarState = false;
+      widget.onToggleNavbar?.call(false);
+    } else if (!scrolledDown && !_showNavbarState) {
+      _showNavbarState = true;
+      widget.onToggleNavbar?.call(true);
+    }
   }
 
   void _onViewModelChanged() {
@@ -148,6 +211,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   @override
   void dispose() {
     _vm.removeListener(_onViewModelChanged);
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
     for (final node in _trackFocusNodes.values) {
       node.dispose();
     }
@@ -155,6 +220,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       node.dispose();
     }
     _upNextFocusNode.dispose();
+    _actionRowRightFocusNode.dispose();
+    _audioShowAllFocusNode.dispose();
+    _subtitleShowAllFocusNode.dispose();
+    _detailsTabFocusNode.dispose();
+    _castFirstFocusNode.dispose();
+    _crewFirstFocusNode.dispose();
+    _studiosFirstFocusNode.dispose();
     super.dispose();
   }
 
@@ -170,12 +242,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   FocusNode _tabNode(int index) {
     while (_tabFocusNodes.length <= index) {
-      _tabFocusNodes.add(FocusNode());
+      final node = FocusNode(debugLabel: 'tab_$index');
+      node.addListener(() {
+        if (node.hasFocus && mounted) {
+          widget.onToggleNavbar?.call(false);
+        }
+      });
+      _tabFocusNodes.add(node);
     }
     return _tabFocusNodes[index];
   }
 
   void _focusSelectedTab() => _tabNode(_selectedTab).requestFocus();
+
+  void _onTabBarNavigateDown() {
+    if (_detailsTabFocusNode.context != null && _detailsTabFocusNode.canRequestFocus) {
+      _detailsTabFocusNode.requestFocus();
+    }
+  }
 
   bool _isAudioItem(AggregatedItem item) {
     final mediaType = item.rawData['MediaType'] as String?;
@@ -282,6 +366,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _seasonsTab(BuildContext context, AggregatedItem item) {
     final l10n = AppLocalizations.of(context);
     final counts = _episodeCountsBySeason();
+    final showPosterUrl = _imageUrl(item);
     final cards = [
       for (final season in _vm.seasons)
         SeasonCard(
@@ -289,25 +374,36 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           subtitle: l10n.episodeCount(
             counts[season.id] ?? season.childCount ?? 0,
           ),
-          imageUrl: _imageUrl(season),
+          imageUrl: _imageUrl(season) ?? showPosterUrl,
+          isFallbackImage: _imageUrl(season) == null,
           landscape: _landscape,
+          onNavigateUp: _focusSelectedTab,
           onTap: () => context.push(
             Destinations.item(season.id, serverId: season.serverId),
           ),
         ),
     ];
     if (_landscape) {
-      return SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            for (final card in cards)
-              Padding(
-                padding: const EdgeInsets.only(right: 12),
-                child: card,
-              ),
-          ],
+      return Focus(
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (final card in cards)
+                Padding(
+                  padding: const EdgeInsets.only(right: 12),
+                  child: card,
+                ),
+            ],
+          ),
         ),
       );
     }
@@ -326,14 +422,29 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (final episode in _vm.episodes)
+        for (var i = 0; i < _vm.episodes.length; i++)
           Padding(
             padding: const EdgeInsets.only(bottom: 8),
-            child: DetailEpisodeCard(
-              episode: episode,
-              imageApi: _vm.imageApi,
-              onChanged: () => _vm.load(),
-            ),
+            child: i == 0
+                ? Focus(
+                    onKeyEvent: (node, event) {
+                      if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                        _focusSelectedTab();
+                        return KeyEventResult.handled;
+                      }
+                      return KeyEventResult.ignored;
+                    },
+                    child: DetailEpisodeCard(
+                      episode: _vm.episodes[i],
+                      imageApi: _vm.imageApi,
+                      onChanged: () => _vm.load(),
+                    ),
+                  )
+                : DetailEpisodeCard(
+                    episode: _vm.episodes[i],
+                    imageApi: _vm.imageApi,
+                    onChanged: () => _vm.load(),
+                  ),
           ),
       ],
     );
@@ -349,8 +460,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return counts;
   }
 
-  /// All episodes of a Series in one sequential list with a "Season N" header
-  /// before each season group.
+  final Set<int> _expandedSeasons = {};
+  bool _initializedExpandedSeasons = false;
+
+  /// All episodes of a Series grouped into collapsible season containers.
   Widget _seriesEpisodesTab(BuildContext context, AggregatedItem item) {
     final l10n = AppLocalizations.of(context);
     final episodes = _vm.seriesEpisodes;
@@ -366,47 +479,122 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         if (sa != sb) return sa.compareTo(sb);
         return (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0);
       });
-    final children = <Widget>[];
-    int? previousSeason;
+
+    // Group by season
+    final Map<int, List<AggregatedItem>> seasonGroups = {};
     for (final episode in sorted) {
-      final season = episode.parentIndexNumber;
-      if (season != previousSeason) {
-        children.add(
-          Padding(
-            padding: EdgeInsets.fromLTRB(0, children.isEmpty ? 0 : 20, 0, 10),
-            child: Text(
-              l10n.seasonNumber(season ?? 0),
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
-            ),
-          ),
-        );
-        previousSeason = season;
+      final s = episode.parentIndexNumber ?? 0;
+      seasonGroups.putIfAbsent(s, () => []).add(episode);
+    }
+
+    if (!_initializedExpandedSeasons && seasonGroups.isNotEmpty) {
+      _initializedExpandedSeasons = true;
+      final nextUpSeason = _vm.nextUp?.parentIndexNumber;
+      if (nextUpSeason != null && seasonGroups.containsKey(nextUpSeason)) {
+        _expandedSeasons.add(nextUpSeason);
+      } else {
+        _expandedSeasons.add(seasonGroups.keys.first);
       }
+    }
+
+    final children = <Widget>[];
+    for (final entry in seasonGroups.entries) {
+      final season = entry.key;
+      final eps = entry.value;
+      final isExpanded = _expandedSeasons.contains(season);
+      final isFirst = children.isEmpty;
+
       children.add(
         Padding(
-          padding: const EdgeInsets.only(bottom: 8),
-          child: DetailEpisodeCard(
-            episode: episode,
-            imageApi: _vm.imageApi,
-            onChanged: () => _vm.load(),
+          padding: const EdgeInsets.only(bottom: 6),
+          child: FocusableWrapper(
+            onNavigateUp: isFirst ? _focusSelectedTab : null,
+            onSelect: () {
+              setState(() {
+                if (_expandedSeasons.contains(season)) {
+                  _expandedSeasons.remove(season);
+                } else {
+                  _expandedSeasons.add(season);
+                }
+              });
+            },
+            borderRadius: 8,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Row(
+                children: [
+                  Icon(
+                    isExpanded ? Icons.expand_more : Icons.chevron_right,
+                    color: Colors.white70,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    l10n.seasonNumber(season),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: Colors.white,
+                        ),
+                  ),
+                  const SizedBox(width: 10),
+                  Text(
+                    '(${eps.length})',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.white38,
+                        ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
       );
+
+      if (isExpanded) {
+        children.add(
+          Padding(
+            padding: const EdgeInsets.only(left: 12, bottom: 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: eps.map((episode) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: DetailEpisodeCard(
+                    episode: episode,
+                    imageApi: _vm.imageApi,
+                    onChanged: () => _vm.load(),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        );
+      }
     }
+
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: children,
     );
   }
 
   Widget _castTab(BuildContext context, AggregatedItem item) => SizedBox(
         height: 200,
-        child: DetailCastRow(
-          people: _vm.actors,
-          imageApi: _vm.imageApi,
-          serverId: item.serverId,
+        child: Focus(
+          onKeyEvent: (node, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: DetailCastRow(
+            people: _vm.actors,
+            imageApi: _vm.imageApi,
+            serverId: item.serverId,
+            firstItemFocusNode: _castFirstFocusNode,
+            onNavigateUp: _focusSelectedTab,
+          ),
         ),
       );
 
@@ -440,18 +628,44 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
     final crew = merged.values.map((person) {
       final roles = person['Roles'] as Set<String>;
+      final normalizedRoles = roles.map((r) {
+        final trimmed = r.trim();
+        if (trimmed.isEmpty) return '';
+        return trimmed.split(RegExp(r'[;,]'))
+            .map((s) => s.trim())
+            .where((s) => s.isNotEmpty)
+            .map((s) {
+              if (s == s.toUpperCase() && s.length > 1) {
+                return s[0] + s.substring(1).toLowerCase();
+              }
+              return s;
+            })
+            .join('\n');
+      }).expand((r) => r.split('\n')).where((r) => r.isNotEmpty).toSet();
+
       return {
         ...person,
-        'Role': roles.join(', '),
+        'Role': normalizedRoles.join('\n'),
       };
     }).toList();
 
     return SizedBox(
       height: 200,
-      child: DetailCastRow(
-        people: crew,
-        imageApi: _vm.imageApi,
-        serverId: item.serverId,
+      child: Focus(
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: DetailCastRow(
+          people: crew,
+          imageApi: _vm.imageApi,
+          serverId: item.serverId,
+          firstItemFocusNode: _crewFirstFocusNode,
+          onNavigateUp: _focusSelectedTab,
+        ),
       ),
     );
   }
@@ -501,55 +715,69 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final cardWidth = isMobile ? 120.0 : 160.0 * desktopScale;
     final cardHeight = isMobile ? 80.0 : 100.0 * desktopScale;
 
-    return SizedBox(
-      height: cardHeight + 20,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        clipBehavior: Clip.none,
-        itemCount: studios.length,
-        separatorBuilder: (_, _) => const SizedBox(width: 16),
-        itemBuilder: (context, index) {
-          final studio = studios[index];
-          final name = studio['Name']?.toString() ?? '';
-          final studioId = studio['Id']?.toString();
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: SizedBox(
+        height: cardHeight + 20,
+        child: Focus(
+          onKeyEvent: (node, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            clipBehavior: Clip.none,
+            itemCount: studios.length,
+            separatorBuilder: (_, _) => const SizedBox(width: 16),
+            itemBuilder: (context, index) {
+              final studio = studios[index];
+              final name = studio['Name']?.toString() ?? '';
+              final studioId = studio['Id']?.toString();
 
-          final imageUrl = studioId != null
-              ? _vm.imageApi.getPrimaryImageUrl(
-                  studioId,
-                  maxHeight: isMobile ? 100 : (160 * desktopScale).round(),
-                )
-              : null;
+              final imageUrl = studioId != null
+                  ? _vm.imageApi.getPrimaryImageUrl(
+                      studioId,
+                      maxHeight: isMobile ? 100 : (160 * desktopScale).round(),
+                    )
+                  : null;
 
-          return FocusableWrapper(
-            onSelect: name.isNotEmpty
-                ? () => context.push(Destinations.searchWith('studio:$name'))
-                : null,
-            borderRadius: 12,
-            suppressFocusGlow: true,
-            child: Container(
-              width: cardWidth,
-              height: cardHeight,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.15),
-                  width: 1,
+              return FocusableWrapper(
+                focusNode: index == 0 ? _studiosFirstFocusNode : null,
+                onSelect: name.isNotEmpty
+                    ? () => context.push(Destinations.searchWith('studio:$name'))
+                    : null,
+                borderRadius: 12,
+                suppressFocusGlow: true,
+                onNavigateUp: _focusSelectedTab,
+                child: Container(
+                  width: cardWidth,
+                  height: cardHeight,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: Colors.white.withValues(alpha: 0.15),
+                      width: 1,
+                    ),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: imageUrl != null
+                        ? CachedNetworkImage(
+                            imageUrl: imageUrl,
+                            fit: BoxFit.contain,
+                            placeholder: (context, url) => _buildStudioFallback(context, name),
+                            errorWidget: (context, url, error) => _buildStudioFallback(context, name),
+                          )
+                        : _buildStudioFallback(context, name),
+                  ),
                 ),
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(12),
-                child: imageUrl != null
-                    ? CachedNetworkImage(
-                        imageUrl: imageUrl,
-                        fit: BoxFit.contain,
-                        placeholder: (context, url) => _buildStudioFallback(context, name),
-                        errorWidget: (context, url, error) => _buildStudioFallback(context, name),
-                      )
-                    : _buildStudioFallback(context, name),
-              ),
-            ),
-          );
-        },
+              );
+            },
+          ),
+        ),
       ),
     );
   }
@@ -558,29 +786,77 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (item.chapters.isEmpty) {
       return const SizedBox.shrink();
     }
-    return DetailChaptersRow(
-      item: item,
-      imageApi: _vm.imageApi,
-      onPlayFromChapter: widget.onPlayFromChapter ?? (_) {},
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          _focusSelectedTab();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: DetailChaptersRow(
+        item: item,
+        imageApi: _vm.imageApi,
+        onPlayFromChapter: widget.onPlayFromChapter ?? (_) {},
+      ),
     );
   }
 
   Widget _extrasTab(BuildContext context, AggregatedItem item) => SizedBox(
         height: 200,
-        child: DetailFeaturesRow(
-          items: _vm.features,
-          imageApi: _vm.imageApi,
-          prefs: widget.prefs,
+        child: Focus(
+          onKeyEvent: (node, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: DetailFeaturesRow(
+            items: _vm.features,
+            imageApi: _vm.imageApi,
+            prefs: widget.prefs,
+          ),
         ),
       );
 
+  AggregatedItem? _getRelevantEpisode(AggregatedItem item) {
+    if (item.type == 'Episode') return item;
+    if (item.type == 'Series') {
+      if (_vm.nextUp != null) {
+        return _vm.nextUp;
+      }
+      if (_vm.episodes.isNotEmpty) {
+        return _vm.episodes.first;
+      }
+    } else if (item.type == 'Season') {
+      if (_vm.episodes.isNotEmpty) {
+        return _vm.episodes.first;
+      }
+    }
+    return null;
+  }
+
   Widget _detailsTab(BuildContext context, AggregatedItem item) {
-    final mediaSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
-    final isPlayable = item.type != 'Series' && item.type != 'Season' && item.type != 'Person';
+    final targetItem = _getRelevantEpisode(item) ?? item;
+    final mediaSource = selectedMediaSourceForItem(targetItem, widget.selectedMediaSourceId);
+    final isPlayable = targetItem.type != 'Series' && targetItem.type != 'Season' && targetItem.type != 'Person';
 
     if (isPlayable && mediaSource != null) {
-      return _FocusableScrollableArea(
-        child: _buildFileInformation(context, item, mediaSource),
+      final List<Map<String, dynamic>> rawStreams = (mediaSource['MediaStreams'] as List?)
+              ?.whereType<Map>()
+              .map((e) => e.cast<String, dynamic>())
+              .toList() ??
+          [];
+      final audioStreams = rawStreams.where((s) => s['Type'] == 'Audio').toList();
+      final subtitleStreams = rawStreams.where((s) => s['Type'] == 'Subtitle').toList();
+      
+      final hasButtons = audioStreams.length > 2 || subtitleStreams.length > 2;
+      return _DetailsContainer(
+        isScrollable: true,
+        canRequestFocus: true,
+        focusNode: _detailsTabFocusNode,
+        child: _buildFileInformation(context, targetItem, mediaSource),
       );
     }
     return const SizedBox.shrink();
@@ -708,39 +984,160 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             ],
           ),
         ),
-        const SizedBox(height: 16),
-
+        const SizedBox(height: 24),
         if (videoDetails.isNotEmpty) ...[
-          _buildInfoRow('Video', videoDetails.join('  •  '), textTheme),
+          _buildInfoRow(
+            'Video',
+            Text(
+              videoDetails.join('  •  '),
+              style: textTheme.bodyMedium?.copyWith(
+                color: Colors.white.withValues(alpha: 0.9),
+                height: 1.3,
+              ),
+            ),
+            textTheme,
+          ),
           const SizedBox(height: 10),
         ],
 
         if (audioStreams.isNotEmpty) ...[
           _buildInfoRow(
             'Audio',
-            audioStreams.map((a) {
-              final title = a['DisplayTitle'] ?? a['Codec']?.toString().toUpperCase();
-              final lang = formatLang(a['Language']);
-              final isDefault = a['IsDefault'] == true ? ' [Default]' : '';
-              return '$title ($lang)$isDefault';
-            }).join('\n'),
+            Text.rich(
+              TextSpan(
+                children: [
+                  ...((_audioExpanded || audioStreams.length <= 2)
+                          ? audioStreams
+                          : audioStreams.take(2))
+                      .toList()
+                      .asMap()
+                      .entries
+                      .map((entry) {
+                    final idx = entry.key;
+                    final a = entry.value;
+                    final activeAudioIndex = _vm.selectedAudioIndex ??
+                        audioStreams.firstWhere((s) => s['IsDefault'] == true, orElse: () => audioStreams.first)['Index'] as int?;
+                    final title = a['DisplayTitle'] ?? a['Codec']?.toString().toUpperCase();
+                    final lang = formatLang(a['Language']);
+                    final isDefault = a['IsDefault'] == true ? ' [Default]' : '';
+                    final isSelected = a['Index'] == activeAudioIndex;
+
+                    return [
+                      if (idx > 0) const TextSpan(text: '\n'),
+                      TextSpan(
+                        text: '$title ($lang)$isDefault',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: Colors.white.withValues(alpha: isSelected ? 1.0 : 0.7),
+                          fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                          decoration: isSelected ? TextDecoration.underline : TextDecoration.none,
+                          decorationColor: AppColorScheme.accent,
+                          decorationThickness: 1.5,
+                          height: 1.3,
+                        ),
+                      ),
+                    ];
+                  }).expand((e) => e),
+                ],
+              ),
+            ),
             textTheme,
           ),
+          if (audioStreams.length > 2) ...[
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                const SizedBox(width: 90),
+                FocusableWrapper(
+                  focusNode: _audioShowAllFocusNode,
+                  onNavigateUp: _focusSelectedTab,
+                  onSelect: () => setState(() => _audioExpanded = !_audioExpanded),
+                  borderRadius: 6,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    child: Text(
+                      _audioExpanded ? 'Show Less' : 'Show All (${audioStreams.length}) Audio Tracks',
+                      style: TextStyle(
+                        color: AppColorScheme.accent,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
           const SizedBox(height: 10),
         ],
 
         if (subtitleStreams.isNotEmpty) ...[
           _buildInfoRow(
             'Subtitles',
-            subtitleStreams.map((s) {
-              final title = s['DisplayTitle'] ?? s['Codec']?.toString().toUpperCase();
-              final lang = formatLang(s['Language']);
-              final isDefault = s['IsDefault'] == true ? ' [Default]' : '';
-              final isForced = s['IsForced'] == true ? ' [Forced]' : '';
-              return '$title ($lang)$isDefault$isForced';
-            }).join('\n'),
+            Text.rich(
+              TextSpan(
+                children: [
+                  ...((_subtitlesExpanded || subtitleStreams.length <= 2)
+                          ? subtitleStreams
+                          : subtitleStreams.take(2))
+                      .toList()
+                      .asMap()
+                      .entries
+                      .map((entry) {
+                    final idx = entry.key;
+                    final s = entry.value;
+                    final activeSubtitleIndex = _vm.selectedSubtitleIndex ??
+                        subtitleStreams.firstWhere((s) => s['IsDefault'] == true, orElse: () => subtitleStreams.first)['Index'] as int?;
+                    final title = s['DisplayTitle'] ?? s['Codec']?.toString().toUpperCase();
+                    final lang = formatLang(s['Language']);
+                    final isDefault = s['IsDefault'] == true ? ' [Default]' : '';
+                    final isForced = s['IsForced'] == true ? ' [Forced]' : '';
+                    final isSelected = s['Index'] == activeSubtitleIndex;
+
+                    return [
+                      if (idx > 0) const TextSpan(text: '\n'),
+                      TextSpan(
+                        text: '$title ($lang)$isDefault$isForced',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: Colors.white.withValues(alpha: isSelected ? 1.0 : 0.7),
+                          fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                          decoration: isSelected ? TextDecoration.underline : TextDecoration.none,
+                          decorationColor: AppColorScheme.accent,
+                          decorationThickness: 1.5,
+                          height: 1.3,
+                        ),
+                      ),
+                    ];
+                  }).expand((e) => e),
+                ],
+              ),
+            ),
             textTheme,
           ),
+          if (subtitleStreams.length > 2) ...[
+            const SizedBox(height: 4),
+            Row(
+              children: [
+                const SizedBox(width: 90),
+                FocusableWrapper(
+                  focusNode: _subtitleShowAllFocusNode,
+                  onNavigateUp: _focusSelectedTab,
+                  onSelect: () => setState(() => _subtitlesExpanded = !_subtitlesExpanded),
+                  borderRadius: 6,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    child: Text(
+                      _subtitlesExpanded ? 'Show Less' : 'Show All (${subtitleStreams.length}) Subtitle Tracks',
+                      style: TextStyle(
+                        color: AppColorScheme.accent,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
           const SizedBox(height: 10),
         ],
 
@@ -750,7 +1147,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  Widget _buildInfoRow(String label, String value, TextTheme textTheme) {
+  Widget _buildInfoRow(String label, Widget child, TextTheme textTheme) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -765,13 +1162,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ),
         ),
         Expanded(
-          child: Text(
-            value,
-            style: textTheme.bodyMedium?.copyWith(
-              color: Colors.white.withValues(alpha: 0.9),
-              height: 1.3,
-            ),
-          ),
+          child: child,
         ),
       ],
     );
@@ -893,49 +1284,67 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         const textHeight = 44.0;
         final childAspectRatio =
             cellWidth / (cellWidth / cardRatio + textHeight);
-        return GridView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          padding: EdgeInsets.zero,
-          itemCount: items.length,
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: crossAxisCount,
-            crossAxisSpacing: spacing,
-            mainAxisSpacing: spacing,
-            childAspectRatio: childAspectRatio,
-          ),
-          itemBuilder: (context, i) {
-            final entry = items[i];
-            return MediaCard(
-              title: entry.name,
-              imageUrl: _imageUrl(entry),
-              width: double.infinity,
-              aspectRatio: cardRatio,
-              isPlayed: entry.isPlayed,
-              isFavorite: entry.isFavorite,
-              itemType: entry.type,
-              watchedBehavior:
-                  widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
-              onTap: () => context.push(
-                Destinations.item(entry.id, serverId: entry.serverId),
-              ),
-            );
+        return Focus(
+          onKeyEvent: (node, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
           },
+          child: GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            padding: EdgeInsets.zero,
+            itemCount: items.length,
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              crossAxisSpacing: spacing,
+              mainAxisSpacing: spacing,
+              childAspectRatio: childAspectRatio,
+            ),
+            itemBuilder: (context, i) {
+              final entry = items[i];
+              return MediaCard(
+                title: entry.name,
+                imageUrl: _imageUrl(entry),
+                width: double.infinity,
+                aspectRatio: cardRatio,
+                isPlayed: entry.isPlayed,
+                isFavorite: entry.isFavorite,
+                itemType: entry.type,
+                watchedBehavior:
+                    widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
+                onTap: () => context.push(
+                  Destinations.item(entry.id, serverId: entry.serverId),
+                ),
+              );
+            },
+          ),
         );
       },
     );
   }
 
   Widget _tracksTab(BuildContext context, AggregatedItem item) {
-    return DetailTrackList(
-      tracks: _vm.tracks,
-      imageApi: _vm.imageApi,
-      isAudiobook: _isAudiobook(item),
-      isPlaylist: item.type == 'Playlist',
-      groupByDisc: item.type == 'MusicAlbum',
-      getFocusNode: (id) =>
-          _trackFocusNodes.putIfAbsent(id, () => FocusNode()),
-      onPlayTrack: (index) => _playTrack(context, index),
+    return Focus(
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          _focusSelectedTab();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: DetailTrackList(
+        tracks: _vm.tracks,
+        imageApi: _vm.imageApi,
+        isAudiobook: _isAudiobook(item),
+        isPlaylist: item.type == 'Playlist',
+        groupByDisc: item.type == 'MusicAlbum',
+        getFocusNode: (id) =>
+            _trackFocusNodes.putIfAbsent(id, () => FocusNode()),
+        onPlayTrack: (index) => _playTrack(context, index),
+      ),
     );
   }
 
@@ -953,6 +1362,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   /// the Play pill (wider for "Resume from S#:E#" labels) plus More (~62); each
   /// circular button is ~62 wide.
   int? _actionButtonCap(BuildContext context, AggregatedItem item) {
+    if (item.type == 'Series' || item.type == 'Season' || item.type == 'Episode') {
+      final hasUpNext = _vm.nextUp != null;
+      if (_landscape && hasUpNext) {
+        return 4;
+      }
+      return null;
+    }
     if (!_landscape) return null;
     final hasUpNext = _buildUpNext(context, item) != null;
     final heroWidth = hasUpNext
@@ -970,51 +1386,72 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _buildHero(BuildContext context, AggregatedItem item) {
     final textTheme = Theme.of(context).textTheme;
     final isEpisode = item.type == 'Episode';
-    final logoTag = item.logoImageTag;
+    final logoTag = item.logoImageTag ?? (isEpisode ? item.seriesLogoImageTag : null);
+    final logoId = logoTag != null ? (item.logoImageTag != null ? item.id : item.seriesId) : null;
     final overview = item.overview?.trim();
+    final hideTitleAndLogo = _landscape && _vm.nextUp != null;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (isEpisode && item.seriesName != null)
-          Text(
-            item.seriesName!,
-            style: textTheme.labelLarge?.copyWith(
-              color: AppColorScheme.onSurface.withValues(alpha: 0.7),
-              letterSpacing: 1.2,
+        if (!hideTitleAndLogo) ...[
+          if (logoTag != null && logoId != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: LogoView(
+                imageUrl: _vm.imageApi
+                    .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
+                maxHeight: _landscape ? 90 : 64,
+                maxWidth: _landscape ? 360 : 260,
+              ),
+            )
+          else ...[
+            if (isEpisode && item.seriesName != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Text(
+                  item.seriesName!,
+                  style: textTheme.labelLarge?.copyWith(
+                    color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                    letterSpacing: 1.2,
+                  ),
+                ),
+              ),
+            Text(
+              item.name,
+              style: (_landscape
+                      ? textTheme.displaySmall
+                      : textTheme.headlineMedium)
+                  ?.copyWith(fontWeight: FontWeight.w700),
             ),
-          ),
-        if (!isEpisode && logoTag != null)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: LogoView(
-              imageUrl: _vm.imageApi
-                  .getLogoImageUrl(item.id, maxWidth: 350, tag: logoTag),
-              maxHeight: _landscape ? 90 : 64,
-              maxWidth: _landscape ? 360 : 260,
-            ),
-          )
-        else
+          ],
+        ],
+        if (isEpisode && logoTag != null) ...[
+          const SizedBox(height: 4),
           Text(
             item.name,
             style: (_landscape
-                    ? textTheme.displaySmall
-                    : textTheme.headlineMedium)
+                    ? textTheme.headlineMedium
+                    : textTheme.titleLarge)
                 ?.copyWith(fontWeight: FontWeight.w700),
           ),
+        ],
         const SizedBox(height: 6),
         _metadataRow(context, item),
         const SizedBox(height: 6),
-        RatingsRow(
-          ratings: _vm.ratings,
-          communityRating: item.communityRating,
-          criticRating: item.criticRating,
-          enableAdditionalRatings:
-              widget.prefs.get(UserPreferences.enableAdditionalRatings),
-          enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
-          showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
-          showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
-        ),
+        if (!_landscape || _vm.nextUp == null) ...[
+          RatingsRow(
+            ratings: _vm.ratings,
+            communityRating: item.communityRating,
+            criticRating: item.criticRating,
+            enableAdditionalRatings:
+                widget.prefs.get(UserPreferences.enableAdditionalRatings),
+            enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
+            showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
+            showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
+          ),
+          const SizedBox(height: 6),
+        ],
         if (item.tagline != null && item.tagline!.trim().isNotEmpty) ...[
           const SizedBox(height: 8),
           Text(
@@ -1038,17 +1475,43 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ),
         ],
         const SizedBox(height: 10),
-        DetailActionButtons(
-          viewModel: _vm,
-          itemId: item.id,
-          selectedMediaSourceId: widget.selectedMediaSourceId,
-          onSelectedMediaSourceChanged: widget.onSelectedMediaSourceChanged,
-          tvPlayFocusNode: widget.initialFocusNode,
-          autoPlay: widget.autoPlay,
-          modernStyle: true,
-          fullWidthPrimary: !_landscape,
-          maxVisibleButtonsOverride: _actionButtonCap(context, item),
-          onArrowRightAtEnd: _landscape ? _focusRightOfActions : null,
+        Focus(
+          canRequestFocus: false,
+          skipTraversal: true,
+          onFocusChange: (focused) {
+            if (focused && _scrollController.hasClients) {
+              _scrollController.animateTo(
+                0.0,
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeInOut,
+              );
+            }
+          },
+          child: DetailActionButtons(
+            viewModel: _vm,
+            itemId: item.id,
+            selectedMediaSourceId: widget.selectedMediaSourceId,
+            onSelectedMediaSourceChanged: widget.onSelectedMediaSourceChanged,
+            tvPlayFocusNode: widget.initialFocusNode,
+            downTarget: _tabNode(_selectedTab >= 0 ? _selectedTab : 0),
+            autoPlay: widget.autoPlay,
+            modernStyle: true,
+            fullWidthPrimary: !_landscape,
+            maxVisibleButtonsOverride: _actionButtonCap(context, item),
+            onArrowRightAtEnd: _landscape ? _focusRightOfActions : null,
+            actionRowRightFocusNode: _actionRowRightFocusNode,
+            onFocusExtra: (isFocused) {
+              if (isFocused) {
+                widget.onToggleNavbar?.call(false);
+              } else {
+                if (_scrollController.hasClients && _scrollController.offset <= 140) {
+                  widget.onToggleNavbar?.call(true);
+                }
+              }
+            },
+            actionsExpanded: widget.actionsExpanded,
+            onActionsExpandedChanged: widget.onActionsExpandedChanged,
+          ),
         ),
       ],
     );
@@ -1155,11 +1618,31 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       progress: progress,
       remainingLabel: _remainingLabel(episode, l10n),
       focusNode: _upNextFocusNode,
-      onNavigateLeft: () => widget.initialFocusNode?.requestFocus(),
+      onNavigateLeft: () {
+        if (_actionRowRightFocusNode.context != null && _actionRowRightFocusNode.canRequestFocus) {
+          _actionRowRightFocusNode.requestFocus();
+        } else {
+          widget.initialFocusNode?.requestFocus();
+        }
+      },
       onNavigateDown: _focusSelectedTab,
-      onTap: () => context.push(
-        Destinations.item(episode.id, serverId: episode.serverId),
-      ),
+      onTap: () async {
+        final manager = GetIt.instance<PlaybackManager>();
+        final hasProgress = (episode.playbackPosition?.inMilliseconds ?? 0) > 0 ||
+                            (episode.playedPercentage ?? 0) > 0;
+        await manager.playItems(
+          [episode],
+          startPosition: hasProgress
+              ? (episode.playbackPosition ?? Duration.zero)
+              : Duration.zero,
+        );
+        if (context.mounted) {
+          final destination = manager.playbackDeferredToExternalPlayer
+              ? Destinations.externalPlayer
+              : Destinations.videoPlayer;
+          unawaited(context.push(destination));
+        }
+      },
     );
   }
 
@@ -1192,7 +1675,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       fit: StackFit.expand,
       children: [
         ColoredBox(color: base),
-        if (url != null && url.isNotEmpty)
+        if (url != null && url.isNotEmpty) ...[
           CachedNetworkImage(
             imageUrl: url,
             fit: BoxFit.cover,
@@ -1201,6 +1684,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             fadeInDuration: const Duration(milliseconds: 250),
             errorWidget: (context, url, error) => const SizedBox.shrink(),
           ),
+          ColoredBox(color: Colors.black.withValues(alpha: 0.40)),
+        ],
         if (landscape) ...[
           DecoratedBox(
             decoration: BoxDecoration(
@@ -1209,10 +1694,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 end: Alignment.centerRight,
                 colors: [
                   base,
-                  base.withValues(alpha: 0.55),
+                  base.withValues(alpha: 0.90),
+                  base.withValues(alpha: 0.45),
                   base.withValues(alpha: 0.0),
                 ],
-                stops: const [0.0, 0.34, 0.62],
+                stops: const [0.0, 0.35, 0.60, 0.85],
               ),
             ),
           ),
@@ -1223,10 +1709,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 end: Alignment.topCenter,
                 colors: [
                   base,
-                  base.withValues(alpha: 0.55),
+                  base.withValues(alpha: 0.80),
                   base.withValues(alpha: 0.0),
                 ],
-                stops: const [0.0, 0.35, 0.68],
+                stops: const [0.0, 0.45, 0.80],
               ),
             ),
           ),
@@ -1269,6 +1755,50 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return _vm.imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
   }
 
+  void _selectTab(int index) {
+    if (index == _selectedTab) {
+      if (PlatformDetection.isTV) {
+        setState(() => _selectedTab = -1);
+        if (_scrollController.hasClients) {
+          _scrollController.animateTo(
+            0.0,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          );
+        }
+      }
+      return;
+    }
+
+    setState(() => _selectedTab = index);
+    if (index >= 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_scrollController.hasClients) {
+          _scrollController.animateTo(
+            220.0,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          );
+        }
+
+        if (PlatformDetection.isTV && _vm.item != null) {
+          final l10n = AppLocalizations.of(context);
+          final tabs = _tabsFor(_vm.item!, l10n);
+          if (index < tabs.length) {
+            final label = tabs[index].label;
+            if (label == l10n.cast) {
+              _castFirstFocusNode.requestFocus();
+            } else if (label == l10n.crewSection) {
+              _crewFirstFocusNode.requestFocus();
+            } else if (label == l10n.studios) {
+              _studiosFirstFocusNode.requestFocus();
+            }
+          }
+        }
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final item = _vm.item;
@@ -1279,36 +1809,81 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
 
     final l10n = AppLocalizations.of(context);
+    final textTheme = Theme.of(context).textTheme;
     _landscape = PlatformDetection.isTV ||
         PlatformDetection.useDesktopUi ||
         MediaQuery.orientationOf(context) == Orientation.landscape;
 
     final tabs = _tabsFor(item, l10n);
-    if (_selectedTab >= tabs.length) _selectedTab = 0;
+    if (_selectedTab >= tabs.length) {
+      _selectedTab = PlatformDetection.isTV ? -1 : 0;
+    }
 
-    if (tabs.isNotEmpty && _selectedTab < tabs.length && tabs[_selectedTab].label == l10n.details) {
-      final isPlayable = item.type != 'Series' && item.type != 'Season' && item.type != 'Person';
+    if (tabs.isNotEmpty && _selectedTab >= 0 && _selectedTab < tabs.length && tabs[_selectedTab].label == l10n.details) {
+      final targetItem = _getRelevantEpisode(item) ?? item;
+      final isPlayable = targetItem.type != 'Series' && targetItem.type != 'Season' && targetItem.type != 'Person';
       if (isPlayable) {
-        _loadPlaybackInfo(item);
+        _loadPlaybackInfo(targetItem);
       }
     }
 
-    final tabContent = tabs.isEmpty
+    final tabContent = (tabs.isEmpty || _selectedTab < 0)
         ? const SizedBox.shrink()
         : tabs[_selectedTab].builder(context, item);
 
     final tabBar = DetailsTabBar(
       labels: [for (final t in tabs) t.label],
       selectedIndex: _selectedTab,
-      onSelect: (i) => setState(() => _selectedTab = i),
+      onSelect: _selectTab,
       focusNodeFor: _tabNode,
       onExitLeft: () => widget.initialFocusNode?.requestFocus(),
+      onNavigateDown: (_selectedTab >= 0 && _selectedTab < tabs.length && tabs[_selectedTab].label == l10n.details)
+          ? _onTabBarNavigateDown
+          : null,
     );
 
     final hero = _buildHero(context, item);
     final upNext = _buildUpNext(context, item);
     final backdrop = _buildBackdrop(_landscape);
     final topInset = TopToolbar.heightFor(context);
+
+    final isEpisode = item.type == 'Episode';
+    final logoTag = item.logoImageTag ?? (isEpisode ? item.seriesLogoImageTag : null);
+    final logoId = logoTag != null ? (item.logoImageTag != null ? item.id : item.seriesId) : null;
+
+    final Widget? aboveHeroWidget = (_vm.nextUp != null)
+        ? Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (logoTag != null && logoId != null) ...[
+                LogoView(
+                  imageUrl: _vm.imageApi
+                      .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
+                  maxHeight: 90,
+                  maxWidth: 360,
+                ),
+                const SizedBox(height: 12),
+              ] else ...[
+                Text(
+                  item.name,
+                  style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 8),
+              ],
+              RatingsRow(
+                ratings: _vm.ratings,
+                communityRating: item.communityRating,
+                criticRating: item.criticRating,
+                enableAdditionalRatings:
+                    widget.prefs.get(UserPreferences.enableAdditionalRatings),
+                enabledRatings: widget.prefs.get(UserPreferences.enabledRatings),
+                showLabels: widget.prefs.get(UserPreferences.showRatingLabels),
+                showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
+              ),
+            ],
+          )
+        : null;
 
     return _landscape
         ? ModernLandscapeLayout(
@@ -1318,6 +1893,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             tabBar: tabBar,
             tabContent: tabContent,
             topInset: topInset,
+            scrollController: _scrollController,
+            aboveHero: aboveHeroWidget,
           )
         : ModernPortraitLayout(
             backdrop: backdrop,
@@ -1336,18 +1913,24 @@ class _ModernTab {
   const _ModernTab(this.label, this.builder);
 }
 
-class _FocusableScrollableArea extends StatefulWidget {
+class _DetailsContainer extends StatefulWidget {
   final Widget child;
+  final bool isScrollable;
+  final bool canRequestFocus;
+  final FocusNode? focusNode;
 
-  const _FocusableScrollableArea({
+  const _DetailsContainer({
     required this.child,
+    required this.isScrollable,
+    required this.canRequestFocus,
+    this.focusNode,
   });
 
   @override
-  State<_FocusableScrollableArea> createState() => _FocusableScrollableAreaState();
+  State<_DetailsContainer> createState() => _DetailsContainerState();
 }
 
-class _FocusableScrollableAreaState extends State<_FocusableScrollableArea> with FocusStateMixin {
+class _DetailsContainerState extends State<_DetailsContainer> with FocusStateMixin {
   final ScrollController _scrollController = ScrollController();
 
   @override
@@ -1366,37 +1949,55 @@ class _FocusableScrollableAreaState extends State<_FocusableScrollableArea> with
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 
     return Focus(
-      onFocusChange: (focused) => setFocused(focused),
-      onKeyEvent: (node, event) {
-        if (event is KeyDownEvent || event is KeyRepeatEvent) {
-          if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-            final maxScroll = _scrollController.position.maxScrollExtent;
-            final currentScroll = _scrollController.offset;
-            if (currentScroll < maxScroll) {
-              _scrollController.animateTo(
-                (currentScroll + 60.0).clamp(0.0, maxScroll),
-                duration: const Duration(milliseconds: 100),
-                curve: Curves.easeOut,
+      focusNode: widget.focusNode,
+      canRequestFocus: widget.canRequestFocus,
+      onFocusChange: (focused) {
+        setFocused(focused);
+        if (focused) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              Scrollable.ensureVisible(
+                context,
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeInOut,
+                alignment: 0.5,
               );
-              return KeyEventResult.handled;
             }
-          } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            final currentScroll = _scrollController.offset;
-            if (currentScroll > 0.0) {
-              _scrollController.animateTo(
-                (currentScroll - 60.0).clamp(0.0, double.infinity),
-                duration: const Duration(milliseconds: 100),
-                curve: Curves.easeOut,
-              );
-              return KeyEventResult.handled;
-            }
-          }
+          });
         }
-        return KeyEventResult.ignored;
       },
+      onKeyEvent: widget.isScrollable
+          ? (node, event) {
+              if (event is KeyDownEvent || event is KeyRepeatEvent) {
+                if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                  final maxScroll = _scrollController.position.maxScrollExtent;
+                  final currentScroll = _scrollController.offset;
+                  if (currentScroll < maxScroll) {
+                    _scrollController.animateTo(
+                      (currentScroll + 60.0).clamp(0.0, maxScroll),
+                      duration: const Duration(milliseconds: 100),
+                      curve: Curves.easeOut,
+                    );
+                    return KeyEventResult.handled;
+                  }
+                } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                  final currentScroll = _scrollController.offset;
+                  if (currentScroll > 0.0) {
+                    _scrollController.animateTo(
+                      (currentScroll - 60.0).clamp(0.0, double.infinity),
+                      duration: const Duration(milliseconds: 100),
+                      curve: Curves.easeOut,
+                    );
+                    return KeyEventResult.handled;
+                  }
+                }
+              }
+              return KeyEventResult.ignored;
+            }
+          : null,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
-        height: 250,
+        height: widget.isScrollable ? 320 : null,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
@@ -1408,14 +2009,16 @@ class _FocusableScrollableAreaState extends State<_FocusableScrollableArea> with
           color: Colors.white.withValues(alpha: 0.02),
         ),
         padding: const EdgeInsets.all(16),
-        child: Scrollbar(
-          controller: _scrollController,
-          thumbVisibility: showFocusBorder,
-          child: SingleChildScrollView(
-            controller: _scrollController,
-            child: widget.child,
-          ),
-        ),
+        child: widget.isScrollable
+            ? Scrollbar(
+                controller: _scrollController,
+                thumbVisibility: showFocusBorder,
+                child: SingleChildScrollView(
+                  controller: _scrollController,
+                  child: widget.child,
+                ),
+              )
+            : widget.child,
       ),
     );
   }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -144,6 +144,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   bool _loadingPlaybackInfo = false;
   String? _loadedPlaybackInfoItemId;
 
+  bool _upNextResolvedThisBuild = false;
+  Widget? _upNextCard;
+
   Future<void> _loadPlaybackInfo(AggregatedItem item) async {
     if (_loadingPlaybackInfo) return;
     if (_playbackInfo != null &&
@@ -3555,6 +3558,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget? _buildUpNext(BuildContext context, AggregatedItem item) {
+    // Queried several times per build but inserted once; build it once.
+    if (!_upNextResolvedThisBuild) {
+      _upNextCard = _computeUpNext(context, item);
+      _upNextResolvedThisBuild = true;
+    }
+    return _upNextCard;
+  }
+
+  Widget? _computeUpNext(BuildContext context, AggregatedItem item) {
     const supported = {'Series', 'Season', 'BoxSet'};
     if (!supported.contains(item.type)) return null;
     final isBoxSet = item.type == 'BoxSet';
@@ -3804,6 +3816,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget build(BuildContext context) {
     final item = _vm.item;
     if (item == null) return const SizedBox.shrink();
+    _upNextResolvedThisBuild = false;
 
     if (item.type == 'Series') {
       _vm.loadAllSeriesEpisodes();

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1325,6 +1325,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           padding: const EdgeInsets.only(bottom: 6),
           child: FocusableWrapper(
             focusNode: headingNode,
+            onFocusChange: (focused) {
+              if (focused && mounted) {
+                Scrollable.ensureVisible(
+                  context,
+                  duration: const Duration(milliseconds: 150),
+                  alignment: 0.3,
+                );
+              }
+            },
             onNavigateLeft: () {
               final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
               if (navbarPosition == NavbarPosition.left) {
@@ -1407,44 +1416,56 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         children.add(
           Padding(
             padding: const EdgeInsets.only(left: 12, bottom: 12),
-            child: SizedBox(
-              height: 200,
-              child: DetailCastRow(
-                people: childActors,
-                imageApi: _vm.imageApi,
-                serverId: childItem.serverId,
-                firstItemFocusNode: rowFirstNode,
-                onNavigateUp: () {
-                  headingNode.requestFocus();
-                },
-                onItemKeyEvent: (index, event) {
-                  if (event is KeyDownEvent || event is KeyRepeatEvent) {
-                    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-                      if (i < sortedItems.length - 1) {
-                        final nextItem = sortedItems[i + 1];
-                        final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_cast_${nextItem.name}'));
-                        nextNode.requestFocus();
-                      }
-                      return KeyEventResult.handled;
-                    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                      headingNode.requestFocus();
-                      return KeyEventResult.handled;
-                    } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft && index == 0) {
-                      final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
-                      if (navbarPosition == NavbarPosition.left) {
-                        final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
-                        if (focusNavbar != null) {
-                          focusNavbar();
-                          return KeyEventResult.handled;
+            child: Focus(
+              canRequestFocus: false,
+              onFocusChange: (focused) {
+                if (focused && mounted) {
+                  Scrollable.ensureVisible(
+                    context,
+                    duration: const Duration(milliseconds: 150),
+                    alignment: 0.5,
+                  );
+                }
+              },
+              child: SizedBox(
+                height: 200,
+                child: DetailCastRow(
+                  people: childActors,
+                  imageApi: _vm.imageApi,
+                  serverId: childItem.serverId,
+                  firstItemFocusNode: rowFirstNode,
+                  onNavigateUp: () {
+                    headingNode.requestFocus();
+                  },
+                  onItemKeyEvent: (index, event) {
+                    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+                      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                        if (i < sortedItems.length - 1) {
+                          final nextItem = sortedItems[i + 1];
+                          final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_cast_${nextItem.name}'));
+                          nextNode.requestFocus();
                         }
+                        return KeyEventResult.handled;
+                      } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                        headingNode.requestFocus();
+                        return KeyEventResult.handled;
+                      } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft && index == 0) {
+                        final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+                        if (navbarPosition == NavbarPosition.left) {
+                          final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+                          if (focusNavbar != null) {
+                            focusNavbar();
+                            return KeyEventResult.handled;
+                          }
+                        }
+                        return KeyEventResult.handled; // Cap on left
+                      } else if (event.logicalKey == LogicalKeyboardKey.arrowRight && index == childActors.length - 1) {
+                        return KeyEventResult.handled; // Cap on right
                       }
-                      return KeyEventResult.handled; // Cap on left
-                    } else if (event.logicalKey == LogicalKeyboardKey.arrowRight && index == childActors.length - 1) {
-                      return KeyEventResult.handled; // Cap on right
                     }
-                  }
-                  return KeyEventResult.ignored;
-                },
+                    return KeyEventResult.ignored;
+                  },
+                ),
               ),
             ),
           ),
@@ -1553,6 +1574,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           padding: const EdgeInsets.only(bottom: 6),
           child: FocusableWrapper(
             focusNode: headingNode,
+            onFocusChange: (focused) {
+              if (focused && mounted) {
+                Scrollable.ensureVisible(
+                  context,
+                  duration: const Duration(milliseconds: 150),
+                  alignment: 0.3,
+                );
+              }
+            },
             onNavigateLeft: () {
               final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
               if (navbarPosition == NavbarPosition.left) {
@@ -1635,44 +1665,56 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         children.add(
           Padding(
             padding: const EdgeInsets.only(left: 12, bottom: 12),
-            child: SizedBox(
-              height: 200,
-              child: DetailCastRow(
-                people: childCrew,
-                imageApi: _vm.imageApi,
-                serverId: childItem.serverId,
-                firstItemFocusNode: rowFirstNode,
-                onNavigateUp: () {
-                  headingNode.requestFocus();
-                },
-                onItemKeyEvent: (index, event) {
-                  if (event is KeyDownEvent || event is KeyRepeatEvent) {
-                    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-                      if (i < sortedItems.length - 1) {
-                        final nextItem = sortedItems[i + 1];
-                        final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_crew_${nextItem.name}'));
-                        nextNode.requestFocus();
-                      }
-                      return KeyEventResult.handled;
-                    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                      headingNode.requestFocus();
-                      return KeyEventResult.handled;
-                    } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft && index == 0) {
-                      final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
-                      if (navbarPosition == NavbarPosition.left) {
-                        final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
-                        if (focusNavbar != null) {
-                          focusNavbar();
-                          return KeyEventResult.handled;
+            child: Focus(
+              canRequestFocus: false,
+              onFocusChange: (focused) {
+                if (focused && mounted) {
+                  Scrollable.ensureVisible(
+                    context,
+                    duration: const Duration(milliseconds: 150),
+                    alignment: 0.5,
+                  );
+                }
+              },
+              child: SizedBox(
+                height: 200,
+                child: DetailCastRow(
+                  people: childCrew,
+                  imageApi: _vm.imageApi,
+                  serverId: childItem.serverId,
+                  firstItemFocusNode: rowFirstNode,
+                  onNavigateUp: () {
+                    headingNode.requestFocus();
+                  },
+                  onItemKeyEvent: (index, event) {
+                    if (event is KeyDownEvent || event is KeyRepeatEvent) {
+                      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                        if (i < sortedItems.length - 1) {
+                          final nextItem = sortedItems[i + 1];
+                          final nextNode = _boxSetHeadingFocusNodes.putIfAbsent(nextItem.id, () => FocusNode(debugLabel: 'heading_crew_${nextItem.name}'));
+                          nextNode.requestFocus();
                         }
+                        return KeyEventResult.handled;
+                      } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                        headingNode.requestFocus();
+                        return KeyEventResult.handled;
+                      } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft && index == 0) {
+                        final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
+                        if (navbarPosition == NavbarPosition.left) {
+                          final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+                          if (focusNavbar != null) {
+                            focusNavbar();
+                            return KeyEventResult.handled;
+                          }
+                        }
+                        return KeyEventResult.handled; // Cap on left
+                      } else if (event.logicalKey == LogicalKeyboardKey.arrowRight && index == childCrew.length - 1) {
+                        return KeyEventResult.handled; // Cap on right
                       }
-                      return KeyEventResult.handled; // Cap on left
-                    } else if (event.logicalKey == LogicalKeyboardKey.arrowRight && index == childCrew.length - 1) {
-                      return KeyEventResult.handled; // Cap on right
                     }
-                  }
-                  return KeyEventResult.ignored;
-                },
+                    return KeyEventResult.ignored;
+                  },
+                ),
               ),
             ),
           ),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1,10 +1,12 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:playback_core/playback_core.dart';
 import 'package:server_core/server_core.dart';
+import '../../../mixins/focus_state_mixin.dart';
 
 import '../../../../data/models/aggregated_item.dart';
 import '../../../../data/viewmodels/item_detail_view_model.dart';
@@ -414,21 +416,25 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     for (final d in _vm.directors) {
       final id = d['Id']?.toString() ?? d['Name']?.toString() ?? '';
       if (id.isEmpty) continue;
+      final roleStr = d['Role']?.toString().trim();
+      final role = (roleStr != null && roleStr.isNotEmpty) ? roleStr : l10n.director;
       merged[id] = {
         ...d,
-        'Roles': <String>{d['Role'] as String? ?? l10n.director},
+        'Roles': <String>{role},
       };
     }
     for (final w in _vm.writers) {
       final id = w['Id']?.toString() ?? w['Name']?.toString() ?? '';
       if (id.isEmpty) continue;
+      final roleStr = w['Role']?.toString().trim();
+      final role = (roleStr != null && roleStr.isNotEmpty) ? roleStr : l10n.writer;
       if (merged.containsKey(id)) {
         final roles = merged[id]!['Roles'] as Set<String>;
-        roles.add(w['Role'] as String? ?? l10n.writer);
+        roles.add(role);
       } else {
         merged[id] = {
           ...w,
-          'Roles': <String>{w['Role'] as String? ?? l10n.writer},
+          'Roles': <String>{role},
         };
       }
     }
@@ -519,6 +525,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 ? () => context.push(Destinations.searchWith('studio:$name'))
                 : null,
             borderRadius: 12,
+            suppressFocusGlow: true,
             child: Container(
               width: cardWidth,
               height: cardHeight,
@@ -571,13 +578,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final mediaSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
     final isPlayable = item.type != 'Series' && item.type != 'Season' && item.type != 'Person';
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (isPlayable && mediaSource != null)
-          _buildFileInformation(context, item, mediaSource),
-      ],
-    );
+    if (isPlayable && mediaSource != null) {
+      return _FocusableScrollableArea(
+        child: _buildFileInformation(context, item, mediaSource),
+      );
+    }
+    return const SizedBox.shrink();
   }
 
   Widget _buildFileInformation(
@@ -996,9 +1002,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                     : textTheme.headlineMedium)
                 ?.copyWith(fontWeight: FontWeight.w700),
           ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 6),
         _metadataRow(context, item),
-        const SizedBox(height: 12),
+        const SizedBox(height: 6),
         RatingsRow(
           ratings: _vm.ratings,
           communityRating: item.communityRating,
@@ -1010,7 +1016,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           showBadges: widget.prefs.get(UserPreferences.showRatingBadges),
         ),
         if (item.tagline != null && item.tagline!.trim().isNotEmpty) ...[
-          const SizedBox(height: 14),
+          const SizedBox(height: 8),
           Text(
             item.tagline!.trim(),
             style: textTheme.titleSmall?.copyWith(
@@ -1020,7 +1026,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ),
         ],
         if (overview != null && overview.isNotEmpty) ...[
-          const SizedBox(height: 14),
+          const SizedBox(height: 8),
           Text(
             overview,
             maxLines: _landscape ? 4 : 6,
@@ -1031,7 +1037,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             ),
           ),
         ],
-        const SizedBox(height: 18),
+        const SizedBox(height: 10),
         DetailActionButtons(
           viewModel: _vm,
           itemId: item.id,
@@ -1328,4 +1334,89 @@ class _ModernTab {
   final String label;
   final Widget Function(BuildContext, AggregatedItem) builder;
   const _ModernTab(this.label, this.builder);
+}
+
+class _FocusableScrollableArea extends StatefulWidget {
+  final Widget child;
+
+  const _FocusableScrollableArea({
+    required this.child,
+  });
+
+  @override
+  State<_FocusableScrollableArea> createState() => _FocusableScrollableAreaState();
+}
+
+class _FocusableScrollableAreaState extends State<_FocusableScrollableArea> with FocusStateMixin {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+
+    return Focus(
+      onFocusChange: (focused) => setFocused(focused),
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent || event is KeyRepeatEvent) {
+          if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+            final maxScroll = _scrollController.position.maxScrollExtent;
+            final currentScroll = _scrollController.offset;
+            if (currentScroll < maxScroll) {
+              _scrollController.animateTo(
+                (currentScroll + 60.0).clamp(0.0, maxScroll),
+                duration: const Duration(milliseconds: 100),
+                curve: Curves.easeOut,
+              );
+              return KeyEventResult.handled;
+            }
+          } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            final currentScroll = _scrollController.offset;
+            if (currentScroll > 0.0) {
+              _scrollController.animateTo(
+                (currentScroll - 60.0).clamp(0.0, double.infinity),
+                duration: const Duration(milliseconds: 100),
+                curve: Curves.easeOut,
+              );
+              return KeyEventResult.handled;
+            }
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        height: 250,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: showFocusBorder
+                ? (isNeon ? AppColorScheme.accent : focusColor)
+                : Colors.white.withValues(alpha: 0.08),
+            width: showFocusBorder ? 1.5 : 1.0,
+          ),
+          color: Colors.white.withValues(alpha: 0.02),
+        ),
+        padding: const EdgeInsets.all(16),
+        child: Scrollbar(
+          controller: _scrollController,
+          thumbVisibility: showFocusBorder,
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            child: widget.child,
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -2841,6 +2841,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return (circles + 2).clamp(2, 12);
   }
 
+  List<Shadow>? _neonTextGlow(double blurRadius) =>
+      ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+          ? [Shadow(color: AppColorScheme.accent, blurRadius: blurRadius)]
+          : null;
+
   Widget _buildHero(BuildContext context, AggregatedItem item) {
     final textTheme = Theme.of(context).textTheme;
     final isEpisode = item.type == 'Episode';
@@ -2861,7 +2866,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final profileUrl = _imageUrl(item);
       final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
       final focusColor = Color(widget.prefs.get(UserPreferences.focusColor).colorValue);
-      final profileBorderColor = isNeon ? const Color(0xFFFF2E92) : focusColor;
+      final profileBorderColor = isNeon ? AppColorScheme.accent : focusColor;
 
 
       final avatar = Container(
@@ -3034,14 +3039,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             style: textTheme.displaySmall?.copyWith(
               fontWeight: FontWeight.w700,
               color: Colors.white,
-              shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                  ? [
-                      const Shadow(
-                        color: Color(0xFFFF2E92),
-                        blurRadius: 12,
-                      ),
-                    ]
-                  : null,
+              shadows: _neonTextGlow(12),
             ),
           ),
           if (item.type == 'MusicAlbum' && artistName != null) ...[
@@ -3103,14 +3101,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                         style: textTheme.titleMedium?.copyWith(
                           color: AppColorScheme.accent,
                           fontWeight: FontWeight.bold,
-                          shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                              ? [
-                                  const Shadow(
-                                    color: Color(0xFFFF2E92),
-                                    blurRadius: 8,
-                                  ),
-                                ]
-                              : null,
+                          shadows: _neonTextGlow(8),
                         ),
                       ),
                     ),
@@ -3887,14 +3878,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           style: textTheme.titleLarge?.copyWith(
             fontWeight: FontWeight.bold,
             color: Colors.white,
-            shadows: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? [
-                    const Shadow(
-                      color: Color(0xFFFF2E92),
-                      blurRadius: 10,
-                    ),
-                  ]
-                : null,
+            shadows: _neonTextGlow(10),
           ),
         ),
       );

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -599,7 +599,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return _tabFocusNodes[index];
   }
 
-  void _focusSelectedTab() => _tabNode(_selectedTab).requestFocus();
+  void _focusSelectedTab() {
+    // On TV _selectedTab starts at -1 (no tab chosen); guard the list index.
+    if (_selectedTab < 0) return;
+    _tabNode(_selectedTab).requestFocus();
+  }
 
   void _onTabBarNavigateDown(int tabIndex) {
     if (_vm.item == null) return;

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -85,7 +85,15 @@ class ModernLandscapeLayout extends StatelessWidget {
                   child: tabBar,
                 ),
                 Padding(
-                  padding: EdgeInsets.fromLTRB(leftPadding, 0, 40, 16),
+                  padding: EdgeInsets.fromLTRB(
+                    leftPadding,
+                    0,
+                    40,
+                    80.0 *
+                        GetIt.instance<UserPreferences>()
+                            .get(UserPreferences.desktopUiScale)
+                            .scaleFactor,
+                  ),
                   child: tabContent,
                 ),
               ],

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -11,6 +11,8 @@ class ModernLandscapeLayout extends StatelessWidget {
   final Widget tabBar;
   final Widget tabContent;
   final double topInset;
+  final ScrollController? scrollController;
+  final Widget? aboveHero;
 
   const ModernLandscapeLayout({
     super.key,
@@ -20,6 +22,8 @@ class ModernLandscapeLayout extends StatelessWidget {
     required this.tabContent,
     required this.topInset,
     this.upNext,
+    this.scrollController,
+    this.aboveHero,
   });
 
   @override
@@ -35,14 +39,20 @@ class ModernLandscapeLayout extends StatelessWidget {
         backdrop,
         SafeArea(
           child: SingleChildScrollView(
+            controller: scrollController,
             padding: EdgeInsets.only(top: topInset - 12),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if (aboveHero != null)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(40, 8, 40, 0),
+                    child: aboveHero!,
+                  ),
                 Padding(
                   padding: const EdgeInsets.fromLTRB(40, 8, 40, 0),
                   child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.end,
                     children: [
                       SizedBox(width: heroWidth, child: hero),
                       const SizedBox(width: 24),

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -35,12 +35,12 @@ class ModernLandscapeLayout extends StatelessWidget {
         backdrop,
         SafeArea(
           child: SingleChildScrollView(
-            padding: EdgeInsets.only(top: topInset),
+            padding: EdgeInsets.only(top: topInset - 12),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(40, 24, 40, 0),
+                  padding: const EdgeInsets.fromLTRB(40, 8, 40, 0),
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
@@ -61,11 +61,11 @@ class ModernLandscapeLayout extends StatelessWidget {
                   ),
                 ),
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(40, 24, 40, 8),
+                  padding: const EdgeInsets.fromLTRB(40, 10, 40, 4),
                   child: tabBar,
                 ),
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(40, 0, 40, 40),
+                  padding: const EdgeInsets.fromLTRB(40, 0, 40, 16),
                   child: tabContent,
                 ),
               ],

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -58,7 +58,7 @@ class ModernLandscapeLayout extends StatelessWidget {
                   ),
                 ),
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(40, 0, 40, 8),
+                  padding: const EdgeInsets.fromLTRB(40, 24, 40, 8),
                   child: tabBar,
                 ),
                 Padding(

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import '../../../../preference/preference_constants.dart';
 import '../../../../preference/user_preferences.dart';
+import '../../../../util/platform_detection.dart';
 
 /// Arranges the Modern detail pieces for landscape (TV, desktop, any landscape
 /// device): full-bleed backdrop, a left hero column, a floating Up Next card on
@@ -47,6 +48,7 @@ class ModernLandscapeLayout extends StatelessWidget {
         SafeArea(
           child: SingleChildScrollView(
             controller: scrollController,
+            physics: PlatformDetection.isTV ? const NeverScrollableScrollPhysics() : const ScrollPhysics(),
             padding: EdgeInsets.only(top: hasUpNext ? topInset - 24 : topInset - 12),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -57,16 +59,16 @@ class ModernLandscapeLayout extends StatelessWidget {
                     child: aboveHero!,
                   ),
                 Padding(
-                  padding: EdgeInsets.fromLTRB(leftPadding, 8, 40, 0),
+                  padding: EdgeInsets.fromLTRB(leftPadding, 20, 40, 0),
                   child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.end,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       SizedBox(width: heroWidth, child: hero),
-                      const SizedBox(width: 24),
-                      if (upNext != null)
+                      if (upNext != null) ...[
+                        const SizedBox(width: 24),
                         Expanded(
                           child: Align(
-                            alignment: Alignment.bottomRight,
+                            alignment: Alignment.topRight,
                             child: ConstrainedBox(
                               constraints:
                                   const BoxConstraints(maxWidth: 460),
@@ -74,6 +76,7 @@ class ModernLandscapeLayout extends StatelessWidget {
                             ),
                           ),
                         ),
+                      ],
                     ],
                   ),
                 ),

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -17,6 +17,7 @@ class ModernLandscapeLayout extends StatelessWidget {
   final double topInset;
   final ScrollController? scrollController;
   final Widget? aboveHero;
+  final bool isBoxSet;
 
   const ModernLandscapeLayout({
     super.key,
@@ -28,15 +29,19 @@ class ModernLandscapeLayout extends StatelessWidget {
     this.upNext,
     this.scrollController,
     this.aboveHero,
+    this.isBoxSet = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
     final hasUpNext = upNext != null;
+    final scale = GetIt.instance<UserPreferences>().get(UserPreferences.desktopUiScale).scaleFactor;
     final heroWidth = hasUpNext
-        ? (size.width * 0.45).clamp(360.0, 620.0)
-        : (size.width * 0.75).clamp(450.0, 960.0);
+        ? (isBoxSet
+            ? (size.width * 0.70).clamp(450.0, 950.0)
+            : (size.width * 0.50).clamp(360.0, 680.0))
+        : (size.width * 0.85).clamp(450.0, 1100.0);
 
     final hasLeftSidebar = GetIt.instance<UserPreferences>().get(UserPreferences.navbarPosition) == NavbarPosition.left;
     final leftPadding = hasLeftSidebar ? 120.0 : 40.0;
@@ -49,30 +54,46 @@ class ModernLandscapeLayout extends StatelessWidget {
           child: SingleChildScrollView(
             controller: scrollController,
             physics: PlatformDetection.isTV ? const NeverScrollableScrollPhysics() : const ScrollPhysics(),
-            padding: EdgeInsets.only(top: hasUpNext ? topInset - 24 : topInset - 12),
+            padding: EdgeInsets.only(top: (hasUpNext ? topInset - 24 : topInset - 12) / scale),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                if (aboveHero != null)
+                if (aboveHero != null && !(isBoxSet && hasUpNext))
                   Padding(
-                    padding: EdgeInsets.fromLTRB(leftPadding, hasUpNext ? 2.0 : 8.0, 40, 0),
+                    padding: EdgeInsets.fromLTRB(leftPadding, (hasUpNext ? 2.0 : 8.0) / scale, 40, 0),
                     child: aboveHero!,
                   ),
                 Padding(
-                  padding: EdgeInsets.fromLTRB(leftPadding, 20, 40, 0),
+                  padding: EdgeInsets.fromLTRB(leftPadding, 10 / scale, 40, 0),
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      SizedBox(width: heroWidth, child: hero),
+                      SizedBox(
+                        width: heroWidth,
+                        child: (isBoxSet && hasUpNext)
+                            ? Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  if (aboveHero != null) aboveHero!,
+                                  const SizedBox(height: 10),
+                                  hero,
+                                ],
+                              )
+                            : hero,
+                      ),
                       if (upNext != null) ...[
                         const SizedBox(width: 24),
                         Expanded(
                           child: Align(
                             alignment: Alignment.topRight,
-                            child: ConstrainedBox(
-                              constraints:
-                                  const BoxConstraints(maxWidth: 460),
-                              child: upNext,
+                            child: Padding(
+                              padding: EdgeInsets.only(top: isBoxSet ? 24.0 / scale : 0.0),
+                              child: ConstrainedBox(
+                                constraints:
+                                    const BoxConstraints(maxWidth: 410),
+                                child: upNext,
+                              ),
                             ),
                           ),
                         ),
@@ -81,7 +102,7 @@ class ModernLandscapeLayout extends StatelessWidget {
                   ),
                 ),
                 Padding(
-                  padding: EdgeInsets.fromLTRB(leftPadding, 24, 40, 8),
+                  padding: EdgeInsets.fromLTRB(leftPadding, 16 / scale, 40, 8 / scale),
                   child: tabBar,
                 ),
                 Padding(
@@ -89,10 +110,7 @@ class ModernLandscapeLayout extends StatelessWidget {
                     leftPadding,
                     0,
                     40,
-                    80.0 *
-                        GetIt.instance<UserPreferences>()
-                            .get(UserPreferences.desktopUiScale)
-                            .scaleFactor,
+                    40.0 / scale,
                   ),
                   child: tabContent,
                 ),

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -25,7 +25,10 @@ class ModernLandscapeLayout extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
-    final heroWidth = (size.width * 0.45).clamp(360.0, 620.0);
+    final hasUpNext = upNext != null;
+    final heroWidth = hasUpNext
+        ? (size.width * 0.45).clamp(360.0, 620.0)
+        : (size.width * 0.75).clamp(450.0, 960.0);
     return Stack(
       fit: StackFit.expand,
       children: [

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import '../../../../preference/preference_constants.dart';
+import '../../../../preference/user_preferences.dart';
 
 /// Arranges the Modern detail pieces for landscape (TV, desktop, any landscape
 /// device): full-bleed backdrop, a left hero column, a floating Up Next card on
@@ -33,6 +36,10 @@ class ModernLandscapeLayout extends StatelessWidget {
     final heroWidth = hasUpNext
         ? (size.width * 0.45).clamp(360.0, 620.0)
         : (size.width * 0.75).clamp(450.0, 960.0);
+
+    final hasLeftSidebar = GetIt.instance<UserPreferences>().get(UserPreferences.navbarPosition) == NavbarPosition.left;
+    final leftPadding = hasLeftSidebar ? 120.0 : 40.0;
+
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -40,17 +47,17 @@ class ModernLandscapeLayout extends StatelessWidget {
         SafeArea(
           child: SingleChildScrollView(
             controller: scrollController,
-            padding: EdgeInsets.only(top: topInset - 12),
+            padding: EdgeInsets.only(top: hasUpNext ? topInset - 24 : topInset - 12),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 if (aboveHero != null)
                   Padding(
-                    padding: const EdgeInsets.fromLTRB(40, 8, 40, 0),
+                    padding: EdgeInsets.fromLTRB(leftPadding, hasUpNext ? 2.0 : 8.0, 40, 0),
                     child: aboveHero!,
                   ),
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(40, 8, 40, 0),
+                  padding: EdgeInsets.fromLTRB(leftPadding, 8, 40, 0),
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.end,
                     children: [
@@ -71,11 +78,11 @@ class ModernLandscapeLayout extends StatelessWidget {
                   ),
                 ),
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(40, 10, 40, 4),
+                  padding: EdgeInsets.fromLTRB(leftPadding, 24, 40, 8),
                   child: tabBar,
                 ),
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(40, 0, 40, 16),
+                  padding: EdgeInsets.fromLTRB(leftPadding, 0, 40, 16),
                   child: tabContent,
                 ),
               ],

--- a/lib/ui/screens/detail/modern/modern_portrait_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_portrait_layout.dart
@@ -49,7 +49,7 @@ class ModernPortraitLayout extends StatelessWidget {
                     padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
                     child: upNext!,
                   ),
-                const SizedBox(height: 16),
+                const SizedBox(height: 24),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 20),
                   child: tabBar,

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -38,7 +38,7 @@ class DetailsTabBar extends StatelessWidget {
               child: FocusableWrapper(
                 focusNode: focusNodeFor(i),
                 disableScale: true,
-                useBackgroundFocus: true,
+                useBackgroundFocus: false,
                 borderRadius: 8,
                 onSelect: () => onSelect(i),
                 onNavigateLeft: () {

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -39,6 +39,7 @@ class DetailsTabBar extends StatelessWidget {
                 focusNode: focusNodeFor(i),
                 disableScale: true,
                 useBackgroundFocus: false,
+                suppressFocusGlow: true,
                 borderRadius: 8,
                 onSelect: () => onSelect(i),
                 onNavigateLeft: () {

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -12,6 +12,7 @@ class DetailsTabBar extends StatelessWidget {
   final ValueChanged<int> onSelect;
   final FocusNode Function(int index) focusNodeFor;
   final VoidCallback? onExitLeft;
+  final VoidCallback? onNavigateDown;
 
   const DetailsTabBar({
     super.key,
@@ -20,6 +21,7 @@ class DetailsTabBar extends StatelessWidget {
     required this.onSelect,
     required this.focusNodeFor,
     this.onExitLeft,
+    this.onNavigateDown,
   });
 
   @override
@@ -42,6 +44,7 @@ class DetailsTabBar extends StatelessWidget {
                 suppressFocusGlow: true,
                 borderRadius: 8,
                 onSelect: () => onSelect(i),
+                onNavigateDown: onNavigateDown,
                 onNavigateLeft: () {
                   if (i > 0) {
                     focusNodeFor(i - 1).requestFocus();
@@ -55,7 +58,7 @@ class DetailsTabBar extends StatelessWidget {
                   }
                 },
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
                   child: IntrinsicWidth(
                     child: Column(
                       mainAxisSize: MainAxisSize.min,

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:moonfin_design/moonfin_design.dart';
-
-import '../../../../widgets/focus/focusable_wrapper.dart';
 
 /// Clean text tab bar with an underline under the active tab. Focusable and
 /// d-pad friendly: tabs select on press, left/right move focus between tabs, and
@@ -12,23 +11,22 @@ class DetailsTabBar extends StatelessWidget {
   final ValueChanged<int> onSelect;
   final FocusNode Function(int index) focusNodeFor;
   final VoidCallback? onExitLeft;
+  final VoidCallback? onExitUp;
   final VoidCallback? onNavigateDown;
 
   const DetailsTabBar({
-    super.key,
+    key,
     required this.labels,
     required this.selectedIndex,
     required this.onSelect,
     required this.focusNodeFor,
     this.onExitLeft,
+    this.onExitUp,
     this.onNavigateDown,
-  });
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final accent = AppColorScheme.accent;
-    final muted = AppColorScheme.onSurface.withValues(alpha: 0.7);
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Row(
@@ -37,14 +35,13 @@ class DetailsTabBar extends StatelessWidget {
           for (var i = 0; i < labels.length; i++)
             Padding(
               padding: const EdgeInsets.only(right: 20),
-              child: FocusableWrapper(
+              child: _DetailsTabItem(
+                label: labels[i],
+                isSelected: selectedIndex == i,
                 focusNode: focusNodeFor(i),
-                disableScale: true,
-                useBackgroundFocus: false,
-                suppressFocusGlow: true,
-                borderRadius: 8,
                 onSelect: () => onSelect(i),
                 onNavigateDown: onNavigateDown,
+                onNavigateUp: onExitUp,
                 onNavigateLeft: () {
                   if (i > 0) {
                     focusNodeFor(i - 1).requestFocus();
@@ -57,43 +54,149 @@ class DetailsTabBar extends StatelessWidget {
                     focusNodeFor(i + 1).requestFocus();
                   }
                 },
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-                  child: IntrinsicWidth(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          labels[i],
-                          textAlign: TextAlign.center,
-                          style: textTheme.titleSmall?.copyWith(
-                          color: selectedIndex == i
-                              ? AppColorScheme.onSurface
-                              : muted,
-                          fontWeight: selectedIndex == i
-                              ? FontWeight.w700
-                              : FontWeight.w500,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      AnimatedContainer(
-                        duration: const Duration(milliseconds: 150),
-                        height: 3,
-                        decoration: BoxDecoration(
-                          color: selectedIndex == i
-                              ? accent
-                              : Colors.transparent,
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                    ],
-                  ),
-                  ),
-                ),
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _DetailsTabItem extends StatefulWidget {
+  final String label;
+  final bool isSelected;
+  final FocusNode focusNode;
+  final VoidCallback onSelect;
+  final VoidCallback? onNavigateDown;
+  final VoidCallback? onNavigateUp;
+  final VoidCallback onNavigateLeft;
+  final VoidCallback onNavigateRight;
+
+  const _DetailsTabItem({
+    required this.label,
+    required this.isSelected,
+    required this.focusNode,
+    required this.onSelect,
+    this.onNavigateDown,
+    this.onNavigateUp,
+    required this.onNavigateLeft,
+    required this.onNavigateRight,
+  });
+
+  @override
+  State<_DetailsTabItem> createState() => _DetailsTabItemState();
+}
+
+class _DetailsTabItemState extends State<_DetailsTabItem> {
+  bool _isFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.focusNode.addListener(_onFocusChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant _DetailsTabItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.focusNode != oldWidget.focusNode) {
+      oldWidget.focusNode.removeListener(_onFocusChanged);
+      widget.focusNode.addListener(_onFocusChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.focusNode.removeListener(_onFocusChanged);
+    super.dispose();
+  }
+
+  void _onFocusChanged() {
+    if (mounted) {
+      setState(() {
+        _isFocused = widget.focusNode.hasFocus;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final accent = AppColorScheme.accent;
+    final muted = AppColorScheme.onSurface.withValues(alpha: 0.7);
+
+    return Focus(
+      focusNode: widget.focusNode,
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent) {
+          if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+            if (widget.onNavigateDown != null) {
+              widget.onNavigateDown!();
+              return KeyEventResult.handled;
+            }
+          } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            if (widget.onNavigateUp != null) {
+              widget.onNavigateUp!();
+              return KeyEventResult.handled;
+            }
+          } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+            widget.onNavigateLeft();
+            return KeyEventResult.handled;
+          } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+            widget.onNavigateRight();
+            return KeyEventResult.handled;
+          } else if (event.logicalKey == LogicalKeyboardKey.enter ||
+              event.logicalKey == LogicalKeyboardKey.select) {
+            widget.onSelect();
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: widget.onSelect,
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            // Border is ALWAYS present with a fixed width to eliminate visual judder!
+            border: Border.all(
+              color: _isFocused ? accent : Colors.transparent,
+              width: 1.5,
+            ),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          child: IntrinsicWidth(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  widget.label,
+                  textAlign: TextAlign.center,
+                  style: textTheme.titleSmall?.copyWith(
+                    color: (widget.isSelected || _isFocused)
+                        ? AppColorScheme.onSurface
+                        : muted,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                // Underline is ALWAYS present, color is visible when selected or focused
+                AnimatedContainer(
+                  duration: const Duration(milliseconds: 150),
+                  height: 3,
+                  decoration: BoxDecoration(
+                    color: (widget.isSelected || _isFocused)
+                        ? accent
+                        : Colors.transparent,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -45,9 +45,13 @@ class DetailsTabBar extends StatelessWidget {
                 onNavigateLeft: () {
                   if (i > 0) {
                     focusNodeFor(i - 1).requestFocus();
-                  } else {
-                    onExitLeft?.call();
+                    return true;
                   }
+                  if (onExitLeft != null) {
+                    onExitLeft!();
+                    return true;
+                  }
+                  return false;
                 },
                 onNavigateRight: () {
                   if (i < labels.length - 1) {
@@ -69,7 +73,8 @@ class _DetailsTabItem extends StatefulWidget {
   final VoidCallback onSelect;
   final VoidCallback? onNavigateDown;
   final VoidCallback? onNavigateUp;
-  final VoidCallback onNavigateLeft;
+  // True if the left key was consumed; false to let focus traversal handle it.
+  final bool Function() onNavigateLeft;
   final VoidCallback onNavigateRight;
 
   const _DetailsTabItem({
@@ -142,7 +147,8 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
           return KeyEventResult.handled;
         } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
           if (isDownOrRepeat) {
-            widget.onNavigateLeft();
+            final handled = widget.onNavigateLeft();
+            return handled ? KeyEventResult.handled : KeyEventResult.ignored;
           }
           return KeyEventResult.handled;
         } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
@@ -152,7 +158,8 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
           return KeyEventResult.handled;
         } else if (event.logicalKey == LogicalKeyboardKey.enter ||
             event.logicalKey == LogicalKeyboardKey.select) {
-          if (isDownOrRepeat) {
+          // Activate on press only so holding select does not reselect on repeat.
+          if (event is KeyDownEvent) {
             widget.onSelect();
           }
           return KeyEventResult.handled;

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -42,18 +42,8 @@ class DetailsTabBar extends StatelessWidget {
                 onSelect: () => onSelect(i),
                 onNavigateDown: onNavigateDown != null ? () => onNavigateDown!(i) : null,
                 onNavigateUp: onExitUp,
-                onNavigateLeft: () {
-                  if (i > 0) {
-                    focusNodeFor(i - 1).requestFocus();
-                  } else {
-                    onExitLeft?.call();
-                  }
-                },
-                onNavigateRight: () {
-                  if (i < labels.length - 1) {
-                    focusNodeFor(i + 1).requestFocus();
-                  }
-                },
+                onNavigateLeft: i == 0 ? onExitLeft : null,
+                onNavigateRight: i == labels.length - 1 ? () {} : null,
               ),
             ),
         ],
@@ -69,8 +59,8 @@ class _DetailsTabItem extends StatefulWidget {
   final VoidCallback onSelect;
   final VoidCallback? onNavigateDown;
   final VoidCallback? onNavigateUp;
-  final VoidCallback onNavigateLeft;
-  final VoidCallback onNavigateRight;
+  final VoidCallback? onNavigateLeft;
+  final VoidCallback? onNavigateRight;
 
   const _DetailsTabItem({
     required this.label,
@@ -79,8 +69,8 @@ class _DetailsTabItem extends StatefulWidget {
     required this.onSelect,
     this.onNavigateDown,
     this.onNavigateUp,
-    required this.onNavigateLeft,
-    required this.onNavigateRight,
+    this.onNavigateLeft,
+    this.onNavigateRight,
   });
 
   @override
@@ -141,15 +131,21 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
           }
           return KeyEventResult.handled;
         } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-          if (isDownOrRepeat) {
-            widget.onNavigateLeft();
+          if (widget.onNavigateLeft != null) {
+            if (isDownOrRepeat) {
+              widget.onNavigateLeft!();
+            }
+            return KeyEventResult.handled;
           }
-          return KeyEventResult.handled;
+          return KeyEventResult.ignored;
         } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
-          if (isDownOrRepeat) {
-            widget.onNavigateRight();
+          if (widget.onNavigateRight != null) {
+            if (isDownOrRepeat) {
+              widget.onNavigateRight!();
+            }
+            return KeyEventResult.handled;
           }
-          return KeyEventResult.handled;
+          return KeyEventResult.ignored;
         } else if (event.logicalKey == LogicalKeyboardKey.enter ||
             event.logicalKey == LogicalKeyboardKey.select) {
           if (isDownOrRepeat) {

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -12,7 +12,7 @@ class DetailsTabBar extends StatelessWidget {
   final FocusNode Function(int index) focusNodeFor;
   final VoidCallback? onExitLeft;
   final VoidCallback? onExitUp;
-  final VoidCallback? onNavigateDown;
+  final void Function(int index)? onNavigateDown;
 
   const DetailsTabBar({
     key,
@@ -40,7 +40,7 @@ class DetailsTabBar extends StatelessWidget {
                 isSelected: selectedIndex == i,
                 focusNode: focusNodeFor(i),
                 onSelect: () => onSelect(i),
-                onNavigateDown: onNavigateDown,
+                onNavigateDown: onNavigateDown != null ? () => onNavigateDown!(i) : null,
                 onNavigateUp: onExitUp,
                 onNavigateLeft: () {
                   if (i > 0) {

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -128,28 +128,34 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
     return Focus(
       focusNode: widget.focusNode,
       onKeyEvent: (node, event) {
-        if (event is KeyDownEvent) {
-          if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-            if (widget.onNavigateDown != null) {
-              widget.onNavigateDown!();
-              return KeyEventResult.handled;
-            }
-          } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            if (widget.onNavigateUp != null) {
-              widget.onNavigateUp!();
-              return KeyEventResult.handled;
-            }
-          } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-            widget.onNavigateLeft();
-            return KeyEventResult.handled;
-          } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
-            widget.onNavigateRight();
-            return KeyEventResult.handled;
-          } else if (event.logicalKey == LogicalKeyboardKey.enter ||
-              event.logicalKey == LogicalKeyboardKey.select) {
-            widget.onSelect();
-            return KeyEventResult.handled;
+        final isDownOrRepeat = event is KeyDownEvent || event is KeyRepeatEvent;
+        
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+          if (isDownOrRepeat && widget.onNavigateDown != null) {
+            widget.onNavigateDown!();
           }
+          return KeyEventResult.handled;
+        } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          if (isDownOrRepeat && widget.onNavigateUp != null) {
+            widget.onNavigateUp!();
+          }
+          return KeyEventResult.handled;
+        } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+          if (isDownOrRepeat) {
+            widget.onNavigateLeft();
+          }
+          return KeyEventResult.handled;
+        } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+          if (isDownOrRepeat) {
+            widget.onNavigateRight();
+          }
+          return KeyEventResult.handled;
+        } else if (event.logicalKey == LogicalKeyboardKey.enter ||
+            event.logicalKey == LogicalKeyboardKey.select) {
+          if (isDownOrRepeat) {
+            widget.onSelect();
+          }
+          return KeyEventResult.handled;
         }
         return KeyEventResult.ignored;
       },

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -42,8 +42,18 @@ class DetailsTabBar extends StatelessWidget {
                 onSelect: () => onSelect(i),
                 onNavigateDown: onNavigateDown != null ? () => onNavigateDown!(i) : null,
                 onNavigateUp: onExitUp,
-                onNavigateLeft: i == 0 ? onExitLeft : null,
-                onNavigateRight: i == labels.length - 1 ? () {} : null,
+                onNavigateLeft: () {
+                  if (i > 0) {
+                    focusNodeFor(i - 1).requestFocus();
+                  } else {
+                    onExitLeft?.call();
+                  }
+                },
+                onNavigateRight: () {
+                  if (i < labels.length - 1) {
+                    focusNodeFor(i + 1).requestFocus();
+                  }
+                },
               ),
             ),
         ],
@@ -59,8 +69,8 @@ class _DetailsTabItem extends StatefulWidget {
   final VoidCallback onSelect;
   final VoidCallback? onNavigateDown;
   final VoidCallback? onNavigateUp;
-  final VoidCallback? onNavigateLeft;
-  final VoidCallback? onNavigateRight;
+  final VoidCallback onNavigateLeft;
+  final VoidCallback onNavigateRight;
 
   const _DetailsTabItem({
     required this.label,
@@ -69,8 +79,8 @@ class _DetailsTabItem extends StatefulWidget {
     required this.onSelect,
     this.onNavigateDown,
     this.onNavigateUp,
-    this.onNavigateLeft,
-    this.onNavigateRight,
+    required this.onNavigateLeft,
+    required this.onNavigateRight,
   });
 
   @override
@@ -131,21 +141,15 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
           }
           return KeyEventResult.handled;
         } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-          if (widget.onNavigateLeft != null) {
-            if (isDownOrRepeat) {
-              widget.onNavigateLeft!();
-            }
-            return KeyEventResult.handled;
+          if (isDownOrRepeat) {
+            widget.onNavigateLeft();
           }
-          return KeyEventResult.ignored;
+          return KeyEventResult.handled;
         } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
-          if (widget.onNavigateRight != null) {
-            if (isDownOrRepeat) {
-              widget.onNavigateRight!();
-            }
-            return KeyEventResult.handled;
+          if (isDownOrRepeat) {
+            widget.onNavigateRight();
           }
-          return KeyEventResult.ignored;
+          return KeyEventResult.handled;
         } else if (event.logicalKey == LogicalKeyboardKey.enter ||
             event.logicalKey == LogicalKeyboardKey.select) {
           if (isDownOrRepeat) {

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -15,7 +15,7 @@ class DetailsTabBar extends StatelessWidget {
   final void Function(int index)? onNavigateDown;
 
   const DetailsTabBar({
-    key,
+    super.key,
     required this.labels,
     required this.selectedIndex,
     required this.onSelect,
@@ -23,7 +23,7 @@ class DetailsTabBar extends StatelessWidget {
     this.onExitLeft,
     this.onExitUp,
     this.onNavigateDown,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -20,6 +20,11 @@ class SeasonCard extends StatelessWidget {
   final VoidCallback? onNavigateUp;
   final VoidCallback? onNavigateRight;
 
+  /// Optional explicit size; when null the card falls back to fixed
+  /// landscape/portrait defaults.
+  final double? width;
+  final double? height;
+
   const SeasonCard({
     super.key,
     required this.title,
@@ -32,14 +37,16 @@ class SeasonCard extends StatelessWidget {
     this.focusNode,
     this.onNavigateUp,
     this.onNavigateRight,
+    this.width,
+    this.height,
   });
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final radius = JellyfinTokens.shapes.mediumRadius;
-    final cardWidth = landscape ? 130.0 : 90.0;
-    final cardHeight = landscape ? 195.0 : 135.0;
+    final cardWidth = width ?? (landscape ? 130.0 : 90.0);
+    final cardHeight = height ?? (landscape ? 195.0 : 135.0);
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 
     return FocusableWrapper(

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -17,6 +17,7 @@ class SeasonCard extends StatelessWidget {
   final FocusNode? focusNode;
 
   final VoidCallback? onNavigateUp;
+  final VoidCallback? onNavigateRight;
 
   const SeasonCard({
     super.key,
@@ -28,6 +29,7 @@ class SeasonCard extends StatelessWidget {
     required this.onTap,
     this.focusNode,
     this.onNavigateUp,
+    this.onNavigateRight,
   });
 
   @override
@@ -42,6 +44,7 @@ class SeasonCard extends StatelessWidget {
       onSelect: onTap,
       borderRadius: radius.topLeft.x,
       onNavigateUp: onNavigateUp,
+      onNavigateRight: onNavigateRight,
       child: GestureDetector(
         onTap: onTap,
         child: Container(
@@ -102,14 +105,17 @@ class SeasonCard extends StatelessWidget {
                       ),
                       const SizedBox(height: 2),
                     ],
-                    Text(
-                      subtitle,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: textTheme.bodySmall?.copyWith(
-                        color: Colors.white.withValues(alpha: 0.85),
-                        fontWeight: FontWeight.w500,
-                        fontSize: 9,
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: Text(
+                        subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: Colors.white.withValues(alpha: 0.85),
+                          fontWeight: FontWeight.w500,
+                          fontSize: 9,
+                        ),
                       ),
                     ),
                   ],

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -11,33 +11,42 @@ class SeasonCard extends StatelessWidget {
   final String title;
   final String subtitle;
   final String? imageUrl;
+  final bool isFallbackImage;
   final bool landscape;
   final VoidCallback onTap;
   final FocusNode? focusNode;
+
+  final VoidCallback? onNavigateUp;
 
   const SeasonCard({
     super.key,
     required this.title,
     required this.subtitle,
     required this.imageUrl,
+    required this.isFallbackImage,
     required this.landscape,
     required this.onTap,
     this.focusNode,
+    this.onNavigateUp,
   });
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final radius = JellyfinTokens.shapes.mediumRadius;
+    final cardWidth = landscape ? 130.0 : 90.0;
+    final cardHeight = landscape ? 195.0 : 135.0;
+
     return FocusableWrapper(
       focusNode: focusNode,
       onSelect: onTap,
       borderRadius: radius.topLeft.x,
+      onNavigateUp: onNavigateUp,
       child: GestureDetector(
         onTap: onTap,
         child: Container(
-          width: landscape ? 300 : double.infinity,
-          height: landscape ? 96 : 84,
+          width: cardWidth,
+          height: cardHeight,
           decoration: BoxDecoration(
             borderRadius: radius,
             color: AppColorScheme.surface.withValues(alpha: 0.35),
@@ -56,50 +65,52 @@ class SeasonCard extends StatelessWidget {
                   errorWidget: (context, url, error) =>
                       const SizedBox.shrink(),
                 ),
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.centerLeft,
-                    end: Alignment.centerRight,
-                    colors: [
-                      AppColorScheme.background.withValues(alpha: 0.92),
-                      AppColorScheme.background.withValues(alpha: 0.55),
-                    ],
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.transparent,
+                        Colors.black.withValues(alpha: 0.2),
+                        Colors.black.withValues(alpha: 0.85),
+                      ],
+                      stops: const [0.0, 0.4, 1.0],
+                    ),
                   ),
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 16, vertical: 12),
-                child: Row(
+              Positioned(
+                left: 8,
+                right: 8,
+                bottom: 8,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            title,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: textTheme.titleMedium,
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            subtitle,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: textTheme.bodySmall?.copyWith(
-                              color:
-                                  AppColorScheme.onSurface.withValues(alpha: 0.7),
-                            ),
-                          ),
-                        ],
+                    if (isFallbackImage) ...[
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textTheme.labelLarge?.copyWith(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 11,
+                        ),
                       ),
-                    ),
-                    Icon(
-                      Icons.chevron_right,
-                      color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                      const SizedBox(height: 2),
+                    ],
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: textTheme.bodySmall?.copyWith(
+                        color: Colors.white.withValues(alpha: 0.85),
+                        fontWeight: FontWeight.w500,
+                        fontSize: 9,
+                      ),
                     ),
                   ],
                 ),

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -13,6 +13,7 @@ class SeasonCard extends StatelessWidget {
   final String? imageUrl;
   final bool isFallbackImage;
   final bool landscape;
+  final bool isNextUp;
   final VoidCallback onTap;
   final FocusNode? focusNode;
 
@@ -27,6 +28,7 @@ class SeasonCard extends StatelessWidget {
     required this.isFallbackImage,
     required this.landscape,
     required this.onTap,
+    this.isNextUp = false,
     this.focusNode,
     this.onNavigateUp,
     this.onNavigateRight,
@@ -38,6 +40,7 @@ class SeasonCard extends StatelessWidget {
     final radius = JellyfinTokens.shapes.mediumRadius;
     final cardWidth = landscape ? 130.0 : 90.0;
     final cardHeight = landscape ? 195.0 : 135.0;
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 
     return FocusableWrapper(
       focusNode: focusNode,
@@ -53,75 +56,86 @@ class SeasonCard extends StatelessWidget {
           decoration: BoxDecoration(
             borderRadius: radius,
             color: AppColorScheme.surface.withValues(alpha: 0.35),
-            border: Border.all(
-              color: AppColorScheme.onSurface.withValues(alpha: 0.12),
-            ),
+            border: isNextUp
+                ? Border.fromBorderSide(
+                    ThemeRegistry.active.borders.focusBorder.copyWith(
+                      color: isNeon
+                          ? const Color(0xFF00FFFF)
+                          : Colors.cyan.withValues(alpha: 0.7),
+                      width: 1.5,
+                    ),
+                  )
+                : Border.all(
+                    color: AppColorScheme.onSurface.withValues(alpha: 0.12),
+                  ),
           ),
-          clipBehavior: Clip.antiAlias,
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              if (imageUrl != null && imageUrl!.isNotEmpty)
-                CachedNetworkImage(
-                  imageUrl: imageUrl!,
-                  fit: BoxFit.cover,
-                  errorWidget: (context, url, error) =>
-                      const SizedBox.shrink(),
-                ),
-              Positioned.fill(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        Colors.transparent,
-                        Colors.black.withValues(alpha: 0.2),
-                        Colors.black.withValues(alpha: 0.85),
-                      ],
-                      stops: const [0.0, 0.4, 1.0],
+          child: ClipRRect(
+            borderRadius: radius,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (imageUrl != null && imageUrl!.isNotEmpty)
+                  CachedNetworkImage(
+                    imageUrl: imageUrl!,
+                    fit: BoxFit.cover,
+                    errorWidget: (context, url, error) =>
+                        const SizedBox.shrink(),
+                  ),
+                Positioned.fill(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.transparent,
+                          Colors.black.withValues(alpha: 0.2),
+                          Colors.black.withValues(alpha: 0.85),
+                        ],
+                        stops: const [0.0, 0.4, 1.0],
+                      ),
                     ),
                   ),
                 ),
-              ),
-              Positioned(
-                left: 8,
-                right: 8,
-                bottom: 8,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (isFallbackImage) ...[
-                      Text(
-                        title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: textTheme.labelLarge?.copyWith(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 11,
+                Positioned(
+                  left: 8,
+                  right: 8,
+                  bottom: 8,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (isFallbackImage) ...[
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.labelLarge?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 11,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                      ],
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: Text(
+                          subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.bodySmall?.copyWith(
+                            color: Colors.white.withValues(alpha: 0.85),
+                            fontWeight: FontWeight.w500,
+                            fontSize: 9,
+                          ),
                         ),
                       ),
-                      const SizedBox(height: 2),
                     ],
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: Text(
-                        subtitle,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: textTheme.bodySmall?.copyWith(
-                          color: Colors.white.withValues(alpha: 0.85),
-                          fontWeight: FontWeight.w500,
-                          fontSize: 9,
-                        ),
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -25,6 +25,10 @@ class SeasonCard extends StatelessWidget {
   final double? width;
   final double? height;
 
+  /// Scroll the card into view when it gains focus (used in the grid layout so
+  /// d-pad can reach rows below the fold).
+  final bool autoScroll;
+
   const SeasonCard({
     super.key,
     required this.title,
@@ -39,6 +43,7 @@ class SeasonCard extends StatelessWidget {
     this.onNavigateRight,
     this.width,
     this.height,
+    this.autoScroll = false,
   });
 
   @override
@@ -53,6 +58,8 @@ class SeasonCard extends StatelessWidget {
       focusNode: focusNode,
       onSelect: onTap,
       borderRadius: radius.topLeft.x,
+      autoScroll: autoScroll,
+      scrollAlignment: 0.5,
       onNavigateUp: onNavigateUp,
       onNavigateRight: onNavigateRight,
       child: GestureDetector(

--- a/lib/ui/screens/detail/modern/widgets/up_next_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/up_next_card.dart
@@ -48,18 +48,32 @@ class UpNextCard extends StatelessWidget {
       onNavigateLeft: onNavigateLeft,
       onNavigateDown: onNavigateDown,
       borderRadius: radius.topLeft.x,
+      suppressFocusGlow: true,
+      focusColor: const Color(0xFF00F0FF),
       child: GestureDetector(
         onTap: onTap,
         child: SizedBox(
           width: width,
-          child: adaptiveGlass(
-            cornerRadius: radius.topLeft.x,
-            blur: 18,
-            fallbackColor: AppColorScheme.surface.withValues(alpha: 0.42),
-            tint: AppColorScheme.surface.withValues(alpha: 0.22),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(radius.topLeft.x),
+              border: Border.all(
+                color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                    ? const Color(0xFF00F0FF)
+                    : Colors.white.withValues(alpha: 0.12),
+                width: 1.25,
+              ),
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(radius.topLeft.x - 1.25),
+              child: adaptiveGlass(
+                cornerRadius: radius.topLeft.x - 1.25,
+                blur: 18,
+                fallbackColor: AppColorScheme.surface.withValues(alpha: 0.42),
+                tint: AppColorScheme.surface.withValues(alpha: 0.22),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
               children: [
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
@@ -143,8 +157,10 @@ class UpNextCard extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
+    ),
+  ),
+);
+}
 
   Widget _thumbnail() {
     return SizedBox(

--- a/lib/ui/screens/detail/modern/widgets/up_next_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/up_next_card.dart
@@ -21,6 +21,7 @@ class UpNextCard extends StatefulWidget {
   final VoidCallback? onNavigateLeft;
   final VoidCallback? onNavigateDown;
   final double width;
+  final bool minimal;
 
   const UpNextCard({
     super.key,
@@ -35,6 +36,7 @@ class UpNextCard extends StatefulWidget {
     this.onNavigateLeft,
     this.onNavigateDown,
     this.width = double.infinity,
+    this.minimal = false,
   });
 
   @override
@@ -70,6 +72,82 @@ class _UpNextCardState extends State<UpNextCard> {
     final radius = JellyfinTokens.shapes.mediumRadius;
     final muted = AppColorScheme.onSurface.withValues(alpha: 0.7);
     final hasFocus = _effectiveNode.hasFocus;
+
+    if (widget.minimal) {
+      return FocusableWrapper(
+        focusNode: _effectiveNode,
+        onSelect: widget.onTap,
+        onNavigateLeft: widget.onNavigateLeft,
+        onNavigateDown: widget.onNavigateDown,
+        borderRadius: radius.topLeft.x,
+        suppressFocusGlow: true,
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: Container(
+            width: widget.width,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(radius.topLeft.x),
+              border: Border.all(
+                color: hasFocus
+                    ? (ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                        ? const Color(0xFFFF2E92)
+                        : AppColorScheme.accent)
+                    : (ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                        ? const Color(0xFF00F0FF)
+                        : Colors.white.withValues(alpha: 0.12)),
+                width: 1.25,
+              ),
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(radius.topLeft.x - 1.25),
+              child: adaptiveGlass(
+                cornerRadius: radius.topLeft.x - 1.25,
+                blur: 18,
+                fallbackColor: AppColorScheme.surface.withValues(alpha: 0.42),
+                tint: AppColorScheme.surface.withValues(alpha: 0.22),
+                child: Padding(
+                  padding: const EdgeInsets.all(12.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        widget.label,
+                        style: textTheme.labelMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.4,
+                          color: AppColorScheme.accent,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      // Poster
+                      AspectRatio(
+                        aspectRatio: 2 / 3,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(radius.topLeft.x - 4),
+                          child: _thumbnail(isMinimal: true),
+                        ),
+                      ),
+                      if (widget.title.isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          widget.title,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
 
     return FocusableWrapper(
       focusNode: _effectiveNode,
@@ -112,6 +190,7 @@ class _UpNextCardState extends State<UpNextCard> {
                         style: textTheme.labelMedium?.copyWith(
                           fontWeight: FontWeight.w700,
                           letterSpacing: 0.4,
+                          color: AppColorScheme.accent,
                         ),
                       ),
                     ),
@@ -119,7 +198,6 @@ class _UpNextCardState extends State<UpNextCard> {
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
-                          _thumbnail(),
                           Expanded(
                             child: Padding(
                               padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
@@ -127,15 +205,8 @@ class _UpNextCardState extends State<UpNextCard> {
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 children: [
-                                  Text(
-                                    widget.title,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: textTheme.titleMedium,
-                                  ),
                                   if (widget.description != null &&
                                       widget.description!.isNotEmpty) ...[
-                                    const SizedBox(height: 6),
                                     Text(
                                       widget.description!,
                                       maxLines: 3,
@@ -179,6 +250,7 @@ class _UpNextCardState extends State<UpNextCard> {
                               ),
                             ),
                           ),
+                          _thumbnail(),
                         ],
                       ),
                     ),
@@ -192,9 +264,9 @@ class _UpNextCardState extends State<UpNextCard> {
     );
   }
 
-  Widget _thumbnail() {
+  Widget _thumbnail({bool isMinimal = false}) {
     return SizedBox(
-      width: 150,
+      width: isMinimal ? null : 150,
       child: Stack(
         fit: StackFit.expand,
         children: [

--- a/lib/ui/screens/detail/modern/widgets/up_next_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/up_next_card.dart
@@ -9,7 +9,7 @@ import '../../../../widgets/focus/focusable_wrapper.dart';
 /// play overlay on the left and the episode title + short description on the
 /// right, with a progress bar and remaining time pinned to the bottom. Purely
 /// presentational and theme-tokenized.
-class UpNextCard extends StatelessWidget {
+class UpNextCard extends StatefulWidget {
   final String label;
   final String title;
   final String? description;
@@ -38,29 +38,59 @@ class UpNextCard extends StatelessWidget {
   });
 
   @override
+  State<UpNextCard> createState() => _UpNextCardState();
+}
+
+class _UpNextCardState extends State<UpNextCard> {
+  late final FocusNode _effectiveNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _effectiveNode = widget.focusNode ?? FocusNode();
+    _effectiveNode.addListener(_onFocusChange);
+  }
+
+  @override
+  void dispose() {
+    _effectiveNode.removeListener(_onFocusChange);
+    if (widget.focusNode == null) {
+      _effectiveNode.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onFocusChange() {
+    setState(() {});
+  }
+
+  @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final radius = JellyfinTokens.shapes.mediumRadius;
     final muted = AppColorScheme.onSurface.withValues(alpha: 0.7);
+    final hasFocus = _effectiveNode.hasFocus;
+
     return FocusableWrapper(
-      focusNode: focusNode,
-      onSelect: onTap,
-      onNavigateLeft: onNavigateLeft,
-      onNavigateDown: onNavigateDown,
+      focusNode: _effectiveNode,
+      onSelect: widget.onTap,
+      onNavigateLeft: widget.onNavigateLeft,
+      onNavigateDown: widget.onNavigateDown,
       borderRadius: radius.topLeft.x,
       suppressFocusGlow: true,
-      focusColor: const Color(0xFF00F0FF),
       child: GestureDetector(
-        onTap: onTap,
+        onTap: widget.onTap,
         child: SizedBox(
-          width: width,
+          width: widget.width,
           child: Container(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(radius.topLeft.x),
               border: Border.all(
-                color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                    ? const Color(0xFF00F0FF)
-                    : Colors.white.withValues(alpha: 0.12),
+                color: hasFocus
+                    ? Colors.transparent
+                    : (ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+                        ? const Color(0xFF00F0FF)
+                        : Colors.white.withValues(alpha: 0.12)),
                 width: 1.25,
               ),
             ),
@@ -74,93 +104,93 @@ class UpNextCard extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                  child: Text(
-                    label,
-                    style: textTheme.labelMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      letterSpacing: 0.4,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                      child: Text(
+                        widget.label,
+                        style: textTheme.labelMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0.4,
+                        ),
+                      ),
                     ),
-                  ),
-                ),
-                IntrinsicHeight(
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      _thumbnail(),
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                title,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: textTheme.titleMedium,
-                              ),
-                              if (description != null &&
-                                  description!.isNotEmpty) ...[
-                                const SizedBox(height: 6),
-                                Text(
-                                  description!,
-                                  maxLines: 3,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: textTheme.bodySmall
-                                      ?.copyWith(color: muted),
-                                ),
-                              ],
-                              const SizedBox(height: 12),
-                              Row(
+                    IntrinsicHeight(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _thumbnail(),
+                          Expanded(
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisAlignment: MainAxisAlignment.center,
                                 children: [
-                                  if (progress > 0)
-                                    Expanded(
-                                      child: ClipRRect(
-                                        borderRadius: BorderRadius.circular(2),
-                                        child: LinearProgressIndicator(
-                                          value: progress.clamp(0.0, 1.0),
-                                          minHeight: 4,
-                                          backgroundColor: AppColorScheme
-                                              .onSurface
-                                              .withValues(alpha: 0.20),
-                                          valueColor:
-                                              AlwaysStoppedAnimation<Color>(
-                                                  AppColorScheme.accent),
-                                        ),
-                                      ),
-                                    )
-                                  else
-                                    const Spacer(),
-                                  if (remainingLabel != null) ...[
-                                    const SizedBox(width: 12),
+                                  Text(
+                                    widget.title,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: textTheme.titleMedium,
+                                  ),
+                                  if (widget.description != null &&
+                                      widget.description!.isNotEmpty) ...[
+                                    const SizedBox(height: 6),
                                     Text(
-                                      remainingLabel!,
-                                      style: textTheme.labelSmall
+                                      widget.description!,
+                                      maxLines: 3,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: textTheme.bodySmall
                                           ?.copyWith(color: muted),
                                     ),
                                   ],
+                                  const SizedBox(height: 12),
+                                  Row(
+                                    children: [
+                                      if (widget.progress > 0)
+                                        Expanded(
+                                          child: ClipRRect(
+                                            borderRadius: BorderRadius.circular(2),
+                                            child: LinearProgressIndicator(
+                                              value: widget.progress.clamp(0.0, 1.0),
+                                              minHeight: 4,
+                                              backgroundColor: AppColorScheme
+                                                  .onSurface
+                                                  .withValues(alpha: 0.20),
+                                              valueColor:
+                                                  AlwaysStoppedAnimation<Color>(
+                                                      AppColorScheme.accent),
+                                            ),
+                                          ),
+                                        )
+                                      else
+                                        const Spacer(),
+                                      if (widget.remainingLabel != null) ...[
+                                        const SizedBox(width: 12),
+                                        Text(
+                                          widget.remainingLabel!,
+                                          style: textTheme.labelSmall
+                                              ?.copyWith(color: muted),
+                                        ),
+                                      ],
+                                    ],
+                                  ),
                                 ],
                               ),
-                            ],
+                            ),
                           ),
-                        ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
         ),
       ),
-    ),
-  ),
-);
-}
+    );
+  }
 
   Widget _thumbnail() {
     return SizedBox(
@@ -168,9 +198,9 @@ class UpNextCard extends StatelessWidget {
       child: Stack(
         fit: StackFit.expand,
         children: [
-          if (imageUrl != null && imageUrl!.isNotEmpty)
+          if (widget.imageUrl != null && widget.imageUrl!.isNotEmpty)
             CachedNetworkImage(
-              imageUrl: imageUrl!,
+              imageUrl: widget.imageUrl!,
               fit: BoxFit.cover,
               errorWidget: (context, url, error) => const SizedBox.shrink(),
             )

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2880,7 +2880,7 @@ class _ContentRowsState extends State<_ContentRows>
       UserPreferences.enableAdditionalRatings,
     );
     final hasAdditionalRatingsPadding = hasAdditionalRatings ? 8.0 : 0.0;
-    final heightBudget = 136.0 + hasAdditionalRatingsPadding;
+    final heightBudget = 165.0 + hasAdditionalRatingsPadding;
     return heightBudget;
   }
 

--- a/lib/ui/widgets/focus/focusable_toolbar_button.dart
+++ b/lib/ui/widgets/focus/focusable_toolbar_button.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
-import '../../../preference/user_preferences.dart';
 import 'focus_theme.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../mixins/focus_state_mixin.dart';
@@ -52,12 +50,7 @@ class _FocusableToolbarButtonState extends State<FocusableToolbarButton>
     with FocusStateMixin {
   @override
   Widget build(BuildContext context) {
-    final prefFocusColor = Color(
-      GetIt.instance<UserPreferences>()
-          .get(UserPreferences.focusColor)
-          .colorValue,
-    );
-    final focusColor = widget.accentColor ?? prefFocusColor;
+    final focusColor = widget.accentColor ?? this.focusColor;
 
     Widget content = AnimatedContainer(
       duration: const Duration(milliseconds: 150),
@@ -68,6 +61,7 @@ class _FocusableToolbarButtonState extends State<FocusableToolbarButton>
         radius: 6,
         color: focusColor,
         backgroundColor: _backgroundColor(),
+        suppressFocusGlow: ThemeRegistry.active.id == ThemeRegistry.neonPulseId,
       ),
       child: Icon(
         widget.icon,

--- a/lib/ui/widgets/focus/focusable_toolbar_button.dart
+++ b/lib/ui/widgets/focus/focusable_toolbar_button.dart
@@ -28,6 +28,7 @@ class FocusableToolbarButton extends StatefulWidget {
   final int unfocusedIconAlpha;
   /// Multiplicative scale applied while focused. 1.0 disables scaling.
   final double scaleOnFocus;
+  final FocusNode? focusNode;
 
   const FocusableToolbarButton({
     super.key,
@@ -40,6 +41,7 @@ class FocusableToolbarButton extends StatefulWidget {
     this.accentColor,
     this.unfocusedIconAlpha = 179,
     this.scaleOnFocus = 1.0,
+    this.focusNode,
   });
 
   @override
@@ -83,6 +85,7 @@ class _FocusableToolbarButtonState extends State<FocusableToolbarButton>
       onEnter: (_) => setHovered(true),
       onExit: (_) => setHovered(false),
       child: Focus(
+        focusNode: widget.focusNode,
         onFocusChange: (f) => setFocused(f),
         onKeyEvent: (_, event) {
           if (isActivateKey(event)) {

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -493,16 +493,16 @@ class _CardImage extends StatelessWidget {
         children: [
           if (showGlow)
             Positioned(
-              top: -1.0,
-              bottom: -1.0,
-              left: -1.0,
-              right: -1.0,
+              top: -3.5,
+              bottom: -3.5,
+              left: -3.5,
+              right: -3.5,
               child: IgnorePointer(
                 child: Container(
                   decoration: BoxDecoration(
                     borderRadius: isCircular
-                        ? BorderRadius.circular(radius + 1.0)
-                        : borders.cardRadius + BorderRadius.circular(1.0),
+                        ? BorderRadius.circular(radius + 3.5)
+                        : borders.cardRadius + BorderRadius.circular(3.5),
                     boxShadow: borders.focusGlow,
                   ),
                 ),
@@ -591,18 +591,21 @@ class _CardImage extends StatelessWidget {
           ),
           if (showBorder)
             Positioned(
-              top: -1.0,
-              bottom: -1.0,
-              left: -1.0,
-              right: -1.0,
+              top: -3.5,
+              bottom: -3.5,
+              left: -3.5,
+              right: -3.5,
               child: IgnorePointer(
                 child: Container(
                   decoration: BoxDecoration(
                     borderRadius: isCircular
-                        ? BorderRadius.circular(radius + 1.0)
-                        : borders.cardRadius + BorderRadius.circular(1.0),
+                        ? BorderRadius.circular(radius + 3.5)
+                        : borders.cardRadius + BorderRadius.circular(3.5),
                     border: Border.fromBorderSide(
-                      borders.focusBorder.copyWith(color: borderColor),
+                      borders.focusBorder.copyWith(
+                        color: borderColor,
+                        width: 3.0,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -51,6 +51,7 @@ class NavigationLayout extends StatefulWidget {
   static final focusContentFromNavbarNotifier = ValueNotifier<VoidCallback?>(
     null,
   );
+  static final focusDetailsPlayButtonNotifier = ValueNotifier<FocusNode?>(null);
 
   const NavigationLayout({
     super.key,
@@ -137,9 +138,6 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.showNavigationChrome) {
-      return widget.child;
-    }
     final layout = switch (_position) {
       NavbarPosition.left => _buildSidebar(),
       NavbarPosition.top => _buildToolbar(),
@@ -162,7 +160,14 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
             Expanded(child: content),
             const DownloadProgressBar(),
             const BottomMusicBar(),
-            MobileBottomNavBar(activeRoute: widget.activeRoute),
+            AnimatedOpacity(
+              opacity: widget.showNavigationChrome ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: IgnorePointer(
+                ignoring: !widget.showNavigationChrome,
+                child: MobileBottomNavBar(activeRoute: widget.activeRoute),
+              ),
+            ),
           ],
         ),
         if (widget.showBackButton)
@@ -184,10 +189,17 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
       skipTraversal: true,
       child: widget.child,
     );
-    final toolbar = TopToolbar(
-      activeRoute: widget.activeRoute,
-      showBackButton: widget.showBackButton,
-      contentFocusNode: _contentFocusNode,
+    final toolbar = AnimatedOpacity(
+      opacity: widget.showNavigationChrome ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 200),
+      child: IgnorePointer(
+        ignoring: !widget.showNavigationChrome,
+        child: TopToolbar(
+          activeRoute: widget.activeRoute,
+          showBackButton: widget.showBackButton,
+          contentFocusNode: _contentFocusNode,
+        ),
+      ),
     );
     final maxTranslate = TopToolbar.heightFor(context);
     final body = translateWithScroll
@@ -221,13 +233,15 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
                 ValueListenableBuilder<double>(
                   valueListenable: _toolbarScrollOffset,
                   builder: (_, offset, child) {
-                    final translate = offset.clamp(0.0, maxTranslate);
+                    final translate = widget.showNavigationChrome
+                        ? offset.clamp(0.0, maxTranslate)
+                        : maxTranslate;
                     return Positioned(
                       left: 0,
                       right: 0,
                       top: -translate,
                       child: IgnorePointer(
-                        ignoring: translate >= maxTranslate,
+                        ignoring: !widget.showNavigationChrome || translate >= maxTranslate,
                         child: child!,
                       ),
                     );
@@ -256,10 +270,17 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
       child: widget.child,
     );
 
-    final sidebar = LeftSidebar(
-      activeRoute: widget.activeRoute,
-      contentFocusNode: _contentFocusNode,
-      showBackButton: widget.showBackButton,
+    final sidebar = AnimatedOpacity(
+      opacity: widget.showNavigationChrome ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 200),
+      child: IgnorePointer(
+        ignoring: !widget.showNavigationChrome,
+        child: LeftSidebar(
+          activeRoute: widget.activeRoute,
+          contentFocusNode: _contentFocusNode,
+          showBackButton: widget.showBackButton,
+        ),
+      ),
     );
 
     if (PlatformDetection.isTV || (PlatformDetection.isDesktop || (PlatformDetection.isWeb && !PlatformDetection.useMobileUi))) {

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -2036,15 +2036,7 @@ class _TopMusicBarState extends State<TopMusicBar> {
             color: AppColorScheme.onSurface.withValues(alpha: 0.15),
             width: 1.0,
           );
-    final boxShadow = isNeon
-        ? const [
-            BoxShadow(
-              color: Color(0x3300F0FF), // cyan glow!
-              blurRadius: 8,
-              spreadRadius: 1,
-            )
-          ]
-        : null;
+    final boxShadow = null;
 
     if (AppColorScheme.isGlass) {
       return Container(

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -2036,14 +2036,11 @@ class _TopMusicBarState extends State<TopMusicBar> {
             color: AppColorScheme.onSurface.withValues(alpha: 0.15),
             width: 1.0,
           );
-    final boxShadow = null;
-
     if (AppColorScheme.isGlass) {
       return Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(24),
           border: border,
-          boxShadow: boxShadow,
         ),
         child: GlassSurface(
           cornerRadius: 24,
@@ -2062,7 +2059,6 @@ class _TopMusicBarState extends State<TopMusicBar> {
         ),
         borderRadius: BorderRadius.circular(24),
         border: border,
-        boxShadow: boxShadow,
       ),
       child: child,
     );

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -324,6 +324,11 @@ class _TopToolbarState extends State<TopToolbar> {
   }
 
   void _restoreFocusBelowToolbar() {
+    final playBtnNode = NavigationLayout.focusDetailsPlayButtonNotifier.value;
+    if (playBtnNode != null && playBtnNode.context != null && playBtnNode.canRequestFocus) {
+      playBtnNode.requestFocus();
+      return;
+    }
     final focusContent = NavigationLayout.focusContentFromNavbarNotifier.value;
     if (focusContent != null && widget.activeRoute == Destinations.home) {
       focusContent();
@@ -545,7 +550,8 @@ class _TopToolbarState extends State<TopToolbar> {
                     }
                   }
 
-                  if (widget.activeRoute != Destinations.home) {
+                  if (widget.activeRoute != Destinations.home &&
+                      NavigationLayout.focusDetailsPlayButtonNotifier.value == null) {
                     final success =
                         primary.focusInDirection(TraversalDirection.down);
                     if (success) {

--- a/packages/server_core/lib/src/api/items_api.dart
+++ b/packages/server_core/lib/src/api/items_api.dart
@@ -32,7 +32,7 @@ abstract class ItemsApi {
     String? anyProviderIdEquals,
   });
 
-  Future<Map<String, dynamic>> getItem(String itemId);
+  Future<Map<String, dynamic>> getItem(String itemId, {String? mediaSourceId});
   Future<List<Map<String, dynamic>>> getAncestors(String itemId);
   Future<Map<String, dynamic>> getSimilarItems(String itemId, {int? limit});
 

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -91,9 +91,14 @@ class EmbyItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getItem(String itemId) async {
+  Future<Map<String, dynamic>> getItem(String itemId, {String? mediaSourceId}) async {
     final userId = _getUserId();
-    final response = await _dio.get('/Users/$userId/Items/$itemId');
+    final response = await _dio.get(
+      '/Users/$userId/Items/$itemId',
+      queryParameters: {
+        if (mediaSourceId != null) 'mediaSourceId': mediaSourceId,
+      },
+    );
     return response.data as Map<String, dynamic>;
   }
 

--- a/packages/server_jellyfin/lib/src/api/jellyfin_item_fields.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_item_fields.dart
@@ -1,2 +1,2 @@
 const kItemFields =
-    'Trickplay,Chapters,MediaSources,MediaStreams,People,Overview,Genres,RecursiveItemCount,ChildCount';
+    'Trickplay,Chapters,MediaSources,MediaStreams,People,Overview,Genres,RecursiveItemCount,ChildCount,ParentLogoItemId,ParentLogoImageTag';

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -93,11 +93,14 @@ class JellyfinItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getItem(String itemId) async {
+  Future<Map<String, dynamic>> getItem(String itemId, {String? mediaSourceId}) async {
     final userId = _getUserId();
     final response = await _dio.get(
       '/Users/$userId/Items/$itemId',
-      queryParameters: {'Fields': kItemFields},
+      queryParameters: {
+        'Fields': kItemFields,
+        if (mediaSourceId != null) 'mediaSourceId': mediaSourceId,
+      },
     );
     return response.data as Map<String, dynamic>;
   }


### PR DESCRIPTION
# Pull Request

## Summary
Collaboration on Details 2.0!

## Pages Adjusted:
* Movies / TV Shows / Seasons / Episodes
* People Pages (Person details)
* Playlists (Playlist details)
* Music Pages (MusicArtist and MusicAlbum details)
* Collections (BoxSet details)

## Technical Stuff Tested:
* UI scaling (small, medium, large, very large) - goal is to always have the "tab bar" visible no matter the scaling on every page. current attempt uses logo sizing as a way to adjust this (bigger UI scale, small logo image)
* left bar vs top nav - pages with left bar should have larger left margin
* Read More display issues 
* Lots of custom navigation links 
* AndroidTV (primarily), Windows Desktop (a bit), Mobile (built; not tested et)

## Things Not checked yet:
* AudioBooks / Books (AudioBook and Book details)
* Trailers / MusicVideos / Videos (other video types); Mixed Media folder items

## Things To be fixed:
* Internal audio links that still go to old pages
* Search engine for people not finding our Cast detail pages
* Implement collection custom order hook on Moonbase (see Playlist view; which added `fetchCustomCollectionOrder` and `saveCustomCollectionOrder` inside `PluginSyncService` pointing to `/Moonfin/Collections/{id}/Order`. Ideally custom Collection order will be able to be saved on Moonbase and pushed to users on a server)
* Some UI scaling adjustments needed for Desktop and for Mobile