### PR TITLE
Beginning of carplay compatibility

### DIFF
--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.developer.networking.multicast</key>
 	<true/>
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
# Pull Request

## Summary
Now that #251 is fixed, adding carplay to the ios entitlements so currently playing media *should* show up in carplay

Note: you still need to register the app as carplay compatible with apple: https://developer.apple.com/download/files/CarPlay-Developer-Guide.pdf

<img width="847" height="569" alt="image" src="https://github.com/user-attachments/assets/0495bfb3-a3fc-44e8-a057-1e575f986bdb" />

Note2: similar to #580, this only adds the existing media controls as they are available in notifications. Media still has to be queued from the phone. Library browsing in car will have to be added for both android auto and carplay at a later date (that's a 2.4 problem imo, this should be enough of a start for 2.3)

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add carplay-audio to ios entitlements
- add to correct entitlements file unlike #629 

## Platform
- [ ] Android
- [X] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
