### PR TITLE
home screen performance pass

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3131,9 +3131,16 @@ class _ContentRowsState extends State<_ContentRows>
       final rowBottom = rowViewportTop + rowExtents[rowIndex];
       if (focusedRowIndex != null) {
         if (fullScreenRows) {
-          if (rowIndex != focusedRowIndex) {
+          final distance = (rowIndex - focusedRowIndex).abs();
+          if (distance > 1) {
             return IgnorePointer(
               child: Visibility(visible: false, child: child),
+            );
+          }
+          // Keep immediate neighbors in the tree so they are focusable
+          if (distance == 1) {
+            return IgnorePointer(
+              child: Opacity(opacity: 0.0, child: child),
             );
           }
         } else if (rowIndex < focusedRowIndex) {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -707,6 +707,7 @@ class _ContentRowsState extends State<_ContentRows>
   final Map<String, String?> _v2TmdbIdByKey = {};
   late bool _lastMedia3PreviewPreference;
   List<double> _rowTopOffsets = [];
+  List<double> _rowExtents = [];
   List<double> _cachedRowTargetOffsets = [];
   double _cachedRowTargetMaxScrollExtent = -1.0;
   bool _cachedRowTargetFullScreenRows = false;
@@ -935,6 +936,7 @@ class _ContentRowsState extends State<_ContentRows>
       _onMainPlaybackChanged,
     );
     _audioArbiter.register(this);
+    _activeFocusedRowNotifier.addListener(_updateOffsets);
     widget.viewModel.addListener(_onViewModelChanged);
     widget.mediaBarViewModel.addListener(_onMediaBarStateChanged);
     _lastMediaBarStateRuntime = widget.mediaBarViewModel.state.runtimeType;
@@ -947,6 +949,7 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   void _onViewModelChanged() {
+    _updateOffsets();
     if (mounted) setState(() {});
   }
 
@@ -961,7 +964,68 @@ class _ContentRowsState extends State<_ContentRows>
     }
     _lastMediaBarStateRuntime = runtime;
     _lastMediaBarItemCount = itemCount;
+    _updateOffsets();
     setState(() {});
+  }
+
+  void _updateOffsets() {
+    if (!mounted) return;
+    final rows = widget.viewModel.rows;
+    final prefs = widget.prefs;
+    final posterSize = (_isHomeRowsStyleV2() && !prefs.containsPreference(UserPreferences.posterSize))
+        ? PosterSize.small
+        : prefs.get(UserPreferences.posterSize);
+
+    final includeMediaBar = _isMediaBarIncluded();
+    final bannerMode = _isBannerMode();
+    final showInfoOverlay = _showHomeRowInfoOverlay();
+    final safeTop = MediaQuery.of(context).padding.top;
+    final navbarIsTop = prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
+    final fullScreenRows = !PlatformDetection.useMobileUi && prefs.get(UserPreferences.fullScreenRows);
+
+    final navbarHeight = PlatformDetection.isTV
+        ? (fullScreenRows ? 95.0 : (navbarIsTop ? 45.0 : 15.0))
+        : (navbarIsTop ? (PlatformDetection.useMobileUi ? 60.0 : 80.0) : (fullScreenRows ? 0.0 : 80.0));
+
+    final listTopPadding = includeMediaBar || showInfoOverlay
+        ? 0.0
+        : _isHomeRowsStyleV2()
+            ? (fullScreenRows ? (safeTop + navbarHeight + 8.0).clamp(56.0, double.infinity) : safeTop + navbarHeight + 8)
+            : safeTop + 56;
+
+    final infoTopBasePadding = (!PlatformDetection.useMobileUi && navbarHeight == 0) ? 14.0 : 8.0;
+    final infoTopPadding = safeTop + navbarHeight + infoTopBasePadding;
+    final desktopScale = _desktopUiScaleFactor();
+    final infoAreaHeight = InfoArea.fixedHeight(isMobile: PlatformDetection.useMobileUi, desktopScale: desktopScale);
+    final infoBottomPadding = includeMediaBar ? 20.0 : 8.0;
+    final infoOverlayPlaceholder = showInfoOverlay ? infoTopPadding + infoAreaHeight + infoBottomPadding : 0.0;
+
+    final overlayBottom = _isHomeRowsStyleV2()
+        ? (fullScreenRows ? (navbarHeight > 48.0 ? navbarHeight : 48.0) : navbarHeight)
+        : showInfoOverlay
+            ? infoTopPadding + infoAreaHeight
+            : (fullScreenRows ? safeTop + 48.0 : 0.0);
+
+    final rowExtents = _computeRowExtents(rows, posterSize, prefs);
+    final rowTopOffsets = <double>[];
+    var currentTop = listTopPadding + (bannerMode ? 0.0 : infoOverlayPlaceholder);
+    if (includeMediaBar) {
+      currentTop += _mediaBarHeight();
+    }
+    final focusedRowSpacing = PlatformDetection.isTV && !fullScreenRows ? _focusedRowExtraSpacing * 2 : 0.0;
+
+    for (var i = 0; i < rowExtents.length; i++) {
+      rowTopOffsets.add(currentTop);
+      currentTop += rowExtents[i];
+      if (i == _activeFocusedRowIndex) {
+        currentTop += focusedRowSpacing;
+      }
+    }
+
+    _invalidateRowTargetOffsetCache();
+    _rowTopOffsets = rowTopOffsets;
+    _rowExtents = rowExtents;
+    _overlayBottom = overlayBottom;
   }
 
   @override
@@ -1008,6 +1072,7 @@ class _ContentRowsState extends State<_ContentRows>
     }
     _scrollIdleTimer?.cancel();
     _mediaBarFocusNode.dispose();
+    _activeFocusedRowNotifier.removeListener(_updateOffsets);
     widget.viewModel.removeListener(_onViewModelChanged);
     widget.mediaBarViewModel.removeListener(_onMediaBarStateChanged);
     _mainPlaybackSub?.cancel();
@@ -3200,6 +3265,7 @@ class _ContentRowsState extends State<_ContentRows>
       return const Center(child: CircularProgressIndicator());
     }
 
+    _updateOffsets();
     final includeMediaBar = _isMediaBarIncluded();
     final bannerMode = _isBannerMode();
     final mediaBarHeight = _mediaBarHeight();
@@ -3260,33 +3326,9 @@ class _ContentRowsState extends State<_ContentRows>
           )
         : SizedBox(height: infoOverlayPlaceholder);
 
-    final overlayBottom = _isHomeRowsStyleV2()
-        ? (fullScreenRows
-              ? (navbarHeight > 48.0 ? navbarHeight : 48.0)
-              : navbarHeight)
-        : showInfoOverlay
-        ? infoTopPadding + infoAreaHeight
-        : (fullScreenRows ? safeTop + 48.0 : 0.0);
-    final rowExtents = _computeRowExtents(rows, posterSize, prefs);
-    final rowTopOffsets = <double>[];
-    var currentTop = listTopPadding + (bannerMode ? 0.0 : infoOverlayPlaceholder);
-    if (includeMediaBar) {
-      currentTop += mediaBarHeight;
-    }
-    final focusedRowSpacing = PlatformDetection.isTV && !fullScreenRows
-        ? _focusedRowExtraSpacing * 2
-        : 0.0;
-    for (var i = 0; i < rowExtents.length; i++) {
-      rowTopOffsets.add(currentTop);
-      currentTop += rowExtents[i];
-      if (i == _activeFocusedRowIndex) {
-        currentTop += focusedRowSpacing;
-      }
-    }
-
-    _invalidateRowTargetOffsetCache();
-    _rowTopOffsets = rowTopOffsets;
-    _overlayBottom = overlayBottom;
+    final overlayBottom = _overlayBottom;
+    final rowTopOffsets = _rowTopOffsets;
+    final rowExtents = _rowExtents;
     final headerCount = (includeMediaBar ? 1 : 0) + 1;
 
     // Ensure the last row can be scrolled so its top sits just below the info

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -623,7 +623,7 @@ class _ContentRowsState extends State<_ContentRows>
   bool _previewReady = false;
   bool _previewUsingMedia3 = false;
   bool _previewUsingAppleTv = false;
-  double _scrollOffset = 0;
+  final ValueNotifier<double> _scrollOffsetNotifier = ValueNotifier<double>(0);
   double _previewStartScrollOffset = 0;
   bool _isScrolledToTop = true;
   bool _isActivelyScrolling = false;
@@ -643,6 +643,13 @@ class _ContentRowsState extends State<_ContentRows>
   bool _chromeAudioActive = false;
   bool _windowHasFocus = true;
   bool _holdMediaBarWhileSidebarFocused = false;
+
+  double get _scrollOffset => _scrollOffsetNotifier.value;
+  set _scrollOffset(double value) {
+    if (_scrollOffsetNotifier.value != value) {
+      _scrollOffsetNotifier.value = value;
+    }
+  }
   bool get _isSidebarFocus => LeftSidebar.isFocusedNotifier.value;
   bool _wasSidebarFocused = false;
   VoidCallback? _previousFocusContentFromNavbarCallback;
@@ -878,6 +885,7 @@ class _ContentRowsState extends State<_ContentRows>
     LeftSidebar.isFocusedNotifier.removeListener(_onGlobalFocusChanged);
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
+    _scrollOffsetNotifier.dispose();
     if (identical(
       NavigationLayout.focusContentFromNavbarNotifier.value,
       _focusContentFromNavbar,
@@ -2481,7 +2489,8 @@ class _ContentRowsState extends State<_ContentRows>
     final previousOffset = _scrollOffset;
     final scrollingUp = offset < previousOffset;
     final atTop = offset <= 0;
-    if (atTop != _isScrolledToTop) {
+    final topStateChanged = atTop != _isScrolledToTop;
+    if (topStateChanged) {
       _isScrolledToTop = atTop;
       widget.onScrolledToTopChanged?.call(atTop);
     }
@@ -2491,7 +2500,9 @@ class _ContentRowsState extends State<_ContentRows>
         !PlatformDetection.useMobileUi &&
         widget.prefs.get(UserPreferences.fullScreenRows);
 
-    if (isDesktop && _rowTopOffsets.isNotEmpty && _scrollController.hasClients) {
+    final shouldUpdateActiveRow =
+        isDesktop && _rowTopOffsets.isNotEmpty && _scrollController.hasClients;
+    if (shouldUpdateActiveRow) {
       double minDiff = double.infinity;
       int? closestRowIndex;
 
@@ -2547,7 +2558,8 @@ class _ContentRowsState extends State<_ContentRows>
       }
     }
 
-    if (!_isActivelyScrolling) {
+    final shouldMarkScrolling = !_isActivelyScrolling;
+    if (shouldMarkScrolling) {
       _isActivelyScrolling = true;
       if (mounted) setState(() {});
     }
@@ -3240,191 +3252,196 @@ class _ContentRowsState extends State<_ContentRows>
       },
       child: Stack(
         children: [
-        Positioned.fill(
-          child: Focus(
-            canRequestFocus: false,
-            skipTraversal: true,
-            onKeyEvent: (_, event) => _handleRowsKeyEvent(event),
-            child: ListView.builder(
-              controller: _scrollController,
-              padding: EdgeInsets.only(
-                top: listTopPadding,
-                bottom: neededBottomPadding,
-              ),
-              itemCount: rows.length + headerCount,
-              cacheExtent: 600,
-              itemBuilder: (context, index) {
-              if (includeMediaBar && index == 0) {
-                return AnimatedOpacity(
-                  duration: _mediaBarFadeDuration,
-                  curve: Curves.easeInOutCubic,
-                  opacity: _mediaBarVisible ? 1.0 : 0.0,
-                  child: IgnorePointer(
-                    ignoring: !_mediaBarVisible,
-                    child: bannerMode
-                        ? BannerMediaBar(
-                            viewModel: widget.mediaBarViewModel,
-                            prefs: prefs,
-                            height: mediaBarHeight,
-                            externallyPaused:
-                                carouselPaused ||
-                                !_mediaBarVisible ||
-                                _activePreviewKey != null,
-                            focusNode: _mediaBarFocusNode,
-                            onNavigateDown: _moveFocusFromMediaBarToRows,
-                            onNavigateUp: _navigateFromMediaBarToNavbar,
-                            onNavigateLeft: navbarIsLeft
-                                ? _navigateFromMediaBarToNavbar
-                                : null,
-                            onOpen: (item) => context.push(
-                              Destinations.item(
-                                item.itemId,
-                                serverId: item.serverId,
-                              ),
-                            ),
-                            onPlay: (item) => context.push(
-                              Destinations.item(
-                                item.itemId,
-                                serverId: item.serverId,
-                                autoPlay: true,
-                              ),
-                            ),
+        ValueListenableBuilder<double>(
+          valueListenable: _scrollOffsetNotifier,
+          builder: (context, _, _) {
+            return Positioned.fill(
+              child: Focus(
+                canRequestFocus: false,
+                skipTraversal: true,
+                onKeyEvent: (_, event) => _handleRowsKeyEvent(event),
+                child: ListView.builder(
+                  controller: _scrollController,
+                  padding: EdgeInsets.only(
+                    top: listTopPadding,
+                    bottom: neededBottomPadding,
+                  ),
+                  itemCount: rows.length + headerCount,
+                  cacheExtent: 600,
+                  itemBuilder: (context, index) {
+                    if (includeMediaBar && index == 0) {
+                      return AnimatedOpacity(
+                        duration: _mediaBarFadeDuration,
+                        curve: Curves.easeInOutCubic,
+                        opacity: _mediaBarVisible ? 1.0 : 0.0,
+                        child: IgnorePointer(
+                          ignoring: !_mediaBarVisible,
+                          child: bannerMode
+                              ? BannerMediaBar(
+                                  viewModel: widget.mediaBarViewModel,
+                                  prefs: prefs,
+                                  height: mediaBarHeight,
+                                  externallyPaused:
+                                      carouselPaused ||
+                                      !_mediaBarVisible ||
+                                      _activePreviewKey != null,
+                                  focusNode: _mediaBarFocusNode,
+                                  onNavigateDown: _moveFocusFromMediaBarToRows,
+                                  onNavigateUp: _navigateFromMediaBarToNavbar,
+                                  onNavigateLeft: navbarIsLeft
+                                      ? _navigateFromMediaBarToNavbar
+                                      : null,
+                                  onOpen: (item) => context.push(
+                                    Destinations.item(
+                                      item.itemId,
+                                      serverId: item.serverId,
+                                    ),
+                                  ),
+                                  onPlay: (item) => context.push(
+                                    Destinations.item(
+                                      item.itemId,
+                                      serverId: item.serverId,
+                                      autoPlay: true,
+                                    ),
+                                  ),
+                                )
+                              : MediaBar(
+                                  viewModel: widget.mediaBarViewModel,
+                                  prefs: prefs,
+                                  externallyPaused:
+                                      carouselPaused ||
+                                      !_mediaBarVisible ||
+                                      _activePreviewKey != null,
+                                  height: mediaBarHeight,
+                                  onNavigateDown: _moveFocusFromMediaBarToRows,
+                                  onNavigateUp: _navigateFromMediaBarToNavbar,
+                                  onNavigateLeft: navbarIsLeft
+                                      ? _navigateFromMediaBarToNavbar
+                                      : null,
+                                  focusNode: _mediaBarFocusNode,
+                                ),
+                        ),
+                      );
+                    }
+                    final infoIndex = includeMediaBar ? 1 : 0;
+                    if (index == infoIndex) {
+                      return SizedBox(height: infoPlaceholderHeight);
+                    }
+                    final row = rows[index - headerCount];
+                    final rowIndex = index - headerCount;
+                    final l10n = AppLocalizations.of(context);
+                    late final Widget rowChild;
+                    if (row.isLoading) {
+                      rowChild = LibraryRow(
+                        title: _localizedRowTitle(row, l10n),
+                        isLoading: true,
+                        children: const [],
+                      );
+                    } else if (row.rowType == HomeRowType.liveTv) {
+                      rowChild = _buildLiveTvRow(
+                        row,
+                        focusColor,
+                        cardExpansion,
+                        posterSize: posterSize,
+                        rowIndex: rowIndex,
+                        rows: rows,
+                      );
+                    } else if (row.rowType == HomeRowType.libraryTilesSmall) {
+                      rowChild = _buildLibraryButtonsRow(
+                        row,
+                        focusColor,
+                        cardExpansion,
+                        posterSize: posterSize,
+                        rowIndex: rowIndex,
+                        rows: rows,
+                      );
+                    } else {
+                      rowChild = _buildMediaRow(
+                        row: row,
+                        rowIndex: rowIndex,
+                        rows: rows,
+                        prefs: prefs,
+                        posterSize: posterSize,
+                        watchedBehavior: watchedBehavior,
+                        focusColor: focusColor,
+                        cardExpansion: cardExpansion,
+                        useSeriesThumbs: useSeriesThumbs,
+                        l10n: l10n,
+                      );
+                    }
+
+                    final contentHeight = _rowContentHeight(row, posterSize, prefs);
+                    final targetExtent = rowExtents[rowIndex];
+                    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
+                    final extraTopPadding = fullScreenRows
+                        ? (isRowsV2
+                            ? ((targetExtent - contentHeight) * 0.1).clamp(0.0, double.infinity)
+                            : ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity))
+                        : 0.0;
+
+                    final paddedRowChild = extraTopPadding > 0.0
+                        ? Padding(
+                            padding: EdgeInsets.only(top: extraTopPadding),
+                            child: rowChild,
                           )
-                        : MediaBar(
-                            viewModel: widget.mediaBarViewModel,
-                            prefs: prefs,
-                            externallyPaused:
-                                carouselPaused ||
-                                !_mediaBarVisible ||
-                                _activePreviewKey != null,
-                            height: mediaBarHeight,
-                            onNavigateDown: _moveFocusFromMediaBarToRows,
-                            onNavigateUp: _navigateFromMediaBarToNavbar,
-                            onNavigateLeft: navbarIsLeft
-                                ? _navigateFromMediaBarToNavbar
-                                : null,
-                            focusNode: _mediaBarFocusNode,
-                          ),
-                  ),
-                );
-              }
-              final infoIndex = includeMediaBar ? 1 : 0;
-              if (index == infoIndex) {
-                return SizedBox(height: infoPlaceholderHeight);
-              }
-              final row = rows[index - headerCount];
-              final rowIndex = index - headerCount;
-              final l10n = AppLocalizations.of(context);
-              late final Widget rowChild;
-              if (row.isLoading) {
-                rowChild = LibraryRow(
-                  title: _localizedRowTitle(row, l10n),
-                  isLoading: true,
-                  children: const [],
-                );
-              } else if (row.rowType == HomeRowType.liveTv) {
-                rowChild = _buildLiveTvRow(
-                  row,
-                  focusColor,
-                  cardExpansion,
-                  posterSize: posterSize,
-                  rowIndex: rowIndex,
-                  rows: rows,
-                );
-              } else if (row.rowType == HomeRowType.libraryTilesSmall) {
-                rowChild = _buildLibraryButtonsRow(
-                  row,
-                  focusColor,
-                  cardExpansion,
-                  posterSize: posterSize,
-                  rowIndex: rowIndex,
-                  rows: rows,
-                );
-              } else {
-                rowChild = _buildMediaRow(
-                  row: row,
-                  rowIndex: rowIndex,
-                  rows: rows,
-                  prefs: prefs,
-                  posterSize: posterSize,
-                  watchedBehavior: watchedBehavior,
-                  focusColor: focusColor,
-                  cardExpansion: cardExpansion,
-                  useSeriesThumbs: useSeriesThumbs,
-                  l10n: l10n,
-                );
-              }
+                        : rowChild;
 
-              final contentHeight = _rowContentHeight(row, posterSize, prefs);
-              final targetExtent = rowExtents[rowIndex];
-              final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isSeerrFilterRow(row);
-              final extraTopPadding = fullScreenRows
-                  ? (isRowsV2
-                      ? ((targetExtent - contentHeight) * 0.1).clamp(0.0, double.infinity)
-                      : ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity))
-                  : 0.0;
+                    if (row.isLoading) {
+                      final itemWidget = Padding(
+                        padding: EdgeInsets.only(left: rowLeftInset),
+                        child: _buildShiftedRow(
+                          child: paddedRowChild,
+                          rowIndex: rowIndex,
+                          rowTopOffsets: rowTopOffsets,
+                          rowExtents: rowExtents,
+                          showInfoOverlay: showInfoOverlay,
+                          overlayBottom: overlayBottom,
+                        ),
+                      );
+                      if (fullScreenRows) {
+                        return SizedBox(
+                          height: rowExtents[rowIndex],
+                          child: itemWidget,
+                        );
+                      }
+                      return itemWidget;
+                    }
 
-              final paddedRowChild = extraTopPadding > 0.0
-                  ? Padding(
-                      padding: EdgeInsets.only(top: extraTopPadding),
-                      child: rowChild,
-                    )
-                  : rowChild;
-
-              if (row.isLoading) {
-                final itemWidget = Padding(
-                  padding: EdgeInsets.only(left: rowLeftInset),
-                  child: _buildShiftedRow(
-                    child: paddedRowChild,
-                    rowIndex: rowIndex,
-                    rowTopOffsets: rowTopOffsets,
-                    rowExtents: rowExtents,
-                    showInfoOverlay: showInfoOverlay,
-                    overlayBottom: overlayBottom,
-                  ),
-                );
-                if (fullScreenRows) {
-                  return SizedBox(
-                    height: rowExtents[rowIndex],
-                    child: itemWidget,
-                  );
-                }
-                return itemWidget;
-              }
-
-              final itemWidget = Padding(
-                padding: EdgeInsets.only(left: rowLeftInset),
-                child: AnimatedPadding(
-                  duration: _focusedRowSpacingDuration,
-                  curve: Curves.easeOut,
-                  padding: EdgeInsets.symmetric(
-                    vertical:
-                        (PlatformDetection.isTV &&
-                            !fullScreenRows &&
-                            rowIndex == _activeFocusedRowIndex)
-                        ? _focusedRowExtraSpacing
-                        : 0,
-                  ),
-                  child: _buildShiftedRow(
-                    child: paddedRowChild,
-                    rowIndex: rowIndex,
-                    rowTopOffsets: rowTopOffsets,
-                    rowExtents: rowExtents,
-                    showInfoOverlay: showInfoOverlay,
-                    overlayBottom: overlayBottom,
-                  ),
+                    final itemWidget = Padding(
+                      padding: EdgeInsets.only(left: rowLeftInset),
+                      child: AnimatedPadding(
+                        duration: _focusedRowSpacingDuration,
+                        curve: Curves.easeOut,
+                        padding: EdgeInsets.symmetric(
+                          vertical:
+                              (PlatformDetection.isTV &&
+                                  !fullScreenRows &&
+                                  rowIndex == _activeFocusedRowIndex)
+                              ? _focusedRowExtraSpacing
+                              : 0,
+                        ),
+                        child: _buildShiftedRow(
+                          child: paddedRowChild,
+                          rowIndex: rowIndex,
+                          rowTopOffsets: rowTopOffsets,
+                          rowExtents: rowExtents,
+                          showInfoOverlay: showInfoOverlay,
+                          overlayBottom: overlayBottom,
+                        ),
+                      ),
+                    );
+                    if (fullScreenRows) {
+                      return SizedBox(
+                        height: rowExtents[rowIndex],
+                        child: itemWidget,
+                      );
+                    }
+                    return itemWidget;
+                  },
                 ),
-              );
-              if (fullScreenRows) {
-                return SizedBox(
-                  height: rowExtents[rowIndex],
-                  child: itemWidget,
-                );
-              }
-              return itemWidget;
-              },
-            ),
-          ),
+              ),
+            );
+          },
         ),
         if (_infoRevealed && showInfoOverlay)
           Positioned(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3287,16 +3287,13 @@ class _ContentRowsState extends State<_ContentRows>
       },
       child: Stack(
         children: [
-        ValueListenableBuilder<double>(
-          valueListenable: _scrollOffsetNotifier,
-          builder: (context, _, _) {
-            return Positioned.fill(
-              child: Focus(
-                canRequestFocus: false,
-                skipTraversal: true,
-                onKeyEvent: (_, event) => _handleRowsKeyEvent(event),
-                child: ListView.builder(
-                  controller: _scrollController,
+        Positioned.fill(
+          child: Focus(
+            canRequestFocus: false,
+            skipTraversal: true,
+            onKeyEvent: (_, event) => _handleRowsKeyEvent(event),
+            child: ListView.builder(
+              controller: _scrollController,
                   padding: EdgeInsets.only(
                     top: listTopPadding,
                     bottom: neededBottomPadding,
@@ -3424,13 +3421,18 @@ class _ContentRowsState extends State<_ContentRows>
                     if (row.isLoading) {
                       final itemWidget = Padding(
                         padding: EdgeInsets.only(left: rowLeftInset),
-                        child: _buildShiftedRow(
-                          child: paddedRowChild,
-                          rowIndex: rowIndex,
-                          rowTopOffsets: rowTopOffsets,
-                          rowExtents: rowExtents,
-                          showInfoOverlay: showInfoOverlay,
-                          overlayBottom: overlayBottom,
+                        child: ValueListenableBuilder<double>(
+                          valueListenable: _scrollOffsetNotifier,
+                          builder: (context, scrollOffset, _) {
+                            return _buildShiftedRow(
+                              child: paddedRowChild,
+                              rowIndex: rowIndex,
+                              rowTopOffsets: rowTopOffsets,
+                              rowExtents: rowExtents,
+                              showInfoOverlay: showInfoOverlay,
+                              overlayBottom: overlayBottom,
+                            );
+                          },
                         ),
                       );
                       if (fullScreenRows) {
@@ -3455,13 +3457,18 @@ class _ContentRowsState extends State<_ContentRows>
                               ? _focusedRowExtraSpacing
                               : 0,
                         ),
-                        child: _buildShiftedRow(
-                          child: paddedRowChild,
-                          rowIndex: rowIndex,
-                          rowTopOffsets: rowTopOffsets,
-                          rowExtents: rowExtents,
-                          showInfoOverlay: showInfoOverlay,
-                          overlayBottom: overlayBottom,
+                        child: ValueListenableBuilder<double>(
+                          valueListenable: _scrollOffsetNotifier,
+                          builder: (context, scrollOffset, _) {
+                            return _buildShiftedRow(
+                              child: paddedRowChild,
+                              rowIndex: rowIndex,
+                              rowTopOffsets: rowTopOffsets,
+                              rowExtents: rowExtents,
+                              showInfoOverlay: showInfoOverlay,
+                              overlayBottom: overlayBottom,
+                            );
+                          },
                         ),
                       ),
                     );
@@ -3475,9 +3482,7 @@ class _ContentRowsState extends State<_ContentRows>
                   },
                 ),
               ),
-            );
-          },
-        ),
+            ),
         if (_infoRevealed && showInfoOverlay)
           Positioned(
             top: 0,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -98,7 +98,7 @@ class _HomeShellState extends State<_HomeShell>
   late final HomeViewModel _viewModel;
 
   final ValueNotifier<AggregatedItem?> _selectedItemNotifier = ValueNotifier(null);
-  String? _backdropUrl;
+  final ValueNotifier<String?> _backdropUrlNotifier = ValueNotifier(null);
   Timer? _selectionDebounce;
   Timer? _backdropDebounce;
   Timer? _hoverPauseTimer;
@@ -131,9 +131,9 @@ class _HomeShellState extends State<_HomeShell>
       _viewModel.refresh(preserveExisting: true);
     }
     _backgroundSub = _backgroundService.backgroundStream.listen((url) {
-      if (mounted) setState(() => _backdropUrl = url);
+      if (mounted) _backdropUrlNotifier.value = url;
     });
-    _backdropUrl = _backgroundService.currentUrl;
+    _backdropUrlNotifier.value = _backgroundService.currentUrl;
 
     _viewModel.addListener(_onViewModelChanged);
     _viewModel.mediaBarViewModel.addListener(_onMediaBarStateChanged);
@@ -184,6 +184,7 @@ class _HomeShellState extends State<_HomeShell>
     _hoverPauseTimer?.cancel();
     _backgroundSub?.cancel();
     _selectedItemNotifier.dispose();
+    _backdropUrlNotifier.dispose();
     _isHoverPausedNotifier.dispose();
     _isScrolledToTopNotifier.dispose();
     _viewModel.mediaBarViewModel.removeListener(_onMediaBarStateChanged);
@@ -402,10 +403,15 @@ class _HomeShellState extends State<_HomeShell>
             fit: StackFit.expand,
             children: [
               if (backdropEnabled)
-                _Backdrop(
-                  url: _backdropUrl,
-                  blurAmount: blurAmount,
-                  useMakdBackdropFx: useMakdBackdropFx,
+                ValueListenableBuilder<String?>(
+                  valueListenable: _backdropUrlNotifier,
+                  builder: (context, url, _) {
+                    return _Backdrop(
+                      url: url,
+                      blurAmount: blurAmount,
+                      useMakdBackdropFx: useMakdBackdropFx,
+                    );
+                  },
                 ),
               const _GradientScrim(),
               Positioned.fill(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -349,7 +349,6 @@ class _HomeShellState extends State<_HomeShell>
 
   @override
   Widget build(BuildContext context) {
-    final watch = Stopwatch()..start();
     final backdropEnabled = _userPrefs.get(UserPreferences.backdropEnabled);
     final blurAmount = _userPrefs
         .get(UserPreferences.browsingBackgroundBlurAmount)
@@ -362,7 +361,7 @@ class _HomeShellState extends State<_HomeShell>
         PlatformDetection.useMobileUi &&
         mediaBarMode == UserPreferences.mediaBarModeMakd;
 
-    final result = PopScope(
+    return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
@@ -410,8 +409,6 @@ class _HomeShellState extends State<_HomeShell>
         ),
       ),
     );
-    _homeBuildMonitor.recordShell(watch.elapsedMicroseconds);
-    return result;
   }
 
   Future<void> _showExitConfirmation(BuildContext context) async {
@@ -3243,7 +3240,6 @@ class _ContentRowsState extends State<_ContentRows>
 
   @override
   Widget build(BuildContext context) {
-    final watch = Stopwatch()..start();
     final rows = widget.viewModel.rows;
     // Guard against a stale focused-row index pointing past the end of the
     // (potentially shorter) new row list
@@ -3372,7 +3368,7 @@ class _ContentRowsState extends State<_ContentRows>
       );
     }
 
-    final result = Listener(
+    return Listener(
       behavior: HitTestBehavior.translucent,
       onPointerDown: (_) => _markUserGesture(),
       onPointerSignal: (pointerSignal) {
@@ -3644,8 +3640,6 @@ class _ContentRowsState extends State<_ContentRows>
       ],
     ),
     );
-    _homeBuildMonitor.recordContent(watch.elapsedMicroseconds);
-    return result;
   }
 
   Widget _buildLiveTvRow(
@@ -3821,7 +3815,6 @@ class _ContentRowsState extends State<_ContentRows>
     required bool useSeriesThumbs,
     required AppLocalizations l10n,
   }) {
-    final watch = Stopwatch()..start();
     final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
     final isSeerrRowOverride = _isSeerrFilterRow(row);
     final isRowsV2 =
@@ -3899,7 +3892,7 @@ class _ContentRowsState extends State<_ContentRows>
 
     final subtitle = _rowSubtitle(row, l10n);
     final hasSubtitle = subtitle != null;
-    final result = _buildTitledRow(
+    return _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),
       subtitle: subtitle,
@@ -4284,8 +4277,6 @@ class _ContentRowsState extends State<_ContentRows>
       ),
     ),
     );
-    _homeBuildMonitor.recordRow(watch.elapsedMicroseconds);
-    return result;
   }
 
   Widget _buildV2ExtendedSection(
@@ -5250,52 +5241,5 @@ class _PreviewCardShell extends StatelessWidget {
         ],
       ),
     );
-  }
-}
-
-final _homeBuildMonitor = _BuildMonitor();
-
-class _BuildMonitor {
-  int _shellCount = 0;
-  int _contentCount = 0;
-  int _rowCount = 0;
-  int _totalTimeUs = 0;
-  Timer? _reportTimer;
-
-  void recordShell(int us) {
-    _shellCount++;
-    _totalTimeUs += us;
-    _ensureTimer();
-  }
-
-  void recordContent(int us) {
-    _contentCount++;
-    _totalTimeUs += us;
-    _ensureTimer();
-  }
-
-  void recordRow(int us) {
-    _rowCount++;
-    _totalTimeUs += us;
-    _ensureTimer();
-  }
-
-  void _ensureTimer() {
-    _reportTimer ??= Timer(const Duration(seconds: 2), () {
-      final shell = _shellCount;
-      final content = _contentCount;
-      final row = _rowCount;
-      final avgTime = shell + content + row == 0 
-          ? 0 
-          : _totalTimeUs / (shell + content + row);
-      
-      debugPrint('[BASELINE] 2s Window | Shell: $shell | Content: $content | Rows: $row | Avg Build: ${avgTime.toStringAsFixed(1)}μs');
-      
-      _shellCount = 0;
-      _contentCount = 0;
-      _rowCount = 0;
-      _totalTimeUs = 0;
-      _reportTimer = null;
-    });
   }
 }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -633,7 +633,6 @@ class _ContentRowsState extends State<_ContentRows>
   StreamSubscription<void>? _appleTvPreviewCompletedSub;
   int _previewRequestId = 0;
   bool _mainPlaybackActive = false;
-  bool _previewReady = false;
   bool _previewUsingMedia3 = false;
   bool _previewUsingAppleTv = false;
   final ValueNotifier<double> _scrollOffsetNotifier = ValueNotifier<double>(0);
@@ -643,7 +642,6 @@ class _ContentRowsState extends State<_ContentRows>
   Timer? _scrollIdleTimer;
   double _lastActiveRowOffsetUpdate = 0;
   bool _infoRevealed = false;
-  bool _mediaBarVisible = true;
   bool _initialFocusResolved = false;
   bool _hasEverFocusedHomeContent = false;
   String? _lastObservedPath;
@@ -653,10 +651,47 @@ class _ContentRowsState extends State<_ContentRows>
   DateTime? _lastMouseWheelTime;
   DateTime? _lastVerticalNavAt;
   bool _verticalNavInFlight = false;
-  bool _chromeFocusActive = false;
-  bool _chromeAudioActive = false;
   bool _windowHasFocus = true;
   bool _holdMediaBarWhileSidebarFocused = false;
+
+  final ValueNotifier<String?> _activePreviewKeyNotifier = ValueNotifier(null);
+  String? get _activePreviewKey => _activePreviewKeyNotifier.value;
+  set _activePreviewKey(String? value) {
+    if (_activePreviewKeyNotifier.value != value) {
+      _activePreviewKeyNotifier.value = value;
+    }
+  }
+
+  final ValueNotifier<bool> _previewReadyNotifier = ValueNotifier(false);
+  bool get _previewReady => _previewReadyNotifier.value;
+  set _previewReady(bool value) {
+    if (_previewReadyNotifier.value != value) {
+      _previewReadyNotifier.value = value;
+    }
+  }
+
+  final ValueNotifier<bool> _mediaBarVisibleNotifier = ValueNotifier(true);
+  bool get _mediaBarVisible => _mediaBarVisibleNotifier.value;
+  set _mediaBarVisible(bool value) {
+    if (_mediaBarVisibleNotifier.value != value) {
+      _mediaBarVisibleNotifier.value = value;
+    }
+  }
+
+  final ValueNotifier<bool> _chromeFocusActiveNotifier = ValueNotifier(false);
+  bool get _chromeFocusActive => _chromeFocusActiveNotifier.value;
+  set _chromeFocusActive(bool value) {
+    if (_chromeFocusActiveNotifier.value != value) {
+      _chromeFocusActiveNotifier.value = value;
+    }
+  }
+
+  final ValueNotifier<bool> _chromeAudioActiveNotifier = ValueNotifier(false);
+  set _chromeAudioActive(bool value) {
+    if (_chromeAudioActiveNotifier.value != value) {
+      _chromeAudioActiveNotifier.value = value;
+    }
+  }
 
   double get _scrollOffset => _scrollOffsetNotifier.value;
   set _scrollOffset(double value) {
@@ -668,7 +703,6 @@ class _ContentRowsState extends State<_ContentRows>
   bool _wasSidebarFocused = false;
   VoidCallback? _previousFocusContentFromNavbarCallback;
   FocusNode? _lastGlobalPrimaryFocus;
-  String? _activePreviewKey;
   String? _mobilePressedV2Key;
   String? _mouseHoveredV2Key;
   final Set<String> _v2FocusPrefetchedUrls = <String>{};
@@ -786,15 +820,13 @@ class _ContentRowsState extends State<_ContentRows>
               (_verticalNavInFlight && _mediaBarVisible) ||
               (!onSidebar && _activeFocusedRowIndex == null);
     final chromeChanged =
-        _chromeFocusActive != chromeFocusActive ||
-        _chromeAudioActive != chromeAudioActive;
+        _chromeFocusActiveNotifier.value != chromeFocusActive ||
+        _chromeAudioActiveNotifier.value != chromeAudioActive;
 
-    if (_mediaBarVisible != nextMediaBarVisible || chromeChanged) {
-      setState(() {
-        _mediaBarVisible = nextMediaBarVisible;
-        _chromeFocusActive = chromeFocusActive;
-        _chromeAudioActive = chromeAudioActive;
-      });
+    if (_mediaBarVisibleNotifier.value != nextMediaBarVisible || chromeChanged) {
+      _mediaBarVisible = nextMediaBarVisible;
+      _chromeFocusActive = chromeFocusActive;
+      _chromeAudioActive = chromeAudioActive;
     }
 
     if (wasOnSidebar && !onSidebar && _activeFocusedRowIndex != null) {
@@ -941,6 +973,11 @@ class _ContentRowsState extends State<_ContentRows>
     _scrollOffsetNotifier.dispose();
     _activeFocusedRowNotifier.dispose();
     _v2AdditionalRatingsNotifier.dispose();
+    _mediaBarVisibleNotifier.dispose();
+    _chromeFocusActiveNotifier.dispose();
+    _chromeAudioActiveNotifier.dispose();
+    _activePreviewKeyNotifier.dispose();
+    _previewReadyNotifier.dispose();
     if (identical(
       NavigationLayout.focusContentFromNavbarNotifier.value,
       _focusContentFromNavbar,
@@ -1129,10 +1166,8 @@ class _ContentRowsState extends State<_ContentRows>
         return;
       }
       _previewStartScrollOffset = _scrollController.offset;
-      setState(() {
-        _activePreviewKey = previewKey;
-        _previewReady = false;
-      });
+      _activePreviewKey = previewKey;
+      _previewReady = false;
       await _startSharedPreview(item, previewKey);
     });
     _previewDelayTimer = thisTimer;
@@ -1188,15 +1223,8 @@ class _ContentRowsState extends State<_ContentRows>
     }
 
     if (_activePreviewKey != null || _previewReady) {
-      if (updateUi && mounted) {
-        setState(() {
-          _activePreviewKey = null;
-          _previewReady = false;
-        });
-      } else {
-        _activePreviewKey = null;
-        _previewReady = false;
-      }
+      _activePreviewKey = null;
+      _previewReady = false;
     }
     _themeMusicService.setExternalAudioActive(false);
   }
@@ -1330,7 +1358,7 @@ class _ContentRowsState extends State<_ContentRows>
       });
 
       if (_isPreviewRequestActive(requestId, previewKey)) {
-        setState(() => _previewReady = true);
+        _previewReady = true;
       }
     } catch (_) {
       if (_isPreviewRequestActive(requestId, previewKey)) {
@@ -1901,7 +1929,7 @@ class _ContentRowsState extends State<_ContentRows>
     _forceRevealOnNextRowFocusFromMediaBar = true;
     final isBanner = _isBannerMode();
     if (mounted && _mediaBarVisible && !isBanner) {
-      setState(() => _mediaBarVisible = false);
+      _mediaBarVisible = false;
     }
     if (!isBanner && _scrollController.hasClients) {
       final offsetAdjustment = _isBookshelfMode() ? (_overlayBottom + 8) : 0.0;
@@ -3303,69 +3331,79 @@ class _ContentRowsState extends State<_ContentRows>
                   itemBuilder: (context, index) {
                     if (includeMediaBar && index == 0) {
                       return ValueListenableBuilder<bool>(
-                        valueListenable: widget.isHoverPausedNotifier,
-                        builder: (context, isHoverPaused, _) {
-                          return ValueListenableBuilder<bool>(
-                            valueListenable: widget.isScrolledToTopNotifier,
-                            builder: (context, isScrolledToTop, _) {
-                              final barPaused = isHoverPaused ||
-                                  !isScrolledToTop ||
-                                  _isActivelyScrolling ||
-                                  _chromeAudioActive;
+                        valueListenable: _mediaBarVisibleNotifier,
+                        builder: (context, mediaBarVisible, _) {
+                          return AnimatedOpacity(
+                            duration: _mediaBarFadeDuration,
+                            curve: Curves.easeInOutCubic,
+                            opacity: mediaBarVisible ? 1.0 : 0.0,
+                            child: IgnorePointer(
+                              ignoring: !mediaBarVisible,
+                              child: ValueListenableBuilder<bool>(
+                                valueListenable: widget.isHoverPausedNotifier,
+                                builder: (context, isHoverPaused, _) {
+                                  return ValueListenableBuilder<bool>(
+                                    valueListenable: widget.isScrolledToTopNotifier,
+                                    builder: (context, isScrolledToTop, _) {
+                                      return ValueListenableBuilder<bool>(
+                                        valueListenable: _chromeAudioActiveNotifier,
+                                        builder: (context, chromeAudioActive, _) {
+                                          final barPaused = isHoverPaused ||
+                                              !isScrolledToTop ||
+                                              _isActivelyScrolling ||
+                                              chromeAudioActive;
 
-                              return AnimatedOpacity(
-                                duration: _mediaBarFadeDuration,
-                                curve: Curves.easeInOutCubic,
-                                opacity: _mediaBarVisible ? 1.0 : 0.0,
-                                child: IgnorePointer(
-                                  ignoring: !_mediaBarVisible,
-                                  child: bannerMode
-                                      ? BannerMediaBar(
-                                          viewModel: widget.mediaBarViewModel,
-                                          prefs: prefs,
-                                          height: mediaBarHeight,
-                                          externallyPaused:
-                                              barPaused ||
-                                              !_mediaBarVisible ||
-                                              _activePreviewKey != null,
-                                          focusNode: _mediaBarFocusNode,
-                                          onNavigateDown: _moveFocusFromMediaBarToRows,
-                                          onNavigateUp: _navigateFromMediaBarToNavbar,
-                                          onNavigateLeft: navbarIsLeft
-                                              ? _navigateFromMediaBarToNavbar
-                                              : null,
-                                          onOpen: (item) => context.push(
-                                            Destinations.item(
-                                              item.itemId,
-                                              serverId: item.serverId,
-                                            ),
-                                          ),
-                                          onPlay: (item) => context.push(
-                                            Destinations.item(
-                                              item.itemId,
-                                              serverId: item.serverId,
-                                              autoPlay: true,
-                                            ),
-                                          ),
-                                        )
-                                      : MediaBar(
-                                          viewModel: widget.mediaBarViewModel,
-                                          prefs: prefs,
-                                          externallyPaused:
-                                              barPaused ||
-                                              !_mediaBarVisible ||
-                                              _activePreviewKey != null,
-                                          height: mediaBarHeight,
-                                          onNavigateDown: _moveFocusFromMediaBarToRows,
-                                          onNavigateUp: _navigateFromMediaBarToNavbar,
-                                          onNavigateLeft: navbarIsLeft
-                                              ? _navigateFromMediaBarToNavbar
-                                              : null,
-                                          focusNode: _mediaBarFocusNode,
-                                        ),
-                                ),
-                              );
-                            },
+                                          return bannerMode
+                                              ? BannerMediaBar(
+                                                  viewModel: widget.mediaBarViewModel,
+                                                  prefs: prefs,
+                                                  height: mediaBarHeight,
+                                                  externallyPaused:
+                                                      barPaused ||
+                                                      !mediaBarVisible ||
+                                                      _activePreviewKey != null,
+                                                  focusNode: _mediaBarFocusNode,
+                                                  onNavigateDown: _moveFocusFromMediaBarToRows,
+                                                  onNavigateUp: _navigateFromMediaBarToNavbar,
+                                                  onNavigateLeft: navbarIsLeft
+                                                      ? _navigateFromMediaBarToNavbar
+                                                      : null,
+                                                  onOpen: (item) => context.push(
+                                                    Destinations.item(
+                                                      item.itemId,
+                                                      serverId: item.serverId,
+                                                    ),
+                                                  ),
+                                                  onPlay: (item) => context.push(
+                                                    Destinations.item(
+                                                      item.itemId,
+                                                      serverId: item.serverId,
+                                                      autoPlay: true,
+                                                    ),
+                                                  ),
+                                                )
+                                              : MediaBar(
+                                                  viewModel: widget.mediaBarViewModel,
+                                                  prefs: prefs,
+                                                  externallyPaused:
+                                                      barPaused ||
+                                                      !mediaBarVisible ||
+                                                      _activePreviewKey != null,
+                                                  height: mediaBarHeight,
+                                                  onNavigateDown: _moveFocusFromMediaBarToRows,
+                                                  onNavigateUp: _navigateFromMediaBarToNavbar,
+                                                  onNavigateLeft: navbarIsLeft
+                                                      ? _navigateFromMediaBarToNavbar
+                                                      : null,
+                                                  focusNode: _mediaBarFocusNode,
+                                                );
+                                        },
+                                      );
+                                    },
+                                  );
+                                },
+                              ),
+                            ),
                           );
                         },
                       );
@@ -3939,31 +3977,35 @@ class _ContentRowsState extends State<_ContentRows>
 
           final canPreview = _supportsEpisodePreview(item);
 
-          final showPreviewVideo =
-              _activePreviewKey == previewKey && _previewReady;
+          return ValueListenableBuilder<String?>(
+            valueListenable: _activePreviewKeyNotifier,
+            builder: (context, activePreviewKey, _) {
+              return ValueListenableBuilder<bool>(
+                valueListenable: _previewReadyNotifier,
+                builder: (context, previewReady, _) {
+                  final showPreviewVideo = activePreviewKey == previewKey && previewReady;
 
-          void navigateToItem() {
-            if (row.rowType == HomeRowType.libraryTiles) {
-              _navigateToLibrary(context, item);
-            } else if (row.rowType == HomeRowType.genres &&
-                row.id == 'genres') {
-              context.push(Destinations.genre(item.name, genreId: item.id));
-            } else if (item.serverId == 'seerr') {
-              _navigateToSeerrItem(context, item);
-            } else {
-              context.push(
-                Destinations.itemOrPhoto(
-                  item.id,
-                  serverId: item.serverId,
-                  type: item.type,
-                ),
-              );
-            }
-          }
+                  void navigateToItem() {
+                    if (row.rowType == HomeRowType.libraryTiles) {
+                      _navigateToLibrary(context, item);
+                    } else if (row.rowType == HomeRowType.genres && row.id == 'genres') {
+                      context.push(Destinations.genre(item.name, genreId: item.id));
+                    } else if (item.serverId == 'seerr') {
+                      _navigateToSeerrItem(context, item);
+                    } else {
+                      context.push(
+                        Destinations.itemOrPhoto(
+                          item.id,
+                          serverId: item.serverId,
+                          type: item.type,
+                        ),
+                      );
+                    }
+                  }
 
-          final String cardTitle;
-          final String? cardSubtitle;
-          final Widget? cardSubtitleWidget;
+                  final String cardTitle;
+                  final String? cardSubtitle;
+                  final Widget? cardSubtitleWidget;
 
           if (isRowsV2 && item.type == 'Episode') {
             final s = item.parentIndexNumber;
@@ -4030,140 +4072,140 @@ class _ContentRowsState extends State<_ContentRows>
             cardSubtitleWidget = null;
           }
 
-          final card = MediaCard(
-            title: cardTitle,
-            subtitle: cardSubtitle,
-            subtitleWidget: cardSubtitleWidget,
-            imageUrl: imageUrl,
-            width: width,
-            aspectRatio: ar,
-            isFavorite: item.isFavorite,
-            isPlayed: item.isPlayed,
-            unplayedCount: item.unplayedItemCount,
-            playedPercentage: item.playedPercentage,
-            watchedBehavior: watchedBehavior,
-            itemType: item.type,
-            seerrMediaType: item.seerrMediaType,
-            seerrStatus: item.seerrStatus,
-            focusColor:
-                (row.rowType == HomeRowType.genres && row.id == 'genres')
-                ? ThemeRegistry.active.borders.focusBorder.color
-                : focusColor,
-            cardFocusExpansion: isRowsV2
-                ? false
-                : cardExpansion && !showPreviewVideo,
-            externalIsFocused: effectiveV2Focused,
-            suppressImageFocusBorder: showPreviewVideo,
-            suppressFocusGlow: suppressFocusGlow,
-            onHoverStart: () {
-              unawaited(_revealAndScrollToPinnedInfo());
-              widget.onItemSelected(item);
-              if (isRowsV2) {
-                if (_mouseHoveredV2Key != previewKey) {
-                  setState(() => _mouseHoveredV2Key = previewKey);
-                }
-                if (!row.isAudio) {
-                  _primeV2FocusedRatings(item);
-                }
-              }
-              if (!PlatformDetection.useMobileUi && canPreview) {
-                _schedulePreview(item, delay: _previewStartDelay);
-              } else {
-                _finishSharedPreview();
-              }
-            },
-            onHoverEnd: () {
-              if (isRowsV2) {
-                if (_mouseHoveredV2Key == previewKey) {
-                  setState(() => _mouseHoveredV2Key = null);
-                }
-                _finishSharedPreview();
-              } else {
-                _stopPreviewFor(item);
-              }
-            },
-            onLongPress: () => showContextMenu(
-              context,
-              item,
-              onChanged: () => setState(() {}),
-            ),
-            onTap: () {
-              if (isV2MobileTouch) {
-                if (_mobilePressedV2Key == previewKey) {
-                  setState(() => _mobilePressedV2Key = null);
-                  _finishSharedPreview(releaseResources: true);
-                  navigateToItem();
-                } else {
-                  setState(() {
-                    _mobilePressedV2Key = previewKey;
-                    _mouseHoveredV2Key = null;
-                  });
-                  widget.onItemSelected(item);
-                  _primeV2FocusedRatings(item);
-                }
-                return;
-              }
+                  final card = MediaCard(
+                    title: cardTitle,
+                    subtitle: cardSubtitle,
+                    subtitleWidget: cardSubtitleWidget,
+                    imageUrl: imageUrl,
+                    width: width,
+                    aspectRatio: ar,
+                    isFavorite: item.isFavorite,
+                    isPlayed: item.isPlayed,
+                    unplayedCount: item.unplayedItemCount,
+                    playedPercentage: item.playedPercentage,
+                    watchedBehavior: watchedBehavior,
+                    itemType: item.type,
+                    seerrMediaType: item.seerrMediaType,
+                    seerrStatus: item.seerrStatus,
+                    focusColor: (row.rowType == HomeRowType.genres && row.id == 'genres')
+                        ? ThemeRegistry.active.borders.focusBorder.color
+                        : focusColor,
+                    cardFocusExpansion: isRowsV2 ? false : cardExpansion && !showPreviewVideo,
+                    externalIsFocused: effectiveV2Focused,
+                    suppressImageFocusBorder: showPreviewVideo,
+                    suppressFocusGlow: suppressFocusGlow,
+                    onHoverStart: () {
+                      unawaited(_revealAndScrollToPinnedInfo());
+                      widget.onItemSelected(item);
+                      if (isRowsV2) {
+                        if (_mouseHoveredV2Key != previewKey) {
+                          setState(() => _mouseHoveredV2Key = previewKey);
+                        }
+                        if (!row.isAudio) {
+                          _primeV2FocusedRatings(item);
+                        }
+                      }
+                      if (!PlatformDetection.useMobileUi && canPreview) {
+                        _schedulePreview(item, delay: _previewStartDelay);
+                      } else {
+                        _finishSharedPreview();
+                      }
+                    },
+                    onHoverEnd: () {
+                      if (isRowsV2) {
+                        if (_mouseHoveredV2Key == previewKey) {
+                          setState(() => _mouseHoveredV2Key = null);
+                        }
+                        _finishSharedPreview();
+                      } else {
+                        _stopPreviewFor(item);
+                      }
+                    },
+                    onLongPress: () => showContextMenu(
+                      context,
+                      item,
+                      onChanged: () => setState(() {}),
+                    ),
+                    onTap: () {
+                      if (isV2MobileTouch) {
+                        if (_mobilePressedV2Key == previewKey) {
+                          setState(() => _mobilePressedV2Key = null);
+                          _finishSharedPreview(releaseResources: true);
+                          navigateToItem();
+                        } else {
+                          setState(() {
+                            _mobilePressedV2Key = previewKey;
+                            _mouseHoveredV2Key = null;
+                          });
+                          widget.onItemSelected(item);
+                          _primeV2FocusedRatings(item);
+                        }
+                        return;
+                      }
 
-              if (isRowsV2 &&
-                  (_mobilePressedV2Key != null || _mouseHoveredV2Key != null)) {
-                setState(() {
-                  _mobilePressedV2Key = null;
-                  _mouseHoveredV2Key = null;
-                });
-              }
-              _finishSharedPreview(releaseResources: true);
-              navigateToItem();
+                      if (isRowsV2 && (_mobilePressedV2Key != null || _mouseHoveredV2Key != null)) {
+                        setState(() {
+                          _mobilePressedV2Key = null;
+                          _mouseHoveredV2Key = null;
+                        });
+                      }
+                      _finishSharedPreview(releaseResources: true);
+                      navigateToItem();
+                    },
+                  );
+
+                  final previewWrappedCard = !canPreview
+                      ? card
+                      : _PreviewCardShell(
+                          card: card,
+                          width: width,
+                          aspectRatio: ar,
+                          showVideo: showPreviewVideo,
+                          useMedia3: showPreviewVideo && _previewUsingMedia3,
+                          controller: _previewController,
+                          appleTvTextureId: showPreviewVideo && _previewUsingAppleTv
+                              ? _appleTvPreviewPlayer?.textureId
+                              : null,
+                          isFocused: isFocused,
+                          focusColor: focusColor,
+                        );
+
+                  if (isRowsV2) {
+                    final showExtendedSection = effectiveV2Focused;
+                    final extendedSection = showExtendedSection
+                        ? _buildV2ExtendedSection(
+                            ctx,
+                            item,
+                            previewKey,
+                            cardWidth: width,
+                            extendedWidth: v2ExtendedWidth,
+                            isAudioRow: row.isAudio,
+                          )
+                        : null;
+                    return AnimatedSize(
+                      duration: const Duration(milliseconds: 150),
+                      curve: Curves.easeInOutCubic,
+                      alignment: Alignment.topLeft,
+                      clipBehavior: Clip.none,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          previewWrappedCard,
+                          if (extendedSection != null) ...[
+                            const SizedBox(height: 4),
+                            extendedSection,
+                          ],
+                        ],
+                      ),
+                    );
+                  }
+
+                  return previewWrappedCard;
+                },
+              );
             },
           );
-
-          final previewWrappedCard = !canPreview
-              ? card
-              : _PreviewCardShell(
-                  card: card,
-                  width: width,
-                  aspectRatio: ar,
-                  showVideo: showPreviewVideo,
-                  useMedia3: showPreviewVideo && _previewUsingMedia3,
-                  controller: _previewController,
-                  appleTvTextureId: showPreviewVideo && _previewUsingAppleTv
-                      ? _appleTvPreviewPlayer?.textureId
-                      : null,
-                  isFocused: isFocused,
-                  focusColor: focusColor,
-                );
-
-          if (isRowsV2) {
-            final showExtendedSection = effectiveV2Focused;
-            final extendedSection = showExtendedSection
-                ? _buildV2ExtendedSection(
-                    ctx,
-                    item,
-                    previewKey,
-                    cardWidth: width,
-                    extendedWidth: v2ExtendedWidth,
-                    isAudioRow: row.isAudio,
-                  )
-                : null;
-            return AnimatedSize(
-              duration: const Duration(milliseconds: 150),
-              curve: Curves.easeInOutCubic,
-              alignment: Alignment.topLeft,
-              clipBehavior: Clip.none,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  previewWrappedCard,
-                  if (extendedSection != null) ...[
-                    const SizedBox(height: 4),
-                    extendedSection,
-                  ],
-                ],
-              ),
-            );
-          }
-
-          return previewWrappedCard;
         },
       ),
     ),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -638,10 +638,24 @@ class _ContentRowsState extends State<_ContentRows>
   final ValueNotifier<double> _scrollOffsetNotifier = ValueNotifier<double>(0);
   double _previewStartScrollOffset = 0;
   bool get _isScrolledToTop => widget.isScrolledToTopNotifier.value;
-  bool _isActivelyScrolling = false;
+  final ValueNotifier<bool> _isActivelyScrollingNotifier = ValueNotifier(false);
+  bool get _isActivelyScrolling => _isActivelyScrollingNotifier.value;
+  set _isActivelyScrolling(bool value) {
+    if (_isActivelyScrollingNotifier.value != value) {
+      _isActivelyScrollingNotifier.value = value;
+    }
+  }
+
+  final ValueNotifier<bool> _infoRevealedNotifier = ValueNotifier(false);
+  bool get _infoRevealed => _infoRevealedNotifier.value;
+  set _infoRevealed(bool value) {
+    if (_infoRevealedNotifier.value != value) {
+      _infoRevealedNotifier.value = value;
+    }
+  }
+
   Timer? _scrollIdleTimer;
   double _lastActiveRowOffsetUpdate = 0;
-  bool _infoRevealed = false;
   bool _initialFocusResolved = false;
   bool _hasEverFocusedHomeContent = false;
   String? _lastObservedPath;
@@ -978,6 +992,8 @@ class _ContentRowsState extends State<_ContentRows>
     _chromeAudioActiveNotifier.dispose();
     _activePreviewKeyNotifier.dispose();
     _previewReadyNotifier.dispose();
+    _isActivelyScrollingNotifier.dispose();
+    _infoRevealedNotifier.dispose();
     if (identical(
       NavigationLayout.focusContentFromNavbarNotifier.value,
       _focusContentFromNavbar,
@@ -1825,7 +1841,7 @@ class _ContentRowsState extends State<_ContentRows>
     }
 
     if (mounted) {
-      setState(() => _infoRevealed = true);
+      _infoRevealed = true;
     }
   }
 
@@ -2625,7 +2641,6 @@ class _ContentRowsState extends State<_ContentRows>
     final shouldMarkScrolling = !_isActivelyScrolling;
     if (shouldMarkScrolling) {
       _isActivelyScrolling = true;
-      if (mounted) setState(() {});
     }
 
     _scrollIdleTimer?.cancel();
@@ -2633,12 +2648,8 @@ class _ContentRowsState extends State<_ContentRows>
       Duration(milliseconds: isMouseScroll ? 1000 : 250),
       () {
         if (!mounted) return;
-        final shouldClearScrolling = _isActivelyScrolling;
         _isActivelyScrolling = false;
         _snapToNearestRow();
-        if (shouldClearScrolling && mounted) {
-          setState(() {});
-        }
       },
     );
     if (_activePreviewKey != null) {
@@ -3232,9 +3243,16 @@ class _ContentRowsState extends State<_ContentRows>
     final infoOverlayPlaceholder = showInfoOverlay
         ? infoTopPadding + infoAreaHeight + infoBottomPadding
         : 0.0;
-    final infoPlaceholderHeight = bannerMode
-        ? (_infoRevealed ? infoOverlayPlaceholder : 0.0)
-        : infoOverlayPlaceholder;
+
+    final infoPlaceholderHeightBuilder = bannerMode
+        ? ValueListenableBuilder<bool>(
+            valueListenable: _infoRevealedNotifier,
+            builder: (context, revealed, _) => SizedBox(
+              height: revealed ? infoOverlayPlaceholder : 0.0,
+            ),
+          )
+        : SizedBox(height: infoOverlayPlaceholder);
+
     final overlayBottom = _isHomeRowsStyleV2()
         ? (fullScreenRows
               ? (navbarHeight > 48.0 ? navbarHeight : 48.0)
@@ -3244,7 +3262,7 @@ class _ContentRowsState extends State<_ContentRows>
         : (fullScreenRows ? safeTop + 48.0 : 0.0);
     final rowExtents = _computeRowExtents(rows, posterSize, prefs);
     final rowTopOffsets = <double>[];
-    var currentTop = listTopPadding + infoPlaceholderHeight;
+    var currentTop = listTopPadding + (bannerMode ? 0.0 : infoOverlayPlaceholder);
     if (includeMediaBar) {
       currentTop += mediaBarHeight;
     }
@@ -3410,7 +3428,7 @@ class _ContentRowsState extends State<_ContentRows>
                     }
                     final infoIndex = includeMediaBar ? 1 : 0;
                     if (index == infoIndex) {
-                      return SizedBox(height: infoPlaceholderHeight);
+                      return infoPlaceholderHeightBuilder;
                     }
                     final row = rows[index - headerCount];
                     final rowIndex = index - headerCount;
@@ -3540,35 +3558,42 @@ class _ContentRowsState extends State<_ContentRows>
                 ),
               ),
             ),
-        if (_infoRevealed && showInfoOverlay)
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            child: IgnorePointer(
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(
-                  PlatformDetection.useMobileUi
-                      ? navbarLeftInset
-                      : rowLeftInset,
-                  infoTopPadding,
-                  16,
-                  8,
+        ValueListenableBuilder<bool>(
+          valueListenable: _infoRevealedNotifier,
+          builder: (context, infoRevealed, _) {
+            if (infoRevealed && showInfoOverlay) {
+              return Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: IgnorePointer(
+                  child: Padding(
+                    padding: EdgeInsets.fromLTRB(
+                      PlatformDetection.useMobileUi
+                          ? navbarLeftInset
+                          : rowLeftInset,
+                      infoTopPadding,
+                      16,
+                      8,
+                    ),
+                    child: ValueListenableBuilder<AggregatedItem?>(
+                      valueListenable: widget.selectedItemNotifier,
+                      builder: (context, selectedItem, _) {
+                        return InfoArea(
+                          item: selectedItem,
+                          headerLeftInset: infoHeaderLeftInset,
+                        );
+                      },
+                    ),
+                  ),
                 ),
-                child: ValueListenableBuilder<AggregatedItem?>(
-                  valueListenable: widget.selectedItemNotifier,
-                  builder: (context, selectedItem, _) {
-                    return InfoArea(
-                      item: selectedItem,
-                      headerLeftInset: infoHeaderLeftInset,
-                    );
-                  },
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
+              );
+            }
+            return const SizedBox.shrink();
+          },
+        ),
+      ],
+    ),
     );
     _homeBuildMonitor.recordContent(watch.elapsedMicroseconds);
     return result;

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -445,20 +445,22 @@ class _GradientScrim extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [
-            AppColorScheme.scrim.withValues(alpha: 0.8),
-            AppColorScheme.scrim.withValues(alpha: 0.4),
-            AppColorScheme.scrim.withValues(alpha: 0.8),
-          ],
-          stops: [0.0, 0.3, 1.0],
+    return RepaintBoundary(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              AppColorScheme.scrim.withValues(alpha: 0.8),
+              AppColorScheme.scrim.withValues(alpha: 0.4),
+              AppColorScheme.scrim.withValues(alpha: 0.8),
+            ],
+            stops: [0.0, 0.3, 1.0],
+          ),
         ),
+        child: SizedBox.expand(),
       ),
-      child: SizedBox.expand(),
     );
   }
 }
@@ -476,43 +478,45 @@ class _Backdrop extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FullscreenBackdropSwitcher(
-      imageUrl: url,
-      duration: BackgroundService.transitionDuration,
-      imageBuilder: (imageUrl) {
-        final image = _blurredImage(context, imageUrl, blurAmount);
-        if (!useMakdBackdropFx) {
-          return image;
-        }
+    return RepaintBoundary(
+      child: FullscreenBackdropSwitcher(
+        imageUrl: url,
+        duration: BackgroundService.transitionDuration,
+        imageBuilder: (imageUrl) {
+          final image = _blurredImage(context, imageUrl, blurAmount);
+          if (!useMakdBackdropFx) {
+            return image;
+          }
 
-        return ClipRect(
-          child: TweenAnimationBuilder<double>(
-            key: ValueKey('makd_home_backdrop_$imageUrl'),
-            tween: Tween(begin: 1.0, end: 1.08),
-            duration: const Duration(seconds: 10),
-            curve: Curves.easeOut,
-            builder: (context, scale, child) {
-              return Transform.scale(
-                scale: scale,
-                alignment: Alignment.center,
-                child: child,
-              );
-            },
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                image,
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: AppColorScheme.scrim.withValues(alpha: 0.26),
+          return ClipRect(
+            child: TweenAnimationBuilder<double>(
+              key: ValueKey('makd_home_backdrop_$imageUrl'),
+              tween: Tween(begin: 1.0, end: 1.08),
+              duration: const Duration(seconds: 10),
+              curve: Curves.easeOut,
+              builder: (context, scale, child) {
+                return Transform.scale(
+                  scale: scale,
+                  alignment: Alignment.center,
+                  child: child,
+                );
+              },
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  image,
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: AppColorScheme.scrim.withValues(alpha: 0.26),
+                    ),
+                    child: const SizedBox.expand(),
                   ),
-                  child: const SizedBox.expand(),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 
@@ -2044,7 +2048,7 @@ class _ContentRowsState extends State<_ContentRows>
       childHeight = maxCardHeight + (10 * metadataScale);
     }
 
-    final subtitle = _rowSubtitle(row, AppLocalizations.of(context)!);
+    final subtitle = _rowSubtitle(row, AppLocalizations.of(context));
     final hasSubtitle = subtitle != null &&
         (row.rowType != HomeRowType.liveTv &&
             row.rowType != HomeRowType.libraryTilesSmall);
@@ -2945,14 +2949,20 @@ class _ContentRowsState extends State<_ContentRows>
       if (focusedRowIndex != null) {
         if (fullScreenRows) {
           if (rowIndex != focusedRowIndex) {
-            return IgnorePointer(child: Opacity(opacity: 0, child: child));
+            return IgnorePointer(
+              child: Visibility(visible: false, child: child),
+            );
           }
         } else if (rowIndex < focusedRowIndex) {
-          return IgnorePointer(child: Opacity(opacity: 0, child: child));
+          return IgnorePointer(
+            child: Visibility(visible: false, child: child),
+          );
         }
       }
       if (rowBottom < overlayBottom - 80) {
-        return IgnorePointer(child: Opacity(opacity: 0, child: child));
+        return IgnorePointer(
+          child: Visibility(visible: false, child: child),
+        );
       }
       return child;
     }
@@ -2968,7 +2978,9 @@ class _ContentRowsState extends State<_ContentRows>
     final rowViewportBottom = rowViewportTop + rowExtents[rowIndex];
 
     if (rowViewportBottom <= overlayBottom + 8) {
-      return IgnorePointer(child: Opacity(opacity: 0, child: child));
+      return IgnorePointer(
+        child: Visibility(visible: false, child: child),
+      );
     }
 
     if (focusedRowIndex != null &&

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -5,7 +5,7 @@ import 'dart:ui' as ui;
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
@@ -609,6 +609,7 @@ class _ContentRowsState extends State<_ContentRows>
   final Map<String, String?> _rowImageUrlCache = {};
   final Map<String, String> _dynamicBackdrops = {};
   final Set<String> _fetchingBackdrops = {};
+  final Map<int, double> _staticRowHeightCache = {};
   int? _activeFocusedRowIndex;
   Timer? _previewDelayTimer;
   Timer? _previewStopTimer;
@@ -670,6 +671,19 @@ class _ContentRowsState extends State<_ContentRows>
     final player = _previewPlayer;
     if (player == null || _activePreviewKey == null) return;
     unawaited(player.setVolume(100.0));
+  }
+
+  @override
+  void didUpdateWidget(covariant _ContentRows oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final rowsChanged = !listEquals(oldWidget.viewModel.rows, widget.viewModel.rows);
+    if (rowsChanged || oldWidget.prefs != widget.prefs) {
+      _invalidateStaticRowHeightCache();
+    }
+  }
+
+  void _invalidateStaticRowHeightCache() {
+    _staticRowHeightCache.clear();
   }
 
   int? _focusedRowIndex(FocusNode? node) {
@@ -1995,6 +2009,11 @@ class _ContentRowsState extends State<_ContentRows>
     final row = rowIndex < widget.viewModel.rows.length ? widget.viewModel.rows[rowIndex] : null;
     if (row == null) return 0.0;
 
+    final cached = _staticRowHeightCache[rowIndex];
+    if (cached != null) {
+      return cached;
+    }
+
     final prefs = widget.prefs;
     final posterSize =
         (_isHomeRowsStyleV2() &&
@@ -2058,7 +2077,9 @@ class _ContentRowsState extends State<_ContentRows>
     final subtitleHeight = hasSubtitle ? (18.0 * metadataScale) : 0.0;
     final headerHeight = headerPaddingTop + headerPaddingBottom + titleHeight + subtitleHeight;
 
-    return childHeight + headerHeight;
+    final totalHeight = childHeight + headerHeight;
+    _staticRowHeightCache[rowIndex] = totalHeight;
+    return totalHeight;
   }
 
   double _tvTargetTopForRow(int rowIndex) {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -374,6 +374,7 @@ class _HomeShellState extends State<_HomeShell>
 
   @override
   Widget build(BuildContext context) {
+    final watch = Stopwatch()..start();
     final backdropEnabled = _userPrefs.get(UserPreferences.backdropEnabled);
     final blurAmount = _userPrefs
         .get(UserPreferences.browsingBackgroundBlurAmount)
@@ -386,7 +387,7 @@ class _HomeShellState extends State<_HomeShell>
         PlatformDetection.useMobileUi &&
         mediaBarMode == UserPreferences.mediaBarModeMakd;
 
-    return PopScope(
+    final result = PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
@@ -428,6 +429,8 @@ class _HomeShellState extends State<_HomeShell>
         ),
       ),
     );
+    _homeBuildMonitor.recordShell(watch.elapsedMicroseconds);
+    return result;
   }
 
   Future<void> _showExitConfirmation(BuildContext context) async {
@@ -3124,6 +3127,7 @@ class _ContentRowsState extends State<_ContentRows>
 
   @override
   Widget build(BuildContext context) {
+    final watch = Stopwatch()..start();
     final rows = widget.viewModel.rows;
     // Guard against a stale focused-row index pointing past the end of the
     // (potentially shorter) new row list
@@ -3273,7 +3277,7 @@ class _ContentRowsState extends State<_ContentRows>
       );
     }
 
-    return Listener(
+    final result = Listener(
       behavior: HitTestBehavior.translucent,
       onPointerDown: (_) => _markUserGesture(),
       onPointerSignal: (pointerSignal) {
@@ -3499,6 +3503,8 @@ class _ContentRowsState extends State<_ContentRows>
         ],
       ),
     );
+    _homeBuildMonitor.recordContent(watch.elapsedMicroseconds);
+    return result;
   }
 
   Widget _buildLiveTvRow(
@@ -3670,6 +3676,7 @@ class _ContentRowsState extends State<_ContentRows>
     required bool useSeriesThumbs,
     required AppLocalizations l10n,
   }) {
+    final watch = Stopwatch()..start();
     final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
     final isSeerrRowOverride = _isSeerrFilterRow(row);
     final isRowsV2 =
@@ -3747,7 +3754,7 @@ class _ContentRowsState extends State<_ContentRows>
 
     final subtitle = _rowSubtitle(row, l10n);
     final hasSubtitle = subtitle != null;
-    return _buildTitledRow(
+    final result = _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),
       subtitle: subtitle,
@@ -4126,6 +4133,8 @@ class _ContentRowsState extends State<_ContentRows>
         },
       ),
     );
+    _homeBuildMonitor.recordRow(watch.elapsedMicroseconds);
+    return result;
   }
 
   Widget _buildV2ExtendedSection(
@@ -5086,5 +5095,52 @@ class _PreviewCardShell extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+final _homeBuildMonitor = _BuildMonitor();
+
+class _BuildMonitor {
+  int _shellCount = 0;
+  int _contentCount = 0;
+  int _rowCount = 0;
+  int _totalTimeUs = 0;
+  Timer? _reportTimer;
+
+  void recordShell(int us) {
+    _shellCount++;
+    _totalTimeUs += us;
+    _ensureTimer();
+  }
+
+  void recordContent(int us) {
+    _contentCount++;
+    _totalTimeUs += us;
+    _ensureTimer();
+  }
+
+  void recordRow(int us) {
+    _rowCount++;
+    _totalTimeUs += us;
+    _ensureTimer();
+  }
+
+  void _ensureTimer() {
+    _reportTimer ??= Timer(const Duration(seconds: 2), () {
+      final shell = _shellCount;
+      final content = _contentCount;
+      final row = _rowCount;
+      final avgTime = shell + content + row == 0 
+          ? 0 
+          : _totalTimeUs / (shell + content + row);
+      
+      debugPrint('[BASELINE] 2s Window | Shell: $shell | Content: $content | Rows: $row | Avg Build: ${avgTime.toStringAsFixed(1)}μs');
+      
+      _shellCount = 0;
+      _contentCount = 0;
+      _rowCount = 0;
+      _totalTimeUs = 0;
+      _reportTimer = null;
+    });
   }
 }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -664,6 +664,9 @@ class _ContentRowsState extends State<_ContentRows>
   final Map<String, String?> _v2TmdbIdByKey = {};
   late bool _lastMedia3PreviewPreference;
   List<double> _rowTopOffsets = [];
+  List<double> _cachedRowTargetOffsets = [];
+  double _cachedRowTargetMaxScrollExtent = -1.0;
+  bool _cachedRowTargetFullScreenRows = false;
   double _overlayBottom = 0;
   static const _previewScrollThreshold = 150.0;
   static const _previewOpenTimeout = Duration(seconds: 10);
@@ -693,6 +696,40 @@ class _ContentRowsState extends State<_ContentRows>
 
   void _invalidateStaticRowHeightCache() {
     _staticRowHeightCache.clear();
+  }
+
+  void _invalidateRowTargetOffsetCache() {
+    _cachedRowTargetOffsets = [];
+    _cachedRowTargetMaxScrollExtent = -1.0;
+    _cachedRowTargetFullScreenRows = false;
+  }
+
+  List<double> _rowTargetOffsetsForScroll({required bool fullScreenRows}) {
+    final maxScrollExtent = _scrollController.hasClients
+        ? _scrollController.position.maxScrollExtent
+        : double.infinity;
+    if (_cachedRowTargetOffsets.length == _rowTopOffsets.length &&
+        _cachedRowTargetFullScreenRows == fullScreenRows &&
+        _cachedRowTargetMaxScrollExtent == maxScrollExtent) {
+      return _cachedRowTargetOffsets;
+    }
+
+    final targets = <double>[];
+    for (var i = 0; i < _rowTopOffsets.length; i++) {
+      targets.add(
+        fullScreenRows
+            ? (_rowTopOffsets[i] - _tvTargetTopForRow(i)).clamp(
+                0.0,
+                maxScrollExtent,
+              )
+            : _rowTopOffsets[i].clamp(0.0, maxScrollExtent),
+      );
+    }
+
+    _cachedRowTargetOffsets = targets;
+    _cachedRowTargetMaxScrollExtent = maxScrollExtent;
+    _cachedRowTargetFullScreenRows = fullScreenRows;
+    return targets;
   }
 
   int? _focusedRowIndex(FocusNode? node) {
@@ -2513,7 +2550,6 @@ class _ContentRowsState extends State<_ContentRows>
       _lastActiveRowOffsetUpdate = offset;
       double minDiff = double.infinity;
       int? closestRowIndex;
-      final maxScrollExtent = _scrollController.position.maxScrollExtent;
 
       if (_isMediaBarIncluded()) {
         final mediaBarDiff = offset.abs();
@@ -2523,14 +2559,9 @@ class _ContentRowsState extends State<_ContentRows>
         }
       }
 
-      for (var i = 0; i < _rowTopOffsets.length; i++) {
-        final target = fullScreenRows
-            ? (_rowTopOffsets[i] - _tvTargetTopForRow(i)).clamp(
-                0.0,
-                maxScrollExtent,
-              )
-            : _rowTopOffsets[i].clamp(0.0, maxScrollExtent);
-        final diff = (target - offset).abs();
+      final targets = _rowTargetOffsetsForScroll(fullScreenRows: fullScreenRows);
+      for (var i = 0; i < targets.length; i++) {
+        final diff = (targets[i] - offset).abs();
         if (diff < minDiff) {
           minDiff = diff;
           closestRowIndex = i;
@@ -3194,6 +3225,7 @@ class _ContentRowsState extends State<_ContentRows>
       }
     }
 
+    _invalidateRowTargetOffsetCache();
     _rowTopOffsets = rowTopOffsets;
     _overlayBottom = overlayBottom;
     final headerCount = (includeMediaBar ? 1 : 0) + 1;

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -106,8 +106,6 @@ class _HomeShellState extends State<_HomeShell>
   final ValueNotifier<bool> _isHoverPausedNotifier = ValueNotifier(false);
   final ValueNotifier<bool> _isScrolledToTopNotifier = ValueNotifier(true);
   String _lastSectionsJson = '';
-  Type? _lastMediaBarStateRuntime;
-  int _lastMediaBarItemCount = 0;
   bool _lastMultiServer = false;
   bool _lastMergeContinueWatchingNextUp = false;
   String _lastBlockedParentalRatings = '';
@@ -135,12 +133,6 @@ class _HomeShellState extends State<_HomeShell>
     });
     _backdropUrlNotifier.value = _backgroundService.currentUrl;
 
-    _viewModel.addListener(_onViewModelChanged);
-    _viewModel.mediaBarViewModel.addListener(_onMediaBarStateChanged);
-    _lastMediaBarStateRuntime = _viewModel.mediaBarViewModel.state.runtimeType;
-    _lastMediaBarItemCount = _viewModel.mediaBarViewModel.state is MediaBarReady
-        ? (_viewModel.mediaBarViewModel.state as MediaBarReady).items.length
-        : 0;
     _lastSectionsJson = _userPrefs.get(UserPreferences.homeSectionsJson);
     _lastMultiServer = _userPrefs.get(
       UserPreferences.enableMultiServerLibraries,
@@ -187,8 +179,6 @@ class _HomeShellState extends State<_HomeShell>
     _backdropUrlNotifier.dispose();
     _isHoverPausedNotifier.dispose();
     _isScrolledToTopNotifier.dispose();
-    _viewModel.mediaBarViewModel.removeListener(_onMediaBarStateChanged);
-    _viewModel.removeListener(_onViewModelChanged);
     _pluginSyncService.removeListener(_onPluginSyncChanged);
     _userPrefs.removeListener(_onPrefsChanged);
     if (_themeMusicRegistered) {
@@ -198,9 +188,6 @@ class _HomeShellState extends State<_HomeShell>
     super.dispose();
   }
 
-  void _onViewModelChanged() {
-    if (mounted) setState(() {});
-  }
 
   void _onPluginSyncChanged() {
     if (!mounted) return;
@@ -208,20 +195,6 @@ class _HomeShellState extends State<_HomeShell>
     if (seerrAvailable == _lastSeerrAvailable) return;
     _lastSeerrAvailable = seerrAvailable;
     _viewModel.refresh(preserveExisting: true);
-  }
-
-  void _onMediaBarStateChanged() {
-    if (!mounted) return;
-    final state = _viewModel.mediaBarViewModel.state;
-    final runtime = state.runtimeType;
-    final itemCount = state is MediaBarReady ? state.items.length : 0;
-    if (runtime == _lastMediaBarStateRuntime &&
-        itemCount == _lastMediaBarItemCount) {
-      return;
-    }
-    _lastMediaBarStateRuntime = runtime;
-    _lastMediaBarItemCount = itemCount;
-    setState(() {});
   }
 
   @override
@@ -617,6 +590,8 @@ class _ContentRowsState extends State<_ContentRows>
   int _cachedExtentPrefsVersion = -1;
   List<double>? _cachedRowExtents;
   int _layoutPrefsVersion = 0;
+  Type? _lastMediaBarStateRuntime;
+  int _lastMediaBarItemCount = 0;
   // Cache for non-focused row image URLs (independent of focus state). Cleared
   // with the extent cache on data/pref/scale change, and size-capped.
   final Map<String, String?> _rowImageUrlCache = {};
@@ -960,9 +935,33 @@ class _ContentRowsState extends State<_ContentRows>
       _onMainPlaybackChanged,
     );
     _audioArbiter.register(this);
+    widget.viewModel.addListener(_onViewModelChanged);
+    widget.mediaBarViewModel.addListener(_onMediaBarStateChanged);
+    _lastMediaBarStateRuntime = widget.mediaBarViewModel.state.runtimeType;
+    _lastMediaBarItemCount = widget.mediaBarViewModel.state is MediaBarReady
+        ? (widget.mediaBarViewModel.state as MediaBarReady).items.length
+        : 0;
     if (!_isMediaBarEnabledByMode()) {
       _infoRevealed = true;
     }
+  }
+
+  void _onViewModelChanged() {
+    if (mounted) setState(() {});
+  }
+
+  void _onMediaBarStateChanged() {
+    if (!mounted) return;
+    final state = widget.mediaBarViewModel.state;
+    final runtime = state.runtimeType;
+    final itemCount = state is MediaBarReady ? state.items.length : 0;
+    if (runtime == _lastMediaBarStateRuntime &&
+        itemCount == _lastMediaBarItemCount) {
+      return;
+    }
+    _lastMediaBarStateRuntime = runtime;
+    _lastMediaBarItemCount = itemCount;
+    setState(() {});
   }
 
   @override
@@ -1009,6 +1008,8 @@ class _ContentRowsState extends State<_ContentRows>
     }
     _scrollIdleTimer?.cancel();
     _mediaBarFocusNode.dispose();
+    widget.viewModel.removeListener(_onViewModelChanged);
+    widget.mediaBarViewModel.removeListener(_onMediaBarStateChanged);
     _mainPlaybackSub?.cancel();
     widget.prefs.removeListener(_onPreviewPrefsChanged);
     _rowKeys.clear();

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -613,7 +613,13 @@ class _ContentRowsState extends State<_ContentRows>
   final Map<String, String> _dynamicBackdrops = {};
   final Set<String> _fetchingBackdrops = {};
   final Map<int, double> _staticRowHeightCache = {};
-  int? _activeFocusedRowIndex;
+  final ValueNotifier<int?> _activeFocusedRowNotifier = ValueNotifier(null);
+  int? get _activeFocusedRowIndex => _activeFocusedRowNotifier.value;
+  set _activeFocusedRowIndex(int? value) {
+    if (_activeFocusedRowNotifier.value != value) {
+      _activeFocusedRowNotifier.value = value;
+    }
+  }
   Timer? _previewDelayTimer;
   Timer? _previewStopTimer;
   StreamSubscription<bool>? _mainPlaybackSub;
@@ -662,7 +668,8 @@ class _ContentRowsState extends State<_ContentRows>
   String? _mobilePressedV2Key;
   String? _mouseHoveredV2Key;
   final Set<String> _v2FocusPrefetchedUrls = <String>{};
-  final Map<String, Map<String, double>> _v2AdditionalRatingsByKey = {};
+  final ValueNotifier<Map<String, Map<String, double>>> _v2AdditionalRatingsNotifier = ValueNotifier({});
+  Map<String, Map<String, double>> get _v2AdditionalRatingsByKey => _v2AdditionalRatingsNotifier.value;
   final Map<String, Future<void>> _v2RatingsRequests = {};
   final Map<String, String?> _v2TmdbIdByKey = {};
   late bool _lastMedia3PreviewPreference;
@@ -928,6 +935,8 @@ class _ContentRowsState extends State<_ContentRows>
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     _scrollOffsetNotifier.dispose();
+    _activeFocusedRowNotifier.dispose();
+    _v2AdditionalRatingsNotifier.dispose();
     if (identical(
       NavigationLayout.focusContentFromNavbarNotifier.value,
       _focusContentFromNavbar,
@@ -1712,9 +1721,10 @@ class _ContentRowsState extends State<_ContentRows>
       return;
     }
 
-    setState(() {
-      _v2AdditionalRatingsByKey[itemKey] = result;
-    });
+    _v2AdditionalRatingsNotifier.value = {
+      ..._v2AdditionalRatingsByKey,
+      itemKey: result,
+    };
   }
 
   double _mediaBarHeight() {
@@ -2474,24 +2484,18 @@ class _ContentRowsState extends State<_ContentRows>
 
   void _onRowFocusTracked(int rowIndex, bool focused) {
     if (!mounted) return;
-    final isMobileUi = PlatformDetection.useMobileUi;
     if (focused) {
       _hasEverFocusedHomeContent = true;
       if (_activeFocusedRowIndex != rowIndex && _activePreviewKey != null) {
         _finishSharedPreview();
       }
-      final indexChanged = _activeFocusedRowIndex != rowIndex;
       _activeFocusedRowIndex = rowIndex;
-      final fullScreenRows =
-          !PlatformDetection.useMobileUi &&
-          widget.prefs.get(UserPreferences.fullScreenRows);
-      if (!isMobileUi &&
+
+      if (!PlatformDetection.useMobileUi &&
           _mediaBarVisible &&
           !_verticalNavInFlight &&
           !_isBannerMode()) {
         setState(() => _mediaBarVisible = false);
-      } else if (indexChanged && (PlatformDetection.isTV || fullScreenRows)) {
-        setState(() {});
       }
     } else if (_activeFocusedRowIndex == rowIndex) {
       if (_isSidebarFocus) {
@@ -2572,9 +2576,7 @@ class _ContentRowsState extends State<_ContentRows>
       }
 
       if (closestRowIndex != _activeFocusedRowIndex) {
-        setState(() {
-          _activeFocusedRowIndex = closestRowIndex;
-        });
+        _activeFocusedRowIndex = closestRowIndex;
       }
     }
 
@@ -3451,30 +3453,34 @@ class _ContentRowsState extends State<_ContentRows>
 
                     final itemWidget = Padding(
                       padding: EdgeInsets.only(left: rowLeftInset),
-                      child: AnimatedPadding(
-                        duration: _focusedRowSpacingDuration,
-                        curve: Curves.easeOut,
-                        padding: EdgeInsets.symmetric(
-                          vertical:
-                              (PlatformDetection.isTV &&
-                                  !fullScreenRows &&
-                                  rowIndex == _activeFocusedRowIndex)
-                              ? _focusedRowExtraSpacing
-                              : 0,
-                        ),
-                        child: ValueListenableBuilder<double>(
-                          valueListenable: _scrollOffsetNotifier,
-                          builder: (context, scrollOffset, _) {
-                            return _buildShiftedRow(
-                              child: paddedRowChild,
-                              rowIndex: rowIndex,
-                              rowTopOffsets: rowTopOffsets,
-                              rowExtents: rowExtents,
-                              showInfoOverlay: showInfoOverlay,
-                              overlayBottom: overlayBottom,
-                            );
-                          },
-                        ),
+                      child: ValueListenableBuilder<int?>(
+                        valueListenable: _activeFocusedRowNotifier,
+                        builder: (context, activeRowIndex, _) {
+                          return AnimatedPadding(
+                            duration: _focusedRowSpacingDuration,
+                            curve: Curves.easeOut,
+                            padding: EdgeInsets.symmetric(
+                              vertical: (PlatformDetection.isTV &&
+                                      !fullScreenRows &&
+                                      rowIndex == activeRowIndex)
+                                  ? _focusedRowExtraSpacing
+                                  : 0,
+                            ),
+                            child: ValueListenableBuilder<double>(
+                              valueListenable: _scrollOffsetNotifier,
+                              builder: (context, scrollOffset, _) {
+                                return _buildShiftedRow(
+                                  child: paddedRowChild,
+                                  rowIndex: rowIndex,
+                                  rowTopOffsets: rowTopOffsets,
+                                  rowExtents: rowExtents,
+                                  showInfoOverlay: showInfoOverlay,
+                                  overlayBottom: overlayBottom,
+                                );
+                              },
+                            ),
+                          );
+                        },
                       ),
                     );
                     if (fullScreenRows) {
@@ -3558,45 +3564,47 @@ class _ContentRowsState extends State<_ContentRows>
       rowIndex: rowIndex,
       hasItems: actions.isNotEmpty,
       height: rowHeight,
-      child: LockedFocusRow<_LiveTvAction>(
-        key: _rowKey(rowIndex),
-        items: actions,
-        hubKey: _hubKeyForRow(row),
-        controller: _rowHorizontalController(rowIndex),
-        height: rowHeight,
-        itemExtent: squarePosterSide,
-        itemSpacing: 12,
-        leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
-        padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
-        onIndexChanged: (_, _) {
-          _onHomeRowTileFocused(null);
-        },
-        onFocusChange: (has) => _onRowFocusTracked(rowIndex, has),
-        onVerticalNavigation: (isUp) => _onRowVerticalNavigation(
-          rowIndex: rowIndex,
-          rows: rows,
-          isUp: isUp,
-        ),
-        onLeftEdge: _onRowLeftEdge,
-        onTap: (_, action) => context.push(action.destination),
-        itemBuilder: (ctx, action, idx, isFocused) {
-          return Align(
-            alignment: Alignment.topCenter,
-            child: SizedBox.square(
-              dimension: squarePosterSide,
-              child: GridButtonCard(
-                icon: action.icon,
-                label: action.label,
-                width: squarePosterSide,
-                height: squarePosterSide,
-                focusColor: focusColor,
-                cardFocusExpansion: cardExpansion,
-                externalIsFocused: isFocused,
-                onTap: () => context.push(action.destination),
+      child: RepaintBoundary(
+        child: LockedFocusRow<_LiveTvAction>(
+          key: _rowKey(rowIndex),
+          items: actions,
+          hubKey: _hubKeyForRow(row),
+          controller: _rowHorizontalController(rowIndex),
+          height: rowHeight,
+          itemExtent: squarePosterSide,
+          itemSpacing: 12,
+          leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
+          padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
+          onIndexChanged: (_, _) {
+            _onHomeRowTileFocused(null);
+          },
+          onFocusChange: (has) => _onRowFocusTracked(rowIndex, has),
+          onVerticalNavigation: (isUp) => _onRowVerticalNavigation(
+            rowIndex: rowIndex,
+            rows: rows,
+            isUp: isUp,
+          ),
+          onLeftEdge: _onRowLeftEdge,
+          onTap: (_, action) => context.push(action.destination),
+          itemBuilder: (ctx, action, idx, isFocused) {
+            return Align(
+              alignment: Alignment.topCenter,
+              child: SizedBox.square(
+                dimension: squarePosterSide,
+                child: GridButtonCard(
+                  icon: action.icon,
+                  label: action.label,
+                  width: squarePosterSide,
+                  height: squarePosterSide,
+                  focusColor: focusColor,
+                  cardFocusExpansion: cardExpansion,
+                  externalIsFocused: isFocused,
+                  onTap: () => context.push(action.destination),
+                ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }
@@ -3619,62 +3627,64 @@ class _ContentRowsState extends State<_ContentRows>
       rowIndex: rowIndex,
       hasItems: row.items.isNotEmpty,
       height: rowHeight,
-      child: LockedFocusRow<AggregatedItem>(
-        key: _rowKey(rowIndex),
-        items: row.items,
-        hubKey: _hubKeyForRow(row),
-        controller: _rowHorizontalController(rowIndex),
-        height: rowHeight,
-        itemExtent: squarePosterSide,
-        itemSpacing: 12,
-        leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
-        padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
-        onIndexChanged: (_, item) {
-          _onHomeRowTileFocused(item);
-        },
-        onFocusChange: (has) => _onRowFocusTracked(rowIndex, has),
-        onVerticalNavigation: (isUp) => _onRowVerticalNavigation(
-          rowIndex: rowIndex,
-          rows: rows,
-          isUp: isUp,
-        ),
-        onLeftEdge: _onRowLeftEdge,
-        onTap: (_, item) => _navigateToLibrary(context, item),
-        onLongPress: (_, item) =>
-            showContextMenu(context, item, onChanged: () => setState(() {})),
-        itemBuilder: (ctx, item, idx, isFocused) {
-          final collectionType =
-              (item.rawData['CollectionType'] as String? ?? '').toLowerCase();
-          final icon = isGameLibrary(collectionType, item.name)
-              ? gameLibraryIcon
-              : _iconForCollectionType(collectionType);
-          return Align(
-            alignment: Alignment.topCenter,
-            child: SizedBox.square(
-              dimension: squarePosterSide,
-              child: GridButtonCard(
-                icon: icon,
-                label: item.name,
-                width: squarePosterSide,
-                height: squarePosterSide,
-                focusColor: focusColor,
-                cardFocusExpansion: cardExpansion,
-                externalIsFocused: isFocused,
-                onTap: () => _navigateToLibrary(context, item),
-                onLongPress: () => showContextMenu(
-                  context,
-                  item,
-                  onChanged: () => setState(() {}),
-                ),
-                onSecondaryTap: () => showContextMenu(
-                  context,
-                  item,
-                  onChanged: () => setState(() {}),
+      child: RepaintBoundary(
+        child: LockedFocusRow<AggregatedItem>(
+          key: _rowKey(rowIndex),
+          items: row.items,
+          hubKey: _hubKeyForRow(row),
+          controller: _rowHorizontalController(rowIndex),
+          height: rowHeight,
+          itemExtent: squarePosterSide,
+          itemSpacing: 12,
+          leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
+          padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
+          onIndexChanged: (_, item) {
+            _onHomeRowTileFocused(item);
+          },
+          onFocusChange: (has) => _onRowFocusTracked(rowIndex, has),
+          onVerticalNavigation: (isUp) => _onRowVerticalNavigation(
+            rowIndex: rowIndex,
+            rows: rows,
+            isUp: isUp,
+          ),
+          onLeftEdge: _onRowLeftEdge,
+          onTap: (_, item) => _navigateToLibrary(context, item),
+          onLongPress: (_, item) =>
+              showContextMenu(context, item, onChanged: () => setState(() {})),
+          itemBuilder: (ctx, item, idx, isFocused) {
+            final collectionType =
+                (item.rawData['CollectionType'] as String? ?? '').toLowerCase();
+            final icon = isGameLibrary(collectionType, item.name)
+                ? gameLibraryIcon
+                : _iconForCollectionType(collectionType);
+            return Align(
+              alignment: Alignment.topCenter,
+              child: SizedBox.square(
+                dimension: squarePosterSide,
+                child: GridButtonCard(
+                  icon: icon,
+                  label: item.name,
+                  width: squarePosterSide,
+                  height: squarePosterSide,
+                  focusColor: focusColor,
+                  cardFocusExpansion: cardExpansion,
+                  externalIsFocused: isFocused,
+                  onTap: () => _navigateToLibrary(context, item),
+                  onLongPress: () => showContextMenu(
+                    context,
+                    item,
+                    onChanged: () => setState(() {}),
+                  ),
+                  onSecondaryTap: () => showContextMenu(
+                    context,
+                    item,
+                    onChanged: () => setState(() {}),
+                  ),
                 ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }
@@ -3776,25 +3786,26 @@ class _ContentRowsState extends State<_ContentRows>
       rowIndex: rowIndex,
       hasItems: row.items.isNotEmpty,
       height: maxCardHeight + (10 * metadataScale) + (hasSubtitle ? 18.0 : 0.0),
-      child: LockedFocusRow<AggregatedItem>(
-        key: _rowKey(rowIndex),
-        items: row.items,
-        hubKey: _hubKeyForRow(row),
-        controller: _rowHorizontalController(rowIndex),
-        height: maxCardHeight + (10 * metadataScale),
-        itemExtent: firstCardWidth,
-        itemSpacing: 12,
-        leadingPadding: isRowsV2 ? _kHomeRowLabelInset : 0,
-        clipBehavior: isRowsV2 ? Clip.none : Clip.hardEdge,
-        padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
-        onFocusChange: (has) => _onRowFocusTracked(rowIndex, has),
-        onVerticalNavigation: (isUp) => _onRowVerticalNavigation(
-          rowIndex: rowIndex,
-          rows: rows,
-          isUp: isUp,
-        ),
-        onLeftEdge: _onRowLeftEdge,
-        onIndexChanged: (index, item) {
+      child: RepaintBoundary(
+        child: LockedFocusRow<AggregatedItem>(
+          key: _rowKey(rowIndex),
+          items: row.items,
+          hubKey: _hubKeyForRow(row),
+          controller: _rowHorizontalController(rowIndex),
+          height: maxCardHeight + (10 * metadataScale),
+          itemExtent: firstCardWidth,
+          itemSpacing: 12,
+          leadingPadding: isRowsV2 ? _kHomeRowLabelInset : 0,
+          clipBehavior: isRowsV2 ? Clip.none : Clip.hardEdge,
+          padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
+          onFocusChange: (has) => _onRowFocusTracked(rowIndex, has),
+          onVerticalNavigation: (isUp) => _onRowVerticalNavigation(
+            rowIndex: rowIndex,
+            rows: rows,
+            isUp: isUp,
+          ),
+          onLeftEdge: _onRowLeftEdge,
+          onIndexChanged: (index, item) {
           final forceReveal = _forceRevealOnNextRowFocusFromMediaBar;
           _forceRevealOnNextRowFocusFromMediaBar = false;
           widget.onItemSelected(item);
@@ -4147,6 +4158,7 @@ class _ContentRowsState extends State<_ContentRows>
           return previewWrappedCard;
         },
       ),
+    ),
     );
     _homeBuildMonitor.recordRow(watch.elapsedMicroseconds);
     return result;
@@ -4160,15 +4172,17 @@ class _ContentRowsState extends State<_ContentRows>
     required double extendedWidth,
     required bool isAudioRow,
   }) {
-    final additionalRatings = _v2AdditionalRatingsByKey[itemKey] ?? {};
-    final hasAnyRating =
-        item.communityRating != null ||
-        item.criticRating != null ||
-        additionalRatings.isNotEmpty;
-    final overview = isAudioRow ? '' : (item.overview ?? '');
-    if (!hasAnyRating && overview.isEmpty) {
-      return SizedBox(width: cardWidth);
-    }
+    return ValueListenableBuilder<Map<String, Map<String, double>>>(
+      valueListenable: _v2AdditionalRatingsNotifier,
+      builder: (context, ratingsByKey, _) {
+        final additionalRatings = ratingsByKey[itemKey] ?? {};
+        final hasAnyRating = item.communityRating != null ||
+            item.criticRating != null ||
+            additionalRatings.isNotEmpty;
+        final overview = isAudioRow ? '' : (item.overview ?? '');
+        if (!hasAnyRating && overview.isEmpty) {
+          return SizedBox(width: cardWidth);
+        }
 
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final baseStyle =
@@ -4181,51 +4195,53 @@ class _ContentRowsState extends State<_ContentRows>
       height: 1.4,
     );
 
-    return SizedBox(
-      width: cardWidth,
-      child: Stack(
-        clipBehavior: Clip.none,
-        alignment: Alignment.topLeft,
-        children: [
-          SizedBox(
-            width: extendedWidth,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (hasAnyRating)
-                  RatingsRow(
-                    ratings: additionalRatings,
-                    communityRating: item.communityRating,
-                    criticRating: item.criticRating,
-                    enableAdditionalRatings: widget.prefs.get(
-                      UserPreferences.enableAdditionalRatings,
-                    ),
-                    enabledRatings: widget.prefs.get(
-                      UserPreferences.enabledRatings,
-                    ),
-                    showLabels: widget.prefs.get(
-                      UserPreferences.showRatingLabels,
-                    ),
-                    showBadges: widget.prefs.get(
-                      UserPreferences.showRatingBadges,
-                    ),
-                  ),
-                if (overview.isNotEmpty)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Text(
-                      overview,
-                      maxLines: 3,
-                      overflow: TextOverflow.ellipsis,
-                      style: overviewStyle,
-                    ),
-                  ),
-              ],
-            ),
+        return SizedBox(
+          width: cardWidth,
+          child: Stack(
+            clipBehavior: Clip.none,
+            alignment: Alignment.topLeft,
+            children: [
+              SizedBox(
+                width: extendedWidth,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (hasAnyRating)
+                      RatingsRow(
+                        ratings: additionalRatings,
+                        communityRating: item.communityRating,
+                        criticRating: item.criticRating,
+                        enableAdditionalRatings: widget.prefs.get(
+                          UserPreferences.enableAdditionalRatings,
+                        ),
+                        enabledRatings: widget.prefs.get(
+                          UserPreferences.enabledRatings,
+                        ),
+                        showLabels: widget.prefs.get(
+                          UserPreferences.showRatingLabels,
+                        ),
+                        showBadges: widget.prefs.get(
+                          UserPreferences.showRatingBadges,
+                        ),
+                      ),
+                    if (overview.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          overview,
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                          style: overviewStyle,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2597,9 +2597,12 @@ class _ContentRowsState extends State<_ContentRows>
       Duration(milliseconds: isMouseScroll ? 1000 : 250),
       () {
         if (!mounted) return;
+        final shouldClearScrolling = _isActivelyScrolling;
         _isActivelyScrolling = false;
         _snapToNearestRow();
-        setState(() {});
+        if (shouldClearScrolling && mounted) {
+          setState(() {});
+        }
       },
     );
     if (_activePreviewKey != null) {
@@ -2613,19 +2616,18 @@ class _ContentRowsState extends State<_ContentRows>
     if (_infoRevealed && _isMediaBarIncluded() && _showHomeRowInfoOverlay()) {
       final collapseOffset = _pinnedInfoCollapseOffset();
       if (scrollingUp && offset < collapseOffset) {
-        setState(() {
+        if (_infoRevealed) {
           _infoRevealed = false;
           _scrollOffset = offset;
-        });
+          if (mounted) {
+            setState(() {});
+          }
+        }
         return;
       }
     }
 
-    if (_infoRevealed && _isMediaBarIncluded()) {
-      setState(() => _scrollOffset = offset);
-    } else {
-      _scrollOffset = offset;
-    }
+    _scrollOffset = offset;
   }
 
   void _snapToNearestRow() {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -628,6 +628,7 @@ class _ContentRowsState extends State<_ContentRows>
   bool _isScrolledToTop = true;
   bool _isActivelyScrolling = false;
   Timer? _scrollIdleTimer;
+  double _lastActiveRowOffsetUpdate = 0;
   bool _infoRevealed = false;
   bool _mediaBarVisible = true;
   bool _initialFocusResolved = false;
@@ -671,6 +672,7 @@ class _ContentRowsState extends State<_ContentRows>
   static const _focusHandoffDuration = Duration(milliseconds: 220);
   static const _focusHandoffCurve = Curves.easeInOutCubic;
   static const _mediaBarFadeDuration = Duration(milliseconds: 220);
+  static const double _activeRowRecalcDistance = 48.0;
 
   void _markUserGesture() {
     if (!kIsWeb) return;
@@ -2500,43 +2502,38 @@ class _ContentRowsState extends State<_ContentRows>
         !PlatformDetection.useMobileUi &&
         widget.prefs.get(UserPreferences.fullScreenRows);
 
-    final shouldUpdateActiveRow =
-        isDesktop && _rowTopOffsets.isNotEmpty && _scrollController.hasClients;
+    final shouldUpdateActiveRow = isDesktop &&
+        _rowTopOffsets.isNotEmpty &&
+        _scrollController.hasClients &&
+        (_activeFocusedRowIndex == null ||
+            (offset - _lastActiveRowOffsetUpdate).abs() >=
+                _activeRowRecalcDistance ||
+            offset <= 0);
     if (shouldUpdateActiveRow) {
+      _lastActiveRowOffsetUpdate = offset;
       double minDiff = double.infinity;
       int? closestRowIndex;
+      final maxScrollExtent = _scrollController.position.maxScrollExtent;
 
-      final List<double> targets = [];
       if (_isMediaBarIncluded()) {
-        targets.add(0.0);
-      }
-      for (var i = 0; i < _rowTopOffsets.length; i++) {
-        final double target;
-        if (fullScreenRows) {
-          final targetTop = _tvTargetTopForRow(i);
-          target = (_rowTopOffsets[i] - targetTop).clamp(
-            0.0,
-            _scrollController.position.maxScrollExtent,
-          );
-        } else {
-          target = _rowTopOffsets[i].clamp(
-            0.0,
-            _scrollController.position.maxScrollExtent,
-          );
+        final mediaBarDiff = offset.abs();
+        if (mediaBarDiff < minDiff) {
+          minDiff = mediaBarDiff;
+          closestRowIndex = null;
         }
-        targets.add(target);
       }
 
-      for (var i = 0; i < targets.length; i++) {
-        final target = targets[i];
+      for (var i = 0; i < _rowTopOffsets.length; i++) {
+        final target = fullScreenRows
+            ? (_rowTopOffsets[i] - _tvTargetTopForRow(i)).clamp(
+                0.0,
+                maxScrollExtent,
+              )
+            : _rowTopOffsets[i].clamp(0.0, maxScrollExtent);
         final diff = (target - offset).abs();
         if (diff < minDiff) {
           minDiff = diff;
-          if (_isMediaBarIncluded()) {
-            closestRowIndex = i == 0 ? null : i - 1;
-          } else {
-            closestRowIndex = i;
-          }
+          closestRowIndex = i;
         }
       }
 

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3416,7 +3416,8 @@ class _ContentRowsState extends State<_ContentRows>
                                               _isActivelyScrolling ||
                                               chromeAudioActive;
 
-                                          return bannerMode
+                                          return RepaintBoundary(
+                                            child: bannerMode
                                               ? BannerMediaBar(
                                                   viewModel: widget.mediaBarViewModel,
                                                   prefs: prefs,
@@ -3459,7 +3460,8 @@ class _ContentRowsState extends State<_ContentRows>
                                                       ? _navigateFromMediaBarToNavbar
                                                       : null,
                                                   focusNode: _mediaBarFocusNode,
-                                                );
+                                            ),
+                                          );
                                         },
                                       );
                                     },
@@ -3678,10 +3680,9 @@ class _ContentRowsState extends State<_ContentRows>
       rowIndex: rowIndex,
       hasItems: actions.isNotEmpty,
       height: rowHeight,
-      child: RepaintBoundary(
-        child: LockedFocusRow<_LiveTvAction>(
-          key: _rowKey(rowIndex),
-          items: actions,
+      child: LockedFocusRow<_LiveTvAction>(
+        key: _rowKey(rowIndex),
+        items: actions,
           hubKey: _hubKeyForRow(row),
           controller: _rowHorizontalController(rowIndex),
           height: rowHeight,
@@ -3719,7 +3720,6 @@ class _ContentRowsState extends State<_ContentRows>
             );
           },
         ),
-      ),
     );
   }
 
@@ -3741,10 +3741,9 @@ class _ContentRowsState extends State<_ContentRows>
       rowIndex: rowIndex,
       hasItems: row.items.isNotEmpty,
       height: rowHeight,
-      child: RepaintBoundary(
-        child: LockedFocusRow<AggregatedItem>(
-          key: _rowKey(rowIndex),
-          items: row.items,
+      child: LockedFocusRow<AggregatedItem>(
+        key: _rowKey(rowIndex),
+        items: row.items,
           hubKey: _hubKeyForRow(row),
           controller: _rowHorizontalController(rowIndex),
           height: rowHeight,
@@ -3799,7 +3798,6 @@ class _ContentRowsState extends State<_ContentRows>
             );
           },
         ),
-      ),
     );
   }
 
@@ -3899,10 +3897,9 @@ class _ContentRowsState extends State<_ContentRows>
       rowIndex: rowIndex,
       hasItems: row.items.isNotEmpty,
       height: maxCardHeight + (10 * metadataScale) + (hasSubtitle ? 18.0 : 0.0),
-      child: RepaintBoundary(
-        child: LockedFocusRow<AggregatedItem>(
-          key: _rowKey(rowIndex),
-          items: row.items,
+      child: LockedFocusRow<AggregatedItem>(
+        key: _rowKey(rowIndex),
+        items: row.items,
           hubKey: _hubKeyForRow(row),
           controller: _rowHorizontalController(rowIndex),
           height: maxCardHeight + (10 * metadataScale),
@@ -4275,7 +4272,6 @@ class _ContentRowsState extends State<_ContentRows>
           );
         },
       ),
-    ),
     );
   }
 
@@ -4430,73 +4426,75 @@ class _ContentRowsState extends State<_ContentRows>
     final isRowsV2 = _isHomeRowsStyleV2();
     final showHeaderControls =
         hasItems && PlatformDetection.useDesktopUi && !PlatformDetection.isTV;
-    return Column(
-      key: key,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Padding(
-          padding: EdgeInsets.fromLTRB(
-            _kHomeRowLabelInset,
-            isRowsV2 ? 6 : 16,
-            8,
-            isRowsV2 ? 1 : 8,
-          ),
-          child: Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      title,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: AppColorScheme.onSurface,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    if (subtitle != null && subtitle.isNotEmpty) ...[
-                      const SizedBox(height: 2),
+    return RepaintBoundary(
+      child: Column(
+        key: key,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              _kHomeRowLabelInset,
+              isRowsV2 ? 6 : 16,
+              8,
+              isRowsV2 ? 1 : 8,
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
                       Text(
-                        subtitle,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: AppColorScheme.onSurface.withValues(
-                            alpha: 0.5,
-                          ),
+                        title,
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: AppColorScheme.onSurface,
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
+                      if (subtitle != null && subtitle.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          subtitle,
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: AppColorScheme.onSurface.withValues(
+                              alpha: 0.5,
+                            ),
+                          ),
+                        ),
+                      ],
                     ],
-                  ],
-                ),
-              ),
-              if (showHeaderControls) ...[
-                Focus(
-                  canRequestFocus: false,
-                  skipTraversal: true,
-                  descendantsAreFocusable: false,
-                  child: IconButton(
-                    icon: const Icon(Icons.chevron_left),
-                    onPressed: () => _scrollHomeRowHorizontal(rowIndex, -480),
-                    visualDensity: VisualDensity.compact,
                   ),
                 ),
-                Focus(
-                  canRequestFocus: false,
-                  skipTraversal: true,
-                  descendantsAreFocusable: false,
-                  child: IconButton(
-                    icon: const Icon(Icons.chevron_right),
-                    onPressed: () => _scrollHomeRowHorizontal(rowIndex, 480),
-                    visualDensity: VisualDensity.compact,
+                if (showHeaderControls) ...[
+                  Focus(
+                    canRequestFocus: false,
+                    skipTraversal: true,
+                    descendantsAreFocusable: false,
+                    child: IconButton(
+                      icon: const Icon(Icons.chevron_left),
+                      onPressed: () => _scrollHomeRowHorizontal(rowIndex, -480),
+                      visualDensity: VisualDensity.compact,
+                    ),
                   ),
-                ),
+                  Focus(
+                    canRequestFocus: false,
+                    skipTraversal: true,
+                    descendantsAreFocusable: false,
+                    child: IconButton(
+                      icon: const Icon(Icons.chevron_right),
+                      onPressed: () => _scrollHomeRowHorizontal(rowIndex, 480),
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ),
+                ],
               ],
-            ],
+            ),
           ),
-        ),
-        child,
-      ],
+          child,
+        ],
+      ),
     );
   }
 

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -104,7 +104,7 @@ class _HomeShellState extends State<_HomeShell>
   Timer? _hoverPauseTimer;
   StreamSubscription<String?>? _backgroundSub;
   final ValueNotifier<bool> _isHoverPausedNotifier = ValueNotifier(false);
-  bool _isScrolledToTop = true;
+  final ValueNotifier<bool> _isScrolledToTopNotifier = ValueNotifier(true);
   String _lastSectionsJson = '';
   Type? _lastMediaBarStateRuntime;
   int _lastMediaBarItemCount = 0;
@@ -185,6 +185,7 @@ class _HomeShellState extends State<_HomeShell>
     _backgroundSub?.cancel();
     _selectedItemNotifier.dispose();
     _isHoverPausedNotifier.dispose();
+    _isScrolledToTopNotifier.dispose();
     _viewModel.mediaBarViewModel.removeListener(_onMediaBarStateChanged);
     _viewModel.removeListener(_onViewModelChanged);
     _pluginSyncService.removeListener(_onPluginSyncChanged);
@@ -415,9 +416,10 @@ class _HomeShellState extends State<_HomeShell>
                   selectedItemNotifier: _selectedItemNotifier,
                   onItemSelected: onItemSelected,
                   isHoverPausedNotifier: _isHoverPausedNotifier,
+                  isScrolledToTopNotifier: _isScrolledToTopNotifier,
                   onScrolledToTopChanged: (atTop) {
-                    if (atTop != _isScrolledToTop) {
-                      setState(() => _isScrolledToTop = atTop);
+                    if (atTop != _isScrolledToTopNotifier.value) {
+                      _isScrolledToTopNotifier.value = atTop;
                     }
                   },
                 ),
@@ -560,6 +562,7 @@ class _ContentRows extends StatefulWidget {
   final ValueNotifier<AggregatedItem?> selectedItemNotifier;
   final ValueChanged<AggregatedItem?> onItemSelected;
   final ValueNotifier<bool> isHoverPausedNotifier;
+  final ValueNotifier<bool> isScrolledToTopNotifier;
   final ValueChanged<bool>? onScrolledToTopChanged;
 
   const _ContentRows({
@@ -569,6 +572,7 @@ class _ContentRows extends StatefulWidget {
     required this.selectedItemNotifier,
     required this.onItemSelected,
     required this.isHoverPausedNotifier,
+    required this.isScrolledToTopNotifier,
     this.onScrolledToTopChanged,
   });
 
@@ -634,7 +638,7 @@ class _ContentRowsState extends State<_ContentRows>
   bool _previewUsingAppleTv = false;
   final ValueNotifier<double> _scrollOffsetNotifier = ValueNotifier<double>(0);
   double _previewStartScrollOffset = 0;
-  bool _isScrolledToTop = true;
+  bool get _isScrolledToTop => widget.isScrolledToTopNotifier.value;
   bool _isActivelyScrolling = false;
   Timer? _scrollIdleTimer;
   double _lastActiveRowOffsetUpdate = 0;
@@ -2537,7 +2541,6 @@ class _ContentRowsState extends State<_ContentRows>
     final atTop = offset <= 0;
     final topStateChanged = atTop != _isScrolledToTop;
     if (topStateChanged) {
-      _isScrolledToTop = atTop;
       widget.onScrolledToTopChanged?.call(atTop);
     }
 
@@ -3302,62 +3305,67 @@ class _ContentRowsState extends State<_ContentRows>
                       return ValueListenableBuilder<bool>(
                         valueListenable: widget.isHoverPausedNotifier,
                         builder: (context, isHoverPaused, _) {
-                          final barPaused = isHoverPaused ||
-                              !_isScrolledToTop ||
-                              _isActivelyScrolling ||
-                              _chromeAudioActive;
+                          return ValueListenableBuilder<bool>(
+                            valueListenable: widget.isScrolledToTopNotifier,
+                            builder: (context, isScrolledToTop, _) {
+                              final barPaused = isHoverPaused ||
+                                  !isScrolledToTop ||
+                                  _isActivelyScrolling ||
+                                  _chromeAudioActive;
 
-                          return AnimatedOpacity(
-                            duration: _mediaBarFadeDuration,
-                            curve: Curves.easeInOutCubic,
-                            opacity: _mediaBarVisible ? 1.0 : 0.0,
-                            child: IgnorePointer(
-                              ignoring: !_mediaBarVisible,
-                              child: bannerMode
-                                  ? BannerMediaBar(
-                                      viewModel: widget.mediaBarViewModel,
-                                      prefs: prefs,
-                                      height: mediaBarHeight,
-                                      externallyPaused:
-                                          barPaused ||
-                                          !_mediaBarVisible ||
-                                          _activePreviewKey != null,
-                                      focusNode: _mediaBarFocusNode,
-                                      onNavigateDown: _moveFocusFromMediaBarToRows,
-                                      onNavigateUp: _navigateFromMediaBarToNavbar,
-                                      onNavigateLeft: navbarIsLeft
-                                          ? _navigateFromMediaBarToNavbar
-                                          : null,
-                                      onOpen: (item) => context.push(
-                                        Destinations.item(
-                                          item.itemId,
-                                          serverId: item.serverId,
+                              return AnimatedOpacity(
+                                duration: _mediaBarFadeDuration,
+                                curve: Curves.easeInOutCubic,
+                                opacity: _mediaBarVisible ? 1.0 : 0.0,
+                                child: IgnorePointer(
+                                  ignoring: !_mediaBarVisible,
+                                  child: bannerMode
+                                      ? BannerMediaBar(
+                                          viewModel: widget.mediaBarViewModel,
+                                          prefs: prefs,
+                                          height: mediaBarHeight,
+                                          externallyPaused:
+                                              barPaused ||
+                                              !_mediaBarVisible ||
+                                              _activePreviewKey != null,
+                                          focusNode: _mediaBarFocusNode,
+                                          onNavigateDown: _moveFocusFromMediaBarToRows,
+                                          onNavigateUp: _navigateFromMediaBarToNavbar,
+                                          onNavigateLeft: navbarIsLeft
+                                              ? _navigateFromMediaBarToNavbar
+                                              : null,
+                                          onOpen: (item) => context.push(
+                                            Destinations.item(
+                                              item.itemId,
+                                              serverId: item.serverId,
+                                            ),
+                                          ),
+                                          onPlay: (item) => context.push(
+                                            Destinations.item(
+                                              item.itemId,
+                                              serverId: item.serverId,
+                                              autoPlay: true,
+                                            ),
+                                          ),
+                                        )
+                                      : MediaBar(
+                                          viewModel: widget.mediaBarViewModel,
+                                          prefs: prefs,
+                                          externallyPaused:
+                                              barPaused ||
+                                              !_mediaBarVisible ||
+                                              _activePreviewKey != null,
+                                          height: mediaBarHeight,
+                                          onNavigateDown: _moveFocusFromMediaBarToRows,
+                                          onNavigateUp: _navigateFromMediaBarToNavbar,
+                                          onNavigateLeft: navbarIsLeft
+                                              ? _navigateFromMediaBarToNavbar
+                                              : null,
+                                          focusNode: _mediaBarFocusNode,
                                         ),
-                                      ),
-                                      onPlay: (item) => context.push(
-                                        Destinations.item(
-                                          item.itemId,
-                                          serverId: item.serverId,
-                                          autoPlay: true,
-                                        ),
-                                      ),
-                                    )
-                                  : MediaBar(
-                                      viewModel: widget.mediaBarViewModel,
-                                      prefs: prefs,
-                                      externallyPaused:
-                                          barPaused ||
-                                          !_mediaBarVisible ||
-                                          _activePreviewKey != null,
-                                      height: mediaBarHeight,
-                                      onNavigateDown: _moveFocusFromMediaBarToRows,
-                                      onNavigateUp: _navigateFromMediaBarToNavbar,
-                                      onNavigateLeft: navbarIsLeft
-                                          ? _navigateFromMediaBarToNavbar
-                                          : null,
-                                      focusNode: _mediaBarFocusNode,
-                                    ),
-                            ),
+                                ),
+                              );
+                            },
                           );
                         },
                       );

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -97,13 +97,13 @@ class _HomeShellState extends State<_HomeShell>
   final _pluginSyncService = GetIt.instance<PluginSyncService>();
   late final HomeViewModel _viewModel;
 
-  AggregatedItem? _selectedItem;
+  final ValueNotifier<AggregatedItem?> _selectedItemNotifier = ValueNotifier(null);
   String? _backdropUrl;
   Timer? _selectionDebounce;
   Timer? _backdropDebounce;
   Timer? _hoverPauseTimer;
   StreamSubscription<String?>? _backgroundSub;
-  bool _isHoverPaused = false;
+  final ValueNotifier<bool> _isHoverPausedNotifier = ValueNotifier(false);
   bool _isScrolledToTop = true;
   String _lastSectionsJson = '';
   Type? _lastMediaBarStateRuntime;
@@ -183,6 +183,8 @@ class _HomeShellState extends State<_HomeShell>
     _backdropDebounce?.cancel();
     _hoverPauseTimer?.cancel();
     _backgroundSub?.cancel();
+    _selectedItemNotifier.dispose();
+    _isHoverPausedNotifier.dispose();
     _viewModel.mediaBarViewModel.removeListener(_onMediaBarStateChanged);
     _viewModel.removeListener(_onViewModelChanged);
     _pluginSyncService.removeListener(_onPluginSyncChanged);
@@ -269,14 +271,12 @@ class _HomeShellState extends State<_HomeShell>
     _selectionDebounce?.cancel();
     _selectionDebounce = Timer(_selectionDelay, () {
       if (!mounted) return;
-      setState(() {
-        _selectedItem = item;
-        _isHoverPaused = true;
-      });
+      _selectedItemNotifier.value = item;
+      _isHoverPausedNotifier.value = true;
 
       _hoverPauseTimer?.cancel();
       _hoverPauseTimer = Timer(const Duration(seconds: 15), () {
-        if (mounted) setState(() => _isHoverPaused = false);
+        if (mounted) _isHoverPausedNotifier.value = false;
       });
 
       _backdropDebounce?.cancel();
@@ -341,8 +341,8 @@ class _HomeShellState extends State<_HomeShell>
     }
 
     _maybeRegisterThemeMusic();
-    if (_selectedItem != null) {
-      _maybePlayThemeMusic(_selectedItem);
+    if (_selectedItemNotifier.value != null) {
+      _maybePlayThemeMusic(_selectedItemNotifier.value);
     }
   }
 
@@ -367,8 +367,8 @@ class _HomeShellState extends State<_HomeShell>
       }
     });
     _maybeRegisterThemeMusic();
-    if (_selectedItem != null) {
-      _maybePlayThemeMusic(_selectedItem);
+    if (_selectedItemNotifier.value != null) {
+      _maybePlayThemeMusic(_selectedItemNotifier.value);
     }
   }
 
@@ -412,9 +412,9 @@ class _HomeShellState extends State<_HomeShell>
                   viewModel: _viewModel,
                   mediaBarViewModel: _viewModel.mediaBarViewModel,
                   prefs: _userPrefs,
-                  selectedItem: _selectedItem,
+                  selectedItemNotifier: _selectedItemNotifier,
                   onItemSelected: onItemSelected,
-                  isHoverPaused: _isHoverPaused,
+                  isHoverPausedNotifier: _isHoverPausedNotifier,
                   onScrolledToTopChanged: (atTop) {
                     if (atTop != _isScrolledToTop) {
                       setState(() => _isScrolledToTop = atTop);
@@ -557,18 +557,18 @@ class _ContentRows extends StatefulWidget {
   final HomeViewModel viewModel;
   final MediaBarViewModel mediaBarViewModel;
   final UserPreferences prefs;
-  final AggregatedItem? selectedItem;
+  final ValueNotifier<AggregatedItem?> selectedItemNotifier;
   final ValueChanged<AggregatedItem?> onItemSelected;
-  final bool isHoverPaused;
+  final ValueNotifier<bool> isHoverPausedNotifier;
   final ValueChanged<bool>? onScrolledToTopChanged;
 
   const _ContentRows({
     required this.viewModel,
     required this.mediaBarViewModel,
     required this.prefs,
-    required this.selectedItem,
+    required this.selectedItemNotifier,
     required this.onItemSelected,
-    this.isHoverPaused = false,
+    required this.isHoverPausedNotifier,
     this.onScrolledToTopChanged,
   });
 
@@ -3152,11 +3152,6 @@ class _ContentRowsState extends State<_ContentRows>
     final includeMediaBar = _isMediaBarIncluded();
     final bannerMode = _isBannerMode();
     final mediaBarHeight = _mediaBarHeight();
-    final carouselPaused =
-        widget.isHoverPaused ||
-        !_isScrolledToTop ||
-        _isActivelyScrolling ||
-        _chromeAudioActive;
     final showInfoOverlay = _showHomeRowInfoOverlay();
     final safeTop = MediaQuery.of(context).padding.top;
     final desktopScale = _desktopUiScaleFactor();
@@ -3302,57 +3297,67 @@ class _ContentRowsState extends State<_ContentRows>
                   cacheExtent: 600,
                   itemBuilder: (context, index) {
                     if (includeMediaBar && index == 0) {
-                      return AnimatedOpacity(
-                        duration: _mediaBarFadeDuration,
-                        curve: Curves.easeInOutCubic,
-                        opacity: _mediaBarVisible ? 1.0 : 0.0,
-                        child: IgnorePointer(
-                          ignoring: !_mediaBarVisible,
-                          child: bannerMode
-                              ? BannerMediaBar(
-                                  viewModel: widget.mediaBarViewModel,
-                                  prefs: prefs,
-                                  height: mediaBarHeight,
-                                  externallyPaused:
-                                      carouselPaused ||
-                                      !_mediaBarVisible ||
-                                      _activePreviewKey != null,
-                                  focusNode: _mediaBarFocusNode,
-                                  onNavigateDown: _moveFocusFromMediaBarToRows,
-                                  onNavigateUp: _navigateFromMediaBarToNavbar,
-                                  onNavigateLeft: navbarIsLeft
-                                      ? _navigateFromMediaBarToNavbar
-                                      : null,
-                                  onOpen: (item) => context.push(
-                                    Destinations.item(
-                                      item.itemId,
-                                      serverId: item.serverId,
+                      return ValueListenableBuilder<bool>(
+                        valueListenable: widget.isHoverPausedNotifier,
+                        builder: (context, isHoverPaused, _) {
+                          final barPaused = isHoverPaused ||
+                              !_isScrolledToTop ||
+                              _isActivelyScrolling ||
+                              _chromeAudioActive;
+
+                          return AnimatedOpacity(
+                            duration: _mediaBarFadeDuration,
+                            curve: Curves.easeInOutCubic,
+                            opacity: _mediaBarVisible ? 1.0 : 0.0,
+                            child: IgnorePointer(
+                              ignoring: !_mediaBarVisible,
+                              child: bannerMode
+                                  ? BannerMediaBar(
+                                      viewModel: widget.mediaBarViewModel,
+                                      prefs: prefs,
+                                      height: mediaBarHeight,
+                                      externallyPaused:
+                                          barPaused ||
+                                          !_mediaBarVisible ||
+                                          _activePreviewKey != null,
+                                      focusNode: _mediaBarFocusNode,
+                                      onNavigateDown: _moveFocusFromMediaBarToRows,
+                                      onNavigateUp: _navigateFromMediaBarToNavbar,
+                                      onNavigateLeft: navbarIsLeft
+                                          ? _navigateFromMediaBarToNavbar
+                                          : null,
+                                      onOpen: (item) => context.push(
+                                        Destinations.item(
+                                          item.itemId,
+                                          serverId: item.serverId,
+                                        ),
+                                      ),
+                                      onPlay: (item) => context.push(
+                                        Destinations.item(
+                                          item.itemId,
+                                          serverId: item.serverId,
+                                          autoPlay: true,
+                                        ),
+                                      ),
+                                    )
+                                  : MediaBar(
+                                      viewModel: widget.mediaBarViewModel,
+                                      prefs: prefs,
+                                      externallyPaused:
+                                          barPaused ||
+                                          !_mediaBarVisible ||
+                                          _activePreviewKey != null,
+                                      height: mediaBarHeight,
+                                      onNavigateDown: _moveFocusFromMediaBarToRows,
+                                      onNavigateUp: _navigateFromMediaBarToNavbar,
+                                      onNavigateLeft: navbarIsLeft
+                                          ? _navigateFromMediaBarToNavbar
+                                          : null,
+                                      focusNode: _mediaBarFocusNode,
                                     ),
-                                  ),
-                                  onPlay: (item) => context.push(
-                                    Destinations.item(
-                                      item.itemId,
-                                      serverId: item.serverId,
-                                      autoPlay: true,
-                                    ),
-                                  ),
-                                )
-                              : MediaBar(
-                                  viewModel: widget.mediaBarViewModel,
-                                  prefs: prefs,
-                                  externallyPaused:
-                                      carouselPaused ||
-                                      !_mediaBarVisible ||
-                                      _activePreviewKey != null,
-                                  height: mediaBarHeight,
-                                  onNavigateDown: _moveFocusFromMediaBarToRows,
-                                  onNavigateUp: _navigateFromMediaBarToNavbar,
-                                  onNavigateLeft: navbarIsLeft
-                                      ? _navigateFromMediaBarToNavbar
-                                      : null,
-                                  focusNode: _mediaBarFocusNode,
-                                ),
-                        ),
+                            ),
+                          );
+                        },
                       );
                     }
                     final infoIndex = includeMediaBar ? 1 : 0;
@@ -3498,9 +3503,14 @@ class _ContentRowsState extends State<_ContentRows>
                   16,
                   8,
                 ),
-                child: InfoArea(
-                  item: widget.selectedItem,
-                  headerLeftInset: infoHeaderLeftInset,
+                child: ValueListenableBuilder<AggregatedItem?>(
+                  valueListenable: widget.selectedItemNotifier,
+                  builder: (context, selectedItem, _) {
+                    return InfoArea(
+                      item: selectedItem,
+                      headerLeftInset: infoHeaderLeftInset,
+                    );
+                  },
                 ),
               ),
             ),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -946,6 +946,7 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   void _onViewModelChanged() {
+    _invalidateStaticRowHeightCache();
     _updateOffsets();
     if (mounted) setState(() {});
   }
@@ -3012,7 +3013,7 @@ class _ContentRowsState extends State<_ContentRows>
     final viewportHeight = MediaQuery.sizeOf(context).height;
 
     if (_cachedRowExtents != null &&
-        identical(_cachedExtentRows, rows) &&
+        listEquals(_cachedExtentRows, rows) &&
         _cachedExtentPosterSize == posterSize &&
         _cachedExtentDesktopScale == desktopScale &&
         _cachedExtentFullScreenRows == fullScreenRows &&
@@ -3023,6 +3024,9 @@ class _ContentRowsState extends State<_ContentRows>
         _cachedExtentPrefsVersion == _layoutPrefsVersion) {
       return _cachedRowExtents!;
     }
+
+    _invalidateStaticRowHeightCache();
+
     final extents = <double>[];
     for (var i = 0; i < rows.length; i++) {
       extents.add(_estimatedRowExtent(i, rows[i], posterSize, prefs));
@@ -3460,7 +3464,7 @@ class _ContentRowsState extends State<_ContentRows>
                                                       ? _navigateFromMediaBarToNavbar
                                                       : null,
                                                   focusNode: _mediaBarFocusNode,
-                                            ),
+                                                ),
                                           );
                                         },
                                       );
@@ -3641,8 +3645,8 @@ class _ContentRowsState extends State<_ContentRows>
         ),
       ],
     ),
-    );
-  }
+  );
+}
 
   Widget _buildLiveTvRow(
     HomeRow row,
@@ -3889,7 +3893,7 @@ class _ContentRowsState extends State<_ContentRows>
     }
 
     final subtitle = _rowSubtitle(row, l10n);
-    final hasSubtitle = subtitle != null;
+    final hasSubtitle = subtitle != null && subtitle.isNotEmpty;
     return _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),


### PR DESCRIPTION
## Summary
home screen performance improvements, cutting down on the need for widget builds and reducing build times.  This reduces HomeShell and ContentRows rebuilds massively on scrolling.  Most builds now will be from horizontal scrolling within the rows.

The visibility, repaintboundary's should help with gpu.

Preview player building is still something that's going to cause large build times.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Visibility wrappers on rows, replacing opacity
- RepaintBoundary wrappers in: _Backdrop, _GradientScrim, _buildTitledRow, and around the media bar
- moved to ValueNotifiers:  _selectedItem, _isHoverPaused, _activeFocusedRowIndex, _isScrolledToTop, _isActivelyScrolling, _infoRevealed, _mediaBarVisible, _chromeFocusActive, _chromeAudioActive, _backdropUrl, _activePreviewKey, _previewReady, _v2AdditionalRatingsByKey
- added ValueListenableBuilders to listen to notifiers and do builds when they change and cleaned up a lot of setState calls
- added a cache to store the calculated row heights instead of re-calculating every build
- refactor _onScroll handling so it only fires when it has moved at least _activeRowRecalcDistance
- added a cache for row target offsets
- moved the viewmodel listener out of _HomeShellState and into _ContentRowsState
- added _updateOffsets to centralize needed calculations

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.you can try to use flutter devtools if it doesn't crash, otherwise you can add some prints to count builds, and stopwatch to measure times.
2. scroll down several rows, then back up
3. scroll horizontally in rows to get offscreen, and then back

## Screenshots (if applicable)

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
