### PR TITLE
Enhance home screen text legibility under Neon Pulse theme

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2894,7 +2894,7 @@ class _ContentRowsState extends State<_ContentRows>
       UserPreferences.enableAdditionalRatings,
     );
     final hasAdditionalRatingsPadding = hasAdditionalRatings ? 8.0 : 0.0;
-    final heightBudget = 165.0 + hasAdditionalRatingsPadding;
+    final heightBudget = 175.0 + hasAdditionalRatingsPadding;
     return heightBudget;
   }
 
@@ -3854,14 +3854,16 @@ class _ContentRowsState extends State<_ContentRows>
                   ? '$episodeInfo - ${item.name}'
                   : item.name;
               final row3Text = _v2MetadataLine(item);
+              final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
               final baseTextStyle =
                   Theme.of(context).textTheme.bodySmall ??
                   const TextStyle(fontSize: 12);
-              final subtitleColor = Theme.of(
-                context,
-              ).colorScheme.onSurface.withAlpha(153);
+              final subtitleColor = isNeon
+                  ? AppColorScheme.onSurface
+                  : Theme.of(context).colorScheme.onSurface.withAlpha(180);
               final subtitleStyle = baseTextStyle.copyWith(
                 color: subtitleColor,
+                shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
               );
               cardSubtitleWidget = Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -4060,10 +4062,14 @@ class _ContentRowsState extends State<_ContentRows>
       return SizedBox(width: cardWidth);
     }
 
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final baseStyle =
         Theme.of(context).textTheme.bodySmall ?? const TextStyle(fontSize: 12);
     final overviewStyle = baseStyle.copyWith(
-      color: Theme.of(context).colorScheme.onSurface.withAlpha(140),
+      color: isNeon
+          ? AppColorScheme.onSurface
+          : Theme.of(context).colorScheme.onSurface.withAlpha(180),
+      shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
       height: 1.4,
     );
 

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -159,13 +159,21 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
         Theme.of(context).textTheme.bodySmall ?? const TextStyle(fontSize: 12);
     final subtitleColor =
         widget.subtitleColor ??
-        Theme.of(context).colorScheme.onSurface.withAlpha(153);
+        (isNeon
+            ? AppColorScheme.onSurface
+            : Theme.of(context).colorScheme.onSurface.withAlpha(153));
     final titleStyle = baseTextStyle.copyWith(
       color:
           widget.titleColor ??
           (isNeon ? AppColorScheme.accent : baseTextStyle.color),
+      fontWeight: FontWeight.bold,
+      fontSize: (baseTextStyle.fontSize ?? 12) + 1.0,
+      shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
     );
-    final subtitleStyle = baseTextStyle.copyWith(color: subtitleColor);
+    final subtitleStyle = baseTextStyle.copyWith(
+      color: subtitleColor,
+      shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
+    );
     final textScaler = MediaQuery.textScalerOf(context);
 
     double lineHeightFor(TextStyle style) {


### PR DESCRIPTION
# Pull Request

## Summary
Enhance legibility of title, subtitle/metadata, and overview text on the Home Screen under the Neon Pulse theme, resolving layout overflow on card expansion. This is to match what the text looks like in the new details page.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added black drop shadows (`[Shadow(blurRadius: 4, color: Colors.black54)]`) to titles and subtitles in `MediaCard`.
- Added black drop shadows to overview text and focused episode metadata subtitles on the Home Screen.
- Made card titles bold and increased their font size by `1.0` dynamically across all cards for better readability.
- Removed text transparency from themed labels/overviews when the `neon_pulse` theme is active, ensuring fully opaque themed colors (cyan/magenta) are used.
- Increased the V2 row metadata height budget from `165.0` to `175.0` in `home_screen.dart` to cleanly fit the enlarged bold titles and prevent a layout overflow.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Apply the Neon Pulse theme.
2. Select cards in rows on the Home Screen and observe text legibility (title, metadata, plot overview) against dynamic, colorful backdrops.
3. Observe that text shadows outline letters and full color opacity prevents washing out.
4. Verify there are no layout height overflows under the card on expansion.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Original
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-01_10-08-25" src="https://github.com/user-attachments/assets/22e36d40-0144-47a0-86b8-72b8c0c94540" />

## New
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-01_10-38-07" src="https://github.com/user-attachments/assets/f1683989-b11f-4a40-bf6b-8f93b2a5b95d" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
