### PR TITLE
New Sort Option: Original

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -59,6 +59,9 @@ class MultiServerRepository {
   static const _defaultSortOrder = 'Ascending';
   static const _genreArtworkConcurrency = 6;
 
+  static String? _sortByParameter(LibrarySortBy? sortBy) =>
+      sortBy == null ? _defaultSortBy : sortBy.sortByParameter;
+
   List<ServerUserSession>? _cachedSessions;
   DateTime _cacheExpiry = DateTime(0);
   final Map<String, int> _rowOffsets = {};
@@ -277,8 +280,8 @@ class MultiServerRepository {
 
   Future<HomeRow> getAggregatedPlaylists({
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
     String? mediaType,
   }) async {
     final sessions = await getLoggedInServers();
@@ -314,14 +317,20 @@ class MultiServerRepository {
     );
 
     final all = results.expand((e) => e).toList();
-    if (sortBy == 'SortName') {
+    if (sortBy == null) {
+      // Keep the server-provided order.
+    } else if (sortBy == 'SortName') {
       if (sortOrder == 'Ascending') {
         all.sort((a, b) => a.name.compareTo(b.name));
       } else {
         all.sort((a, b) => b.name.compareTo(a.name));
       }
     } else {
-      _sortAggregatedItems(all, sortBy: sortBy, sortOrder: sortOrder);
+      _sortAggregatedItems(
+        all,
+        sortBy: sortBy,
+        sortOrder: sortOrder ?? _defaultSortOrder,
+      );
     }
 
     final takenItems = all.take(limit).toList();
@@ -341,8 +350,8 @@ class MultiServerRepository {
 
   Future<HomeRow> getAggregatedAudioArtists({
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     final row = await _getAggregatedSortedItemsRow(
       id: 'audioArtists',
@@ -359,8 +368,8 @@ class MultiServerRepository {
 
   Future<HomeRow> getAggregatedAudioAlbums({
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     final row = await _getAggregatedSortedItemsRow(
       id: 'audioAlbums',
@@ -377,8 +386,8 @@ class MultiServerRepository {
 
   Future<HomeRow> getAggregatedAudioPlaylists({
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     return getAggregatedPlaylists(
       limit: limit,
@@ -394,8 +403,8 @@ class MultiServerRepository {
     required String title,
     List<String>? includeItemTypes,
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     return _getAggregatedSortedItemsRow(
       id: rowId,
@@ -412,8 +421,8 @@ class MultiServerRepository {
 
   Future<HomeRow> getAggregatedCollections({
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     return _getAggregatedSortedItemsRow(
       id: 'collections',
@@ -429,8 +438,8 @@ class MultiServerRepository {
 
   Future<HomeRow> getAggregatedGenres({
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
     List<String>? includeItemTypes,
   }) async {
     const cacheKeyPrefix = 'genres';
@@ -463,11 +472,14 @@ class MultiServerRepository {
       ),
     );
 
-    final all = _sortAggregatedItems(
-      results.expand((e) => e).toList(growable: false),
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-    );
+    final combined = results.expand((e) => e).toList(growable: false);
+    final all = sortBy == null
+        ? combined
+        : _sortAggregatedItems(
+            combined,
+            sortBy: sortBy,
+            sortOrder: sortOrder ?? _defaultSortOrder,
+          );
 
     final takenItems = all.take(limit).toList();
     final totalCount = sessions.fold<int>(0, (sum, session) {
@@ -517,9 +529,9 @@ class MultiServerRepository {
               final pageCount = (startIndex / _defaultLimit).ceil();
               final targetStartIndex = pageCount * _defaultLimit;
               _rowOffsets[cacheKey] = targetStartIndex + _defaultLimit;
-              final sortBy =
-                  prefs?.get(UserPreferences.playlistsRowSortBy).apiValue ??
-                  _defaultSortBy;
+              final sortBy = _sortByParameter(
+                prefs?.get(UserPreferences.playlistsRowSortBy),
+              );
 
               final response = await session.client.itemsApi.getItems(
                 includeItemTypes: const ['Playlist'],
@@ -543,9 +555,9 @@ class MultiServerRepository {
               final pageCount = (startIndex / _defaultLimit).ceil();
               final targetStartIndex = pageCount * _defaultLimit;
               _rowOffsets[cacheKey] = targetStartIndex + _defaultLimit;
-              final sortBy =
-                  prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-                  _defaultSortBy;
+              final sortBy = _sortByParameter(
+                prefs?.get(UserPreferences.audioRowsSortBy),
+              );
 
               final response = await session.client.itemsApi.getItems(
                 includeItemTypes: const ['Playlist'],
@@ -568,9 +580,9 @@ class MultiServerRepository {
               return items;
             case HomeRowType.audioArtists:
               _rowOffsets[cacheKey] = startIndex + _defaultLimit;
-              final sortBy =
-                  prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-                  _defaultSortBy;
+              final sortBy = _sortByParameter(
+                prefs?.get(UserPreferences.audioRowsSortBy),
+              );
 
               final response = await session.client.itemsApi.getItems(
                 includeItemTypes: const ['MusicArtist'],
@@ -589,9 +601,9 @@ class MultiServerRepository {
               return items;
             case HomeRowType.audioAlbums:
               _rowOffsets[cacheKey] = startIndex + _defaultLimit;
-              final sortBy =
-                  prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-                  _defaultSortBy;
+              final sortBy = _sortByParameter(
+                prefs?.get(UserPreferences.audioRowsSortBy),
+              );
 
               final response = await session.client.itemsApi.getItems(
                 includeItemTypes: const ['MusicAlbum'],
@@ -610,9 +622,9 @@ class MultiServerRepository {
               return items;
             case HomeRowType.favorites:
               final favoriteFilter = FavoriteTypeFilter.fromRowId(row.id);
-              final sortBy =
-                  prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ??
-                  _defaultSortBy;
+              final sortBy = _sortByParameter(
+                prefs?.get(UserPreferences.favoritesRowSortBy),
+              );
               _rowOffsets[cacheKey] = startIndex + _defaultLimit;
 
               final response = await session.client.itemsApi.getItems(
@@ -632,15 +644,16 @@ class MultiServerRepository {
                   response['TotalRecordCount'] as int? ?? items.length;
               return items;
             case HomeRowType.collections:
-              final sortBy =
-                  prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ??
-                  _defaultSortBy;
+              final sortBy = _sortByParameter(
+                prefs?.get(UserPreferences.collectionsRowSortBy),
+              );
+              final sortOrder = sortBy != null ? 'Ascending' : null;
               _rowOffsets[cacheKey] = startIndex + _defaultLimit;
 
               final response = await session.client.itemsApi.getItems(
                 includeItemTypes: const ['BoxSet'],
                 sortBy: sortBy,
-                sortOrder: 'Ascending',
+                sortOrder: sortOrder,
                 recursive: true,
                 startIndex: startIndex,
                 limit: _defaultLimit,
@@ -653,9 +666,9 @@ class MultiServerRepository {
                   response['TotalRecordCount'] as int? ?? items.length;
               return items;
             case HomeRowType.genres:
-              final sortBy =
-                  prefs?.get(UserPreferences.genresRowSortBy).apiValue ??
-                  _defaultSortBy;
+              final sortBy = _sortByParameter(
+                prefs?.get(UserPreferences.genresRowSortBy),
+              );
               final includeItemTypes = prefs
                   ?.get(UserPreferences.genresRowItemFilter)
                   .includeItemTypes;
@@ -762,10 +775,14 @@ class MultiServerRepository {
         row.rowType == HomeRowType.latestMedia) {
       if (row.rowType == HomeRowType.playlists ||
           row.rowType == HomeRowType.audioPlaylists) {
-        final sortBy = row.rowType == HomeRowType.audioPlaylists
-            ? (prefs?.get(UserPreferences.audioRowsSortBy).apiValue ?? _defaultSortBy)
-            : (prefs?.get(UserPreferences.playlistsRowSortBy).apiValue ?? _defaultSortBy);
-        if (sortBy == 'SortName') {
+        final sortBy = _sortByParameter(
+          row.rowType == HomeRowType.audioPlaylists
+              ? prefs?.get(UserPreferences.audioRowsSortBy)
+              : prefs?.get(UserPreferences.playlistsRowSortBy),
+        );
+        if (sortBy == null) {
+          // Keep the server-provided order.
+        } else if (sortBy == 'SortName') {
           uniqueCombined.sort((a, b) => a.name.compareTo(b.name));
         } else {
           _sortAggregatedItems(
@@ -779,26 +796,24 @@ class MultiServerRepository {
     } else {
       final sortBy = switch (row.rowType) {
         HomeRowType.favorites =>
-          prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ??
-              _defaultSortBy,
+          _sortByParameter(prefs?.get(UserPreferences.favoritesRowSortBy)),
         HomeRowType.collections =>
-          prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ??
-              _defaultSortBy,
+          _sortByParameter(prefs?.get(UserPreferences.collectionsRowSortBy)),
         HomeRowType.genres =>
-          prefs?.get(UserPreferences.genresRowSortBy).apiValue ??
-              _defaultSortBy,
+          _sortByParameter(prefs?.get(UserPreferences.genresRowSortBy)),
         HomeRowType.audioArtists ||
         HomeRowType.audioAlbums =>
-          prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-              _defaultSortBy,
+          _sortByParameter(prefs?.get(UserPreferences.audioRowsSortBy)),
         _ => _defaultSortBy,
       };
 
-      sortedCombined = _sortAggregatedItems(
-        uniqueCombined,
-        sortBy: sortBy,
-        sortOrder: 'Ascending',
-      );
+      sortedCombined = sortBy == null
+          ? uniqueCombined
+          : _sortAggregatedItems(
+              uniqueCombined,
+              sortBy: sortBy,
+              sortOrder: 'Ascending',
+            );
     }
 
     final totalCount = sessions.fold<int>(0, (sum, session) {
@@ -816,8 +831,8 @@ class MultiServerRepository {
     List<String>? includeItemTypes,
     bool? isFavorite,
     int limit = _defaultLimit,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     final sessions = await getLoggedInServers();
     final perServer = (limit * 3).clamp(1, 100);
@@ -844,12 +859,14 @@ class MultiServerRepository {
       ),
     );
 
-    final all = _sortAggregatedItems(
-      results.expand((e) => e).toList(growable: false),
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-    );
-
+    final combined = results.expand((e) => e).toList(growable: false);
+    final all = sortBy == null
+        ? combined
+        : _sortAggregatedItems(
+            combined,
+            sortBy: sortBy,
+            sortOrder: sortOrder ?? _defaultSortOrder,
+          );
     final takenItems = all.take(limit).toList();
     final totalCount = sessions.fold<int>(0, (sum, session) {
       return sum + (_rowTotals['${id}_${session.server.id}'] ?? 0);

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -32,6 +32,9 @@ class RowDataSource {
   static const _defaultSortOrder = 'Ascending';
   static const _genreArtworkConcurrency = 6;
 
+  static String? _sortByParameter(LibrarySortBy? sortBy) =>
+      sortBy == null ? _defaultSortBy : sortBy.sortByParameter;
+
   static const _fields =
       'DateCreated,Type,UserData,Overview,Genres,CommunityRating,CriticRating,'
       'OfficialRating,RunTimeTicks,ProductionYear,SeriesName,'
@@ -246,13 +249,13 @@ class RowDataSource {
   Future<HomeRow> loadPlaylists(
     String serverId, {
     String? mediaType,
-    String? sortBy,
-    String? sortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     final response = await _getItemsWithFallback(
       includeItemTypes: const ['Playlist'],
-      sortBy: sortBy ?? 'SortName',
-      sortOrder: sortOrder ?? 'Ascending',
+      sortBy: sortBy,
+      sortOrder: sortOrder,
       recursive: true,
       limit: _defaultLimit,
       fields: '$_fields,ChildCount,RecursiveItemCount',
@@ -283,8 +286,8 @@ class RowDataSource {
     required String rowId,
     required String title,
     List<String>? includeItemTypes,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     return _loadSortedItemsRow(
       serverId: serverId,
@@ -300,8 +303,8 @@ class RowDataSource {
 
   Future<HomeRow> loadCollections(
     String serverId, {
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     return _loadSortedItemsRow(
       serverId: serverId,
@@ -316,8 +319,8 @@ class RowDataSource {
 
   Future<HomeRow> loadAudioArtists(
     String serverId, {
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     final row = await _loadSortedItemsRow(
       serverId: serverId,
@@ -333,8 +336,8 @@ class RowDataSource {
 
   Future<HomeRow> loadAudioAlbums(
     String serverId, {
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     final row = await _loadSortedItemsRow(
       serverId: serverId,
@@ -350,8 +353,8 @@ class RowDataSource {
 
   Future<HomeRow> loadAudioPlaylists(
     String serverId, {
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
   }) async {
     final row = await loadPlaylists(
       serverId,
@@ -369,8 +372,8 @@ class RowDataSource {
 
   Future<HomeRow> loadGenres(
     String serverId, {
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
     List<String>? includeItemTypes,
     String? parentId,
   }) async {
@@ -526,8 +529,8 @@ class RowDataSource {
     required String collectionId,
     required String title,
     required String rowId,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
     int startIndex = 0,
     int limit = _defaultLimit,
   }) async {
@@ -553,8 +556,8 @@ class RowDataSource {
     required String playlistId,
     required String title,
     required String rowId,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
     int startIndex = 0,
     int limit = _defaultLimit,
   }) async {
@@ -580,8 +583,8 @@ class RowDataSource {
     required String genreId,
     required String title,
     required String rowId,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
     List<String>? includeItemTypes,
     int startIndex = 0,
     int limit = _defaultLimit,
@@ -612,8 +615,8 @@ class RowDataSource {
     required HomeRowType rowType,
     List<String>? includeItemTypes,
     bool? isFavorite,
-    String sortBy = _defaultSortBy,
-    String sortOrder = _defaultSortOrder,
+    String? sortBy = _defaultSortBy,
+    String? sortOrder = _defaultSortOrder,
     int limit = _defaultLimit,
   }) async {
     final response = await _getItemsWithFallback(
@@ -686,8 +689,8 @@ class RowDataSource {
     String parentId,
     String serverId, {
     List<String>? includeItemTypes,
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
+    String? sortBy = 'SortName',
+    String? sortOrder = 'Ascending',
   }) async {
     final response = await _getItemsWithFallback(
       parentId: parentId,
@@ -756,8 +759,8 @@ class RowDataSource {
     String serverId, {
     required String title,
     required List<String> includeItemTypes,
-    String sortBy = 'SortName',
-    String sortOrder = 'Ascending',
+    String? sortBy = 'SortName',
+    String? sortOrder = 'Ascending',
   }) async {
     final isAlbumArtistBrowse =
         includeItemTypes.length == 1 && includeItemTypes.first == 'AlbumArtist';
@@ -837,9 +840,9 @@ class RowDataSource {
         if (parsed != null &&
             parsed.source == HomeSectionPluginSource.playlists) {
           final playlistId = parsed.additionalData;
-          var sortBy = _defaultSortBy;
+          String? sortBy = _defaultSortBy;
           if (prefs != null) {
-            sortBy = prefs.get(UserPreferences.playlistsRowSortBy).apiValue;
+            sortBy = prefs.get(UserPreferences.playlistsRowSortBy).sortByParameter;
           }
           response = await _getItemsWithFallback(
             parentId: playlistId,
@@ -868,9 +871,9 @@ class RowDataSource {
           );
         }
       case HomeRowType.favorites:
-        final sortBy =
-            prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ??
-            _defaultSortBy;
+        final sortBy = _sortByParameter(
+          prefs?.get(UserPreferences.favoritesRowSortBy),
+        );
         response = await _getItemsWithFallback(
           includeItemTypes: FavoriteTypeFilter.fromRowId(row.id).itemTypes,
           sortBy: sortBy,
@@ -881,9 +884,10 @@ class RowDataSource {
           isFavorite: true,
         );
       case HomeRowType.collections:
-        final sortBy =
-            prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ??
-            _defaultSortBy;
+        final sortBy = _sortByParameter(
+          prefs?.get(UserPreferences.collectionsRowSortBy),
+        );
+        final sortOrder = sortBy == null ? null : _defaultSortOrder;
         final parsed = _parseStableId(row.id);
         final parentId =
             (parsed != null &&
@@ -897,15 +901,15 @@ class RowDataSource {
           parentId: parentId,
           includeItemTypes: includeItemTypes,
           sortBy: sortBy,
-          sortOrder: 'Ascending',
+          sortOrder: sortOrder,
           recursive: true,
           startIndex: currentOffset,
           limit: _defaultLimit,
         );
       case HomeRowType.audioArtists:
-        final sortBy =
-            prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-            _defaultSortBy;
+        final sortBy = _sortByParameter(
+          prefs?.get(UserPreferences.audioRowsSortBy),
+        );
         response = await _getItemsWithFallback(
           includeItemTypes: const ['MusicArtist'],
           sortBy: sortBy,
@@ -915,9 +919,9 @@ class RowDataSource {
           limit: _defaultLimit,
         );
       case HomeRowType.audioAlbums:
-        final sortBy =
-            prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-            _defaultSortBy;
+        final sortBy = _sortByParameter(
+          prefs?.get(UserPreferences.audioRowsSortBy),
+        );
         response = await _getItemsWithFallback(
           includeItemTypes: const ['MusicAlbum'],
           sortBy: sortBy,
@@ -927,9 +931,9 @@ class RowDataSource {
           limit: _defaultLimit,
         );
       case HomeRowType.audioPlaylists:
-        final sortBy =
-            prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-            _defaultSortBy;
+        final sortBy = _sortByParameter(
+          prefs?.get(UserPreferences.audioRowsSortBy),
+        );
         final pageCount = (currentOffset / _defaultLimit).ceil();
         final startIndex = pageCount * _defaultLimit;
         response = await _getItemsWithFallback(
@@ -942,9 +946,9 @@ class RowDataSource {
           fields: '$_fields,ChildCount,RecursiveItemCount',
         );
       case HomeRowType.genres:
-        final sortBy =
-            prefs?.get(UserPreferences.genresRowSortBy).apiValue ??
-            _defaultSortBy;
+        final sortBy = _sortByParameter(
+          prefs?.get(UserPreferences.genresRowSortBy),
+        );
         final includeItemTypes = prefs
             ?.get(UserPreferences.genresRowItemFilter)
             .includeItemTypes;
@@ -1462,11 +1466,13 @@ class RowDataSource {
           );
         }
         try {
-          var sortBy = _defaultSortBy;
+          String? sortBy = _defaultSortBy;
+          String? sortOrder = _defaultSortOrder;
           if (GetIt.instance.isRegistered<UserPreferences>()) {
             sortBy = GetIt.instance<UserPreferences>()
                 .get(UserPreferences.collectionsRowSortBy)
-                .apiValue;
+                .sortByParameter;
+            if (sortBy == null) sortOrder = null;
           }
           final row = await loadCollectionRow(
             serverId,
@@ -1474,7 +1480,7 @@ class RowDataSource {
             title: title,
             rowId: rowId,
             sortBy: sortBy,
-            sortOrder: _defaultSortOrder,
+            sortOrder: sortOrder,
           );
           return row;
         } catch (_) {
@@ -1490,11 +1496,11 @@ class RowDataSource {
           return HomeRow(id: rowId, title: title, rowType: HomeRowType.genres);
         }
         try {
-          var sortBy = _defaultSortBy;
+          String? sortBy = _defaultSortBy;
           List<String>? includeItemTypes;
           if (GetIt.instance.isRegistered<UserPreferences>()) {
             final prefs = GetIt.instance<UserPreferences>();
-            sortBy = prefs.get(UserPreferences.genresRowSortBy).apiValue;
+            sortBy = prefs.get(UserPreferences.genresRowSortBy).sortByParameter;
             includeItemTypes = prefs
                 .get(UserPreferences.genresRowItemFilter)
                 .includeItemTypes;
@@ -1522,11 +1528,11 @@ class RowDataSource {
           );
         }
         try {
-          var sortBy = _defaultSortBy;
+          String? sortBy = _defaultSortBy;
           if (GetIt.instance.isRegistered<UserPreferences>()) {
             sortBy = GetIt.instance<UserPreferences>()
                 .get(UserPreferences.playlistsRowSortBy)
-                .apiValue;
+                .sortByParameter;
           }
           final row = await loadPlaylistRow(
             serverId,

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -320,6 +320,7 @@ enum HomeSectionType {
 }
 
 enum LibrarySortBy {
+  original('', 'Original'),
   name('SortName', 'Name'),
   dateAdded('DateCreated', 'Date Added'),
   premiereDate('PremiereDate', 'Premiere Date'),
@@ -332,6 +333,19 @@ enum LibrarySortBy {
   const LibrarySortBy(this.apiValue, this.displayName);
   final String apiValue;
   final String displayName;
+
+  String? get sortByParameter => this == original ? null : apiValue;
+
+  static const sortedValues = [
+    name,
+    dateAdded,
+    premiereDate,
+    rating,
+    runtime,
+    random,
+    criticRating,
+    communityRating,
+  ];
 }
 
 enum GenresRowItemFilter {

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1850,7 +1850,7 @@ class UserPreferences extends ChangeNotifier {
       EnumPreference(
         key: 'library_sort_by_$libraryId',
         defaultValue: LibrarySortBy.name,
-        values: LibrarySortBy.values,
+        values: LibrarySortBy.sortedValues,
       );
 
   static EnumPreference<SortDirection> librarySortDirection(String libraryId) =>

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -778,31 +778,31 @@ class UserPreferences extends ChangeNotifier {
   );
   static final favoritesRowSortBy = EnumPreference(
     key: 'pref_favorites_row_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.original,
     values: LibrarySortBy.values,
   );
 
   static final collectionsRowSortBy = EnumPreference(
     key: 'pref_collections_row_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.original,
     values: LibrarySortBy.values,
   );
 
   static final genresRowSortBy = EnumPreference(
     key: 'pref_genres_row_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.original,
     values: LibrarySortBy.values,
   );
 
   static final playlistsRowSortBy = EnumPreference(
     key: 'pref_playlists_row_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.original,
     values: LibrarySortBy.values,
   );
 
   static final audioRowsSortBy = EnumPreference(
     key: 'pref_audio_rows_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.original,
     values: LibrarySortBy.values,
   );
 

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -1037,7 +1037,7 @@ class _SortDialogState extends State<_SortDialog> {
             ),
             Divider(color: dividerColor),
             _sectionHeader(AppLocalizations.of(context).sortBy),
-            for (final option in LibrarySortBy.values)
+            for (final option in LibrarySortBy.sortedValues)
               _radioTile(
                 label: option.displayName,
                 selected: vm.sortBy == option,

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -1613,7 +1613,7 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                         LibrarySortBy.dateAdded,
                         LibrarySortBy.random,
                       ]
-                    : LibrarySortBy.values.where((o) => !vm.isMusicBrowse || (
+                    : LibrarySortBy.sortedValues.where((o) => !vm.isMusicBrowse || (
                         o != LibrarySortBy.rating &&
                         o != LibrarySortBy.criticRating &&
                         o != LibrarySortBy.communityRating

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -849,15 +849,18 @@ class HomeViewModel extends ChangeNotifier {
     final l10n = currentAppLocalizations();
     final favoritesSortBy = _prefs
         .get(UserPreferences.favoritesRowSortBy)
-        .apiValue;
+        .sortByParameter;
     final collectionsSortBy = _prefs
         .get(UserPreferences.collectionsRowSortBy)
-        .apiValue;
-    final genresSortBy = _prefs.get(UserPreferences.genresRowSortBy).apiValue;
+        .sortByParameter;
+    final genresSortBy = _prefs
+        .get(UserPreferences.genresRowSortBy)
+        .sortByParameter;
     final genresItemFilter = _prefs
         .get(UserPreferences.genresRowItemFilter)
         .includeItemTypes;
     const sortOrder = 'Ascending';
+    final collectionsSortOrder = collectionsSortBy != null ? sortOrder : null;
     switch (section) {
       case HomeSectionType.resume:
         return [
@@ -884,7 +887,7 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.playlists:
         final playlistsSortBy = _prefs
             .get(UserPreferences.playlistsRowSortBy)
-            .apiValue;
+            .sortByParameter;
         return [
           _multiServerEnabled
               ? await _multiServerRepo.getAggregatedPlaylists(
@@ -900,7 +903,7 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.audioArtists:
         final audioSortBy = _prefs
             .get(UserPreferences.audioRowsSortBy)
-            .apiValue;
+            .sortByParameter;
         return [
           _multiServerEnabled
               ? await _multiServerRepo.getAggregatedAudioArtists(
@@ -916,7 +919,7 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.audioAlbums:
         final audioSortBy = _prefs
             .get(UserPreferences.audioRowsSortBy)
-            .apiValue;
+            .sortByParameter;
         return [
           _multiServerEnabled
               ? await _multiServerRepo.getAggregatedAudioAlbums(
@@ -932,7 +935,7 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.audioPlaylists:
         final audioSortBy = _prefs
             .get(UserPreferences.audioRowsSortBy)
-            .apiValue;
+            .sortByParameter;
         return [
           _multiServerEnabled
               ? await _multiServerRepo.getAggregatedAudioPlaylists(
@@ -979,12 +982,12 @@ class HomeViewModel extends ChangeNotifier {
           _multiServerEnabled
               ? await _multiServerRepo.getAggregatedCollections(
                   sortBy: collectionsSortBy,
-                  sortOrder: sortOrder,
+                  sortOrder: collectionsSortOrder,
                 )
               : await _dataSource.loadCollections(
                   _serverId,
                   sortBy: collectionsSortBy,
-                  sortOrder: sortOrder,
+                  sortOrder: collectionsSortOrder,
                 ),
         ];
       case HomeSectionType.genres:


### PR DESCRIPTION
# Pull Request

## Summary
Adds an `Original` sort option for configurable Home rows. When selected, Moonfin preserves the server-provided/default item order by omitting the `sortBy` query parameter instead of applying a Jellyfin sort field.

Home row sort preferences now support `Original` for Favorites, Collections, Genres, Playlists, and Audio playlists. These Home rows also default to `Original`, so their natural order is preserved unless the user explicitly chooses another sort mode.

Normal browse/library sorting keeps the existing behavior and still defaults to sorting by name.

## Related Issues
None.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `LibrarySortBy.original`.
- Added nullable sort parameter mapping so `Original` resolves to no `sortBy` argument.
- Exposed `Original` for Home row sort preferences while keeping regular browse/library sort options unchanged.
- Changed configurable Home row sort defaults to `Original`.
- Updated Home row loading paths so `sortBy` is only passed when the selected option is not `Original`.
- Applied the same behavior across single-server and multi-server row loading.

## Platform
- [x] Android
- [x] iOS
- [x] tvOS
- [x] Web
- [x] macOS
- [x] Windows
- [x] Linux
- [x] All / Shared code

## Testing
- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why)

### Test Steps
changed Home-Collection-Ordering from `Name` to `Original` and back to `Name`

## Screenshots (if applicable)


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced