### PR TITLE
fix(home-rows): small fixes to Home Sections

### DIFF
--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -333,11 +333,17 @@ class HomeSectionConfig {
     if (jsonString.isEmpty) return defaults();
     try {
       final list = jsonDecode(jsonString) as List;
-      return [
-        for (final e in list)
-          if (e is Map<String, dynamic> && isSupportedJson(e))
-            HomeSectionConfig.fromJson(e),
-      ];
+      final parsed = <HomeSectionConfig>[];
+      for (final e in list) {
+        if (e is Map<String, dynamic> && isSupportedJson(e)) {
+          final cfg = HomeSectionConfig.fromJson(e);
+          if (cfg.isBuiltin && cfg.type == HomeSectionType.none) {
+            continue;
+          }
+          parsed.add(cfg);
+        }
+      }
+      return parsed;
     } catch (_) {
       return defaults();
     }

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1246,11 +1246,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         final first = resumeIdx < nextUpIdx ? resumeIdx : nextUpIdx;
         var targetIndex = toIndex;
         if (targetIndex > first) {
-          if (targetIndex <= first + 2) {
-            targetIndex = first;
-          } else {
-            targetIndex -= 2;
-          }
+          targetIndex -= 1;
         }
         focusIndex = targetIndex;
       }
@@ -1917,19 +1913,15 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                     _save();
                   },
                   onMoveUp: () {
-                    debugPrint('TV MoveUp: resume, isFirst: $isFirst');
                     if (isFirst) return;
                     final visibleIndices = _visibleSectionIndices();
                     final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
-                    debugPrint('TV MoveUp: resume, currentIdx: $currentIdx, target: ${currentIdx - 1}');
                     _moveSection(resumeSectionIndex, visibleIndices[currentIdx - 1]);
                   },
                   onMoveDown: () {
-                    debugPrint('TV MoveDown: resume, isLast: $isLast');
                     if (isLast) return;
                     final visibleIndices = _visibleSectionIndices();
                     final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
-                    debugPrint('TV MoveDown: resume, currentIdx: $currentIdx, target: ${currentIdx + 1}, len: ${visibleIndices.length}');
                     if (currentIdx >= visibleIndices.length - 1) return;
                     _moveSection(resumeSectionIndex, visibleIndices[currentIdx + 1]);
                   },
@@ -1957,19 +1949,15 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                     _save();
                   },
                   onMoveUp: () {
-                    debugPrint('TV MoveUp: nextUp, isFirst: $isFirst');
                     if (isFirst) return;
                     final visibleIndices = _visibleSectionIndices();
                     final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
-                    debugPrint('TV MoveUp: nextUp, currentIdx: $currentIdx, target: ${currentIdx - 1}');
                     _moveSection(resumeSectionIndex, visibleIndices[currentIdx - 1]);
                   },
                   onMoveDown: () {
-                    debugPrint('TV MoveDown: nextUp, isLast: $isLast');
                     if (isLast) return;
                     final visibleIndices = _visibleSectionIndices();
                     final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
-                    debugPrint('TV MoveDown: nextUp, currentIdx: $currentIdx, target: ${currentIdx + 1}, len: ${visibleIndices.length}');
                     if (currentIdx >= visibleIndices.length - 1) return;
                     _moveSection(resumeSectionIndex, visibleIndices[currentIdx + 1]);
                   },

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -48,35 +48,6 @@ BoxDecoration _homeSectionTileDecoration(
       ? AppColorScheme.onSurface.withValues(alpha: 0.16)
       : baseBorder.withValues(alpha: 0.55);
 
-  final isMergedResume = mergeEnabled && type == HomeSectionType.resume;
-  final isMergedNextUp = mergeEnabled && type == HomeSectionType.nextUp;
-
-  if (isMergedResume || isMergedNextUp) {
-    final borderColor = focused
-        ? AppColorScheme.accent.withValues(alpha: 0.72)
-        : const Color(0xFF00F0FF); // Neon cyan border for merged rows
-    final borderWidth = focused ? 2.0 : 1.5;
-
-    return BoxDecoration(
-      color: focused
-          ? AppColorScheme.onSurface
-          : colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
-      borderRadius: isMergedResume
-          ? const BorderRadius.vertical(top: Radius.circular(_kHomeSectionTileRadius))
-          : const BorderRadius.vertical(bottom: Radius.circular(_kHomeSectionTileRadius)),
-      border: Border(
-        top: isMergedResume
-            ? BorderSide(color: borderColor, width: borderWidth)
-            : BorderSide.none,
-        bottom: isMergedNextUp
-            ? BorderSide(color: borderColor, width: borderWidth)
-            : BorderSide.none,
-        left: BorderSide(color: borderColor, width: borderWidth),
-        right: BorderSide(color: borderColor, width: borderWidth),
-      ),
-    );
-  }
-
   return BoxDecoration(
     color: focused
         ? AppColorScheme.onSurface
@@ -1245,11 +1216,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
         var targetIndex = toIndex;
         if (targetIndex > first) {
-          if (targetIndex <= first + 2) {
-            targetIndex = first;
-          } else {
-            targetIndex -= 2;
-          }
+          targetIndex -= 1;
         }
 
         _sections.insert(targetIndex, item1);
@@ -1812,6 +1779,22 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         final sectionIndex = visibleIndices[visibleIndex];
         final section = _sections[sectionIndex];
         final isEmpty = _emptySectionIds.contains(section.stableId);
+        final mergeEnabled = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
+
+        if (mergeEnabled && section.type == HomeSectionType.resume) {
+          final nextUpIndex = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
+          if (nextUpIndex >= 0) {
+            return _buildMergedTvTile(
+              context,
+              sectionIndex,
+              nextUpIndex,
+              l10n,
+              visibleIndex == 0,
+              visibleIndex == visibleIndices.length - 1,
+            );
+          }
+        }
+
         return _HomeSectionTile(
           key: ValueKey(section.stableId),
           focusNode: _focusNodes[sectionIndex],
@@ -1853,6 +1836,305 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           },
         );
       },
+    );
+  }
+
+  Widget _buildMergedTvTile(
+    BuildContext context,
+    int resumeSectionIndex,
+    int nextUpSectionIndex,
+    AppLocalizations l10n,
+    bool isFirst,
+    bool isLast,
+  ) {
+    final resumeSection = _sections[resumeSectionIndex];
+    final nextUpSection = _sections[nextUpSectionIndex];
+    final isResumeEmpty = _emptySectionIds.contains(resumeSection.stableId);
+    final isNextUpEmpty = _emptySectionIds.contains(nextUpSection.stableId);
+
+    final resumeNode = _focusNodes[resumeSectionIndex];
+    final nextUpNode = _focusNodes[nextUpSectionIndex];
+
+    return AnimatedBuilder(
+      key: ValueKey(resumeSection.stableId),
+      animation: Listenable.merge([resumeNode, nextUpNode]),
+      builder: (context, _) {
+        final resumeFocused = resumeNode.hasFocus;
+        final nextUpFocused = nextUpNode.hasFocus;
+        final anyFocused = resumeFocused || nextUpFocused;
+
+        final colorScheme = Theme.of(context).colorScheme;
+        final borderTokens = ThemeRegistry.active.borders;
+        final baseBorder = borderTokens.cardBorder.color;
+        final unfocusedBorderColor = baseBorder.a == 0
+            ? AppColorScheme.onSurface.withValues(alpha: 0.16)
+            : baseBorder.withValues(alpha: 0.55);
+
+        final borderColor = anyFocused
+            ? AppColorScheme.accent.withValues(alpha: 0.72)
+            : unfocusedBorderColor;
+        final borderWidth = 1.0;
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          child: Container(
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
+              borderRadius: AppRadius.circular(_kHomeSectionTileRadius),
+              border: Border.all(
+                color: borderColor,
+                width: borderWidth,
+              ),
+              boxShadow: anyFocused
+                  ? [
+                      BoxShadow(
+                        color: AppColorScheme.accent.withValues(alpha: 0.22),
+                        blurRadius: 14,
+                        spreadRadius: 0.5,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildTvTileInner(
+                  context,
+                  focusNode: resumeNode,
+                  section: resumeSection,
+                  label: _labelFor(resumeSection, l10n),
+                  focused: resumeFocused,
+                  isEmpty: isResumeEmpty,
+                  isFirst: isFirst,
+                  isLast: isLast,
+                  autofocus: isFirst,
+                  showArrows: resumeFocused || (!resumeFocused && !nextUpFocused),
+                  onToggle: (enabled) {
+                    setState(() {
+                      _sections[resumeSectionIndex] = resumeSection.copyWith(enabled: enabled);
+                    });
+                    _save();
+                  },
+                  onMoveUp: () {
+                    debugPrint('TV MoveUp: resume, isFirst: $isFirst');
+                    if (isFirst) return;
+                    final visibleIndices = _visibleSectionIndices();
+                    final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
+                    debugPrint('TV MoveUp: resume, currentIdx: $currentIdx, target: ${currentIdx - 1}');
+                    _moveSection(resumeSectionIndex, visibleIndices[currentIdx - 1]);
+                  },
+                  onMoveDown: () {
+                    debugPrint('TV MoveDown: resume, isLast: $isLast');
+                    if (isLast) return;
+                    final visibleIndices = _visibleSectionIndices();
+                    final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
+                    debugPrint('TV MoveDown: resume, currentIdx: $currentIdx, target: ${currentIdx + 1}, len: ${visibleIndices.length}');
+                    if (currentIdx >= visibleIndices.length - 1) return;
+                    _moveSection(resumeSectionIndex, visibleIndices[currentIdx + 1]);
+                  },
+                ),
+                Divider(
+                  height: 1,
+                  color: const Color(0xFF00F0FF).withValues(alpha: 0.4),
+                  indent: 16,
+                  endIndent: 16,
+                ),
+                _buildTvTileInner(
+                  context,
+                  focusNode: nextUpNode,
+                  section: nextUpSection,
+                  label: _labelFor(nextUpSection, l10n),
+                  focused: nextUpFocused,
+                  isEmpty: isNextUpEmpty,
+                  isFirst: isFirst,
+                  isLast: isLast,
+                  showArrows: nextUpFocused,
+                  onToggle: (enabled) {
+                    setState(() {
+                      _sections[nextUpSectionIndex] = nextUpSection.copyWith(enabled: enabled);
+                    });
+                    _save();
+                  },
+                  onMoveUp: () {
+                    debugPrint('TV MoveUp: nextUp, isFirst: $isFirst');
+                    if (isFirst) return;
+                    final visibleIndices = _visibleSectionIndices();
+                    final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
+                    debugPrint('TV MoveUp: nextUp, currentIdx: $currentIdx, target: ${currentIdx - 1}');
+                    _moveSection(resumeSectionIndex, visibleIndices[currentIdx - 1]);
+                  },
+                  onMoveDown: () {
+                    debugPrint('TV MoveDown: nextUp, isLast: $isLast');
+                    if (isLast) return;
+                    final visibleIndices = _visibleSectionIndices();
+                    final currentIdx = visibleIndices.indexOf(resumeSectionIndex);
+                    debugPrint('TV MoveDown: nextUp, currentIdx: $currentIdx, target: ${currentIdx + 1}, len: ${visibleIndices.length}');
+                    if (currentIdx >= visibleIndices.length - 1) return;
+                    _moveSection(resumeSectionIndex, visibleIndices[currentIdx + 1]);
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildTvTileInner(
+    BuildContext context, {
+    required FocusNode focusNode,
+    required HomeSectionConfig section,
+    required String label,
+    required bool focused,
+    required bool isEmpty,
+    required bool isFirst,
+    required bool isLast,
+    required VoidCallback onMoveUp,
+    required VoidCallback onMoveDown,
+    required ValueChanged<bool> onToggle,
+    bool autofocus = false,
+    bool showArrows = true,
+  }) {
+    final l10n = AppLocalizations.of(context);
+    return Focus(
+      focusNode: focusNode,
+      autofocus: autofocus,
+      canRequestFocus: true,
+      onFocusChange: (f) {
+        if (f) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!focusNode.hasFocus) return;
+            Scrollable.ensureVisible(
+              context,
+              duration: const Duration(milliseconds: 120),
+              curve: Curves.easeOut,
+              alignment: 0.2,
+              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+            );
+          });
+        }
+      },
+      onKeyEvent: (node, event) {
+        if (event is! KeyDownEvent) return KeyEventResult.ignored;
+        if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+          onMoveUp();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+          onMoveDown();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.select ||
+            event.logicalKey == LogicalKeyboardKey.enter) {
+          if (!isEmpty) {
+            onToggle(!section.enabled);
+          }
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: Opacity(
+        opacity: isEmpty ? 0.45 : 1.0,
+        child: Container(
+          decoration: BoxDecoration(
+            color: focused
+                ? AppColorScheme.onSurface
+                : Colors.transparent,
+            borderRadius: AppRadius.circular(12),
+          ),
+          child: ListTile(
+            focusColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            contentPadding: _kHomeSectionTileContentPadding,
+            minLeadingWidth: 44,
+            horizontalTitleGap: 14,
+            leading: buildSettingsLeadingIconShell(
+              context,
+              icon: Icon(
+                (section.enabled && !isEmpty)
+                    ? Icons.check_box
+                    : Icons.check_box_outline_blank,
+              ),
+              focused: focused,
+              iconColor: focused
+                  ? AppColors.black.withValues(alpha: 0.54)
+                  : AppColorScheme.onSurface.withValues(alpha: 0.78),
+            ),
+            title: Row(
+              children: [
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: kCleanSettingsFontFamily,
+                    color: focused
+                        ? AppColors.black.withValues(alpha: 0.87)
+                        : AppColorScheme.onSurface,
+                  ),
+                ),
+                if (isEmpty) ...[
+                  const SizedBox(width: 8),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                    decoration: BoxDecoration(
+                      color: Colors.red.withValues(alpha: 0.15),
+                      borderRadius: AppRadius.circular(4),
+                      border: Border.all(
+                        color: Colors.red.withValues(alpha: 0.5),
+                        width: 0.8,
+                      ),
+                    ),
+                    child: Text(
+                      l10n.empty,
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Colors.red,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: kCleanSettingsFontFamily,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+            subtitle: section.isPluginDynamic
+                ? Text(_pluginSubtitle(section))
+                : (_isAudioSectionType(section.type)
+                      ? const Text('Audio row')
+                      : (_isSeerrSectionType(section.type)
+                            ? const Text('Seerr Discovery Rows')
+                            : (_isTmdbSectionType(section.type)
+                                  ? const Text('TMDB Lists')
+                                  : null))),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (showArrows) ...[
+                  if (!isFirst)
+                    Icon(
+                      Icons.arrow_left,
+                      size: 18,
+                      color: focused
+                          ? AppColors.black.withValues(alpha: 0.54)
+                          : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                  if (!isLast)
+                    Icon(
+                      Icons.arrow_right,
+                      size: 18,
+                      color: focused
+                          ? AppColors.black.withValues(alpha: 0.54)
+                          : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 
@@ -1965,6 +2247,7 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+
     return Focus(
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,


### PR DESCRIPTION
# Pull Request

## Summary
Resolved Android TV rendering layout crashes, fixed reordering downwards logic of the merged block, and permanently cleaned up obsolete `None` row items from settings configurations.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.
- **TV Merged Card Layout:** Combined the adjacent Continue Watching and Next Up rows inside a single unified card layout `_buildMergedTvTile` on TV to avoid the `A borderRadius can only be given on borders with uniform colors` rendering exception.
- **Stretched Layout Alignment:** Set the inner tile Column to `CrossAxisAlignment.stretch` so both rows take full width and the focused backdrop spans the entire card, resolving the alignment issue.
- **Reordering Down Fix:** Corrected the index offset math inside `_moveSection` when moving merged blocks down to ensure the entire merged block correctly swaps places with the next card.
- **None Rows Filter:** Modified `fromJsonString` in `home_section_config.dart` to ignore builtin configuration templates mapped to `HomeSectionType.none`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Android TV
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings > Home Sections with "Merge Continue Watching and Next Up" setting toggled on.
2. Verify both Continue Watching and Next Up display inside a single container.
3. Verify only one set of arrows is active at a time (on the focused tile, or top tile when unfocused), and that contrast is high.
4. Verify pressing Left/Right arrow on either row reorders the entire block correctly.
5. Verify no None sections are visible in the configuration list.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### MERGED
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-01_03-56-32" src="https://github.com/user-attachments/assets/504ac30f-a3bc-47d6-8d45-bc163151c8b1" />

### UNMERGED
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-01_03-58-09" src="https://github.com/user-attachments/assets/4acbdf34-0c60-4e94-8c77-4f64cb5426ec" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
