### PR TITLE
fix(settings): resolve focused text contrast issue in custom and seerr lists

### DIFF
--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1008,10 +1008,9 @@ class _SeerrRowSwitchTile extends StatelessWidget {
           secondary: secondary,
           title: Text(
             title,
-            style: TextStyle(
+            style: const TextStyle(
               fontSize: 14,
               fontWeight: FontWeight.w600,
-              color: AppColorScheme.onSurface,
             ),
           ),
           value: value,
@@ -1220,10 +1219,9 @@ class _CustomListsScreenState extends State<_CustomListsScreen> {
                                 Expanded(
                                   child: Text(
                                     config.pluginDisplayText ?? 'Custom Row',
-                                    style: TextStyle(
+                                    style: const TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.w600,
-                                      color: AppColorScheme.onSurface,
                                     ),
                                   ),
                                 ),


### PR DESCRIPTION
# Pull Request

## Summary
Realized the issue popped up in a couple places, so quick PR to resolve focused text contrast styling issues in Custom Home Rows Wizard and Seerr Lists, preventing text from rendering in the highlight color (neon cyan) and becoming invisible when focused on Android TV.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Removed Overridden Colors on Titles:** Removed the explicit `color: AppColorScheme.onSurface` override from the `TextStyle` in both `_SeerrRowSwitchTile` (Seerr Lists) and `_CustomListsScreen` custom row tiles. This allows the title text to correctly inherit the text color from `ListTileTheme.merge` inside `TvFocusHighlight` (resolving to high-contrast `AppColors.black` when focused, and `settingsHeadlineColor()` when unfocused, matching the correct style of `SwitchPreferenceTile`/TMDb Lists).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings > External Home Row Configurations.
2. Select **Seerr Lists**: Focus on a row and verify title text switches to high-contrast black on the cyan focused container.
3. Select **Custom Home Rows Wizard**: Focus on a saved custom row (e.g. "Matt's Activity") and verify the title text remains fully visible and readable in black.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### The Problem
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-01_04-05-38" src="https://github.com/user-attachments/assets/7676e137-8748-4a35-88d3-1172c4eee2a9" />

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-01_04-05-26" src="https://github.com/user-attachments/assets/ed46d21f-8c42-4e11-b62d-1d378c05333e" />

### The Fix
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-01_04-20-19" src="https://github.com/user-attachments/assets/18a26007-828d-414d-bed6-0dfb787b4f25" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
