### PR TITLE
Initial Stab at Audiobook UI

### DIFF
--- a/lib/data/services/audiobook_resume_service.dart
+++ b/lib/data/services/audiobook_resume_service.dart
@@ -1,0 +1,27 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Stores an audiobook's last playback position locally, keyed per server+item.
+///
+/// Audiobooks are so long that Jellyfin's percentage-based resume thresholds
+/// discard early and near complete positions, so the client keeps its own
+/// authoritative resume point rather than relying on the server value.
+class AudiobookResumeService {
+  static String _key(String serverId, String itemId) =>
+      'audiobook_resume_${serverId}_$itemId';
+
+  Future<void> save(String serverId, String itemId, int positionMs) async {
+    if (positionMs <= 0) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_key(serverId, itemId), positionMs);
+  }
+
+  Future<int?> load(String serverId, String itemId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_key(serverId, itemId));
+  }
+
+  Future<void> clear(String serverId, String itemId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key(serverId, itemId));
+  }
+}

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -8,6 +8,7 @@ import '../../data/models/aggregated_item.dart';
 import '../../data/repositories/offline_repository.dart';
 import '../../data/services/audiobook_bookmarks_service.dart';
 import '../../data/services/audiobook_notes_service.dart';
+import '../../data/services/audiobook_resume_service.dart';
 import '../../data/services/media_server_client_factory.dart';
 import '../../data/services/offline_playback_tracker.dart';
 
@@ -583,6 +584,9 @@ void registerPlaybackModule() {
   _getIt.registerLazySingleton<AudiobookNotesService>(
     () => AudiobookNotesService(),
     dispose: (s) => s.dispose(),
+  );
+  _getIt.registerLazySingleton<AudiobookResumeService>(
+    () => AudiobookResumeService(),
   );
   _getIt.registerLazySingleton<SleepTimerController>(
     () => SleepTimerController(_getIt<PlaybackManager>()),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7725,6 +7725,25 @@
   "audiobookBookmarks": "Bookmarks",
   "audiobookNotes": "Notes",
   "audiobookQueue": "Queue",
+  "audiobookTimeline": "Timeline",
+  "audiobookTimelineEmpty": "Timeline is empty",
+  "audiobookWholeBook": "Whole book",
+  "audiobookWholeBookProgress": "{percent}% · {time} left",
+  "@audiobookWholeBookProgress": {
+    "placeholders": {"percent": {"type": "String"}, "time": {"type": "String"}}
+  },
+  "audiobookFocusedTimeline": "Focused Timeline",
+  "audiobookExportBookmarks": "Export Bookmarks",
+  "audiobookExportNotes": "Export Notes",
+  "audiobookExportAll": "Export All",
+  "audiobookExportSuccess": "Exported to {path}",
+  "@audiobookExportSuccess": {
+    "placeholders": {"path": {"type": "String"}}
+  },
+  "audiobookExportFailed": "Export failed: {error}",
+  "@audiobookExportFailed": {
+    "placeholders": {"error": {"type": "String"}}
+  },
   "audiobookLyrics": "Lyrics",
   "audiobookAddBookmark": "Add bookmark",
   "audiobookAddNote": "Add note",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14992,6 +14992,66 @@ abstract class AppLocalizations {
   /// **'Queue'**
   String get audiobookQueue;
 
+  /// No description provided for @audiobookTimeline.
+  ///
+  /// In en, this message translates to:
+  /// **'Timeline'**
+  String get audiobookTimeline;
+
+  /// No description provided for @audiobookTimelineEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'Timeline is empty'**
+  String get audiobookTimelineEmpty;
+
+  /// No description provided for @audiobookWholeBook.
+  ///
+  /// In en, this message translates to:
+  /// **'Whole book'**
+  String get audiobookWholeBook;
+
+  /// No description provided for @audiobookWholeBookProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'{percent}% · {time} left'**
+  String audiobookWholeBookProgress(String percent, String time);
+
+  /// No description provided for @audiobookFocusedTimeline.
+  ///
+  /// In en, this message translates to:
+  /// **'Focused Timeline'**
+  String get audiobookFocusedTimeline;
+
+  /// No description provided for @audiobookExportBookmarks.
+  ///
+  /// In en, this message translates to:
+  /// **'Export Bookmarks'**
+  String get audiobookExportBookmarks;
+
+  /// No description provided for @audiobookExportNotes.
+  ///
+  /// In en, this message translates to:
+  /// **'Export Notes'**
+  String get audiobookExportNotes;
+
+  /// No description provided for @audiobookExportAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Export All'**
+  String get audiobookExportAll;
+
+  /// No description provided for @audiobookExportSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Exported to {path}'**
+  String audiobookExportSuccess(String path);
+
+  /// No description provided for @audiobookExportFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Export failed: {error}'**
+  String audiobookExportFailed(String error);
+
   /// No description provided for @audiobookLyrics.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -8408,6 +8408,42 @@ class AppLocalizationsAf extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -8354,6 +8354,42 @@ class AppLocalizationsAr extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8435,6 +8435,42 @@ class AppLocalizationsBe extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8480,6 +8480,42 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -8396,6 +8396,42 @@ class AppLocalizationsBn extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8530,6 +8530,42 @@ class AppLocalizationsCa extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8416,6 +8416,42 @@ class AppLocalizationsCs extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8429,6 +8429,42 @@ class AppLocalizationsCy extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8400,6 +8400,42 @@ class AppLocalizationsDa extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8474,6 +8474,42 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8526,6 +8526,42 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8371,6 +8371,42 @@ class AppLocalizationsEn extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -8392,6 +8392,42 @@ class AppLocalizationsEo extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8482,6 +8482,42 @@ class AppLocalizationsEs extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8417,6 +8417,42 @@ class AppLocalizationsEt extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -8361,6 +8361,42 @@ class AppLocalizationsFa extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8428,6 +8428,42 @@ class AppLocalizationsFi extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8537,6 +8537,42 @@ class AppLocalizationsFr extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8497,6 +8497,42 @@ class AppLocalizationsGl extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -8296,6 +8296,42 @@ class AppLocalizationsHe extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -8378,6 +8378,42 @@ class AppLocalizationsHi extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -8422,6 +8422,42 @@ class AppLocalizationsHr extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8465,6 +8465,42 @@ class AppLocalizationsHu extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -8423,6 +8423,42 @@ class AppLocalizationsId extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8441,6 +8441,42 @@ class AppLocalizationsIt extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -8205,6 +8205,42 @@ class AppLocalizationsJa extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8433,6 +8433,42 @@ class AppLocalizationsKk extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8448,6 +8448,42 @@ class AppLocalizationsKn extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -8200,6 +8200,42 @@ class AppLocalizationsKo extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8434,6 +8434,42 @@ class AppLocalizationsLt extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8444,6 +8444,42 @@ class AppLocalizationsLv extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8451,6 +8451,42 @@ class AppLocalizationsMk extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8498,6 +8498,42 @@ class AppLocalizationsMl extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8429,6 +8429,42 @@ class AppLocalizationsMn extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8401,6 +8401,42 @@ class AppLocalizationsNb extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8431,6 +8431,42 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -8381,6 +8381,42 @@ class AppLocalizationsPa extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -8443,6 +8443,42 @@ class AppLocalizationsPl extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8462,6 +8462,42 @@ class AppLocalizationsPt extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8446,6 +8446,42 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8452,6 +8452,42 @@ class AppLocalizationsRu extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -8388,6 +8388,42 @@ class AppLocalizationsSi extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8433,6 +8433,42 @@ class AppLocalizationsSk extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8430,6 +8430,42 @@ class AppLocalizationsSl extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8461,6 +8461,42 @@ class AppLocalizationsSq extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -8427,6 +8427,42 @@ class AppLocalizationsSr extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8412,6 +8412,42 @@ class AppLocalizationsSv extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8453,6 +8453,42 @@ class AppLocalizationsSw extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8455,6 +8455,42 @@ class AppLocalizationsTa extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8453,6 +8453,42 @@ class AppLocalizationsTe extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -8347,6 +8347,42 @@ class AppLocalizationsTh extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8480,6 +8480,42 @@ class AppLocalizationsTl extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -8437,6 +8437,42 @@ class AppLocalizationsTr extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -8408,6 +8408,42 @@ class AppLocalizationsUg extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8454,6 +8454,42 @@ class AppLocalizationsUk extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -8414,6 +8414,42 @@ class AppLocalizationsVi extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -8157,6 +8157,42 @@ class AppLocalizationsYue extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8113,6 +8113,42 @@ class AppLocalizationsZh extends AppLocalizations {
   String get audiobookQueue => 'Queue';
 
   @override
+  String get audiobookTimeline => 'Timeline';
+
+  @override
+  String get audiobookTimelineEmpty => 'Timeline is empty';
+
+  @override
+  String get audiobookWholeBook => 'Whole book';
+
+  @override
+  String audiobookWholeBookProgress(String percent, String time) {
+    return '$percent% · $time left';
+  }
+
+  @override
+  String get audiobookFocusedTimeline => 'Focused Timeline';
+
+  @override
+  String get audiobookExportBookmarks => 'Export Bookmarks';
+
+  @override
+  String get audiobookExportNotes => 'Export Notes';
+
+  @override
+  String get audiobookExportAll => 'Export All';
+
+  @override
+  String audiobookExportSuccess(String path) {
+    return 'Exported to $path';
+  }
+
+  @override
+  String audiobookExportFailed(String error) {
+    return 'Export failed: $error';
+  }
+
+  @override
   String get audiobookLyrics => 'Lyrics';
 
   @override

--- a/lib/playback/sleep_timer_controller.dart
+++ b/lib/playback/sleep_timer_controller.dart
@@ -18,6 +18,9 @@ class SleepTimerController extends ChangeNotifier {
   SleepTimerController(this._manager);
 
   final PlaybackManager _manager;
+  final _expiryController = StreamController<void>.broadcast();
+
+  Stream<void> get onExpired => _expiryController.stream;
 
   SleepTimerMode _mode = SleepTimerMode.off;
   Duration _remaining = Duration.zero;
@@ -27,10 +30,19 @@ class SleepTimerController extends ChangeNotifier {
   StreamSubscription? _queueSub;
   int? _chapterTargetMs;
 
+  SleepTimerMode _lastActiveMode = SleepTimerMode.off;
+  Duration _lastActiveDuration = Duration.zero;
+
+  bool _isPaused = false;
+
   SleepTimerMode get mode => _mode;
   Duration get remaining => _remaining;
   Duration get totalRequested => _totalRequested;
   bool get isActive => _mode != SleepTimerMode.off;
+  bool get isPaused => _isPaused;
+
+  SleepTimerMode get lastActiveMode => _lastActiveMode;
+  Duration get lastActiveDuration => _lastActiveDuration;
 
   /// Start a countdown timer of [duration]; on expiry pauses playback.
   void startDuration(Duration duration) {
@@ -39,6 +51,8 @@ class SleepTimerController extends ChangeNotifier {
     _mode = SleepTimerMode.duration;
     _totalRequested = duration;
     _remaining = duration;
+    _lastActiveMode = SleepTimerMode.duration;
+    _lastActiveDuration = duration;
     _tick = Timer.periodic(const Duration(seconds: 1), (_) => _onTick());
     notifyListeners();
   }
@@ -60,9 +74,12 @@ class SleepTimerController extends ChangeNotifier {
     _chapterTargetMs = targetMs;
     _remaining = Duration(milliseconds: targetMs - currentPositionMs);
     _totalRequested = _remaining;
+    _lastActiveMode = SleepTimerMode.endOfChapter;
+    _lastActiveDuration = _remaining;
     _positionSub = _manager.state.positionStream.listen(_onPositionTick);
     _queueSub = _manager.queueService.queueChangedStream.listen((_) => cancel());
     _tick = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (_isPaused || !_manager.state.isPlaying) return;
       final next = _remaining - const Duration(seconds: 1);
       _remaining = next < Duration.zero ? Duration.zero : next;
       notifyListeners();
@@ -81,6 +98,19 @@ class SleepTimerController extends ChangeNotifier {
     _mode = SleepTimerMode.off;
     _remaining = Duration.zero;
     _totalRequested = Duration.zero;
+    _isPaused = false;
+    notifyListeners();
+  }
+
+  void pauseTimer() {
+    if (!isActive) return;
+    _isPaused = true;
+    notifyListeners();
+  }
+
+  void resumeTimer() {
+    if (!isActive) return;
+    _isPaused = false;
     notifyListeners();
   }
 
@@ -104,6 +134,7 @@ class SleepTimerController extends ChangeNotifier {
   }
 
   void _onTick() {
+    if (_isPaused || !_manager.state.isPlaying) return;
     _remaining = _remaining - const Duration(seconds: 1);
     if (_remaining <= Duration.zero) {
       _completeAndStop();
@@ -113,6 +144,7 @@ class SleepTimerController extends ChangeNotifier {
   }
 
   void _onPositionTick(Duration pos) {
+    if (_isPaused || !_manager.state.isPlaying) return;
     final target = _chapterTargetMs;
     if (target == null) return;
     final remainingMs = target - pos.inMilliseconds;
@@ -123,16 +155,18 @@ class SleepTimerController extends ChangeNotifier {
     }
   }
 
-  Future<void> _completeAndStop() async {
+  void _completeAndStop() {
     try {
-      await _manager.pause();
+      unawaited(_manager.pause());
     } catch (_) {}
+    _expiryController.add(null);
     cancel();
   }
 
   @override
   void dispose() {
     cancel();
+    _expiryController.close();
     super.dispose();
   }
 }

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1405,6 +1405,11 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: 15,
   );
 
+  static final audiobookExtendSleepTimer = Preference(
+    key: 'pref_audiobook_extend_sleep_timer',
+    defaultValue: false,
+  );
+
   static final audiobookDrawerTab = Preference(
     key: 'pref_audiobook_drawer_tab',
     defaultValue: 'chapters',

--- a/lib/ui/screens/playback/audio_player_screen.dart
+++ b/lib/ui/screens/playback/audio_player_screen.dart
@@ -7,6 +7,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart' hide RepeatMode;
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:moonfin_native_video/moonfin_native_video.dart';
 import 'package:playback_core/playback_core.dart';
@@ -569,7 +570,9 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
     final item = _resolveCurrentItem();
     final attachMedia3View =
         PlatformDetection.useNativeVideoSurface && _activeMedia3Backend != null;
-    if (item != null && item.isAudiobook) {
+    final isAudiobookRoute = GoRouterState.of(context).uri.queryParameters['isAudiobook'] == 'true';
+    final isAudiobook = (item != null && item.isAudiobook) || isAudiobookRoute;
+    if (isAudiobook) {
       if (!attachMedia3View) {
         return const AudiobookPlayerView();
       }

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -773,20 +773,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                         ),
                         const SizedBox(height: AppSpacing.spaceLg),
                         _TitleBlock(item: item, centered: true),
-                        const SizedBox(height: AppSpacing.spaceLg),
-                        AudiobookProgressBar(
-                          position: _state.position,
-                          duration: _state.duration,
-                          chapters: chapters,
-                          bookmarks: _bookmarksList,
-                          notes: _notesList,
-                          showRemaining: _showRemaining,
-                          isTvFocused: false,
-                          onSeek: (d) => _manager.seekTo(d),
-                          onToggleRemaining: () => _setShowRemaining(!_showRemaining),
-                          formatPosition: formatAudiobookClock,
-                          formatRemaining: _formatRemaining,
-                        ),
                       ],
                     ),
                   ),
@@ -846,34 +832,28 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (splitLayout)
-            AudiobookZoomedProgressBar(
-              position: _state.position,
-              duration: _state.duration,
-              chapters: chapters,
-              bookmarks: _bookmarksList,
-              notes: _notesList,
-              isTvFocused: PlatformDetection.isTV &&
-                  _tvArea == _AudiobookFocusArea.progress,
-              onSeek: (d) => _manager.seekTo(d),
-              formatPosition: formatAudiobookClock,
-              formatRemaining: _formatRemaining,
-            )
-          else
-            AudiobookProgressBar(
-              position: _state.position,
-              duration: _state.duration,
-              chapters: chapters,
-              bookmarks: _bookmarksList,
-              notes: _notesList,
-              showRemaining: _showRemaining,
-              isTvFocused: PlatformDetection.isTV &&
-                  _tvArea == _AudiobookFocusArea.progress,
-              onSeek: (d) => _manager.seekTo(d),
-              onToggleRemaining: () => _setShowRemaining(!_showRemaining),
-              formatPosition: formatAudiobookClock,
-              formatRemaining: _formatRemaining,
-            ),
+          AudiobookZoomedProgressBar(
+            position: _state.position,
+            duration: _state.duration,
+            chapters: chapters,
+            bookmarks: _bookmarksList,
+            notes: _notesList,
+            isTvFocused: PlatformDetection.isTV &&
+                _tvArea == _AudiobookFocusArea.progress,
+            showRemaining: _showRemaining,
+            onSeek: (d) => _manager.seekTo(d),
+            onToggleRemaining: () => _setShowRemaining(!_showRemaining),
+            formatPosition: formatAudiobookClock,
+            formatRemaining: _formatRemaining,
+          ),
+          const SizedBox(height: AppSpacing.spaceXs),
+          AudiobookBookOverview(
+            position: _state.position,
+            duration: _state.duration,
+            chapters: chapters,
+            bookmarks: _bookmarksList,
+            notes: _notesList,
+          ),
           const SizedBox(height: AppSpacing.spaceSm),
           AudiobookTransportRow(
             isPlaying: _state.isPlaying,

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -681,7 +681,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
               if (PlatformDetection.isTV && !_drawerOpen) {
                 _drawerContentActive = false;
                 _tvArea = _AudiobookFocusArea.header;
-                _tvHeaderIndex = 2;
+                _tvHeaderIndex = 1;
               }
             });
           },
@@ -745,7 +745,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
               if (PlatformDetection.isTV && !_drawerOpen) {
                 _drawerContentActive = false;
                 _tvArea = _AudiobookFocusArea.header;
-                _tvHeaderIndex = 2;
+                _tvHeaderIndex = 1;
               }
             });
           },
@@ -1232,9 +1232,9 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     } else if (candidate == _AudiobookFocusArea.actionRail && _tvArea == _AudiobookFocusArea.transport) {
       _tvRailIndex = _tvTransportIndex;
     } else if (candidate == _AudiobookFocusArea.header && _tvArea == _AudiobookFocusArea.progress) {
-      _tvHeaderIndex = 2;
+      _tvHeaderIndex = 1;
     } else if (candidate == _AudiobookFocusArea.header && _tvArea == _AudiobookFocusArea.drawerTabs) {
-      _tvHeaderIndex = 2;
+      _tvHeaderIndex = 1;
     }
 
     if (candidate == _AudiobookFocusArea.drawerContent) {
@@ -1272,7 +1272,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     setState(() {
       switch (_tvArea) {
         case _AudiobookFocusArea.header:
-          _tvHeaderIndex = (_tvHeaderIndex + delta).clamp(0, 2);
+          _tvHeaderIndex = (_tvHeaderIndex + delta).clamp(0, 1);
           break;
         case _AudiobookFocusArea.progress:
           final ms = delta < 0
@@ -1317,9 +1317,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       case _AudiobookFocusArea.header:
         if (_tvHeaderIndex == 0) {
           Navigator.of(context).pop();
-        } else if (_tvHeaderIndex == 1 && item != null) {
-          _castToDevice(item);
-        } else if (_tvHeaderIndex == 2) {
+        } else if (_tvHeaderIndex == 1) {
           setState(() {
             _drawerOpen = !_drawerOpen;
             if (!_drawerOpen) {

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -283,6 +283,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   }
 
   bool _tabHasExport(AudiobookDrawerTab tab) {
+    if (PlatformDetection.isTV) return false;
     return tab == AudiobookDrawerTab.timeline ||
         tab == AudiobookDrawerTab.bookmarks ||
         tab == AudiobookDrawerTab.notes;
@@ -967,10 +968,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                         : -1,
                     tvSubIndex: _tvSubIndex,
                     onExport: () => _exportToCsv('All', _getTimelineEvents(chapters)),
-                    tvExportFocused: (PlatformDetection.isTV &&
-                        _tvArea == _AudiobookFocusArea.drawerContent &&
-                        _drawerContentActive &&
-                        _tvListIndex == -1),
                   ),
                 AudiobookDrawerTab.chapters => AudiobookChaptersList(
                     chapters: chapters,
@@ -1004,10 +1001,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                       )).toList();
                       _exportToCsv('Bookmarks', bEvents);
                     },
-                    tvExportFocused: (PlatformDetection.isTV &&
-                        _tvArea == _AudiobookFocusArea.drawerContent &&
-                        _drawerContentActive &&
-                        _tvListIndex == -1),
                   ),
                 AudiobookDrawerTab.notes => AudiobookNotesList(
                     item: item,
@@ -1034,10 +1027,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                       )).toList();
                       _exportToCsv('Notes', nEvents);
                     },
-                    tvExportFocused: (PlatformDetection.isTV &&
-                        _tvArea == _AudiobookFocusArea.drawerContent &&
-                        _drawerContentActive &&
-                        _tvListIndex == -1),
                   ),
                 AudiobookDrawerTab.queue => AudiobookQueueList(
                     queue: _queue,
@@ -1358,36 +1347,9 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           setState(() {
             _drawerContentActive = true;
             _tvSubIndex = 0;
-            _tvListIndex = _tabHasExport(_drawerTab) ? -1 : 0;
+            _tvListIndex = 0;
           });
         } else {
-          if (_tvListIndex == -1) {
-            if (_drawerTab == AudiobookDrawerTab.bookmarks) {
-              final bEvents = _bookmarksList.map((b) => TimelineEvent(
-                id: 'bookmark_${b.positionMs}',
-                type: TimelineEventType.bookmark,
-                title: b.label,
-                positionMs: b.positionMs,
-                date: b.createdAt,
-                originalObject: b,
-              )).toList();
-              _exportToCsv('Bookmarks', bEvents);
-            } else if (_drawerTab == AudiobookDrawerTab.notes) {
-              final nEvents = _notesList.map((n) => TimelineEvent(
-                id: 'note_${n.id}',
-                type: TimelineEventType.note,
-                title: 'Note: ${n.body}',
-                content: n.body,
-                positionMs: n.positionMs,
-                date: n.updatedAt,
-                originalObject: n,
-              )).toList();
-              _exportToCsv('Notes', nEvents);
-            } else if (_drawerTab == AudiobookDrawerTab.timeline) {
-              _exportToCsv('All', _getTimelineEvents(chapters));
-            }
-            return;
-          }
           switch (_drawerTab) {
             case AudiobookDrawerTab.timeline:
               final events = _getTimelineEvents(chapters);

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -676,47 +676,36 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           onClose: () => Navigator.of(context).pop(),
           onCast: item != null ? () => _castToDevice(item) : null,
           onCastSettings: _showCastControls,
-          onToggleDrawer: () {
-            setState(() {
-              _drawerOpen = !_drawerOpen;
-              if (PlatformDetection.isTV && !_drawerOpen) {
-                _drawerContentActive = false;
-                _tvArea = _AudiobookFocusArea.header;
-                _tvHeaderIndex = 1;
-              }
-            });
-          },
-          drawerOpen: _drawerOpen,
+          onToggleDrawer: () => _openDrawerSheet(context, item, chapters),
+          drawerOpen: false,
           tvFocusIndex: _tvArea == _AudiobookFocusArea.header ? _tvHeaderIndex : -1,
         ),
         Expanded(
-          child: _drawerOpen
-              ? _buildDrawer(context, item, chapters)
-              : SingleChildScrollView(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.spaceLg),
-                  child: Column(
-                    children: [
-                      const SizedBox(height: AppSpacing.spaceMd),
-                      _CoverArt(
-                        coverUrl: coverUrl,
-                        localPosterPath: localPoster,
-                        size: 260,
-                      ),
-                      const SizedBox(height: AppSpacing.spaceLg),
-                      _TitleBlock(item: item, centered: true),
-                      const SizedBox(height: AppSpacing.spaceMd),
-                      AudiobookChapterContextStrip(
-                        chapters: chapters,
-                        position: _state.position,
-                        onTap: () => setState(() {
-                          _drawerOpen = true;
-                          _drawerTab = AudiobookDrawerTab.chapters;
-                        }),
-                      ),
-                    ],
-                  ),
+          child: SingleChildScrollView(
+            padding:
+                const EdgeInsets.symmetric(horizontal: AppSpacing.spaceLg),
+            child: Column(
+              children: [
+                const SizedBox(height: AppSpacing.spaceMd),
+                _CoverArt(
+                  coverUrl: coverUrl,
+                  localPosterPath: localPoster,
+                  size: 260,
                 ),
+                const SizedBox(height: AppSpacing.spaceLg),
+                _TitleBlock(item: item, centered: true),
+                const SizedBox(height: AppSpacing.spaceMd),
+                AudiobookChapterContextStrip(
+                  chapters: chapters,
+                  position: _state.position,
+                  onTap: () {
+                    _setDrawerTab(AudiobookDrawerTab.chapters);
+                    _openDrawerSheet(context, item, chapters);
+                  },
+                ),
+              ],
+            ),
+          ),
         ),
         _buildBottomControls(context, item, chapters),
       ],
@@ -907,6 +896,101 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     );
   }
 
+  Widget _drawerTabContent(
+    AudiobookDrawerTab tab,
+    AggregatedItem? item,
+    List<Chapter> chapters, {
+    required bool tv,
+  }) {
+    final tvIdx = (tv &&
+            PlatformDetection.isTV &&
+            _tvArea == _AudiobookFocusArea.drawerContent &&
+            _drawerContentActive)
+        ? _tvListIndex
+        : -1;
+    final subIdx = tv ? _tvSubIndex : 0;
+
+    return switch (tab) {
+      AudiobookDrawerTab.timeline => AudiobookTimelineList(
+          events: _getTimelineEvents(chapters),
+          onJump: (ev) {
+            if (ev.type == TimelineEventType.chapter) {
+              _jumpToChapter(ev.originalObject as Chapter);
+            } else if (ev.type == TimelineEventType.bookmark) {
+              _manager.seekTo(Duration(
+                  milliseconds: (ev.originalObject as AudiobookBookmark).positionMs));
+            } else if (ev.type == TimelineEventType.note) {
+              _manager.seekTo(Duration(
+                  milliseconds: (ev.originalObject as AudiobookNote).positionMs));
+            }
+          },
+          onEditNote: (n) =>
+              item != null ? _openNoteEditor(item, existing: n) : null,
+          onDeleteBookmark: (b) =>
+              unawaited(_bookmarks.removeAt(item!.serverId, item.id, b.positionMs)),
+          onDeleteNote: (n) =>
+              unawaited(_notes.remove(item!.serverId, item.id, n.id)),
+          tvFocusedIndex: tvIdx,
+          tvSubIndex: subIdx,
+          onExport: () => _exportToCsv('All', _getTimelineEvents(chapters)),
+        ),
+      AudiobookDrawerTab.chapters => AudiobookChaptersList(
+          chapters: chapters,
+          position: _state.position,
+          onTap: (c) => _jumpToChapter(c),
+          tvFocusedIndex: tvIdx,
+        ),
+      AudiobookDrawerTab.bookmarks => AudiobookBookmarksList(
+          item: item,
+          service: _bookmarks,
+          onJump: (b) => _manager.seekTo(Duration(milliseconds: b.positionMs)),
+          tvFocusedIndex: tvIdx,
+          tvSubIndex: subIdx,
+          onExport: () {
+            final bEvents = _bookmarksList
+                .map((b) => TimelineEvent(
+                      id: 'bookmark_${b.positionMs}',
+                      type: TimelineEventType.bookmark,
+                      title: b.label,
+                      positionMs: b.positionMs,
+                      date: b.createdAt,
+                      originalObject: b,
+                    ))
+                .toList();
+            _exportToCsv('Bookmarks', bEvents);
+          },
+        ),
+      AudiobookDrawerTab.notes => AudiobookNotesList(
+          item: item,
+          service: _notes,
+          onJump: (n) => _manager.seekTo(Duration(milliseconds: n.positionMs)),
+          onEdit: (n) =>
+              item != null ? _openNoteEditor(item, existing: n) : null,
+          tvFocusedIndex: tvIdx,
+          tvSubIndex: subIdx,
+          onExport: () {
+            final nEvents = _notesList
+                .map((n) => TimelineEvent(
+                      id: 'note_${n.id}',
+                      type: TimelineEventType.note,
+                      title: 'Note: ${n.body}',
+                      content: n.body,
+                      positionMs: n.positionMs,
+                      date: n.updatedAt,
+                      originalObject: n,
+                    ))
+                .toList();
+            _exportToCsv('Notes', nEvents);
+          },
+        ),
+      AudiobookDrawerTab.queue => AudiobookQueueList(
+          queue: _queue,
+          onPlay: (i) => _manager.playFromQueue(i),
+          tvFocusedIndex: tvIdx,
+        ),
+    };
+  }
+
   Widget _buildDrawer(
     BuildContext context,
     AggregatedItem? item,
@@ -956,105 +1040,42 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                 cornerRadius: 14,
                 fallbackColor: AppColorScheme.surface.withValues(alpha: 0.5),
                 padding: const EdgeInsets.all(6),
-                child: switch (_drawerTab) {
-                AudiobookDrawerTab.timeline => AudiobookTimelineList(
-                    events: _getTimelineEvents(chapters),
-                    onJump: (ev) {
-                      if (ev.type == TimelineEventType.chapter) {
-                        _jumpToChapter(ev.originalObject as Chapter);
-                      } else if (ev.type == TimelineEventType.bookmark) {
-                        _manager.seekTo(Duration(milliseconds: (ev.originalObject as AudiobookBookmark).positionMs));
-                      } else if (ev.type == TimelineEventType.note) {
-                        _manager.seekTo(Duration(milliseconds: (ev.originalObject as AudiobookNote).positionMs));
-                      }
-                    },
-                    onEditNote: (n) =>
-                        item != null ? _openNoteEditor(item, existing: n) : null,
-                    onDeleteBookmark: (b) =>
-                        unawaited(_bookmarks.removeAt(item!.serverId, item.id, b.positionMs)),
-                    onDeleteNote: (n) =>
-                        unawaited(_notes.remove(item!.serverId, item.id, n.id)),
-                    tvFocusedIndex: (PlatformDetection.isTV &&
-                            _tvArea == _AudiobookFocusArea.drawerContent &&
-                            _drawerContentActive)
-                        ? _tvListIndex
-                        : -1,
-                    tvSubIndex: _tvSubIndex,
-                    onExport: () => _exportToCsv('All', _getTimelineEvents(chapters)),
-                  ),
-                AudiobookDrawerTab.chapters => AudiobookChaptersList(
-                    chapters: chapters,
-                    position: _state.position,
-                    onTap: (c) => _jumpToChapter(c),
-                    tvFocusedIndex: (PlatformDetection.isTV &&
-                            _tvArea == _AudiobookFocusArea.drawerContent &&
-                            _drawerContentActive)
-                        ? _tvListIndex
-                        : -1,
-                  ),
-                AudiobookDrawerTab.bookmarks => AudiobookBookmarksList(
-                    item: item,
-                    service: _bookmarks,
-                    onJump: (b) =>
-                        _manager.seekTo(Duration(milliseconds: b.positionMs)),
-                    tvFocusedIndex: (PlatformDetection.isTV &&
-                            _tvArea == _AudiobookFocusArea.drawerContent &&
-                            _drawerContentActive)
-                        ? _tvListIndex
-                        : -1,
-                    tvSubIndex: _tvSubIndex,
-                    onExport: () {
-                      final bEvents = _bookmarksList.map((b) => TimelineEvent(
-                        id: 'bookmark_${b.positionMs}',
-                        type: TimelineEventType.bookmark,
-                        title: b.label,
-                        positionMs: b.positionMs,
-                        date: b.createdAt,
-                        originalObject: b,
-                      )).toList();
-                      _exportToCsv('Bookmarks', bEvents);
-                    },
-                  ),
-                AudiobookDrawerTab.notes => AudiobookNotesList(
-                    item: item,
-                    service: _notes,
-                    onJump: (n) =>
-                        _manager.seekTo(Duration(milliseconds: n.positionMs)),
-                    onEdit: (n) =>
-                        item != null ? _openNoteEditor(item, existing: n) : null,
-                    tvFocusedIndex: (PlatformDetection.isTV &&
-                            _tvArea == _AudiobookFocusArea.drawerContent &&
-                            _drawerContentActive)
-                        ? _tvListIndex
-                        : -1,
-                    tvSubIndex: _tvSubIndex,
-                    onExport: () {
-                      final nEvents = _notesList.map((n) => TimelineEvent(
-                        id: 'note_${n.id}',
-                        type: TimelineEventType.note,
-                        title: 'Note: ${n.body}',
-                        content: n.body,
-                        positionMs: n.positionMs,
-                        date: n.updatedAt,
-                        originalObject: n,
-                      )).toList();
-                      _exportToCsv('Notes', nEvents);
-                    },
-                  ),
-                AudiobookDrawerTab.queue => AudiobookQueueList(
-                    queue: _queue,
-                    onPlay: (i) => _manager.playFromQueue(i),
-                    tvFocusedIndex: (PlatformDetection.isTV &&
-                            _tvArea == _AudiobookFocusArea.drawerContent &&
-                            _drawerContentActive)
-                        ? _tvListIndex
-                        : -1,
-                  ),
-                },
+                child: _drawerTabContent(_drawerTab, item, chapters, tv: true),
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  void _openDrawerSheet(
+    BuildContext context,
+    AggregatedItem? item,
+    List<Chapter> chapters,
+  ) {
+    final l10n = AppLocalizations.of(context);
+    final availableTabs = _getAvailableTabs(chapters);
+    if (availableTabs.isEmpty) return;
+    final labels = {
+      AudiobookDrawerTab.timeline: 'Timeline',
+      AudiobookDrawerTab.chapters: l10n.audiobookChapters,
+      AudiobookDrawerTab.bookmarks: l10n.audiobookBookmarks,
+      AudiobookDrawerTab.notes: l10n.audiobookNotes,
+      AudiobookDrawerTab.queue: l10n.audiobookQueue,
+    };
+    final initial =
+        availableTabs.contains(_drawerTab) ? _drawerTab : availableTabs.first;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => _AudiobookDrawerSheet(
+        initialTab: initial,
+        tabs: availableTabs,
+        labels: labels,
+        onTabChanged: _setDrawerTab,
+        contentBuilder: (tab) => _drawerTabContent(tab, item, chapters, tv: false),
       ),
     );
   }
@@ -1437,6 +1458,79 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
         }
         break;
     }
+  }
+}
+
+class _AudiobookDrawerSheet extends StatefulWidget {
+  const _AudiobookDrawerSheet({
+    required this.initialTab,
+    required this.tabs,
+    required this.labels,
+    required this.onTabChanged,
+    required this.contentBuilder,
+  });
+
+  final AudiobookDrawerTab initialTab;
+  final List<AudiobookDrawerTab> tabs;
+  final Map<AudiobookDrawerTab, String> labels;
+  final ValueChanged<AudiobookDrawerTab> onTabChanged;
+  final Widget Function(AudiobookDrawerTab) contentBuilder;
+
+  @override
+  State<_AudiobookDrawerSheet> createState() => _AudiobookDrawerSheetState();
+}
+
+class _AudiobookDrawerSheetState extends State<_AudiobookDrawerSheet> {
+  late AudiobookDrawerTab _tab = widget.initialTab;
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.sizeOf(context).height * 0.82;
+    return Container(
+      height: height,
+      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
+      child: GlassSurface(
+        cornerRadius: 24,
+        fallbackColor: AppColorScheme.surface.withValues(alpha: 0.98),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                margin: const EdgeInsets.symmetric(vertical: 10),
+                decoration: BoxDecoration(
+                  color: AppColorScheme.onSurface.withValues(alpha: 0.25),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: AudiobookDrawerTabBar(
+                  current: _tab,
+                  tvFocused: false,
+                  tvIndex: 0,
+                  onChanged: (t) {
+                    setState(() => _tab = t);
+                    widget.onTabChanged(t);
+                  },
+                  labels: widget.labels,
+                  tabs: widget.tabs,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: widget.contentBuilder(_tab),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -928,7 +928,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           ),
           const SizedBox(height: AppSpacing.spaceSm),
           Expanded(
-            child: Container(
+            child: DecoratedBox(
               decoration: BoxDecoration(
                 border: Border.all(
                   color: (PlatformDetection.isTV && _tvArea == _AudiobookFocusArea.drawerContent)
@@ -936,10 +936,13 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                       : Colors.transparent,
                   width: 2.0,
                 ),
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.circular(16),
               ),
-              padding: const EdgeInsets.all(4),
-              child: switch (_drawerTab) {
+              child: GlassSurface(
+                cornerRadius: 14,
+                fallbackColor: AppColorScheme.surface.withValues(alpha: 0.5),
+                padding: const EdgeInsets.all(6),
+                child: switch (_drawerTab) {
                 AudiobookDrawerTab.timeline => AudiobookTimelineList(
                     events: _getTimelineEvents(chapters),
                     onJump: (ev) {
@@ -1045,7 +1048,8 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                         ? _tvListIndex
                         : -1,
                   ),
-              },
+                },
+              ),
             ),
           ),
         ],

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -418,7 +418,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Exported successfully to: ${file.path}'),
+            content: Text(AppLocalizations.of(context).audiobookExportSuccess(file.path)),
             backgroundColor: AppColorScheme.accent,
           ),
         );
@@ -427,7 +427,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('Export failed: $e'),
+            content: Text(AppLocalizations.of(context).audiobookExportFailed('$e')),
             backgroundColor: Theme.of(context).colorScheme.error,
           ),
         );
@@ -1063,7 +1063,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     _tvTabIndex = availableTabs.indexOf(_drawerTab).clamp(0, availableTabs.length - 1);
 
     final labels = {
-      AudiobookDrawerTab.timeline: 'Timeline',
+      AudiobookDrawerTab.timeline: l10n.audiobookTimeline,
       AudiobookDrawerTab.chapters: l10n.audiobookChapters,
       AudiobookDrawerTab.bookmarks: l10n.audiobookBookmarks,
       AudiobookDrawerTab.notes: l10n.audiobookNotes,
@@ -1117,7 +1117,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     final availableTabs = _getAvailableTabs(chapters);
     if (availableTabs.isEmpty) return;
     final labels = {
-      AudiobookDrawerTab.timeline: 'Timeline',
+      AudiobookDrawerTab.timeline: l10n.audiobookTimeline,
       AudiobookDrawerTab.chapters: l10n.audiobookChapters,
       AudiobookDrawerTab.bookmarks: l10n.audiobookBookmarks,
       AudiobookDrawerTab.notes: l10n.audiobookNotes,

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -99,10 +99,13 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   PlayerState get _state => _manager.state;
   QueueService get _queue => _manager.queueService;
 
+  bool get _dpadNav => !PlatformDetection.useMobileUi;
+
   @override
   void initState() {
     super.initState();
     _showRemaining = _prefs.get(UserPreferences.audiobookShowRemaining);
+    _drawerOpen = _dpadNav;
     final savedTab = _prefs.get(UserPreferences.audiobookDrawerTab);
     _drawerTab = AudiobookDrawerTab.values.firstWhere(
       (t) => t.name == savedTab,
@@ -135,7 +138,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       unawaited(_manager.setPlaybackSpeed(defaultSpeed));
     }
 
-    if (PlatformDetection.isTV) {
+    if (_dpadNav) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _tvFocus.requestFocus();
       });
@@ -678,12 +681,12 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       },
     );
 
-    final body = PlatformDetection.isTV
+    final body = _dpadNav
         ? Focus(
             focusNode: _tvFocus,
             autofocus: true,
             onKeyEvent: _handleTvKey,
-            child: layout,
+            child: ExcludeFocus(child: layout),
           )
         : layout;
 
@@ -779,7 +782,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           onToggleDrawer: () {
             setState(() {
               _drawerOpen = !_drawerOpen;
-              if (PlatformDetection.isTV && !_drawerOpen) {
+              if (_dpadNav && !_drawerOpen) {
                 _drawerContentActive = false;
                 _tvArea = _AudiobookFocusArea.header;
                 _tvHeaderIndex = 1;
@@ -884,7 +887,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                   chapters: chapters,
                   bookmarks: _bookmarksList,
                   notes: _notesList,
-                  isTvFocused: PlatformDetection.isTV &&
+                  isTvFocused: _dpadNav &&
                       _tvArea == _AudiobookFocusArea.progress,
                   showRemaining: _showRemaining,
                   onSeek: (d) => _manager.seekTo(d),
@@ -915,7 +918,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             const SizedBox(height: AppSpacing.spaceSm),
           AudiobookTransportRow(
             isPlaying: _state.isPlaying,
-            tvFocusIndex: PlatformDetection.isTV &&
+            tvFocusIndex: _dpadNav &&
                     _tvArea == _AudiobookFocusArea.transport
                 ? _tvTransportIndex
                 : -1,
@@ -940,7 +943,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             sleepActive: _sleep.isActive,
             sleepRemaining: _sleep.remaining,
             isFavorite: item != null && _isFavoriteCurrent(item),
-            tvFocusIndex: PlatformDetection.isTV &&
+            tvFocusIndex: _dpadNav &&
                     _tvArea == _AudiobookFocusArea.actionRail
                 ? _tvRailIndex
                 : -1,
@@ -962,7 +965,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     required bool tv,
   }) {
     final tvIdx = (tv &&
-            PlatformDetection.isTV &&
+            _dpadNav &&
             _tvArea == _AudiobookFocusArea.drawerContent &&
             _drawerContentActive)
         ? _tvListIndex
@@ -1076,7 +1079,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
         children: [
           AudiobookDrawerTabBar(
             current: _drawerTab,
-            tvFocused: PlatformDetection.isTV &&
+            tvFocused: _dpadNav &&
                 _tvArea == _AudiobookFocusArea.drawerTabs,
             tvIndex: _tvTabIndex,
             onChanged: _setDrawerTab,
@@ -1088,7 +1091,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             child: DecoratedBox(
               decoration: BoxDecoration(
                 border: Border.all(
-                  color: (PlatformDetection.isTV && _tvArea == _AudiobookFocusArea.drawerContent)
+                  color: (_dpadNav && _tvArea == _AudiobookFocusArea.drawerContent)
                       ? AppColorScheme.accent
                       : Colors.transparent,
                   width: 2.0,

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:path_provider/path_provider.dart';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:playback_core/playback_core.dart';
@@ -15,6 +18,7 @@ import '../../../data/services/audiobook_bookmarks_service.dart';
 import '../../../data/services/audiobook_notes_service.dart';
 import '../../../data/services/cast/cast_service.dart';
 import '../../../data/services/media_server_client_factory.dart';
+import '../../../data/services/storage_path_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../playback/sleep_timer_controller.dart';
 import '../../../preference/user_preferences.dart';
@@ -71,6 +75,16 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   int _tvTransportIndex = 2;
   int _tvRailIndex = 0;
   int _tvTabIndex = 0;
+  bool _drawerContentActive = false;
+  int _tvListIndex = 0;
+  int _tvSubIndex = 0;
+  List<AudiobookBookmark> _bookmarksList = [];
+  List<AudiobookNote> _notesList = [];
+  String? _lastSubscribedItemId;
+  StreamSubscription? _bookmarkSub;
+  StreamSubscription? _noteSub;
+  bool _dialogOpen = false;
+  AggregatedItem? _fullItem;
 
   PlayerState get _state => _manager.state;
   QueueService get _queue => _manager.queueService;
@@ -91,6 +105,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       _state.positionStream.listen((_) => _rebuild()),
       _state.durationStream.listen((_) => _rebuild()),
       _queue.queueChangedStream.listen((_) => _rebuild()),
+      _sleep.onExpired.listen((_) => _onSleepTimerExpired()),
     ]);
     _sleep.addListener(_rebuild);
 
@@ -112,6 +127,8 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   @override
   void dispose() {
+    _bookmarkSub?.cancel();
+    _noteSub?.cancel();
     for (final s in _subs) {
       s.cancel();
     }
@@ -120,11 +137,128 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     super.dispose();
   }
 
+  void _updateStreamSubscriptions() {
+    final item = _resolveItem();
+    if (item == null) return;
+    if (_lastSubscribedItemId == item.id) return;
+    _lastSubscribedItemId = item.id;
+    _fullItem = null;
+
+    if (!_manager.isOfflinePlayback) {
+      unawaited(() async {
+        try {
+          final client = _clientForItem(item);
+          final fullData = await client.itemsApi.getItem(item.id);
+          if (mounted && _lastSubscribedItemId == item.id) {
+            setState(() {
+              _fullItem = AggregatedItem(
+                id: item.id,
+                serverId: item.serverId,
+                rawData: fullData,
+              );
+            });
+          }
+        } catch (e) {
+          // Ignore background fetch failure
+        }
+      }());
+    }
+
+    _bookmarkSub?.cancel();
+    _bookmarkSub = _bookmarks.watch(item.serverId, item.id).listen((list) {
+      if (mounted) setState(() => _bookmarksList = list);
+    });
+
+    _noteSub?.cancel();
+    _noteSub = _notes.watch(item.serverId, item.id).listen((list) {
+      if (mounted) setState(() => _notesList = list);
+    });
+  }
+
   void _rebuild() {
+    _updateStreamSubscriptions();
     if (mounted) setState(() {});
   }
 
+  void _onSleepTimerExpired() {
+    debugPrint('AudiobookPlayerView: _onSleepTimerExpired triggered!');
+    if (!mounted) return;
+
+    final lastMode = _sleep.lastActiveMode;
+    final lastDuration = _sleep.lastActiveDuration;
+    final item = _resolveItem();
+    final chapters = _chapters(item);
+
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        String label = 'chosen timer';
+        if (lastMode == SleepTimerMode.duration) {
+          label = '${lastDuration.inMinutes} min';
+        } else if (lastMode == SleepTimerMode.endOfChapter) {
+          final l10n = AppLocalizations.of(context);
+          label = l10n.audiobookSleepEndOfChapter;
+        }
+
+        return AlertDialog(
+          backgroundColor: AppColorScheme.surface,
+          title: const Text('Sleep Timer Finished'),
+          content: Text('Your sleep timer ($label) has finished. What would you like to do?'),
+          actionsPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          actionsAlignment: MainAxisAlignment.center,
+          actions: [
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                ElevatedButton(
+                  onPressed: () async {
+                    Navigator.of(context).pop();
+                    if (lastMode == SleepTimerMode.duration) {
+                      _sleep.startDuration(lastDuration);
+                    } else if (lastMode == SleepTimerMode.endOfChapter) {
+                      _sleep.startEndOfChapter(
+                        chapterStartMsAscending: chapters.map((c) => c.startMs).toList(),
+                        currentPositionMs: _state.position.inMilliseconds,
+                        totalDurationMs: _state.duration.inMilliseconds,
+                      );
+                    }
+                    await _manager.resume();
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColorScheme.accent,
+                    foregroundColor: AppColorScheme.onAccent,
+                  ),
+                  child: const Text('Restart Sleep Timer'),
+                ),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('Stop Playback'),
+                ),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    _showSleepSheet(chapters, resumeOnSelect: true);
+                  },
+                  child: const Text('Add Custom Value to Timer'),
+                ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   AggregatedItem? _resolveItem() {
+    if (_fullItem != null && _fullItem!.id == _queue.currentItem?.id) {
+      return _fullItem;
+    }
     final current = _queue.currentItem;
     if (current is AggregatedItem) return current;
     final meta = _manager.currentOfflineMetadata;
@@ -134,6 +268,121 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       serverId: meta['ServerId'] as String? ?? '',
       rawData: meta,
     );
+  }
+
+  List<AudiobookDrawerTab> _getAvailableTabs(List<Chapter> chapters) {
+    final list = <AudiobookDrawerTab>[];
+    list.add(AudiobookDrawerTab.timeline);
+    if (chapters.isNotEmpty) {
+      list.add(AudiobookDrawerTab.chapters);
+    }
+    list.add(AudiobookDrawerTab.bookmarks);
+    list.add(AudiobookDrawerTab.notes);
+    list.add(AudiobookDrawerTab.queue);
+    return list;
+  }
+
+  bool _tabHasExport(AudiobookDrawerTab tab) {
+    return tab == AudiobookDrawerTab.timeline ||
+        tab == AudiobookDrawerTab.bookmarks ||
+        tab == AudiobookDrawerTab.notes;
+  }
+
+  List<TimelineEvent> _getTimelineEvents(List<Chapter> chapters) {
+    final events = <TimelineEvent>[];
+    for (var i = 0; i < chapters.length; i++) {
+      final c = chapters[i];
+      events.add(TimelineEvent(
+        id: 'chapter_$i',
+        type: TimelineEventType.chapter,
+        title: c.title,
+        positionMs: c.startMs,
+        date: DateTime.fromMillisecondsSinceEpoch(0),
+        originalObject: c,
+      ));
+    }
+    for (var i = 0; i < _bookmarksList.length; i++) {
+      final b = _bookmarksList[i];
+      events.add(TimelineEvent(
+        id: 'bookmark_${b.positionMs}',
+        type: TimelineEventType.bookmark,
+        title: 'Bookmark ${i + 1}: ${b.label}',
+        positionMs: b.positionMs,
+        date: b.createdAt,
+        originalObject: b,
+      ));
+    }
+    for (var i = 0; i < _notesList.length; i++) {
+      final n = _notesList[i];
+      events.add(TimelineEvent(
+        id: 'note_${n.id}',
+        type: TimelineEventType.note,
+        title: 'Note: ${n.body}',
+        content: n.body,
+        positionMs: n.positionMs,
+        date: n.updatedAt,
+        originalObject: n,
+      ));
+    }
+    events.sort((a, b) {
+      final cmp = a.positionMs.compareTo(b.positionMs);
+      if (cmp != 0) return cmp;
+      return a.type.index.compareTo(b.type.index);
+    });
+    return events;
+  }
+
+  Future<void> _exportToCsv(String label, List<TimelineEvent> events) async {
+    final item = _resolveItem();
+    final csv = StringBuffer();
+    csv.writeln('Timestamp,Type,Content');
+    for (final e in events) {
+      final typeStr = e.type == TimelineEventType.chapter
+          ? 'Chapter'
+          : e.type == TimelineEventType.bookmark
+              ? 'Bookmark'
+              : 'Note';
+      final timestamp = formatAudiobookClock(Duration(milliseconds: e.positionMs));
+      final content = e.content ?? '';
+      
+      String escapeCsv(String val) {
+        if (val.contains(',') || val.contains('"') || val.contains('\n')) {
+          return '"' + val.replaceAll('"', '""') + '"';
+        }
+        return val;
+      }
+      csv.writeln('${escapeCsv(timestamp)},${escapeCsv(typeStr)},${escapeCsv(content)}');
+    }
+    try {
+      final storagePathService = GetIt.instance<StoragePathService>();
+      final baseDir = await storagePathService.getOfflineRoot();
+      final exportDir = Directory('${baseDir.path}/Exports');
+      if (!await exportDir.exists()) {
+        await exportDir.create(recursive: true);
+      }
+      final cleanTitle = (item?.name ?? 'audiobook').replaceAll(RegExp(r'[^\w\s\-]'), '').replaceAll(' ', '_');
+      final dateStr = DateTime.now().toIso8601String().replaceAll(':', '-').split('.').first;
+      final file = File('${exportDir.path}/${cleanTitle}_${label.toLowerCase()}_$dateStr.csv');
+      await file.writeAsString(csv.toString());
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Exported successfully to: ${file.path}'),
+            backgroundColor: AppColorScheme.accent,
+          ),
+        );
+      }
+    } catch (e) {
+      debugPrint('[ExportDebug] Failed to export CSV: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Export failed: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
   }
 
   MediaServerClient _clientForItem(AggregatedItem item) {
@@ -161,6 +410,9 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   List<Chapter> _chapters(AggregatedItem? item) {
     if (item == null) return const [];
+    
+
+
     final out = <Chapter>[];
     for (var i = 0; i < item.chapters.length; i++) {
       final chapter = item.chapters[i];
@@ -222,7 +474,10 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   }
 
   Future<void> _setDrawerTab(AudiobookDrawerTab tab) async {
-    setState(() => _drawerTab = tab);
+    setState(() {
+      _drawerTab = tab;
+      _tvSubIndex = 0;
+    });
     await _prefs.set(UserPreferences.audiobookDrawerTab, tab.name);
   }
 
@@ -296,29 +551,51 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   }
 
   Future<void> _openNoteEditor(AggregatedItem item, {AudiobookNote? existing}) async {
+    debugPrint('[AudiobookPlayer] _openNoteEditor called: dialogOpen=$_dialogOpen');
+    if (_dialogOpen) {
+      debugPrint('[AudiobookPlayer] _openNoteEditor BLOCKED by dialogOpen lock');
+      return;
+    }
+    _dialogOpen = true;
+    debugPrint('[AudiobookPlayer] _openNoteEditor dialog OPENED');
+
     final wasPlaying = _state.isPlaying;
     if (wasPlaying) await _manager.pause();
-    if (!mounted) return;
+    if (!mounted) {
+      _dialogOpen = false;
+      return;
+    }
     final pos = existing?.positionMs ?? _state.position.inMilliseconds;
     final result = await showAudiobookNoteEditor(
       context: context,
       initialText: existing?.body ?? '',
       positionLabel: formatAudiobookClock(Duration(milliseconds: pos)),
     );
-    if (result != null && result.trim().isNotEmpty) {
+    debugPrint('[AudiobookPlayer] _openNoteEditor returned result: ${result != null ? '"$result"' : 'null'}');
+
+    // Hold the lock long enough to cover the dialog route exit animation
+    // and clear any trailing key events. The Select-KeyDownOnly fix in
+    // _handleTvKey already prevents KeyRepeat from re-triggering; 300ms
+    // is enough buffer without making the player feel frozen.
+    await Future.delayed(const Duration(milliseconds: 300));
+    debugPrint('[AudiobookPlayer] _dialogOpen RELEASED');
+    _dialogOpen = false;
+
+    final noteText = result is String ? result.trim() : null;
+    if (noteText != null && noteText.isNotEmpty) {
       if (existing == null) {
         await _notes.add(
           item.serverId,
           item.id,
           positionMs: pos,
-          body: result.trim(),
+          body: noteText,
         );
       } else {
         await _notes.update(
           item.serverId,
           item.id,
           existing.id,
-          body: result.trim(),
+          body: noteText,
         );
       }
     }
@@ -366,10 +643,14 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
         : layout;
 
     return PopScope(
-      canPop: !_drawerOpen,
+      canPop: !_drawerOpen && !_drawerContentActive,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
-        if (_drawerOpen) setState(() => _drawerOpen = false);
+        if (_drawerContentActive) {
+          setState(() => _drawerContentActive = false);
+        } else if (_drawerOpen) {
+          setState(() => _drawerOpen = false);
+        }
       },
       child: Scaffold(
         backgroundColor: AppColorScheme.background,
@@ -394,7 +675,16 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           onClose: () => Navigator.of(context).pop(),
           onCast: item != null ? () => _castToDevice(item) : null,
           onCastSettings: _showCastControls,
-          onToggleDrawer: () => setState(() => _drawerOpen = !_drawerOpen),
+          onToggleDrawer: () {
+            setState(() {
+              _drawerOpen = !_drawerOpen;
+              if (PlatformDetection.isTV && !_drawerOpen) {
+                _drawerContentActive = false;
+                _tvArea = _AudiobookFocusArea.header;
+                _tvHeaderIndex = 2;
+              }
+            });
+          },
           drawerOpen: _drawerOpen,
           tvFocusIndex: _tvArea == _AudiobookFocusArea.header ? _tvHeaderIndex : -1,
         ),
@@ -439,7 +729,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     String? localPoster,
     List<Chapter> chapters,
   ) {
-    final coverSize = PlatformDetection.isTV ? 360.0 : 300.0;
+    final coverSize = PlatformDetection.isTV ? 240.0 : 200.0;
     return Column(
       children: [
         AudiobookHeader(
@@ -449,7 +739,16 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           onClose: () => Navigator.of(context).pop(),
           onCast: item != null ? () => _castToDevice(item) : null,
           onCastSettings: _showCastControls,
-          onToggleDrawer: () => setState(() => _drawerOpen = !_drawerOpen),
+          onToggleDrawer: () {
+            setState(() {
+              _drawerOpen = !_drawerOpen;
+              if (PlatformDetection.isTV && !_drawerOpen) {
+                _drawerContentActive = false;
+                _tvArea = _AudiobookFocusArea.header;
+                _tvHeaderIndex = 2;
+              }
+            });
+          },
           drawerOpen: _drawerOpen,
           tvFocusIndex: _tvArea == _AudiobookFocusArea.header ? _tvHeaderIndex : -1,
         ),
@@ -457,9 +756,8 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: AppSpacing.spaceXl),
             child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-
                 Expanded(
                   flex: 4,
                   child: Padding(
@@ -475,12 +773,25 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                         ),
                         const SizedBox(height: AppSpacing.spaceLg),
                         _TitleBlock(item: item, centered: true),
+                        const SizedBox(height: AppSpacing.spaceLg),
+                        AudiobookProgressBar(
+                          position: _state.position,
+                          duration: _state.duration,
+                          chapters: chapters,
+                          bookmarks: _bookmarksList,
+                          notes: _notesList,
+                          showRemaining: _showRemaining,
+                          isTvFocused: false,
+                          onSeek: (d) => _manager.seekTo(d),
+                          onToggleRemaining: () => _setShowRemaining(!_showRemaining),
+                          formatPosition: formatAudiobookClock,
+                          formatRemaining: _formatRemaining,
+                        ),
                       ],
                     ),
                   ),
                 ),
                 const SizedBox(width: AppSpacing.spaceXl),
-
                 Expanded(
                   flex: 5,
                   child: Padding(
@@ -501,11 +812,10 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                         Expanded(
                           child: _drawerOpen
                               ? _buildDrawer(context, item, chapters)
-                              : _ActiveTimersPanel(
-                                  sleep: _sleep,
-                                  onCancelSleep: _sleep.cancel,
-                                ),
+                              : const SizedBox.shrink(),
                         ),
+                        const SizedBox(height: AppSpacing.spaceMd),
+                        _buildBottomControls(context, item, chapters, splitLayout: true),
                       ],
                     ),
                   ),
@@ -514,7 +824,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             ),
           ),
         ),
-        _buildBottomControls(context, item, chapters),
       ],
     );
   }
@@ -522,30 +831,49 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   Widget _buildBottomControls(
     BuildContext context,
     AggregatedItem? item,
-    List<Chapter> chapters,
-  ) {
+    List<Chapter> chapters, {
+    bool splitLayout = false,
+  }) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.spaceXl,
-        AppSpacing.spaceSm,
-        AppSpacing.spaceXl,
-        AppSpacing.spaceLg,
-      ),
+      padding: splitLayout
+          ? EdgeInsets.zero
+          : const EdgeInsets.fromLTRB(
+              AppSpacing.spaceXl,
+              AppSpacing.spaceSm,
+              AppSpacing.spaceXl,
+              AppSpacing.spaceLg,
+            ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          AudiobookProgressBar(
-            position: _state.position,
-            duration: _state.duration,
-            chapters: chapters,
-            showRemaining: _showRemaining,
-            isTvFocused: PlatformDetection.isTV &&
-                _tvArea == _AudiobookFocusArea.progress,
-            onSeek: (d) => _manager.seekTo(d),
-            onToggleRemaining: () => _setShowRemaining(!_showRemaining),
-            formatPosition: formatAudiobookClock,
-            formatRemaining: _formatRemaining,
-          ),
+          if (splitLayout)
+            AudiobookZoomedProgressBar(
+              position: _state.position,
+              duration: _state.duration,
+              chapters: chapters,
+              bookmarks: _bookmarksList,
+              notes: _notesList,
+              isTvFocused: PlatformDetection.isTV &&
+                  _tvArea == _AudiobookFocusArea.progress,
+              onSeek: (d) => _manager.seekTo(d),
+              formatPosition: formatAudiobookClock,
+              formatRemaining: _formatRemaining,
+            )
+          else
+            AudiobookProgressBar(
+              position: _state.position,
+              duration: _state.duration,
+              chapters: chapters,
+              bookmarks: _bookmarksList,
+              notes: _notesList,
+              showRemaining: _showRemaining,
+              isTvFocused: PlatformDetection.isTV &&
+                  _tvArea == _AudiobookFocusArea.progress,
+              onSeek: (d) => _manager.seekTo(d),
+              onToggleRemaining: () => _setShowRemaining(!_showRemaining),
+              formatPosition: formatAudiobookClock,
+              formatRemaining: _formatRemaining,
+            ),
           const SizedBox(height: AppSpacing.spaceSm),
           AudiobookTransportRow(
             isPlaying: _state.isPlaying,
@@ -591,6 +919,20 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     List<Chapter> chapters,
   ) {
     final l10n = AppLocalizations.of(context);
+    final availableTabs = _getAvailableTabs(chapters);
+    if (!availableTabs.contains(_drawerTab)) {
+      _drawerTab = AudiobookDrawerTab.timeline;
+    }
+    _tvTabIndex = availableTabs.indexOf(_drawerTab).clamp(0, availableTabs.length - 1);
+
+    final labels = {
+      AudiobookDrawerTab.timeline: 'Timeline',
+      AudiobookDrawerTab.chapters: l10n.audiobookChapters,
+      AudiobookDrawerTab.bookmarks: l10n.audiobookBookmarks,
+      AudiobookDrawerTab.notes: l10n.audiobookNotes,
+      AudiobookDrawerTab.queue: l10n.audiobookQueue,
+    };
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.spaceMd),
       child: Column(
@@ -601,40 +943,130 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                 _tvArea == _AudiobookFocusArea.drawerTabs,
             tvIndex: _tvTabIndex,
             onChanged: _setDrawerTab,
-            labels: {
-              AudiobookDrawerTab.chapters: l10n.audiobookChapters,
-              AudiobookDrawerTab.bookmarks: l10n.audiobookBookmarks,
-              AudiobookDrawerTab.notes: l10n.audiobookNotes,
-              AudiobookDrawerTab.queue: l10n.audiobookQueue,
-            },
+            labels: labels,
+            tabs: availableTabs,
           ),
           const SizedBox(height: AppSpacing.spaceSm),
           Expanded(
-            child: switch (_drawerTab) {
-              AudiobookDrawerTab.chapters => AudiobookChaptersList(
-                  chapters: chapters,
-                  position: _state.position,
-                  onTap: (c) => _jumpToChapter(c),
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: (PlatformDetection.isTV && _tvArea == _AudiobookFocusArea.drawerContent)
+                      ? AppColorScheme.accent
+                      : Colors.transparent,
+                  width: 2.0,
                 ),
-              AudiobookDrawerTab.bookmarks => AudiobookBookmarksList(
-                  item: item,
-                  service: _bookmarks,
-                  onJump: (b) =>
-                      _manager.seekTo(Duration(milliseconds: b.positionMs)),
-                ),
-              AudiobookDrawerTab.notes => AudiobookNotesList(
-                  item: item,
-                  service: _notes,
-                  onJump: (n) =>
-                      _manager.seekTo(Duration(milliseconds: n.positionMs)),
-                  onEdit: (n) =>
-                      item != null ? _openNoteEditor(item, existing: n) : null,
-                ),
-              AudiobookDrawerTab.queue => AudiobookQueueList(
-                  queue: _queue,
-                  onPlay: (i) => _manager.playFromQueue(i),
-                ),
-            },
+                borderRadius: BorderRadius.circular(12),
+              ),
+              padding: const EdgeInsets.all(4),
+              child: switch (_drawerTab) {
+                AudiobookDrawerTab.timeline => AudiobookTimelineList(
+                    events: _getTimelineEvents(chapters),
+                    onJump: (ev) {
+                      if (ev.type == TimelineEventType.chapter) {
+                        _jumpToChapter(ev.originalObject as Chapter);
+                      } else if (ev.type == TimelineEventType.bookmark) {
+                        _manager.seekTo(Duration(milliseconds: (ev.originalObject as AudiobookBookmark).positionMs));
+                      } else if (ev.type == TimelineEventType.note) {
+                        _manager.seekTo(Duration(milliseconds: (ev.originalObject as AudiobookNote).positionMs));
+                      }
+                    },
+                    onEditNote: (n) =>
+                        item != null ? _openNoteEditor(item, existing: n) : null,
+                    onDeleteBookmark: (b) =>
+                        unawaited(_bookmarks.removeAt(item!.serverId, item.id, b.positionMs)),
+                    onDeleteNote: (n) =>
+                        unawaited(_notes.remove(item!.serverId, item.id, n.id)),
+                    tvFocusedIndex: (PlatformDetection.isTV &&
+                            _tvArea == _AudiobookFocusArea.drawerContent &&
+                            _drawerContentActive)
+                        ? _tvListIndex
+                        : -1,
+                    tvSubIndex: _tvSubIndex,
+                    onExport: () => _exportToCsv('All', _getTimelineEvents(chapters)),
+                    tvExportFocused: (PlatformDetection.isTV &&
+                        _tvArea == _AudiobookFocusArea.drawerContent &&
+                        _drawerContentActive &&
+                        _tvListIndex == -1),
+                  ),
+                AudiobookDrawerTab.chapters => AudiobookChaptersList(
+                    chapters: chapters,
+                    position: _state.position,
+                    onTap: (c) => _jumpToChapter(c),
+                    tvFocusedIndex: (PlatformDetection.isTV &&
+                            _tvArea == _AudiobookFocusArea.drawerContent &&
+                            _drawerContentActive)
+                        ? _tvListIndex
+                        : -1,
+                  ),
+                AudiobookDrawerTab.bookmarks => AudiobookBookmarksList(
+                    item: item,
+                    service: _bookmarks,
+                    onJump: (b) =>
+                        _manager.seekTo(Duration(milliseconds: b.positionMs)),
+                    tvFocusedIndex: (PlatformDetection.isTV &&
+                            _tvArea == _AudiobookFocusArea.drawerContent &&
+                            _drawerContentActive)
+                        ? _tvListIndex
+                        : -1,
+                    tvSubIndex: _tvSubIndex,
+                    onExport: () {
+                      final bEvents = _bookmarksList.map((b) => TimelineEvent(
+                        id: 'bookmark_${b.positionMs}',
+                        type: TimelineEventType.bookmark,
+                        title: b.label,
+                        positionMs: b.positionMs,
+                        date: b.createdAt,
+                        originalObject: b,
+                      )).toList();
+                      _exportToCsv('Bookmarks', bEvents);
+                    },
+                    tvExportFocused: (PlatformDetection.isTV &&
+                        _tvArea == _AudiobookFocusArea.drawerContent &&
+                        _drawerContentActive &&
+                        _tvListIndex == -1),
+                  ),
+                AudiobookDrawerTab.notes => AudiobookNotesList(
+                    item: item,
+                    service: _notes,
+                    onJump: (n) =>
+                        _manager.seekTo(Duration(milliseconds: n.positionMs)),
+                    onEdit: (n) =>
+                        item != null ? _openNoteEditor(item, existing: n) : null,
+                    tvFocusedIndex: (PlatformDetection.isTV &&
+                            _tvArea == _AudiobookFocusArea.drawerContent &&
+                            _drawerContentActive)
+                        ? _tvListIndex
+                        : -1,
+                    tvSubIndex: _tvSubIndex,
+                    onExport: () {
+                      final nEvents = _notesList.map((n) => TimelineEvent(
+                        id: 'note_${n.id}',
+                        type: TimelineEventType.note,
+                        title: 'Note: ${n.body}',
+                        content: n.body,
+                        positionMs: n.positionMs,
+                        date: n.updatedAt,
+                        originalObject: n,
+                      )).toList();
+                      _exportToCsv('Notes', nEvents);
+                    },
+                    tvExportFocused: (PlatformDetection.isTV &&
+                        _tvArea == _AudiobookFocusArea.drawerContent &&
+                        _drawerContentActive &&
+                        _tvListIndex == -1),
+                  ),
+                AudiobookDrawerTab.queue => AudiobookQueueList(
+                    queue: _queue,
+                    onPlay: (i) => _manager.playFromQueue(i),
+                    tvFocusedIndex: (PlatformDetection.isTV &&
+                            _tvArea == _AudiobookFocusArea.drawerContent &&
+                            _drawerContentActive)
+                        ? _tvListIndex
+                        : -1,
+                  ),
+              },
+            ),
           ),
         ],
       ),
@@ -653,20 +1085,26 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     );
   }
 
-  Future<void> _showSleepSheet(List<Chapter> chapters) async {
+  Future<void> _showSleepSheet(List<Chapter> chapters, {bool resumeOnSelect = false}) async {
     await showAudiobookSleepSheet(
       context: context,
       controller: _sleep,
       onPickPreset: (minutes) async {
         await _prefs.set(UserPreferences.audiobookSleepPresetMin, minutes);
         _sleep.startDuration(Duration(minutes: minutes));
+        if (resumeOnSelect) {
+          await _manager.resume();
+        }
       },
-      onPickEndOfChapter: () {
+      onPickEndOfChapter: () async {
         _sleep.startEndOfChapter(
           chapterStartMsAscending: chapters.map((c) => c.startMs).toList(),
           currentPositionMs: _state.position.inMilliseconds,
           totalDurationMs: _state.duration.inMilliseconds,
         );
+        if (resumeOnSelect) {
+          await _manager.resume();
+        }
       },
       onCancel: _sleep.cancel,
     );
@@ -682,15 +1120,13 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   KeyEventResult _handleTvKey(FocusNode node, KeyEvent event) {
     if (!event.isActionable) return KeyEventResult.ignored;
+    // Consume ALL events while a dialog is open. This prevents KeyRepeat events
+    // that were not handled inside the dialog's focus scope from bubbling up
+    // through the focus node tree to this handler and triggering _activate().
+    if (_dialogOpen) return KeyEventResult.handled;
     final key = event.logicalKey;
 
-    if (key.isBackKey) {
-      if (_drawerOpen) {
-        setState(() => _drawerOpen = false);
-        return KeyEventResult.handled;
-      }
-      return KeyEventResult.ignored;
-    }
+
 
     if (key.isDirectional) {
       if (key.isUpKey) {
@@ -711,29 +1147,124 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       }
     }
 
-    if (key.isSelectKey) {
+    // Select/Enter must only activate ONCE per physical key press (KeyDown only).
+    // KeyRepeat on a select key must NOT re-trigger _activate() — doing so would
+    // open multiple dialogs while the user holds the remote button.
+    // Directional keys remain repeat-enabled for smooth continuous scrolling.
+    if (key.isSelectKey && event is KeyDownEvent) {
       _activate();
       return KeyEventResult.handled;
     }
+    // Consume (but ignore) select KeyRepeat events so they don't bubble further.
+    if (key.isSelectKey) return KeyEventResult.handled;
 
     return KeyEventResult.ignored;
   }
 
   void _moveVertical(int delta) {
-    final all = _AudiobookFocusArea.values;
-    var idx = all.indexOf(_tvArea);
-    final wantsDrawer = _drawerOpen;
-    while (true) {
-      idx += delta;
-      if (idx < 0 || idx >= all.length) return;
-      final candidate = all[idx];
-      if ((candidate == _AudiobookFocusArea.drawerTabs ||
-              candidate == _AudiobookFocusArea.drawerContent) &&
-          !wantsDrawer) {
-        continue;
+    if (_tvArea == _AudiobookFocusArea.drawerContent && _drawerContentActive) {
+      final item = _resolveItem();
+      final chapters = _chapters(item);
+      int count = 0;
+      switch (_drawerTab) {
+        case AudiobookDrawerTab.timeline:
+          count = _getTimelineEvents(chapters).length;
+          break;
+        case AudiobookDrawerTab.chapters:
+          count = chapters.length;
+          break;
+        case AudiobookDrawerTab.bookmarks:
+          count = _bookmarksList.length;
+          break;
+        case AudiobookDrawerTab.notes:
+          count = _notesList.length;
+          break;
+        case AudiobookDrawerTab.queue:
+          count = _queue.items.length;
+          break;
       }
-      setState(() => _tvArea = candidate);
-      return;
+      final hasExport = _tabHasExport(_drawerTab);
+      final minIdx = hasExport ? -1 : 0;
+      if (count > 0 || hasExport) {
+        final nextListIdx = _tvListIndex + delta;
+        if (nextListIdx >= minIdx && nextListIdx < count) {
+          setState(() {
+            _tvListIndex = nextListIdx;
+            _tvSubIndex = 0;
+          });
+          return;
+        }
+      }
+      setState(() => _drawerContentActive = false);
+    }
+
+    final List<_AudiobookFocusArea> list;
+    if (_drawerOpen) {
+      list = [
+        _AudiobookFocusArea.header,
+        _AudiobookFocusArea.drawerTabs,
+        _AudiobookFocusArea.drawerContent,
+        _AudiobookFocusArea.progress,
+        _AudiobookFocusArea.transport,
+        _AudiobookFocusArea.actionRail,
+      ];
+    } else {
+      list = [
+        _AudiobookFocusArea.header,
+        _AudiobookFocusArea.progress,
+        _AudiobookFocusArea.transport,
+        _AudiobookFocusArea.actionRail,
+      ];
+    }
+
+    var idx = list.indexOf(_tvArea);
+    if (idx == -1) idx = 0;
+
+    final nextIdx = idx + delta;
+    if (nextIdx < 0 || nextIdx >= list.length) return;
+
+    final candidate = list[nextIdx];
+
+    if (candidate == _AudiobookFocusArea.transport && _tvArea == _AudiobookFocusArea.actionRail) {
+      _tvTransportIndex = _tvRailIndex;
+    } else if (candidate == _AudiobookFocusArea.transport && _tvArea == _AudiobookFocusArea.progress) {
+      _tvTransportIndex = 2;
+    } else if (candidate == _AudiobookFocusArea.actionRail && _tvArea == _AudiobookFocusArea.transport) {
+      _tvRailIndex = _tvTransportIndex;
+    } else if (candidate == _AudiobookFocusArea.header && _tvArea == _AudiobookFocusArea.progress) {
+      _tvHeaderIndex = 2;
+    } else if (candidate == _AudiobookFocusArea.header && _tvArea == _AudiobookFocusArea.drawerTabs) {
+      _tvHeaderIndex = 2;
+    }
+
+    if (candidate == _AudiobookFocusArea.drawerContent) {
+      _drawerContentActive = true;
+      _tvListIndex = _tabHasExport(_drawerTab) ? -1 : 0;
+      _tvSubIndex = 0;
+    }
+
+    setState(() => _tvArea = candidate);
+  }
+
+  int _maxSubIndex() {
+    final item = _resolveItem();
+    final chapters = _chapters(item);
+    switch (_drawerTab) {
+      case AudiobookDrawerTab.timeline:
+        final events = _getTimelineEvents(chapters);
+        if (_tvListIndex >= 0 && _tvListIndex < events.length) {
+          final ev = events[_tvListIndex];
+          if (ev.type == TimelineEventType.note) return 2;
+          if (ev.type == TimelineEventType.bookmark) return 1;
+        }
+        return 0;
+      case AudiobookDrawerTab.chapters:
+      case AudiobookDrawerTab.queue:
+        return 0;
+      case AudiobookDrawerTab.bookmarks:
+        return 1;
+      case AudiobookDrawerTab.notes:
+        return 2;
     }
   }
 
@@ -744,8 +1275,10 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           _tvHeaderIndex = (_tvHeaderIndex + delta).clamp(0, 2);
           break;
         case _AudiobookFocusArea.progress:
-
-          final step = Duration(milliseconds: 10000 * delta);
+          final ms = delta < 0
+              ? _prefs.get(UserPreferences.skipBackLength)
+              : _prefs.get(UserPreferences.skipForwardLength);
+          final step = Duration(milliseconds: ms * delta);
           final next = _state.position + step;
           _manager.seekTo(next < Duration.zero ? Duration.zero : next);
           break;
@@ -756,14 +1289,22 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           _tvRailIndex = (_tvRailIndex + delta).clamp(0, 4);
           break;
         case _AudiobookFocusArea.drawerTabs:
+          final item = _resolveItem();
+          final chapters = _chapters(item);
+          final availableTabs = _getAvailableTabs(chapters);
           _tvTabIndex =
-              (_tvTabIndex + delta).clamp(0, AudiobookDrawerTab.values.length - 1);
-          _drawerTab = AudiobookDrawerTab.values[_tvTabIndex];
+              (_tvTabIndex + delta).clamp(0, availableTabs.length - 1);
+          _drawerTab = availableTabs[_tvTabIndex];
           unawaited(_prefs.set(
               UserPreferences.audiobookDrawerTab, _drawerTab.name));
           break;
         case _AudiobookFocusArea.drawerContent:
-
+          if (_drawerContentActive) {
+            final maxIdx = _maxSubIndex();
+            if (maxIdx > 0) {
+              _tvSubIndex = (_tvSubIndex + delta).clamp(0, maxIdx);
+            }
+          }
           break;
       }
     });
@@ -779,7 +1320,12 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
         } else if (_tvHeaderIndex == 1 && item != null) {
           _castToDevice(item);
         } else if (_tvHeaderIndex == 2) {
-          setState(() => _drawerOpen = !_drawerOpen);
+          setState(() {
+            _drawerOpen = !_drawerOpen;
+            if (!_drawerOpen) {
+              _drawerContentActive = false;
+            }
+          });
         }
         break;
       case _AudiobookFocusArea.progress:
@@ -826,6 +1372,112 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
         setState(() => _drawerOpen = true);
         break;
       case _AudiobookFocusArea.drawerContent:
+        if (!_drawerContentActive) {
+          setState(() {
+            _drawerContentActive = true;
+            _tvSubIndex = 0;
+            _tvListIndex = _tabHasExport(_drawerTab) ? -1 : 0;
+          });
+        } else {
+          if (_tvListIndex == -1) {
+            if (_drawerTab == AudiobookDrawerTab.bookmarks) {
+              final bEvents = _bookmarksList.map((b) => TimelineEvent(
+                id: 'bookmark_${b.positionMs}',
+                type: TimelineEventType.bookmark,
+                title: b.label,
+                positionMs: b.positionMs,
+                date: b.createdAt,
+                originalObject: b,
+              )).toList();
+              _exportToCsv('Bookmarks', bEvents);
+            } else if (_drawerTab == AudiobookDrawerTab.notes) {
+              final nEvents = _notesList.map((n) => TimelineEvent(
+                id: 'note_${n.id}',
+                type: TimelineEventType.note,
+                title: 'Note: ${n.body}',
+                content: n.body,
+                positionMs: n.positionMs,
+                date: n.updatedAt,
+                originalObject: n,
+              )).toList();
+              _exportToCsv('Notes', nEvents);
+            } else if (_drawerTab == AudiobookDrawerTab.timeline) {
+              _exportToCsv('All', _getTimelineEvents(chapters));
+            }
+            return;
+          }
+          switch (_drawerTab) {
+            case AudiobookDrawerTab.timeline:
+              final events = _getTimelineEvents(chapters);
+              if (_tvListIndex >= 0 && _tvListIndex < events.length) {
+                final ev = events[_tvListIndex];
+                if (ev.type == TimelineEventType.chapter) {
+                  _jumpToChapter(ev.originalObject as Chapter);
+                } else if (ev.type == TimelineEventType.bookmark) {
+                  final b = ev.originalObject as AudiobookBookmark;
+                  if (_tvSubIndex == 0) {
+                    _manager.seekTo(Duration(milliseconds: b.positionMs));
+                  } else if (_tvSubIndex == 1) {
+                    unawaited(_bookmarks.removeAt(item!.serverId, item.id, b.positionMs));
+                    setState(() {
+                      _tvSubIndex = 0;
+                    });
+                  }
+                } else if (ev.type == TimelineEventType.note) {
+                  final n = ev.originalObject as AudiobookNote;
+                  if (_tvSubIndex == 0) {
+                    _manager.seekTo(Duration(milliseconds: n.positionMs));
+                  } else if (_tvSubIndex == 1) {
+                    _openNoteEditor(item!, existing: n);
+                  } else if (_tvSubIndex == 2) {
+                    unawaited(_notes.remove(item!.serverId, item.id, n.id));
+                    setState(() {
+                      _tvSubIndex = 0;
+                    });
+                  }
+                }
+              }
+              break;
+            case AudiobookDrawerTab.chapters:
+              if (_tvListIndex >= 0 && _tvListIndex < chapters.length) {
+                _jumpToChapter(chapters[_tvListIndex]);
+              }
+              break;
+            case AudiobookDrawerTab.bookmarks:
+              if (_tvListIndex >= 0 && _tvListIndex < _bookmarksList.length) {
+                final b = _bookmarksList[_tvListIndex];
+                if (_tvSubIndex == 0) {
+                  _manager.seekTo(Duration(milliseconds: b.positionMs));
+                } else if (_tvSubIndex == 1) {
+                  unawaited(_bookmarks.removeAt(item!.serverId, item.id, b.positionMs));
+                  setState(() {
+                    _tvSubIndex = 0;
+                  });
+                }
+              }
+              break;
+            case AudiobookDrawerTab.notes:
+              if (_tvListIndex >= 0 && _tvListIndex < _notesList.length) {
+                final n = _notesList[_tvListIndex];
+                if (_tvSubIndex == 0) {
+                  _manager.seekTo(Duration(milliseconds: n.positionMs));
+                } else if (_tvSubIndex == 1) {
+                  _openNoteEditor(item!, existing: n);
+                } else if (_tvSubIndex == 2) {
+                  unawaited(_notes.remove(item!.serverId, item.id, n.id));
+                  setState(() {
+                    _tvSubIndex = 0;
+                  });
+                }
+              }
+              break;
+            case AudiobookDrawerTab.queue:
+              if (_tvListIndex >= 0 && _tvListIndex < _queue.items.length) {
+                _manager.playFromQueue(_tvListIndex);
+              }
+              break;
+          }
+        }
         break;
     }
   }
@@ -877,17 +1529,18 @@ class _CoverArt extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const bookAspectRatio = 0.68;
-    final width = size * bookAspectRatio;
-    final height = size;
-
     Widget child;
     if (localPosterPath != null && File(localPosterPath!).existsSync()) {
-      child = Image.file(File(localPosterPath!), fit: BoxFit.cover);
+      child = Image.file(
+        File(localPosterPath!),
+        height: size,
+        fit: BoxFit.contain,
+      );
     } else if (coverUrl != null) {
       child = CachedNetworkImage(
         imageUrl: coverUrl!,
-        fit: BoxFit.cover,
+        height: size,
+        fit: BoxFit.contain,
         placeholder: (_, _) => _placeholder(),
         errorWidget: (_, _, _) => _placeholder(),
       );
@@ -895,40 +1548,27 @@ class _CoverArt extends StatelessWidget {
       child = _placeholder();
     }
 
-    return SizedBox(
-      width: width,
-      height: height,
-      child: Stack(
-        children: [
-          Positioned(
-            left: 8,
-            top: 12,
-            right: -4,
-            bottom: -8,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(10),
-                color: AppColorScheme.accent.withValues(alpha: 0.18),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.45),
-                    blurRadius: 38,
-                    offset: const Offset(6, 14),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(10),
-            child: SizedBox(width: width, height: height, child: child),
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.45),
+            blurRadius: 38,
+            offset: const Offset(6, 14),
           ),
         ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(10),
+        child: child,
       ),
     );
   }
 
   Widget _placeholder() => Container(
+        height: size,
+        width: size * 0.68,
         color: AppColorScheme.surfaceVariant,
         child: Icon(
           Icons.menu_book,
@@ -979,47 +1619,6 @@ class _TitleBlock extends StatelessWidget {
           ),
         ],
       ],
-    );
-  }
-}
-
-class _ActiveTimersPanel extends StatelessWidget {
-  const _ActiveTimersPanel({required this.sleep, required this.onCancelSleep});
-
-  final SleepTimerController sleep;
-  final VoidCallback onCancelSleep;
-
-  @override
-  Widget build(BuildContext context) {
-    if (!sleep.isActive) return const SizedBox.shrink();
-    final l10n = AppLocalizations.of(context);
-    return Card(
-      color: AppColorScheme.surface.withValues(alpha: 0.55),
-      elevation: 0,
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.spaceLg),
-        child: Row(
-          children: [
-            Icon(Icons.bedtime, color: AppColorScheme.accent),
-            const SizedBox(width: AppSpacing.spaceSm),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(l10n.audiobookSleepTimer,
-                      style: const TextStyle(fontWeight: FontWeight.w700)),
-                  Text(l10n.audiobookSleepRemaining(
-                      formatAudiobookCountdown(sleep.remaining))),
-                ],
-              ),
-            ),
-            IconButton(
-              icon: const Icon(Icons.close),
-              onPressed: onCancelSleep,
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -63,6 +63,10 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   final _subs = <StreamSubscription>[];
   final _tvFocus = FocusNode(debugLabel: 'AudiobookTvFocus');
+  // Position ticks arrive several times a second; drive them through a notifier
+  // so only the scrubbers and chapter strip repaint, not the whole view.
+  final ValueNotifier<Duration> _positionNotifier =
+      ValueNotifier(Duration.zero);
 
   AudiobookDrawerTab _drawerTab = AudiobookDrawerTab.chapters;
   bool _drawerOpen = false;
@@ -102,12 +106,13 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     _subs.addAll([
       _manager.backendChangedStream.listen((_) => _rebuild()),
       _state.playingStream.listen((_) => _rebuild()),
-      _state.positionStream.listen((_) => _rebuild()),
+      _state.positionStream.listen((_) => _positionNotifier.value = _state.position),
       _state.durationStream.listen((_) => _rebuild()),
       _queue.queueChangedStream.listen((_) => _rebuild()),
       _sleep.onExpired.listen((_) => _onSleepTimerExpired()),
     ]);
     _sleep.addListener(_rebuild);
+    _positionNotifier.value = _state.position;
 
     if (PlatformDetection.useNativeVideoSurface) {
       unawaited(_manager.backend?.setVolume(100.0));
@@ -134,6 +139,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     }
     _sleep.removeListener(_rebuild);
     _tvFocus.dispose();
+    _positionNotifier.dispose();
     super.dispose();
   }
 
@@ -695,13 +701,16 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                 const SizedBox(height: AppSpacing.spaceLg),
                 _TitleBlock(item: item, centered: true),
                 const SizedBox(height: AppSpacing.spaceMd),
-                AudiobookChapterContextStrip(
-                  chapters: chapters,
-                  position: _state.position,
-                  onTap: () {
-                    _setDrawerTab(AudiobookDrawerTab.chapters);
-                    _openDrawerSheet(context, item, chapters);
-                  },
+                ValueListenableBuilder<Duration>(
+                  valueListenable: _positionNotifier,
+                  builder: (context, pos, _) => AudiobookChapterContextStrip(
+                    chapters: chapters,
+                    position: pos,
+                    onTap: () {
+                      _setDrawerTab(AudiobookDrawerTab.chapters);
+                      _openDrawerSheet(context, item, chapters);
+                    },
+                  ),
                 ),
               ],
             ),
@@ -776,13 +785,17 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        AudiobookChapterContextStrip(
-                          chapters: chapters,
-                          position: _state.position,
-                          onTap: () => setState(() {
-                            _drawerOpen = true;
-                            _drawerTab = AudiobookDrawerTab.chapters;
-                          }),
+                        ValueListenableBuilder<Duration>(
+                          valueListenable: _positionNotifier,
+                          builder: (context, pos, _) =>
+                              AudiobookChapterContextStrip(
+                            chapters: chapters,
+                            position: pos,
+                            onTap: () => setState(() {
+                              _drawerOpen = true;
+                              _drawerTab = AudiobookDrawerTab.chapters;
+                            }),
+                          ),
                         ),
                         const SizedBox(height: AppSpacing.spaceMd),
                         Expanded(
@@ -822,27 +835,35 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          AudiobookZoomedProgressBar(
-            position: _state.position,
-            duration: _state.duration,
-            chapters: chapters,
-            bookmarks: _bookmarksList,
-            notes: _notesList,
-            isTvFocused: PlatformDetection.isTV &&
-                _tvArea == _AudiobookFocusArea.progress,
-            showRemaining: _showRemaining,
-            onSeek: (d) => _manager.seekTo(d),
-            onToggleRemaining: () => _setShowRemaining(!_showRemaining),
-            formatPosition: formatAudiobookClock,
-            formatRemaining: _formatRemaining,
-          ),
-          const SizedBox(height: AppSpacing.spaceXs),
-          AudiobookBookOverview(
-            position: _state.position,
-            duration: _state.duration,
-            chapters: chapters,
-            bookmarks: _bookmarksList,
-            notes: _notesList,
+          ValueListenableBuilder<Duration>(
+            valueListenable: _positionNotifier,
+            builder: (context, pos, _) => Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AudiobookZoomedProgressBar(
+                  position: pos,
+                  duration: _state.duration,
+                  chapters: chapters,
+                  bookmarks: _bookmarksList,
+                  notes: _notesList,
+                  isTvFocused: PlatformDetection.isTV &&
+                      _tvArea == _AudiobookFocusArea.progress,
+                  showRemaining: _showRemaining,
+                  onSeek: (d) => _manager.seekTo(d),
+                  onToggleRemaining: () => _setShowRemaining(!_showRemaining),
+                  formatPosition: formatAudiobookClock,
+                  formatRemaining: _formatRemaining,
+                ),
+                const SizedBox(height: AppSpacing.spaceXs),
+                AudiobookBookOverview(
+                  position: pos,
+                  duration: _state.duration,
+                  chapters: chapters,
+                  bookmarks: _bookmarksList,
+                  notes: _notesList,
+                ),
+              ],
+            ),
           ),
           if (PlatformDetection.useMobileUi) ...[
             const SizedBox(height: AppSpacing.spaceMd),

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -16,6 +16,7 @@ import '../../../data/models/aggregated_item.dart';
 import '../../../data/repositories/item_mutation_repository.dart';
 import '../../../data/services/audiobook_bookmarks_service.dart';
 import '../../../data/services/audiobook_notes_service.dart';
+import '../../../data/services/audiobook_resume_service.dart';
 import '../../../data/services/cast/cast_service.dart';
 import '../../../data/services/media_server_client_factory.dart';
 import '../../../data/services/storage_path_service.dart';
@@ -59,7 +60,12 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   final _prefs = GetIt.instance<UserPreferences>();
   final _bookmarks = GetIt.instance<AudiobookBookmarksService>();
   final _notes = GetIt.instance<AudiobookNotesService>();
+  final _resume = GetIt.instance<AudiobookResumeService>();
   final _sleep = GetIt.instance<SleepTimerController>();
+
+  Timer? _resumeTimer;
+  String? _resumeAppliedForItemId;
+  bool _resumeRestored = false;
 
   final _subs = <StreamSubscription>[];
   final _tvFocus = FocusNode(debugLabel: 'AudiobookTvFocus');
@@ -105,7 +111,10 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
     _subs.addAll([
       _manager.backendChangedStream.listen((_) => _rebuild()),
-      _state.playingStream.listen((_) => _rebuild()),
+      _state.playingStream.listen((_) {
+        _rebuild();
+        if (!_state.isPlaying) _saveResume();
+      }),
       _state.positionStream.listen((_) => _positionNotifier.value = _state.position),
       _state.durationStream.listen((_) => _rebuild()),
       _queue.queueChangedStream.listen((_) => _rebuild()),
@@ -113,6 +122,9 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     ]);
     _sleep.addListener(_rebuild);
     _positionNotifier.value = _state.position;
+    _resumeTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      if (_state.isPlaying) _saveResume();
+    });
 
     if (PlatformDetection.useNativeVideoSurface) {
       unawaited(_manager.backend?.setVolume(100.0));
@@ -132,6 +144,8 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   @override
   void dispose() {
+    _saveResume();
+    _resumeTimer?.cancel();
     _bookmarkSub?.cancel();
     _noteSub?.cancel();
     for (final s in _subs) {
@@ -183,7 +197,38 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   void _rebuild() {
     _updateStreamSubscriptions();
+    unawaited(_maybeApplyResume());
     if (mounted) setState(() {});
+  }
+
+  // Restore the locally storedd resume position once playback is ready, seeking
+  // only if it is ahead of where the server already resumed us to. Saving is
+  // gated until this runs so the initial position never overwrites the store.
+  Future<void> _maybeApplyResume() async {
+    final item = _resolveItem();
+    if (item == null) return;
+    if (_resumeAppliedForItemId == item.id) return;
+    if (_state.duration <= Duration.zero) return;
+    _resumeAppliedForItemId = item.id;
+    _resumeRestored = false;
+    final ms = await _resume.load(item.serverId, item.id);
+    if (!mounted || _resumeAppliedForItemId != item.id) return;
+    final currentMs = _state.position.inMilliseconds;
+    if (ms != null && ms > currentMs + 1500) {
+      await _manager.seekTo(Duration(milliseconds: ms));
+    }
+    _resumeRestored = true;
+  }
+
+  void _saveResume() {
+    final item = _resolveItem();
+    if (item == null ||
+        !_resumeRestored ||
+        _resumeAppliedForItemId != item.id) {
+      return;
+    }
+    unawaited(
+        _resume.save(item.serverId, item.id, _state.position.inMilliseconds));
   }
 
   void _onSleepTimerExpired() {

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -855,7 +855,16 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             bookmarks: _bookmarksList,
             notes: _notesList,
           ),
-          const SizedBox(height: AppSpacing.spaceSm),
+          if (PlatformDetection.useMobileUi) ...[
+            const SizedBox(height: AppSpacing.spaceMd),
+            Divider(
+              height: 1,
+              thickness: 1,
+              color: AppColorScheme.onSurface.withValues(alpha: 0.06),
+            ),
+            const SizedBox(height: AppSpacing.spaceMd),
+          ] else
+            const SizedBox(height: AppSpacing.spaceSm),
           AudiobookTransportRow(
             isPlaying: _state.isPlaying,
             tvFocusIndex: PlatformDetection.isTV &&
@@ -873,7 +882,11 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             onSkipForward: _skipForward,
             onNextChapter: () => _nextChapter(chapters),
           ),
-          const SizedBox(height: AppSpacing.spaceSm),
+          SizedBox(
+            height: PlatformDetection.useMobileUi
+                ? AppSpacing.spaceLg
+                : AppSpacing.spaceSm,
+          ),
           AudiobookActionRail(
             speed: _state.playbackSpeed,
             sleepActive: _sleep.isActive,

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -232,7 +232,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   }
 
   void _onSleepTimerExpired() {
-    debugPrint('AudiobookPlayerView: _onSleepTimerExpired triggered!');
     if (!mounted) return;
 
     final lastMode = _sleep.lastActiveMode;
@@ -425,7 +424,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
         );
       }
     } catch (e) {
-      debugPrint('[ExportDebug] Failed to export CSV: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -603,13 +601,10 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   }
 
   Future<void> _openNoteEditor(AggregatedItem item, {AudiobookNote? existing}) async {
-    debugPrint('[AudiobookPlayer] _openNoteEditor called: dialogOpen=$_dialogOpen');
     if (_dialogOpen) {
-      debugPrint('[AudiobookPlayer] _openNoteEditor BLOCKED by dialogOpen lock');
       return;
     }
     _dialogOpen = true;
-    debugPrint('[AudiobookPlayer] _openNoteEditor dialog OPENED');
 
     final wasPlaying = _state.isPlaying;
     if (wasPlaying) await _manager.pause();
@@ -623,14 +618,12 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       initialText: existing?.body ?? '',
       positionLabel: formatAudiobookClock(Duration(milliseconds: pos)),
     );
-    debugPrint('[AudiobookPlayer] _openNoteEditor returned result: ${result != null ? '"$result"' : 'null'}');
 
     // Hold the lock long enough to cover the dialog route exit animation
     // and clear any trailing key events. The Select-KeyDownOnly fix in
     // _handleTvKey already prevents KeyRepeat from re-triggering; 300ms
     // is enough buffer without making the player feel frozen.
     await Future.delayed(const Duration(milliseconds: 300));
-    debugPrint('[AudiobookPlayer] _dialogOpen RELEASED');
     _dialogOpen = false;
 
     final noteText = result is String ? result.trim() : null;

--- a/lib/ui/widgets/audiobook/audiobook_action_rail.dart
+++ b/lib/ui/widgets/audiobook/audiobook_action_rail.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../util/platform_detection.dart';
 import 'audiobook_focus_ring.dart';
 import 'audiobook_glass.dart';
@@ -36,11 +37,15 @@ class AudiobookActionRail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final apple = PlatformDetection.isApple;
+    final l10n = AppLocalizations.of(context);
 
     final entries = <_RailEntry>[
       _RailEntry(
         icon: apple ? CupertinoIcons.speedometer : Icons.speed,
-        label: '${speed.toStringAsFixed(speed == speed.toInt() ? 1 : 2)}x',
+        label: l10n.audiobookPlaybackSpeed,
+        subLabel: (speed - 1.0).abs() > 0.01
+            ? '${speed.toStringAsFixed(speed == speed.toInt() ? 1 : 2)}x'
+            : null,
         accent: (speed - 1.0).abs() > 0.01,
         onTap: onOpenSpeed,
       ),
@@ -48,22 +53,26 @@ class AudiobookActionRail extends StatelessWidget {
         icon: apple
             ? (sleepActive ? CupertinoIcons.moon_fill : CupertinoIcons.moon)
             : (sleepActive ? Icons.bedtime : Icons.bedtime_outlined),
-        label: sleepActive ? formatAudiobookCompact(sleepRemaining) : null,
+        label: l10n.audiobookSleepTimer,
+        subLabel: sleepActive ? formatAudiobookCompact(sleepRemaining) : null,
         accent: sleepActive,
         onTap: onOpenSleep,
       ),
       _RailEntry(
         icon: apple ? CupertinoIcons.bookmark : Icons.bookmark_add_outlined,
+        label: l10n.audiobookAddBookmark,
         onTap: onAddBookmark,
       ),
       _RailEntry(
         icon: apple ? CupertinoIcons.pencil : Icons.edit_note,
+        label: l10n.audiobookAddNote,
         onTap: onAddNote,
       ),
       _RailEntry(
         icon: isFavorite
             ? (apple ? CupertinoIcons.heart_fill : Icons.favorite)
             : (apple ? CupertinoIcons.heart : Icons.favorite_border),
+        label: isFavorite ? l10n.favorited : l10n.favorite,
         accent: isFavorite,
         onTap: onToggleFavorite,
       ),
@@ -73,9 +82,9 @@ class AudiobookActionRail extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
         for (var i = 0; i < entries.length; i++)
-          AudiobookFocusRing(
+          entries[i].build(
+            apple: apple,
             focused: tvFocusIndex == i,
-            child: entries[i].build(apple: apple),
           ),
       ],
     );
@@ -84,7 +93,7 @@ class AudiobookActionRail extends StatelessWidget {
       cornerRadius: 18,
       fallbackColor: const Color(0x00000000),
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 2),
+        padding: const EdgeInsets.symmetric(vertical: 4),
         child: row,
       ),
     );
@@ -92,53 +101,191 @@ class AudiobookActionRail extends StatelessWidget {
 }
 
 class _RailEntry {
-  _RailEntry({required this.icon, this.label, this.accent = false, this.onTap});
+  _RailEntry({
+    required this.icon,
+    this.label,
+    this.subLabel,
+    this.accent = false,
+    this.onTap,
+  });
 
   final IconData icon;
   final String? label;
+  final String? subLabel;
   final bool accent;
   final VoidCallback? onTap;
 
-  Widget build({required bool apple}) {
-    final color = accent
+  Widget build({required bool apple, required bool focused}) {
+    return _RailEntryWidget(
+      icon: icon,
+      label: label,
+      subLabel: subLabel,
+      accent: accent,
+      onTap: onTap,
+      apple: apple,
+      forceFocused: focused,
+    );
+  }
+}
+
+class _RailEntryWidget extends StatefulWidget {
+  const _RailEntryWidget({
+    required this.icon,
+    this.label,
+    this.subLabel,
+    this.accent,
+    this.onTap,
+    required this.apple,
+    required this.forceFocused,
+  });
+
+  final IconData icon;
+  final String? label;
+  final String? subLabel;
+  final bool? accent;
+  final VoidCallback? onTap;
+  final bool apple;
+  final bool forceFocused;
+
+  @override
+  State<_RailEntryWidget> createState() => _RailEntryWidgetState();
+}
+
+class _RailEntryWidgetState extends State<_RailEntryWidget> {
+  bool _isHovered = false;
+  bool _isFocused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final isExpanded = widget.forceFocused || _isHovered || _isFocused;
+    final color = (widget.accent ?? false)
         ? AppColorScheme.accent
         : AppColorScheme.onSurface.withValues(
-            alpha: onTap == null ? 0.4 : 0.85,
+            alpha: widget.onTap == null ? 0.4 : 0.85,
           );
 
-    final child = Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(icon, color: color, size: 22),
-        if (label != null) ...[
-          const SizedBox(height: 2),
-          Text(
-            label!,
-            style: TextStyle(
-              fontSize: 10,
-              color: color,
+    final height = 40.0;
+    final totalHeight = 40.0;
+
+    final Widget innerWidget;
+    if (isExpanded && widget.label != null) {
+      final Widget textChild;
+      if (widget.subLabel != null) {
+        textChild = RichText(
+          text: TextSpan(
+            style: const TextStyle(
+              fontSize: 12,
               fontWeight: FontWeight.w600,
             ),
+            children: [
+              TextSpan(
+                text: '${widget.label}: ',
+                style: TextStyle(color: color),
+              ),
+              TextSpan(
+                text: widget.subLabel!,
+                style: TextStyle(color: AppColorScheme.onSurface),
+              ),
+            ],
+          ),
+        );
+      } else {
+        textChild = Text(
+          widget.label!,
+          style: TextStyle(
+            fontSize: 12,
+            color: color,
+            fontWeight: FontWeight.w600,
+          ),
+          maxLines: 1,
+          softWrap: false,
+        );
+      }
+
+      innerWidget = Container(
+        height: height,
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(height / 2),
+          color: Colors.white.withValues(alpha: 0.06),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(widget.icon, color: color, size: 20),
+            const SizedBox(width: 8),
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: textChild,
+            ),
+          ],
+        ),
+      );
+    } else {
+      innerWidget = Container(
+        width: height,
+        height: height,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: Colors.white.withValues(alpha: 0.06),
+        ),
+        child: Center(
+          child: Icon(widget.icon, color: color, size: 20),
+        ),
+      );
+    }
+
+    final Widget buttonWidget;
+    if (isExpanded) {
+      buttonWidget = AudiobookFocusRing(
+        focused: widget.forceFocused,
+        borderRadius: BorderRadius.circular(height / 2),
+        child: innerWidget,
+      );
+    } else if (widget.subLabel != null) {
+      buttonWidget = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          innerWidget,
+          const SizedBox(width: 6),
+          Text(
+            widget.subLabel!,
+            style: TextStyle(
+              fontSize: 12,
+              color: AppColorScheme.onSurface,
+              fontWeight: FontWeight.w600,
+            ),
+            maxLines: 1,
+            softWrap: false,
           ),
         ],
-      ],
+      );
+    } else {
+      buttonWidget = innerWidget;
+    }
+
+    final child = SizedBox(
+      height: totalHeight,
+      child: Center(child: buttonWidget),
     );
 
-    if (apple) {
+    if (widget.apple) {
       return CupertinoButton(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        onPressed: onTap,
+        padding: EdgeInsets.zero,
+        onPressed: widget.onTap,
         child: child,
       );
     }
 
+    final inkWellRadius = BorderRadius.circular(20);
+
     return InkWell(
-      borderRadius: BorderRadius.circular(24),
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        child: child,
-      ),
+      borderRadius: inkWellRadius,
+      onTap: widget.onTap,
+      onHover: (h) => setState(() => _isHovered = h),
+      onFocusChange: (f) => setState(() => _isFocused = f),
+      child: child,
     );
   }
 }

--- a/lib/ui/widgets/audiobook/audiobook_action_rail.dart
+++ b/lib/ui/widgets/audiobook/audiobook_action_rail.dart
@@ -155,14 +155,79 @@ class _RailEntryWidgetState extends State<_RailEntryWidget> {
   bool _isHovered = false;
   bool _isFocused = false;
 
+  Widget _buildCaptioned({required Color color, required bool accent}) {
+    final caption = widget.subLabel ?? widget.label;
+    final captionColor = accent
+        ? AppColorScheme.accent
+        : AppColorScheme.onSurface.withValues(alpha: 0.55);
+
+    final content = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 46,
+          height: 46,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: accent
+                ? AppColorScheme.accent.withValues(alpha: 0.14)
+                : AppColorScheme.onSurface.withValues(alpha: 0.05),
+            border: Border.all(
+              color: AppColorScheme.onSurface.withValues(alpha: 0.08),
+            ),
+          ),
+          child: Center(child: Icon(widget.icon, color: color, size: 20)),
+        ),
+        if (caption != null) ...[
+          const SizedBox(height: 6),
+          SizedBox(
+            width: 62,
+            child: Text(
+              caption,
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: captionColor,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+
+    if (widget.apple) {
+      return CupertinoButton(
+        padding: EdgeInsets.zero,
+        onPressed: widget.onTap,
+        child: content,
+      );
+    }
+    return InkWell(
+      borderRadius: BorderRadius.circular(14),
+      onTap: widget.onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: content,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isExpanded = widget.forceFocused || _isHovered || _isFocused;
-    final color = (widget.accent ?? false)
+    final accent = widget.accent ?? false;
+    final color = accent
         ? AppColorScheme.accent
         : AppColorScheme.onSurface.withValues(
             alpha: widget.onTap == null ? 0.4 : 0.85,
           );
+
+    if (PlatformDetection.useMobileUi) {
+      return _buildCaptioned(color: color, accent: accent);
+    }
 
     final height = 40.0;
     final totalHeight = 40.0;

--- a/lib/ui/widgets/audiobook/audiobook_drawer.dart
+++ b/lib/ui/widgets/audiobook/audiobook_drawer.dart
@@ -571,8 +571,9 @@ class _AudiobookNotesListState extends State<AudiobookNotesList> {
                       final isPlayFocused = isTvFocused && widget.tvSubIndex == 0;
                       final isEditFocused = isTvFocused && widget.tvSubIndex == 1;
                       final isDeleteFocused = isTvFocused && widget.tvSubIndex == 2;
-                      return GestureDetector(
+                      return InkWell(
                         onTap: () => widget.onJump(n),
+                        borderRadius: BorderRadius.circular(8),
                         child: Container(
                           height: 52.0,
                           margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
@@ -1029,7 +1030,7 @@ class _AudiobookQueueListState extends State<AudiobookQueueList> {
             final isTvFocused = index == widget.tvFocusedIndex;
             final titleText = item?.name ?? AppLocalizations.of(context).trackNumber(index + 1);
 
-            return GestureDetector(
+            return InkWell(
               onTap: () => widget.onPlay(index),
               child: Container(
                 height: 34.0,

--- a/lib/ui/widgets/audiobook/audiobook_drawer.dart
+++ b/lib/ui/widgets/audiobook/audiobook_drawer.dart
@@ -356,7 +356,7 @@ class _AudiobookBookmarksListState extends State<AudiobookBookmarksList> {
                     TextButton.icon(
                       onPressed: widget.onExport,
                       icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
-                      label: const Text('Export Bookmarks', style: TextStyle(fontSize: 12)),
+                      label: Text(AppLocalizations.of(context).audiobookExportBookmarks, style: const TextStyle(fontSize: 12)),
                       style: TextButton.styleFrom(
                         foregroundColor: AppColorScheme.accent,
                         visualDensity: VisualDensity.compact,
@@ -551,7 +551,7 @@ class _AudiobookNotesListState extends State<AudiobookNotesList> {
                     TextButton.icon(
                       onPressed: widget.onExport,
                       icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
-                      label: const Text('Export Notes', style: TextStyle(fontSize: 12)),
+                      label: Text(AppLocalizations.of(context).audiobookExportNotes, style: const TextStyle(fontSize: 12)),
                       style: TextButton.styleFrom(
                         foregroundColor: AppColorScheme.accent,
                         visualDensity: VisualDensity.compact,
@@ -776,7 +776,7 @@ class _AudiobookTimelineListState extends State<AudiobookTimelineList> {
   @override
   Widget build(BuildContext context) {
     if (widget.events.isEmpty) {
-      return const _EmptyState(text: 'Timeline is empty');
+      return _EmptyState(text: AppLocalizations.of(context).audiobookTimelineEmpty);
     }
     final apple = PlatformDetection.isApple;
     return Column(
@@ -790,7 +790,7 @@ class _AudiobookTimelineListState extends State<AudiobookTimelineList> {
                 TextButton.icon(
                   onPressed: widget.onExport,
                   icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
-                  label: const Text('Export All', style: TextStyle(fontSize: 12)),
+                  label: Text(AppLocalizations.of(context).audiobookExportAll, style: const TextStyle(fontSize: 12)),
                   style: TextButton.styleFrom(
                     foregroundColor: AppColorScheme.accent,
                     visualDensity: VisualDensity.compact,

--- a/lib/ui/widgets/audiobook/audiobook_drawer.dart
+++ b/lib/ui/widgets/audiobook/audiobook_drawer.dart
@@ -271,7 +271,6 @@ class AudiobookBookmarksList extends StatefulWidget {
     required this.tvFocusedIndex,
     required this.tvSubIndex,
     this.onExport,
-    this.tvExportFocused = false,
   });
 
   final AggregatedItem? item;
@@ -280,7 +279,6 @@ class AudiobookBookmarksList extends StatefulWidget {
   final int tvFocusedIndex;
   final int tvSubIndex;
   final VoidCallback? onExport;
-  final bool tvExportFocused;
 
   @override
   State<AudiobookBookmarksList> createState() => _AudiobookBookmarksListState();
@@ -349,24 +347,24 @@ class _AudiobookBookmarksListState extends State<AudiobookBookmarksList> {
         }
         return Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton.icon(
-                    onPressed: widget.onExport,
-                    icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
-                    label: const Text('Export Bookmarks', style: TextStyle(fontSize: 12)),
-                    style: TextButton.styleFrom(
-                      foregroundColor: widget.tvExportFocused ? Colors.white : AppColorScheme.accent,
-                      backgroundColor: widget.tvExportFocused ? AppColorScheme.accent : null,
-                      visualDensity: VisualDensity.compact,
+            if (!PlatformDetection.isTV && widget.onExport != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton.icon(
+                      onPressed: widget.onExport,
+                      icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
+                      label: const Text('Export Bookmarks', style: TextStyle(fontSize: 12)),
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColorScheme.accent,
+                        visualDensity: VisualDensity.compact,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
             Expanded(
               child: LayoutBuilder(
                 builder: (context, constraints) {
@@ -467,7 +465,6 @@ class AudiobookNotesList extends StatefulWidget {
     required this.tvFocusedIndex,
     required this.tvSubIndex,
     this.onExport,
-    this.tvExportFocused = false,
   });
 
   final AggregatedItem? item;
@@ -477,7 +474,6 @@ class AudiobookNotesList extends StatefulWidget {
   final int tvFocusedIndex;
   final int tvSubIndex;
   final VoidCallback? onExport;
-  final bool tvExportFocused;
 
   @override
   State<AudiobookNotesList> createState() => _AudiobookNotesListState();
@@ -546,24 +542,24 @@ class _AudiobookNotesListState extends State<AudiobookNotesList> {
         }
         return Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton.icon(
-                    onPressed: widget.onExport,
-                    icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
-                    label: const Text('Export Notes', style: TextStyle(fontSize: 12)),
-                    style: TextButton.styleFrom(
-                      foregroundColor: widget.tvExportFocused ? Colors.white : AppColorScheme.accent,
-                      backgroundColor: widget.tvExportFocused ? AppColorScheme.accent : null,
-                      visualDensity: VisualDensity.compact,
+            if (!PlatformDetection.isTV && widget.onExport != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton.icon(
+                      onPressed: widget.onExport,
+                      icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
+                      label: const Text('Export Notes', style: TextStyle(fontSize: 12)),
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColorScheme.accent,
+                        visualDensity: VisualDensity.compact,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
             Expanded(
               child: LayoutBuilder(
                 builder: (context, constraints) {
@@ -715,7 +711,6 @@ class AudiobookTimelineList extends StatefulWidget {
     required this.tvFocusedIndex,
     required this.tvSubIndex,
     this.onExport,
-    this.tvExportFocused = false,
   });
 
   final List<TimelineEvent> events;
@@ -726,7 +721,6 @@ class AudiobookTimelineList extends StatefulWidget {
   final int tvFocusedIndex;
   final int tvSubIndex;
   final VoidCallback? onExport;
-  final bool tvExportFocused;
 
   @override
   State<AudiobookTimelineList> createState() => _AudiobookTimelineListState();
@@ -787,24 +781,24 @@ class _AudiobookTimelineListState extends State<AudiobookTimelineList> {
     final apple = PlatformDetection.isApple;
     return Column(
       children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton.icon(
-                onPressed: widget.onExport,
-                icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
-                label: const Text('Export All', style: TextStyle(fontSize: 12)),
-                style: TextButton.styleFrom(
-                  foregroundColor: widget.tvExportFocused ? Colors.white : AppColorScheme.accent,
-                  backgroundColor: widget.tvExportFocused ? AppColorScheme.accent : null,
-                  visualDensity: VisualDensity.compact,
+        if (!PlatformDetection.isTV && widget.onExport != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton.icon(
+                  onPressed: widget.onExport,
+                  icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
+                  label: const Text('Export All', style: TextStyle(fontSize: 12)),
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppColorScheme.accent,
+                    visualDensity: VisualDensity.compact,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-        ),
         Expanded(
           child: LayoutBuilder(
             builder: (context, constraints) {

--- a/lib/ui/widgets/audiobook/audiobook_drawer.dart
+++ b/lib/ui/widgets/audiobook/audiobook_drawer.dart
@@ -11,7 +11,7 @@ import '../../../util/platform_detection.dart';
 import 'audiobook_time.dart';
 import 'chapter.dart';
 
-enum AudiobookDrawerTab { chapters, bookmarks, notes, queue }
+enum AudiobookDrawerTab { timeline, chapters, bookmarks, notes, queue }
 
 class AudiobookDrawerTabBar extends StatelessWidget {
   const AudiobookDrawerTabBar({
@@ -21,6 +21,7 @@ class AudiobookDrawerTabBar extends StatelessWidget {
     required this.labels,
     required this.tvFocused,
     required this.tvIndex,
+    required this.tabs,
   });
 
   final AudiobookDrawerTab current;
@@ -28,10 +29,10 @@ class AudiobookDrawerTabBar extends StatelessWidget {
   final Map<AudiobookDrawerTab, String> labels;
   final bool tvFocused;
   final int tvIndex;
+  final List<AudiobookDrawerTab> tabs;
 
   @override
   Widget build(BuildContext context) {
-    final tabs = AudiobookDrawerTab.values;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Row(
@@ -118,96 +119,219 @@ class AudiobookPillSegment extends StatelessWidget {
   }
 }
 
-class AudiobookChaptersList extends StatelessWidget {
+class AudiobookChaptersList extends StatefulWidget {
   const AudiobookChaptersList({
     super.key,
     required this.chapters,
     required this.position,
     required this.onTap,
+    required this.tvFocusedIndex,
   });
 
   final List<Chapter> chapters;
   final Duration position;
   final ValueChanged<Chapter> onTap;
+  final int tvFocusedIndex;
+
+  @override
+  State<AudiobookChaptersList> createState() => _AudiobookChaptersListState();
+}
+
+class _AudiobookChaptersListState extends State<AudiobookChaptersList> {
+  late final ScrollController _scrollController = ScrollController();
+  double _viewportHeight = 300.0;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(AudiobookChaptersList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.tvFocusedIndex != oldWidget.tvFocusedIndex && widget.tvFocusedIndex != -1) {
+      _scrollToFocused();
+    }
+  }
+
+  void _scrollToFocused() {
+    if (!_scrollController.hasClients) return;
+    const double itemHeight = 44.0; // container height 40 + margin vertical 2*2
+    final double target = widget.tvFocusedIndex * itemHeight;
+    final double currentScroll = _scrollController.offset;
+    
+    if (target < currentScroll) {
+      _scrollController.animateTo(
+        target,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    } else if (target + itemHeight > currentScroll + _viewportHeight) {
+      _scrollController.animateTo(
+        target + itemHeight - _viewportHeight,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (chapters.isEmpty) {
+    if (widget.chapters.isEmpty) {
       return _EmptyState(
         text: AppLocalizations.of(context).audiobookNoChapters,
       );
     }
     var current = 0;
-    for (var i = 0; i < chapters.length; i++) {
-      if (chapters[i].startMs <= position.inMilliseconds) {
+    for (var i = 0; i < widget.chapters.length; i++) {
+      if (widget.chapters[i].startMs <= widget.position.inMilliseconds) {
         current = i;
       } else {
         break;
       }
     }
-    return ListView.builder(
-      itemCount: chapters.length,
-      itemBuilder: (context, index) {
-        final c = chapters[index];
-        final isCurrent = index == current;
-        return ListTile(
-          dense: true,
-          onTap: () => onTap(c),
-          leading: SizedBox(
-            width: 36,
-            child: Text(
-              '${index + 1}',
-              textAlign: TextAlign.right,
-              style: TextStyle(
-                fontFeatures: const [FontFeature.tabularFigures()],
-                color: isCurrent
-                    ? AppColorScheme.accent
-                    : AppColorScheme.onSurface.withValues(alpha: 0.6),
-                fontWeight: FontWeight.w700,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        _viewportHeight = constraints.maxHeight;
+        return ListView.builder(
+          controller: _scrollController,
+          itemCount: widget.chapters.length,
+          itemBuilder: (context, index) {
+            final c = widget.chapters[index];
+            final isCurrent = index == current;
+            final isTvFocused = index == widget.tvFocusedIndex;
+
+            return Container(
+              height: 40.0,
+              margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: isTvFocused ? AppColorScheme.accent : Colors.transparent,
+                  width: 2.0,
+                ),
+                borderRadius: BorderRadius.circular(8),
               ),
-            ),
-          ),
-          title: Text(
-            c.title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: isCurrent ? AppColorScheme.accent : null,
-              fontWeight: isCurrent ? FontWeight.w700 : FontWeight.w500,
-            ),
-          ),
-          trailing: Text(
-            formatAudiobookClock(Duration(milliseconds: c.startMs)),
-            style: TextStyle(
-              fontFeatures: const [FontFeature.tabularFigures()],
-              color: AppColorScheme.onSurface.withValues(alpha: 0.5),
-              fontSize: 12,
-            ),
-          ),
+              child: ListTile(
+                dense: true,
+                onTap: () => widget.onTap(c),
+                leading: SizedBox(
+                  width: 36,
+                  child: Text(
+                    '${index + 1}',
+                    textAlign: TextAlign.right,
+                    style: TextStyle(
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                      color: isCurrent
+                          ? AppColorScheme.accent
+                          : AppColorScheme.onSurface.withValues(alpha: 0.6),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                title: Text(
+                  c.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: isCurrent ? AppColorScheme.accent : null,
+                    fontWeight: isCurrent ? FontWeight.w700 : FontWeight.w500,
+                  ),
+                ),
+                trailing: Text(
+                  formatAudiobookClock(Duration(milliseconds: c.startMs)),
+                  style: TextStyle(
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                    color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            );
+          },
         );
       },
     );
   }
 }
 
-class AudiobookBookmarksList extends StatelessWidget {
+class AudiobookBookmarksList extends StatefulWidget {
   const AudiobookBookmarksList({
     super.key,
     required this.item,
     required this.service,
     required this.onJump,
+    required this.tvFocusedIndex,
+    required this.tvSubIndex,
+    this.onExport,
+    this.tvExportFocused = false,
   });
 
   final AggregatedItem? item;
   final AudiobookBookmarksService service;
   final ValueChanged<AudiobookBookmark> onJump;
+  final int tvFocusedIndex;
+  final int tvSubIndex;
+  final VoidCallback? onExport;
+  final bool tvExportFocused;
+
+  @override
+  State<AudiobookBookmarksList> createState() => _AudiobookBookmarksListState();
+}
+
+class _AudiobookBookmarksListState extends State<AudiobookBookmarksList> {
+  late final ScrollController _scrollController = ScrollController();
+  double _viewportHeight = 300.0;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(AudiobookBookmarksList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.tvFocusedIndex != oldWidget.tvFocusedIndex) {
+      _scrollToFocused();
+    }
+  }
+
+  void _scrollToFocused() {
+    if (!_scrollController.hasClients) return;
+    if (widget.tvFocusedIndex == -1) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+      return;
+    }
+    const double itemHeight = 56.0; // container height 52 + margin vertical 2*2
+    final double target = widget.tvFocusedIndex * itemHeight;
+    final double currentScroll = _scrollController.offset;
+    
+    if (target < currentScroll) {
+      _scrollController.animateTo(
+        target,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    } else if (target + itemHeight > currentScroll + _viewportHeight) {
+      _scrollController.animateTo(
+        target + itemHeight - _viewportHeight,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (item == null) return const SizedBox.shrink();
+    if (widget.item == null) return const SizedBox.shrink();
     final apple = PlatformDetection.isApple;
     return StreamBuilder<List<AudiobookBookmark>>(
-      stream: service.watch(item!.serverId, item!.id),
+      stream: widget.service.watch(widget.item!.serverId, widget.item!.id),
       initialData: const [],
       builder: (context, snapshot) {
         final list = snapshot.data ?? const [];
@@ -216,59 +340,195 @@ class AudiobookBookmarksList extends StatelessWidget {
             text: AppLocalizations.of(context).audiobookNoBookmarks,
           );
         }
-        return ListView.builder(
-          itemCount: list.length,
-          itemBuilder: (context, index) {
-            final b = list[index];
-            return ListTile(
-              leading: Icon(
-                apple ? CupertinoIcons.bookmark_fill : Icons.bookmark,
-                color: AppColorScheme.accent,
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton.icon(
+                    onPressed: widget.onExport,
+                    icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
+                    label: const Text('Export Bookmarks', style: TextStyle(fontSize: 12)),
+                    style: TextButton.styleFrom(
+                      foregroundColor: widget.tvExportFocused ? Colors.white : AppColorScheme.accent,
+                      backgroundColor: widget.tvExportFocused ? AppColorScheme.accent : null,
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ),
+                ],
               ),
-              title: Text(b.label),
-              subtitle: Text(
-                b.createdAt.toLocal().toString().split('.').first,
-                style: TextStyle(
-                  fontSize: 11,
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.5),
-                ),
+            ),
+            Expanded(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  _viewportHeight = constraints.maxHeight;
+                  return ListView.builder(
+                    controller: _scrollController,
+                    itemCount: list.length,
+                    itemBuilder: (context, index) {
+                      final b = list[index];
+                      final isTvFocused = index == widget.tvFocusedIndex;
+                      final isPlayFocused = isTvFocused && widget.tvSubIndex == 0;
+                      final isDeleteFocused = isTvFocused && widget.tvSubIndex == 1;
+                      return Container(
+                        height: 52.0,
+                        margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: isTvFocused ? AppColorScheme.accent : Colors.transparent,
+                            width: 2.0,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: ListTile(
+                          dense: true,
+                          visualDensity: VisualDensity.compact,
+                          tileColor: isPlayFocused ? AppColorScheme.accent.withValues(alpha: 0.12) : null,
+                          leading: Container(
+                            decoration: BoxDecoration(
+                              color: isPlayFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: isPlayFocused ? Colors.white : Colors.transparent,
+                                width: 1.5,
+                              ),
+                            ),
+                            padding: const EdgeInsets.all(4),
+                            child: Icon(
+                              apple ? CupertinoIcons.bookmark_fill : Icons.bookmark,
+                              color: isPlayFocused ? Colors.white : AppColorScheme.accent,
+                              size: 20,
+                            ),
+                          ),
+                          title: Text(
+                            'Bookmark ${index + 1}: ${b.label}',
+                            style: TextStyle(
+                              color: isPlayFocused ? Colors.white : null,
+                              fontWeight: isPlayFocused ? FontWeight.w700 : null,
+                            ),
+                          ),
+                          subtitle: Text(
+                            b.createdAt.toLocal().toString().split('.').first,
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: isPlayFocused ? Colors.white.withValues(alpha: 0.7) : AppColorScheme.onSurface.withValues(alpha: 0.5),
+                            ),
+                          ),
+                          trailing: Container(
+                            decoration: BoxDecoration(
+                              color: isDeleteFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: isDeleteFocused ? Colors.white : Colors.transparent,
+                                width: 1.5,
+                              ),
+                            ),
+                            child: IconButton(
+                              icon: Icon(
+                                apple ? CupertinoIcons.delete : Icons.delete_outline,
+                                size: 20,
+                                color: isDeleteFocused ? Colors.white : null,
+                              ),
+                              onPressed: () =>
+                                  widget.service.removeAt(widget.item!.serverId, widget.item!.id, b.positionMs),
+                            ),
+                          ),
+                          onTap: () => widget.onJump(b),
+                        ),
+                      );
+                    },
+                  );
+                },
               ),
-              trailing: IconButton(
-                icon: Icon(
-                  apple ? CupertinoIcons.delete : Icons.delete_outline,
-                ),
-                onPressed: () =>
-                    service.removeAt(item!.serverId, item!.id, b.positionMs),
-              ),
-              onTap: () => onJump(b),
-            );
-          },
+            ),
+          ],
         );
       },
     );
   }
 }
 
-class AudiobookNotesList extends StatelessWidget {
+class AudiobookNotesList extends StatefulWidget {
   const AudiobookNotesList({
     super.key,
     required this.item,
     required this.service,
     required this.onJump,
     required this.onEdit,
+    required this.tvFocusedIndex,
+    required this.tvSubIndex,
+    this.onExport,
+    this.tvExportFocused = false,
   });
 
   final AggregatedItem? item;
   final AudiobookNotesService service;
   final ValueChanged<AudiobookNote> onJump;
   final ValueChanged<AudiobookNote> onEdit;
+  final int tvFocusedIndex;
+  final int tvSubIndex;
+  final VoidCallback? onExport;
+  final bool tvExportFocused;
+
+  @override
+  State<AudiobookNotesList> createState() => _AudiobookNotesListState();
+}
+
+class _AudiobookNotesListState extends State<AudiobookNotesList> {
+  late final ScrollController _scrollController = ScrollController();
+  double _viewportHeight = 300.0;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(AudiobookNotesList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.tvFocusedIndex != oldWidget.tvFocusedIndex) {
+      _scrollToFocused();
+    }
+  }
+
+  void _scrollToFocused() {
+    if (!_scrollController.hasClients) return;
+    if (widget.tvFocusedIndex == -1) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+      return;
+    }
+    const double itemHeight = 56.0; // container height 52 + margin vertical 2*2
+    final double target = widget.tvFocusedIndex * itemHeight;
+    final double currentScroll = _scrollController.offset;
+    
+    if (target < currentScroll) {
+      _scrollController.animateTo(
+        target,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    } else if (target + itemHeight > currentScroll + _viewportHeight) {
+      _scrollController.animateTo(
+        target + itemHeight - _viewportHeight,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (item == null) return const SizedBox.shrink();
+    if (widget.item == null) return const SizedBox.shrink();
     final apple = PlatformDetection.isApple;
     return StreamBuilder<List<AudiobookNote>>(
-      stream: service.watch(item!.serverId, item!.id),
+      stream: widget.service.watch(widget.item!.serverId, widget.item!.id),
       initialData: const [],
       builder: (context, snapshot) {
         final list = snapshot.data ?? const [];
@@ -277,93 +537,543 @@ class AudiobookNotesList extends StatelessWidget {
             text: AppLocalizations.of(context).audiobookNoNotes,
           );
         }
-        return ListView.separated(
-          padding: const EdgeInsets.symmetric(vertical: 4),
-          itemCount: list.length,
-          separatorBuilder: (_, _) => const Divider(height: 1),
-          itemBuilder: (context, index) {
-            final n = list[index];
-            return ListTile(
-              isThreeLine: true,
-              title: Text(
-                formatAudiobookClock(Duration(milliseconds: n.positionMs)),
-                style: TextStyle(
-                  color: AppColorScheme.accent,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              subtitle: Padding(
-                padding: const EdgeInsets.only(top: 4),
-                child: Text(
-                  n.body,
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              onTap: () => onJump(n),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  IconButton(
-                    icon: Icon(
-                      apple ? CupertinoIcons.pencil : Icons.edit_outlined,
-                      size: 20,
+                  TextButton.icon(
+                    onPressed: widget.onExport,
+                    icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
+                    label: const Text('Export Notes', style: TextStyle(fontSize: 12)),
+                    style: TextButton.styleFrom(
+                      foregroundColor: widget.tvExportFocused ? Colors.white : AppColorScheme.accent,
+                      backgroundColor: widget.tvExportFocused ? AppColorScheme.accent : null,
+                      visualDensity: VisualDensity.compact,
                     ),
-                    onPressed: () => onEdit(n),
-                  ),
-                  IconButton(
-                    icon: Icon(
-                      apple ? CupertinoIcons.delete : Icons.delete_outline,
-                      size: 20,
-                    ),
-                    onPressed: () =>
-                        service.remove(item!.serverId, item!.id, n.id),
                   ),
                 ],
               ),
-            );
-          },
+            ),
+            Expanded(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  _viewportHeight = constraints.maxHeight;
+                  return ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    itemCount: list.length,
+                    itemBuilder: (context, index) {
+                      final n = list[index];
+                      final isTvFocused = index == widget.tvFocusedIndex;
+                      final isPlayFocused = isTvFocused && widget.tvSubIndex == 0;
+                      final isEditFocused = isTvFocused && widget.tvSubIndex == 1;
+                      final isDeleteFocused = isTvFocused && widget.tvSubIndex == 2;
+                      return GestureDetector(
+                        onTap: () => widget.onJump(n),
+                        child: Container(
+                          height: 52.0,
+                          margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: isTvFocused ? AppColorScheme.accent : Colors.transparent,
+                              width: 2.0,
+                            ),
+                            borderRadius: BorderRadius.circular(8),
+                            color: isPlayFocused ? AppColorScheme.accent.withValues(alpha: 0.12) : null,
+                          ),
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          child: Row(
+                            children: [
+                              Container(
+                                decoration: BoxDecoration(
+                                  color: isPlayFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                                  shape: BoxShape.circle,
+                                  border: Border.all(
+                                    color: isPlayFocused ? Colors.white : Colors.transparent,
+                                    width: 1.5,
+                                  ),
+                                ),
+                                padding: const EdgeInsets.all(4),
+                                child: Icon(
+                                  apple ? CupertinoIcons.chat_bubble_text : Icons.note_outlined,
+                                  color: isPlayFocused ? Colors.white : AppColorScheme.accent,
+                                  size: 20,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      formatAudiobookClock(Duration(milliseconds: n.positionMs)),
+                                      style: TextStyle(
+                                        color: isPlayFocused ? Colors.white : AppColorScheme.accent,
+                                        fontSize: 12,
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      n.body,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: TextStyle(
+                                        fontSize: 11,
+                                        color: isPlayFocused
+                                            ? Colors.white.withValues(alpha: 0.7)
+                                            : AppColorScheme.onSurface.withValues(alpha: 0.8),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Container(
+                                    decoration: BoxDecoration(
+                                      color: isEditFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                                      shape: BoxShape.circle,
+                                      border: Border.all(
+                                        color: isEditFocused ? Colors.white : Colors.transparent,
+                                        width: 1.5,
+                                      ),
+                                    ),
+                                    child: IconButton(
+                                      icon: Icon(
+                                        apple ? CupertinoIcons.pencil : Icons.edit_outlined,
+                                        size: 18,
+                                        color: isEditFocused ? Colors.white : null,
+                                      ),
+                                      padding: EdgeInsets.zero,
+                                      constraints: const BoxConstraints(),
+                                      onPressed: () => widget.onEdit(n),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 6),
+                                  Container(
+                                    decoration: BoxDecoration(
+                                      color: isDeleteFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                                      shape: BoxShape.circle,
+                                      border: Border.all(
+                                        color: isDeleteFocused ? Colors.white : Colors.transparent,
+                                        width: 1.5,
+                                      ),
+                                    ),
+                                    child: IconButton(
+                                      icon: Icon(
+                                        apple ? CupertinoIcons.delete : Icons.delete_outline,
+                                        size: 18,
+                                        color: isDeleteFocused ? Colors.white : null,
+                                      ),
+                                      padding: EdgeInsets.zero,
+                                      constraints: const BoxConstraints(),
+                                      onPressed: () =>
+                                          widget.service.remove(widget.item!.serverId, widget.item!.id, n.id),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
         );
       },
     );
   }
 }
 
-class AudiobookQueueList extends StatelessWidget {
+class AudiobookTimelineList extends StatefulWidget {
+  const AudiobookTimelineList({
+    super.key,
+    required this.events,
+    required this.onJump,
+    required this.onEditNote,
+    required this.onDeleteBookmark,
+    required this.onDeleteNote,
+    required this.tvFocusedIndex,
+    required this.tvSubIndex,
+    this.onExport,
+    this.tvExportFocused = false,
+  });
+
+  final List<TimelineEvent> events;
+  final ValueChanged<TimelineEvent> onJump;
+  final ValueChanged<AudiobookNote> onEditNote;
+  final ValueChanged<AudiobookBookmark> onDeleteBookmark;
+  final ValueChanged<AudiobookNote> onDeleteNote;
+  final int tvFocusedIndex;
+  final int tvSubIndex;
+  final VoidCallback? onExport;
+  final bool tvExportFocused;
+
+  @override
+  State<AudiobookTimelineList> createState() => _AudiobookTimelineListState();
+}
+
+class _AudiobookTimelineListState extends State<AudiobookTimelineList> {
+  late final ScrollController _scrollController = ScrollController();
+  double _viewportHeight = 300.0;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(AudiobookTimelineList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.tvFocusedIndex != oldWidget.tvFocusedIndex) {
+      _scrollToFocused();
+    }
+  }
+
+  void _scrollToFocused() {
+    if (!_scrollController.hasClients) return;
+    if (widget.tvFocusedIndex == -1) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+      return;
+    }
+    const double itemHeight = 56.0; // container height 52 + margin vertical 2*2
+    final double target = widget.tvFocusedIndex * itemHeight;
+    final double currentScroll = _scrollController.offset;
+    
+    if (target < currentScroll) {
+      _scrollController.animateTo(
+        target,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    } else if (target + itemHeight > currentScroll + _viewportHeight) {
+      _scrollController.animateTo(
+        target + itemHeight - _viewportHeight,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.events.isEmpty) {
+      return const _EmptyState(text: 'Timeline is empty');
+    }
+    final apple = PlatformDetection.isApple;
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton.icon(
+                onPressed: widget.onExport,
+                icon: Icon(apple ? CupertinoIcons.square_arrow_down : Icons.download, size: 16),
+                label: const Text('Export All', style: TextStyle(fontSize: 12)),
+                style: TextButton.styleFrom(
+                  foregroundColor: widget.tvExportFocused ? Colors.white : AppColorScheme.accent,
+                  backgroundColor: widget.tvExportFocused ? AppColorScheme.accent : null,
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              _viewportHeight = constraints.maxHeight;
+              return ListView.builder(
+                controller: _scrollController,
+                itemCount: widget.events.length,
+                itemBuilder: (context, index) {
+                  final e = widget.events[index];
+                  final isTvFocused = index == widget.tvFocusedIndex;
+                  final isPlayFocused = isTvFocused && widget.tvSubIndex == 0;
+                  
+                  final showEdit = e.type == TimelineEventType.note;
+                  final showDelete = e.type == TimelineEventType.note || e.type == TimelineEventType.bookmark;
+                  
+                  final isEditFocused = isTvFocused && widget.tvSubIndex == 1 && showEdit;
+                  final isDeleteFocused = isTvFocused && 
+                      ((e.type == TimelineEventType.note && widget.tvSubIndex == 2) || 
+                       (e.type == TimelineEventType.bookmark && widget.tvSubIndex == 1));
+
+                  Color iconColor = AppColorScheme.accent;
+                  IconData icon = Icons.bookmark_border;
+                  if (e.type == TimelineEventType.bookmark) {
+                    icon = apple ? CupertinoIcons.bookmark_fill : Icons.bookmark;
+                    iconColor = Colors.orange;
+                  } else if (e.type == TimelineEventType.note) {
+                    icon = apple ? CupertinoIcons.chat_bubble_text : Icons.note_alt;
+                    iconColor = AppColorScheme.accent;
+                  } else if (e.type == TimelineEventType.chapter) {
+                    icon = Icons.menu_open;
+                    iconColor = Colors.teal;
+                  }
+
+                  return Container(
+                    height: 52.0,
+                    margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: isTvFocused ? AppColorScheme.accent : Colors.transparent,
+                        width: 2.0,
+                      ),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: ListTile(
+                      dense: true,
+                      visualDensity: VisualDensity.compact,
+                      tileColor: isPlayFocused ? AppColorScheme.accent.withValues(alpha: 0.12) : null,
+                      leading: Container(
+                        decoration: BoxDecoration(
+                          color: isPlayFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: isPlayFocused ? Colors.white : Colors.transparent,
+                            width: 1.5,
+                          ),
+                        ),
+                        padding: const EdgeInsets.all(4),
+                        child: Icon(
+                          icon,
+                          color: isPlayFocused ? Colors.white : iconColor,
+                          size: 20,
+                        ),
+                      ),
+                      title: Text(
+                        e.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: isPlayFocused ? Colors.white : null,
+                          fontWeight: isPlayFocused ? FontWeight.w700 : null,
+                          fontSize: 13,
+                        ),
+                      ),
+                      subtitle: Text(
+                        '${formatAudiobookClock(Duration(milliseconds: e.positionMs))}'
+                        '${e.date.millisecondsSinceEpoch > 0 ? ' • ${e.date.toLocal().toString().split('.').first}' : ''}',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: isPlayFocused ? Colors.white.withValues(alpha: 0.7) : AppColorScheme.onSurface.withValues(alpha: 0.5),
+                        ),
+                      ),
+                      trailing: (showEdit || showDelete)
+                          ? Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                if (showEdit) ...[
+                                  Container(
+                                    decoration: BoxDecoration(
+                                      color: isEditFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                                      shape: BoxShape.circle,
+                                      border: Border.all(
+                                        color: isEditFocused ? Colors.white : Colors.transparent,
+                                        width: 1.5,
+                                      ),
+                                    ),
+                                    child: IconButton(
+                                      icon: Icon(
+                                        apple ? CupertinoIcons.pencil : Icons.edit_outlined,
+                                        size: 20,
+                                        color: isEditFocused ? Colors.white : null,
+                                      ),
+                                      onPressed: () => widget.onEditNote(e.originalObject as AudiobookNote),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 4),
+                                ],
+                                if (showDelete) ...[
+                                  Container(
+                                    decoration: BoxDecoration(
+                                      color: isDeleteFocused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+                                      shape: BoxShape.circle,
+                                      border: Border.all(
+                                        color: isDeleteFocused ? Colors.white : Colors.transparent,
+                                        width: 1.5,
+                                      ),
+                                    ),
+                                    child: IconButton(
+                                      icon: Icon(
+                                        apple ? CupertinoIcons.delete : Icons.delete_outline,
+                                        size: 20,
+                                        color: isDeleteFocused ? Colors.white : null,
+                                      ),
+                                      onPressed: () {
+                                        if (e.type == TimelineEventType.note) {
+                                          widget.onDeleteNote(e.originalObject as AudiobookNote);
+                                        } else {
+                                          widget.onDeleteBookmark(e.originalObject as AudiobookBookmark);
+                                        }
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            )
+                          : null,
+                      onTap: () => widget.onJump(e),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class AudiobookQueueList extends StatefulWidget {
   const AudiobookQueueList({
     super.key,
     required this.queue,
     required this.onPlay,
+    required this.tvFocusedIndex,
   });
 
   final QueueService queue;
   final ValueChanged<int> onPlay;
+  final int tvFocusedIndex;
+
+  @override
+  State<AudiobookQueueList> createState() => _AudiobookQueueListState();
+}
+
+class _AudiobookQueueListState extends State<AudiobookQueueList> {
+  late final ScrollController _scrollController = ScrollController();
+  double _viewportHeight = 300.0;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(AudiobookQueueList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.tvFocusedIndex != oldWidget.tvFocusedIndex) {
+      _scrollToFocused();
+    }
+  }
+
+  void _scrollToFocused() {
+    if (!_scrollController.hasClients) return;
+    if (widget.tvFocusedIndex == -1) {
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+      return;
+    }
+    const double itemHeight = 34.0; // exact container height
+    final double target = widget.tvFocusedIndex * itemHeight;
+    final double currentScroll = _scrollController.offset;
+    
+    if (target < currentScroll) {
+      _scrollController.animateTo(
+        target,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    } else if (target + itemHeight > currentScroll + _viewportHeight) {
+      _scrollController.animateTo(
+        target + itemHeight - _viewportHeight,
+        duration: const Duration(milliseconds: 150),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final items = queue.items;
-    final current = queue.currentIndex;
+    final items = widget.queue.items;
+    final current = widget.queue.currentIndex;
     if (items.isEmpty) {
       return _EmptyState(text: AppLocalizations.of(context).queueIsEmpty);
     }
-    return ListView.builder(
-      itemCount: items.length,
-      itemBuilder: (context, index) {
-        final raw = items[index];
-        final item = raw is AggregatedItem ? raw : null;
-        final isCurrent = index == current;
-        return ListTile(
-          title: Text(
-            item?.name ?? AppLocalizations.of(context).trackNumber(index + 1),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: isCurrent ? AppColorScheme.accent : null,
-              fontWeight: isCurrent ? FontWeight.w700 : FontWeight.w500,
-            ),
-          ),
-          onTap: () => onPlay(index),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        _viewportHeight = constraints.maxHeight;
+        return ListView.builder(
+          controller: _scrollController,
+          padding: EdgeInsets.zero,
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final raw = items[index];
+            final item = raw is AggregatedItem ? raw : null;
+            final isCurrent = index == current;
+            final isTvFocused = index == widget.tvFocusedIndex;
+            final titleText = item?.name ?? AppLocalizations.of(context).trackNumber(index + 1);
+
+            return GestureDetector(
+              onTap: () => widget.onPlay(index),
+              child: Container(
+                height: 34.0,
+                alignment: Alignment.centerLeft,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                color: isTvFocused
+                    ? AppColorScheme.accent.withValues(alpha: 0.22)
+                    : (isCurrent
+                        ? AppColorScheme.accent.withValues(alpha: 0.08)
+                        : Colors.transparent),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 28,
+                      child: Text(
+                        '${index + 1}.',
+                        style: TextStyle(
+                          color: isCurrent
+                              ? AppColorScheme.accent
+                              : AppColorScheme.onSurface.withValues(alpha: 0.5),
+                          fontWeight: isCurrent ? FontWeight.bold : null,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Text(
+                        titleText,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: isCurrent
+                              ? AppColorScheme.accent
+                              : AppColorScheme.onSurface,
+                          fontWeight: isCurrent ? FontWeight.bold : null,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
         );
       },
     );

--- a/lib/ui/widgets/audiobook/audiobook_drawer.dart
+++ b/lib/ui/widgets/audiobook/audiobook_drawer.dart
@@ -35,19 +35,24 @@ class AudiobookDrawerTabBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          for (var i = 0; i < tabs.length; i++) ...[
-            AudiobookPillSegment(
-              label: labels[tabs[i]] ?? tabs[i].name,
-              selected: tabs[i] == current,
-              tvFocused: tvFocused && tvIndex == i,
-              onTap: () => onChanged(tabs[i]),
-            ),
-            if (i < tabs.length - 1) const SizedBox(width: 6),
+      child: Container(
+        padding: const EdgeInsets.all(3),
+        decoration: BoxDecoration(
+          color: AppColorScheme.surface.withValues(alpha: 0.55),
+          borderRadius: AppRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (var i = 0; i < tabs.length; i++)
+              AudiobookPillSegment(
+                label: labels[tabs[i]] ?? tabs[i].name,
+                selected: tabs[i] == current,
+                tvFocused: tvFocused && tvIndex == i,
+                onTap: () => onChanged(tabs[i]),
+              ),
           ],
-        ],
+        ),
       ),
     );
   }
@@ -82,28 +87,30 @@ class AudiobookPillSegment extends StatelessWidget {
         fg = AppColorScheme.onAccent;
       }
     } else {
-      bg = AppColorScheme.surface.withValues(alpha: 0.6);
-      fg = AppColorScheme.onSurface.withValues(alpha: 0.85);
+      bg = Colors.transparent;
+      fg = AppColorScheme.onSurface.withValues(alpha: 0.6);
     }
 
-    final borderColor = tvFocused
-        ? Colors.white
-        : (selected && apple ? AppColorScheme.accent : Colors.transparent);
+    final radius = AppRadius.circular(9);
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 140),
       decoration: BoxDecoration(
         color: bg,
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: borderColor, width: tvFocused ? 2.2 : 1.5),
+        borderRadius: radius,
+        border: tvFocused
+            ? Border.all(color: Colors.white, width: 2.2)
+            : null,
       ),
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          borderRadius: BorderRadius.circular(999),
+          borderRadius: radius,
+          splashColor: apple ? Colors.transparent : null,
+          highlightColor: apple ? Colors.transparent : null,
           onTap: onTap,
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 8),
             child: Text(
               label,
               style: TextStyle(

--- a/lib/ui/widgets/audiobook/audiobook_focus_ring.dart
+++ b/lib/ui/widgets/audiobook/audiobook_focus_ring.dart
@@ -7,26 +7,37 @@ class AudiobookFocusRing extends StatelessWidget {
     required this.focused,
     required this.child,
     this.borderRadius,
+    this.borderColor,
+    this.padding,
+    this.backgroundColor,
   });
 
   final bool focused;
   final Widget child;
   final BorderRadius? borderRadius;
+  final Color? borderColor;
+  final EdgeInsetsGeometry? padding;
+  final Color? backgroundColor;
 
   @override
   Widget build(BuildContext context) {
     final radius = borderRadius ?? BorderRadius.circular(12);
+    final borderCol = borderColor ?? AppColorScheme.accent;
+    final bgCol = backgroundColor ??
+        (focused
+            ? AppColorScheme.accent.withValues(alpha: 0.18)
+            : Colors.transparent);
+
     return AnimatedContainer(
       duration: const Duration(milliseconds: 120),
+      padding: padding ?? EdgeInsets.zero,
       decoration: BoxDecoration(
         borderRadius: radius,
         border: Border.all(
-          color: focused ? AppColorScheme.accent : Colors.transparent,
+          color: focused ? borderCol : Colors.transparent,
           width: 2.4,
         ),
-        color: focused
-            ? AppColorScheme.accent.withValues(alpha: 0.18)
-            : Colors.transparent,
+        color: focused ? bgCol : Colors.transparent,
       ),
       child: child,
     );

--- a/lib/ui/widgets/audiobook/audiobook_header.dart
+++ b/lib/ui/widgets/audiobook/audiobook_header.dart
@@ -79,7 +79,7 @@ class AudiobookHeader extends StatelessWidget {
       item?.album ?? item?.seriesName ?? '',
       textAlign: apple ? TextAlign.center : TextAlign.start,
       style: TextStyle(
-        color: onSurface.withValues(alpha: 0.7),
+        color: onSurface.withValues(alpha: 0.85),
         fontSize: 12,
         letterSpacing: 1.2,
       ),
@@ -113,6 +113,16 @@ class AudiobookHeader extends StatelessWidget {
       onPressed: onToggleDrawer,
     );
 
+    final Widget rightButton;
+    if (isTv) {
+      rightButton = AudiobookFocusRing(
+        focused: tvFocusIndex == 2,
+        child: drawerButton,
+      );
+    } else {
+      rightButton = drawerButton;
+    }
+
     final row = Padding(
       padding: EdgeInsets.symmetric(
         horizontal: apple ? AppSpacing.spaceXs : AppSpacing.spaceSm,
@@ -123,8 +133,9 @@ class AudiobookHeader extends StatelessWidget {
           backButton,
           const SizedBox(width: AppSpacing.spaceSm),
           Expanded(child: eyebrow),
-          ?castButton,
-          drawerButton,
+          // ignore: use_null_aware_elements
+          if (castButton != null) castButton,
+          rightButton,
         ],
       ),
     );

--- a/lib/ui/widgets/audiobook/audiobook_header.dart
+++ b/lib/ui/widgets/audiobook/audiobook_header.dart
@@ -88,20 +88,18 @@ class AudiobookHeader extends StatelessWidget {
     );
 
     Widget? castButton;
-    if (item != null && onCast != null) {
+    if (!isTv && item != null && onCast != null) {
       castButton = ValueListenableBuilder<CastTargetKind?>(
         valueListenable: castService.activeKindNotifier,
         builder: (context, kind, _) {
           final active = kind != null;
-          final btn = iconButton(
+          return iconButton(
             icon: apple
                 ? CupertinoIcons.antenna_radiowaves_left_right
                 : (active ? Icons.cast_connected : Icons.cast),
             color: active ? AppColorScheme.accent : null,
             onPressed: active ? onCastSettings : onCast!,
           );
-          if (!isTv) return btn;
-          return AudiobookFocusRing(focused: tvFocusIndex == 1, child: btn);
         },
       );
     }
@@ -116,7 +114,7 @@ class AudiobookHeader extends StatelessWidget {
     final Widget rightButton;
     if (isTv) {
       rightButton = AudiobookFocusRing(
-        focused: tvFocusIndex == 2,
+        focused: tvFocusIndex == 1,
         child: drawerButton,
       );
     } else {

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -2,6 +2,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import 'audiobook_time.dart';
+import '../../../data/services/audiobook_bookmarks_service.dart';
+import '../../../data/services/audiobook_notes_service.dart';
 import '../../../util/platform_detection.dart';
 import 'chapter.dart';
 
@@ -11,6 +14,8 @@ class AudiobookProgressBar extends StatelessWidget {
     required this.position,
     required this.duration,
     required this.chapters,
+    required this.bookmarks,
+    required this.notes,
     required this.showRemaining,
     required this.isTvFocused,
     required this.onSeek,
@@ -22,6 +27,8 @@ class AudiobookProgressBar extends StatelessWidget {
   final Duration position;
   final Duration duration;
   final List<Chapter> chapters;
+  final List<AudiobookBookmark> bookmarks;
+  final List<AudiobookNote> notes;
   final bool showRemaining;
   final bool isTvFocused;
   final ValueChanged<Duration> onSeek;
@@ -53,7 +60,10 @@ class AudiobookProgressBar extends StatelessWidget {
       slider = SliderTheme(
         data: SliderThemeData(
           trackHeight: 4,
-          thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
+          thumbShape: _FocusedSliderThumbShape(
+            enabledThumbRadius: 8,
+            isTvFocused: isTvFocused,
+          ),
           overlayShape: const RoundSliderOverlayShape(overlayRadius: 16),
           activeTrackColor: AppColorScheme.rangeProgress,
           inactiveTrackColor: AppColorScheme.rangeTrack,
@@ -68,23 +78,41 @@ class AudiobookProgressBar extends StatelessWidget {
       );
     }
 
+    final double horizontalPadding = apple ? 20.0 : 24.0;
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (chapters.isNotEmpty)
-          SizedBox(
-            height: 8,
-            child: CustomPaint(
-              painter: _ChapterTicksPainter(
-                chapters: chapters,
-                durationMs: maxMs.toInt(),
-                grouped: groupChapters,
-                color: AppColorScheme.onSurface.withValues(alpha: 0.5),
-              ),
-              size: Size.infinite,
-            ),
+        SizedBox(
+          height: 32,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              if (chapters.isNotEmpty || bookmarks.isNotEmpty || notes.isNotEmpty)
+                IgnorePointer(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                    child: CustomPaint(
+                      painter: _TimelineTicksPainter(
+                        chapters: chapters,
+                        bookmarks: bookmarks,
+                        notes: notes,
+                        durationMs: maxMs.toInt(),
+                        grouped: groupChapters,
+                        chapterColor: Colors.white,
+                        bookmarkColor: AppColorScheme.accent,
+                        noteColor: AppColorScheme.navColorCycle.length >= 2
+                            ? AppColorScheme.navColorCycle[1]
+                            : Theme.of(context).colorScheme.secondary,
+                      ),
+                      size: Size.infinite,
+                    ),
+                  ),
+                ),
+              slider,
+            ],
           ),
-        slider,
+        ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4),
           child: Row(
@@ -94,7 +122,15 @@ class AudiobookProgressBar extends StatelessWidget {
                 formatPosition(position),
                 style: TextStyle(
                   fontSize: 12,
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+                ),
+              ),
+              Text(
+                '${maxMs > 0 ? ((position.inMilliseconds / maxMs) * 100).round().clamp(0, 100) : 0}%',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
                 ),
               ),
               GestureDetector(
@@ -106,7 +142,7 @@ class AudiobookProgressBar extends StatelessWidget {
                       : formatPosition(duration),
                   style: TextStyle(
                     fontSize: 12,
-                    color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+                    color: AppColorScheme.onSurface.withValues(alpha: 0.85),
                   ),
                 ),
               ),
@@ -118,40 +154,358 @@ class AudiobookProgressBar extends StatelessWidget {
   }
 }
 
-class _ChapterTicksPainter extends CustomPainter {
-  _ChapterTicksPainter({
+class _TimelineTicksPainter extends CustomPainter {
+  _TimelineTicksPainter({
     required this.chapters,
+    required this.bookmarks,
+    required this.notes,
     required this.durationMs,
     required this.grouped,
-    required this.color,
+    required this.chapterColor,
+    required this.bookmarkColor,
+    required this.noteColor,
   });
 
   final List<Chapter> chapters;
+  final List<AudiobookBookmark> bookmarks;
+  final List<AudiobookNote> notes;
   final int durationMs;
   final bool grouped;
-  final Color color;
+  final Color chapterColor;
+  final Color bookmarkColor;
+  final Color noteColor;
 
   @override
   void paint(Canvas canvas, Size size) {
     if (durationMs <= 0) return;
-    final paint = Paint()
-      ..color = color
+
+    // 1. Draw Chapters
+    final chapterPaint = Paint()
+      ..color = chapterColor
       ..strokeWidth = 1.4;
     if (grouped) {
       final step = (chapters.length / 10).ceil();
       for (var i = 0; i < chapters.length; i += step) {
         final x = (chapters[i].startMs / durationMs) * size.width;
-        canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+        canvas.drawLine(Offset(x, 0), Offset(x, size.height), chapterPaint);
       }
     } else {
       for (final c in chapters) {
         final x = (c.startMs / durationMs) * size.width;
-        canvas.drawLine(Offset(x, 1), Offset(x, size.height - 1), paint);
+        canvas.drawLine(Offset(x, 1), Offset(x, size.height - 1), chapterPaint);
+      }
+    }
+
+    // 2. Draw Bookmarks
+    final bookmarkPaint = Paint()
+      ..color = bookmarkColor
+      ..strokeWidth = 1.8;
+    for (final b in bookmarks) {
+      final x = (b.positionMs / durationMs) * size.width;
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), bookmarkPaint);
+    }
+
+    // 3. Draw Notes
+    final notePaint = Paint()
+      ..color = noteColor
+      ..strokeWidth = 1.8;
+    for (final n in notes) {
+      final x = (n.positionMs / durationMs) * size.width;
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), notePaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_TimelineTicksPainter old) =>
+      old.chapters != chapters ||
+      old.bookmarks != bookmarks ||
+      old.notes != notes ||
+      old.durationMs != durationMs;
+}
+
+class _FocusedSliderThumbShape extends SliderComponentShape {
+  const _FocusedSliderThumbShape({
+    required this.enabledThumbRadius,
+    required this.isTvFocused,
+  });
+
+  final double enabledThumbRadius;
+  final bool isTvFocused;
+
+  @override
+  Size getPreferredSize(bool isEnabled, bool isDiscrete) {
+    return Size.fromRadius(enabledThumbRadius);
+  }
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    required bool isDiscrete,
+    required TextPainter labelPainter,
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    required TextDirection textDirection,
+    required double value,
+    required double textScaleFactor,
+    required Size sizeWithOverflow,
+  }) {
+    final Canvas canvas = context.canvas;
+
+    if (isTvFocused) {
+      final paintOuter = Paint()
+        ..color = AppColorScheme.accent
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2.0;
+      canvas.drawCircle(center, enabledThumbRadius + 4.0, paintOuter);
+    }
+
+    final paintInner = Paint()
+      ..color = isTvFocused
+          ? Colors.white
+          : (sliderTheme.thumbColor ?? AppColorScheme.rangeThumb);
+    canvas.drawCircle(center, enabledThumbRadius, paintInner);
+  }
+}
+
+class AudiobookZoomedProgressBar extends StatelessWidget {
+  const AudiobookZoomedProgressBar({
+    super.key,
+    required this.position,
+    required this.duration,
+    required this.chapters,
+    required this.bookmarks,
+    required this.notes,
+    required this.isTvFocused,
+    required this.onSeek,
+    required this.formatPosition,
+    required this.formatRemaining,
+  });
+
+  final Duration position;
+  final Duration duration;
+  final List<Chapter> chapters;
+  final List<AudiobookBookmark> bookmarks;
+  final List<AudiobookNote> notes;
+  final bool isTvFocused;
+  final ValueChanged<Duration> onSeek;
+  final String Function(Duration) formatPosition;
+  final String Function(Duration position, Duration total) formatRemaining;
+
+  @override
+  Widget build(BuildContext context) {
+    final apple = PlatformDetection.isApple;
+    final totalMs = duration.inMilliseconds.toDouble();
+    final posMs = position.inMilliseconds.toDouble().clamp(0, totalMs);
+
+    final double startMs;
+    final double endMs;
+
+    const double oneHourMs = 3600000.0;
+    const double halfHourMs = 1800000.0;
+
+    if (totalMs <= oneHourMs) {
+      startMs = 0.0;
+      endMs = totalMs > 0 ? totalMs : 1.0;
+    } else {
+      if (posMs < halfHourMs) {
+        startMs = 0.0;
+        endMs = oneHourMs;
+      } else if (posMs > totalMs - halfHourMs) {
+        startMs = totalMs - oneHourMs;
+        endMs = totalMs;
+      } else {
+        startMs = posMs - halfHourMs;
+        endMs = posMs + halfHourMs;
+      }
+    }
+
+    final sliderValue = posMs.clamp(startMs, endMs).toDouble();
+
+    final Widget slider;
+    if (apple) {
+      slider = Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: CupertinoSlider(
+          value: sliderValue,
+          min: startMs,
+          max: endMs,
+          activeColor: AppColorScheme.rangeProgress,
+          onChanged: (v) => onSeek(Duration(milliseconds: v.toInt())),
+        ),
+      );
+    } else {
+      slider = SliderTheme(
+        data: SliderThemeData(
+          trackHeight: 4,
+          thumbShape: _FocusedSliderThumbShape(
+            enabledThumbRadius: 8,
+            isTvFocused: isTvFocused,
+          ),
+          overlayShape: const RoundSliderOverlayShape(overlayRadius: 16),
+          activeTrackColor: AppColorScheme.rangeProgress,
+          inactiveTrackColor: AppColorScheme.rangeTrack,
+          thumbColor: isTvFocused ? Colors.white : AppColorScheme.rangeThumb,
+          overlayColor: AppColorScheme.rangeThumb.withValues(alpha: 0.2),
+        ),
+        child: Slider(
+          value: sliderValue,
+          min: startMs,
+          max: endMs,
+          onChanged: (v) => onSeek(Duration(milliseconds: v.toInt())),
+        ),
+      );
+    }
+
+    final double horizontalPadding = apple ? 20.0 : 24.0;
+    final groupChapters = chapters.length > 40;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          height: 32,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              if (chapters.isNotEmpty || bookmarks.isNotEmpty || notes.isNotEmpty)
+                IgnorePointer(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+                    child: CustomPaint(
+                      painter: _ZoomedTimelineTicksPainter(
+                        chapters: chapters,
+                        bookmarks: bookmarks,
+                        notes: notes,
+                        windowStartMs: startMs,
+                        windowEndMs: endMs,
+                        grouped: groupChapters,
+                        chapterColor: Colors.white,
+                        bookmarkColor: AppColorScheme.accent,
+                        noteColor: AppColorScheme.navColorCycle.length >= 2
+                            ? AppColorScheme.navColorCycle[1]
+                            : Theme.of(context).colorScheme.secondary,
+                      ),
+                      size: Size.infinite,
+                    ),
+                  ),
+                ),
+              slider,
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                formatPosition(position),
+                style: TextStyle(
+                  fontSize: 12,
+                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+                ),
+              ),
+              Text(
+                'Focused Timeline',
+                style: TextStyle(
+                  fontSize: 11,
+                  fontStyle: FontStyle.italic,
+                  color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+                ),
+              ),
+              Text(
+                '-${formatAudiobookClock(Duration(milliseconds: (totalMs - posMs).toInt()))}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ZoomedTimelineTicksPainter extends CustomPainter {
+  _ZoomedTimelineTicksPainter({
+    required this.chapters,
+    required this.bookmarks,
+    required this.notes,
+    required this.windowStartMs,
+    required this.windowEndMs,
+    required this.grouped,
+    required this.chapterColor,
+    required this.bookmarkColor,
+    required this.noteColor,
+  });
+
+  final List<Chapter> chapters;
+  final List<AudiobookBookmark> bookmarks;
+  final List<AudiobookNote> notes;
+  final double windowStartMs;
+  final double windowEndMs;
+  final bool grouped;
+  final Color chapterColor;
+  final Color bookmarkColor;
+  final Color noteColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final range = windowEndMs - windowStartMs;
+    if (range <= 0) return;
+
+    // 1. Draw Chapters
+    final chapterPaint = Paint()
+      ..color = chapterColor
+      ..strokeWidth = 2.0;
+
+    if (grouped) {
+      // Draw simplified grouped chapters if there are too many (none needed for standard display)
+    } else {
+      for (final c in chapters) {
+        final pos = c.startMs.toDouble();
+        if (pos >= windowStartMs && pos <= windowEndMs) {
+          final x = ((pos - windowStartMs) / range) * size.width;
+          canvas.drawLine(Offset(x, 0), Offset(x, size.height), chapterPaint);
+        }
+      }
+    }
+
+    // 2. Draw Bookmarks
+    final bookmarkPaint = Paint()
+      ..color = bookmarkColor
+      ..strokeWidth = 1.8;
+    for (final b in bookmarks) {
+      final pos = b.positionMs.toDouble();
+      if (pos >= windowStartMs && pos <= windowEndMs) {
+        final x = ((pos - windowStartMs) / range) * size.width;
+        canvas.drawLine(Offset(x, 0), Offset(x, size.height), bookmarkPaint);
+      }
+    }
+
+    // 3. Draw Notes
+    final notePaint = Paint()
+      ..color = noteColor
+      ..strokeWidth = 1.8;
+    for (final n in notes) {
+      final pos = n.positionMs.toDouble();
+      if (pos >= windowStartMs && pos <= windowEndMs) {
+        final x = ((pos - windowStartMs) / range) * size.width;
+        canvas.drawLine(Offset(x, 0), Offset(x, size.height), notePaint);
       }
     }
   }
 
   @override
-  bool shouldRepaint(_ChapterTicksPainter old) =>
-      old.chapters != chapters || old.durationMs != durationMs;
+  bool shouldRepaint(_ZoomedTimelineTicksPainter old) =>
+      old.chapters != chapters ||
+      old.bookmarks != bookmarks ||
+      old.notes != notes ||
+      old.windowStartMs != windowStartMs ||
+      old.windowEndMs != windowEndMs;
 }

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -8,20 +8,14 @@ import '../../../data/services/audiobook_notes_service.dart';
 import '../../../util/platform_detection.dart';
 import 'chapter.dart';
 
-class AudiobookProgressBar extends StatelessWidget {
-  const AudiobookProgressBar({
+class AudiobookBookOverview extends StatelessWidget {
+  const AudiobookBookOverview({
     super.key,
     required this.position,
     required this.duration,
     required this.chapters,
     required this.bookmarks,
     required this.notes,
-    required this.showRemaining,
-    required this.isTvFocused,
-    required this.onSeek,
-    required this.onToggleRemaining,
-    required this.formatPosition,
-    required this.formatRemaining,
   });
 
   final Duration position;
@@ -29,122 +23,57 @@ class AudiobookProgressBar extends StatelessWidget {
   final List<Chapter> chapters;
   final List<AudiobookBookmark> bookmarks;
   final List<AudiobookNote> notes;
-  final bool showRemaining;
-  final bool isTvFocused;
-  final ValueChanged<Duration> onSeek;
-  final VoidCallback onToggleRemaining;
-  final String Function(Duration) formatPosition;
-  final String Function(Duration position, Duration total) formatRemaining;
 
   @override
   Widget build(BuildContext context) {
-    final apple = PlatformDetection.isApple;
     final maxMs = duration.inMilliseconds.toDouble();
-    final groupChapters = chapters.length > 40;
-    final value = maxMs > 0
-        ? position.inMilliseconds.toDouble().clamp(0, maxMs)
-        : 0.0;
-
-    final Widget slider;
-    if (apple) {
-      slider = Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4),
-        child: CupertinoSlider(
-          value: value.toDouble(),
-          max: maxMs > 0 ? maxMs : 1,
-          activeColor: AppColorScheme.rangeProgress,
-          onChanged: (v) => onSeek(Duration(milliseconds: v.toInt())),
-        ),
-      );
-    } else {
-      slider = SliderTheme(
-        data: SliderThemeData(
-          trackHeight: 4,
-          thumbShape: _FocusedSliderThumbShape(
-            enabledThumbRadius: 8,
-            isTvFocused: isTvFocused,
-          ),
-          overlayShape: const RoundSliderOverlayShape(overlayRadius: 16),
-          activeTrackColor: AppColorScheme.rangeProgress,
-          inactiveTrackColor: AppColorScheme.rangeTrack,
-          thumbColor: isTvFocused ? Colors.white : AppColorScheme.rangeThumb,
-          overlayColor: AppColorScheme.rangeThumb.withValues(alpha: 0.2),
-        ),
-        child: Slider(
-          value: value.toDouble(),
-          max: maxMs > 0 ? maxMs : 1,
-          onChanged: (v) => onSeek(Duration(milliseconds: v.toInt())),
-        ),
-      );
-    }
-
-    final double horizontalPadding = apple ? 20.0 : 24.0;
+    final fraction =
+        maxMs > 0 ? (position.inMilliseconds / maxMs).clamp(0.0, 1.0) : 0.0;
+    final percent = (fraction * 100).round();
+    final remaining = duration - position;
+    final noteColor = AppColorScheme.navColorCycle.length >= 2
+        ? AppColorScheme.navColorCycle[1]
+        : Theme.of(context).colorScheme.secondary;
+    final captionStyle = TextStyle(
+      fontSize: 11,
+      color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+    );
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SizedBox(
-          height: 32,
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              if (chapters.isNotEmpty || bookmarks.isNotEmpty || notes.isNotEmpty)
-                IgnorePointer(
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
-                    child: CustomPaint(
-                      painter: _TimelineTicksPainter(
-                        chapters: chapters,
-                        bookmarks: bookmarks,
-                        notes: notes,
-                        durationMs: maxMs.toInt(),
-                        grouped: groupChapters,
-                        chapterColor: Colors.white,
-                        bookmarkColor: AppColorScheme.accent,
-                        noteColor: AppColorScheme.navColorCycle.length >= 2
-                            ? AppColorScheme.navColorCycle[1]
-                            : Theme.of(context).colorScheme.secondary,
-                      ),
-                      size: Size.infinite,
-                    ),
-                  ),
-                ),
-              slider,
-            ],
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: SizedBox(
+            height: 8,
+            child: CustomPaint(
+              size: Size.infinite,
+              painter: _BookOverviewPainter(
+                fraction: fraction.toDouble(),
+                chapters: chapters,
+                bookmarks: bookmarks,
+                notes: notes,
+                durationMs: maxMs.toInt(),
+                grouped: chapters.length > 40,
+                trackColor: AppColorScheme.rangeTrack,
+                fillColor: AppColorScheme.rangeProgress,
+                chapterColor: AppColorScheme.onSurface.withValues(alpha: 0.35),
+                bookmarkColor: AppColorScheme.accent,
+                noteColor: noteColor,
+              ),
+            ),
           ),
         ),
+        const SizedBox(height: 5),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
+              Text('Whole book', style: captionStyle),
               Text(
-                formatPosition(position),
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
-                ),
-              ),
-              Text(
-                '${maxMs > 0 ? ((position.inMilliseconds / maxMs) * 100).round().clamp(0, 100) : 0}%',
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.bold,
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
-                ),
-              ),
-              GestureDetector(
-                onTap: onToggleRemaining,
-                behavior: HitTestBehavior.opaque,
-                child: Text(
-                  showRemaining
-                      ? formatRemaining(position, duration)
-                      : formatPosition(duration),
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: AppColorScheme.onSurface.withValues(alpha: 0.85),
-                  ),
-                ),
+                '$percent% · ${formatAudiobookClock(remaining)} left',
+                style: captionStyle,
               ),
             ],
           ),
@@ -154,35 +83,57 @@ class AudiobookProgressBar extends StatelessWidget {
   }
 }
 
-class _TimelineTicksPainter extends CustomPainter {
-  _TimelineTicksPainter({
+class _BookOverviewPainter extends CustomPainter {
+  _BookOverviewPainter({
+    required this.fraction,
     required this.chapters,
     required this.bookmarks,
     required this.notes,
     required this.durationMs,
     required this.grouped,
+    required this.trackColor,
+    required this.fillColor,
     required this.chapterColor,
     required this.bookmarkColor,
     required this.noteColor,
   });
 
+  final double fraction;
   final List<Chapter> chapters;
   final List<AudiobookBookmark> bookmarks;
   final List<AudiobookNote> notes;
   final int durationMs;
   final bool grouped;
+  final Color trackColor;
+  final Color fillColor;
   final Color chapterColor;
   final Color bookmarkColor;
   final Color noteColor;
 
   @override
   void paint(Canvas canvas, Size size) {
+    final cy = size.height / 2;
+
+    final trackPaint = Paint()
+      ..color = trackColor
+      ..strokeWidth = 3
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(Offset(0, cy), Offset(size.width, cy), trackPaint);
+
+    if (fraction > 0) {
+      final fillPaint = Paint()
+        ..color = fillColor
+        ..strokeWidth = 3
+        ..strokeCap = StrokeCap.round;
+      canvas.drawLine(
+          Offset(0, cy), Offset(size.width * fraction, cy), fillPaint);
+    }
+
     if (durationMs <= 0) return;
 
-    // 1. Draw Chapters
     final chapterPaint = Paint()
       ..color = chapterColor
-      ..strokeWidth = 1.4;
+      ..strokeWidth = 1.2;
     if (grouped) {
       final step = (chapters.length / 10).ceil();
       for (var i = 0; i < chapters.length; i += step) {
@@ -192,23 +143,21 @@ class _TimelineTicksPainter extends CustomPainter {
     } else {
       for (final c in chapters) {
         final x = (c.startMs / durationMs) * size.width;
-        canvas.drawLine(Offset(x, 1), Offset(x, size.height - 1), chapterPaint);
+        canvas.drawLine(Offset(x, 0), Offset(x, size.height), chapterPaint);
       }
     }
 
-    // 2. Draw Bookmarks
     final bookmarkPaint = Paint()
       ..color = bookmarkColor
-      ..strokeWidth = 1.8;
+      ..strokeWidth = 1.6;
     for (final b in bookmarks) {
       final x = (b.positionMs / durationMs) * size.width;
       canvas.drawLine(Offset(x, 0), Offset(x, size.height), bookmarkPaint);
     }
 
-    // 3. Draw Notes
     final notePaint = Paint()
       ..color = noteColor
-      ..strokeWidth = 1.8;
+      ..strokeWidth = 1.6;
     for (final n in notes) {
       final x = (n.positionMs / durationMs) * size.width;
       canvas.drawLine(Offset(x, 0), Offset(x, size.height), notePaint);
@@ -216,7 +165,8 @@ class _TimelineTicksPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_TimelineTicksPainter old) =>
+  bool shouldRepaint(_BookOverviewPainter old) =>
+      old.fraction != fraction ||
       old.chapters != chapters ||
       old.bookmarks != bookmarks ||
       old.notes != notes ||
@@ -270,6 +220,8 @@ class _FocusedSliderThumbShape extends SliderComponentShape {
   }
 }
 
+/// The primary scrubber: a 1-hour window centered on the current position so a
+/// 17+ hour book stays draggable with real precision.
 class AudiobookZoomedProgressBar extends StatelessWidget {
   const AudiobookZoomedProgressBar({
     super.key,
@@ -279,7 +231,9 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
     required this.bookmarks,
     required this.notes,
     required this.isTvFocused,
+    required this.showRemaining,
     required this.onSeek,
+    required this.onToggleRemaining,
     required this.formatPosition,
     required this.formatRemaining,
   });
@@ -290,7 +244,9 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
   final List<AudiobookBookmark> bookmarks;
   final List<AudiobookNote> notes;
   final bool isTvFocused;
+  final bool showRemaining;
   final ValueChanged<Duration> onSeek;
+  final VoidCallback onToggleRemaining;
   final String Function(Duration) formatPosition;
   final String Function(Duration position, Duration total) formatRemaining;
 
@@ -361,6 +317,10 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
 
     final double horizontalPadding = apple ? 20.0 : 24.0;
     final groupChapters = chapters.length > 40;
+    final labelStyle = TextStyle(
+      fontSize: 12,
+      color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+    );
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -401,13 +361,7 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                formatPosition(position),
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
-                ),
-              ),
+              Text(formatPosition(position), style: labelStyle),
               Text(
                 'Focused Timeline',
                 style: TextStyle(
@@ -416,11 +370,17 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
                   color: AppColorScheme.onSurface.withValues(alpha: 0.5),
                 ),
               ),
-              Text(
-                '-${formatAudiobookClock(Duration(milliseconds: (totalMs - posMs).toInt()))}',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+              InkWell(
+                onTap: onToggleRemaining,
+                borderRadius: BorderRadius.circular(6),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                  child: Text(
+                    showRemaining
+                        ? formatRemaining(position, duration)
+                        : formatPosition(duration),
+                    style: labelStyle,
+                  ),
                 ),
               ),
             ],
@@ -459,13 +419,12 @@ class _ZoomedTimelineTicksPainter extends CustomPainter {
     final range = windowEndMs - windowStartMs;
     if (range <= 0) return;
 
-    // 1. Draw Chapters
     final chapterPaint = Paint()
       ..color = chapterColor
       ..strokeWidth = 2.0;
 
     if (grouped) {
-      // Draw simplified grouped chapters if there are too many (none needed for standard display)
+      // Simplified grouped chapters are not drawn in the zoomed window.
     } else {
       for (final c in chapters) {
         final pos = c.startMs.toDouble();
@@ -476,7 +435,6 @@ class _ZoomedTimelineTicksPainter extends CustomPainter {
       }
     }
 
-    // 2. Draw Bookmarks
     final bookmarkPaint = Paint()
       ..color = bookmarkColor
       ..strokeWidth = 1.8;
@@ -488,7 +446,6 @@ class _ZoomedTimelineTicksPainter extends CustomPainter {
       }
     }
 
-    // 3. Draw Notes
     final notePaint = Paint()
       ..color = noteColor
       ..strokeWidth = 1.8;

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -5,6 +5,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import 'audiobook_time.dart';
 import '../../../data/services/audiobook_bookmarks_service.dart';
 import '../../../data/services/audiobook_notes_service.dart';
+import '../../../l10n/app_localizations.dart';
 import '../../../util/platform_detection.dart';
 import 'chapter.dart';
 
@@ -26,6 +27,7 @@ class AudiobookBookOverview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final maxMs = duration.inMilliseconds.toDouble();
     final fraction =
         maxMs > 0 ? (position.inMilliseconds / maxMs).clamp(0.0, 1.0) : 0.0;
@@ -70,9 +72,12 @@ class AudiobookBookOverview extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text('Whole book', style: captionStyle),
+              Text(l10n.audiobookWholeBook, style: captionStyle),
               Text(
-                '$percent% · ${formatAudiobookClock(remaining)} left',
+                l10n.audiobookWholeBookProgress(
+                  '$percent',
+                  formatAudiobookClock(remaining),
+                ),
                 style: captionStyle,
               ),
             ],
@@ -252,6 +257,7 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final apple = PlatformDetection.isApple;
     final totalMs = duration.inMilliseconds.toDouble();
     final posMs = position.inMilliseconds.toDouble().clamp(0, totalMs);
@@ -363,7 +369,7 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
             children: [
               Text(formatPosition(position), style: labelStyle),
               Text(
-                'Focused Timeline',
+                l10n.audiobookFocusedTimeline,
                 style: TextStyle(
                   fontSize: 11,
                   fontStyle: FontStyle.italic,

--- a/lib/ui/widgets/audiobook/audiobook_sheets.dart
+++ b/lib/ui/widgets/audiobook/audiobook_sheets.dart
@@ -757,6 +757,7 @@ Future<dynamic> showAudiobookNoteEditor({
       positionLabel: positionLabel,
       dialogContext: ctx,
     ),
+    scrollControlled: true,
     floating: true,
   );
 }

--- a/lib/ui/widgets/audiobook/audiobook_sheets.dart
+++ b/lib/ui/widgets/audiobook/audiobook_sheets.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:moonfin_design/moonfin_design.dart';
+import '../../../preference/user_preferences.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../playback/sleep_timer_controller.dart';
@@ -16,6 +20,7 @@ Future<void> showAudiobookSpeedSheet({
   return _showAdaptiveSheet<void>(
     context,
     (ctx) => _SpeedSheet(current: current, onChanged: onChanged),
+    floating: true,
   );
 }
 
@@ -34,45 +39,87 @@ Future<void> showAudiobookSleepSheet({
       onPickEndOfChapter: onPickEndOfChapter,
       onCancel: onCancel,
     ),
+    floating: true,
   );
 }
 
-Future<String?> showAudiobookNoteEditor({
-  required BuildContext context,
-  required String initialText,
-  required String positionLabel,
-}) {
-  return _showAdaptiveSheet<String>(
-    context,
-    (ctx) => _NoteEditorSheet(
-      initialText: initialText,
-      positionLabel: positionLabel,
-    ),
-    scrollControlled: true,
-  );
-}
 
 Future<T?> _showAdaptiveSheet<T>(
   BuildContext context,
   WidgetBuilder builder, {
   bool scrollControlled = false,
+  bool floating = false,
 }) {
   if (PlatformDetection.isApple) {
     return showCupertinoModalPopup<T>(
       context: context,
-      builder: (ctx) => _CupertinoSheetShell(child: builder(ctx)),
+      builder: (ctx) {
+        final child = builder(ctx);
+        if (floating) {
+          return _FloatingSheetShell(child: child);
+        }
+        return _CupertinoSheetShell(child: child);
+      },
     );
   }
   return showFocusRestoringModalBottomSheet<T>(
     context: context,
     isScrollControlled: scrollControlled,
     useSafeArea: scrollControlled,
-    backgroundColor: AppColorScheme.surface,
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-    ),
-    builder: builder,
+    backgroundColor: floating ? Colors.transparent : AppColorScheme.surface,
+    elevation: floating ? 0 : null,
+    shape: floating
+        ? null
+        : const RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+    builder: (ctx) {
+      final child = builder(ctx);
+      if (floating) {
+        return _FloatingSheetShell(child: child);
+      }
+      return child;
+    },
   );
+}
+
+class _FloatingSheetShell extends StatelessWidget {
+  const _FloatingSheetShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          16,
+          0,
+          16,
+          16 + MediaQuery.viewInsetsOf(context).bottom,
+        ),
+        child: Container(
+          decoration: BoxDecoration(
+            color: AppColorScheme.surface,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.3),
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Material(
+            type: MaterialType.transparency,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _CupertinoSheetShell extends StatelessWidget {
@@ -109,7 +156,7 @@ class _SheetTitle extends StatelessWidget {
   }
 }
 
-class _SheetChoice extends StatelessWidget {
+class _SheetChoice extends StatefulWidget {
   const _SheetChoice({
     required this.label,
     required this.selected,
@@ -121,69 +168,81 @@ class _SheetChoice extends StatelessWidget {
   final VoidCallback onTap;
 
   @override
+  State<_SheetChoice> createState() => _SheetChoiceState();
+}
+
+class _SheetChoiceState extends State<_SheetChoice> {
+  bool _isFocused = false;
+  bool _isHovered = false;
+
+  @override
   Widget build(BuildContext context) {
-    if (!PlatformDetection.isApple) {
-      return ChoiceChip(
-        label: Text(label),
-        selected: selected,
-        onSelected: (_) => onTap(),
-      );
+    final focused = _isFocused || _isHovered;
+    final selected = widget.selected;
+    final prefs = GetIt.instance<UserPreferences>();
+    final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
+
+    final Color borderColor;
+    final double borderWidth;
+    if (focused) {
+      borderColor = focusColor;
+      borderWidth = 2.0;
+    } else if (selected) {
+      borderColor = AppColorScheme.onSurface.withValues(alpha: 0.8);
+      borderWidth = 1.5;
+    } else {
+      borderColor = AppColorScheme.onSurface.withValues(alpha: 0.15);
+      borderWidth = 1.0;
     }
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
+
+    return InkWell(
+      onTap: widget.onTap,
+      onFocusChange: (f) => setState(() => _isFocused = f),
+      onHover: (h) => setState(() => _isHovered = h),
+      borderRadius: BorderRadius.circular(10),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+        height: 38,
+        alignment: Alignment.center,
+        padding: const EdgeInsets.symmetric(horizontal: 4),
         decoration: BoxDecoration(
-          color: selected
-              ? AppColorScheme.accent.withValues(alpha: 0.18)
-              : AppColorScheme.onSurface.withValues(alpha: 0.07),
-          borderRadius: BorderRadius.circular(999),
+          color: Colors.transparent,
           border: Border.all(
-            color: selected ? AppColorScheme.accent : Colors.transparent,
-            width: 1.5,
+            color: borderColor,
+            width: borderWidth,
           ),
+          borderRadius: BorderRadius.circular(10),
         ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-            color: selected ? AppColorScheme.accent : AppColorScheme.onSurface,
-          ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                widget.label,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: selected ? FontWeight.bold : FontWeight.w500,
+                  color: AppColorScheme.onSurface,
+                ),
+              ),
+            ),
+            if (selected) ...[
+              const SizedBox(height: 2),
+              Container(
+                width: 16,
+                height: 3,
+                decoration: BoxDecoration(
+                  color: AppColorScheme.accent,
+                  borderRadius: BorderRadius.circular(1.5),
+                ),
+              ),
+            ],
+          ],
         ),
       ),
     );
   }
-}
-
-Widget _adaptiveSheetSlider({
-  required double value,
-  required double min,
-  required double max,
-  required int divisions,
-  required ValueChanged<double> onChanged,
-  ValueChanged<double>? onChangeEnd,
-}) {
-  if (PlatformDetection.isApple) {
-    return CupertinoSlider(
-      value: value.clamp(min, max),
-      min: min,
-      max: max,
-      divisions: divisions,
-      activeColor: AppColorScheme.accent,
-      onChanged: onChanged,
-      onChangeEnd: onChangeEnd,
-    );
-  }
-  return Slider(
-    value: value.clamp(min, max),
-    min: min,
-    max: max,
-    divisions: divisions,
-    onChanged: onChanged,
-    onChangeEnd: onChangeEnd,
-  );
 }
 
 class _SpeedSheet extends StatefulWidget {
@@ -198,12 +257,34 @@ class _SpeedSheet extends StatefulWidget {
 
 class _SpeedSheetState extends State<_SpeedSheet> {
   late double _value = widget.current;
-  static const _presets = [0.8, 1.0, 1.25, 1.5, 1.75, 2.0, 3.0];
+  late final FocusNode _sliderFocusNode = FocusNode();
+  bool _sliderEditing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _sliderFocusNode.addListener(_onFocusChange);
+  }
+
+  void _onFocusChange() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _sliderFocusNode.removeListener(_onFocusChange);
+    _sliderFocusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final apple = PlatformDetection.isApple;
+    String statusText = '';
+    if (_sliderFocusNode.hasFocus) {
+      statusText = _sliderEditing ? ' (Adjusting)' : ' (Press OK to Adjust)';
+    }
+
     return Padding(
       padding: EdgeInsets.fromLTRB(
         AppSpacing.spaceLg,
@@ -216,53 +297,191 @@ class _SpeedSheetState extends State<_SpeedSheet> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _SheetTitle(l10n.audiobookPlaybackSpeed),
-          const SizedBox(height: AppSpacing.spaceMd),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
+          const SizedBox(height: AppSpacing.spaceSm),
+          Column(
             children: [
-              for (final p in _presets)
-                _SheetChoice(
-                  label: '${p}x',
-                  selected: (_value - p).abs() < 0.01,
-                  onTap: () {
-                    setState(() => _value = p);
-                    widget.onChanged(p);
-                  },
-                ),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.spaceMd),
-          Row(
-            children: [
-              SizedBox(width: 52, child: Text('${_value.toStringAsFixed(2)}x')),
-              Expanded(
-                child: _adaptiveSheetSlider(
-                  value: _value,
-                  min: 0.5,
-                  max: 3.5,
-                  divisions: 30,
-                  onChanged: (v) => setState(() => _value = v),
-                  onChangeEnd: widget.onChanged,
+              Row(
+                children: [
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '0.5x',
+                      selected: (_value - 0.5).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 0.5);
+                        widget.onChanged(0.5);
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '0.65x',
+                      selected: (_value - 0.65).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 0.65);
+                        widget.onChanged(0.65);
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '0.8x',
+                      selected: (_value - 0.8).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 0.8);
+                        widget.onChanged(0.8);
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '1.0x',
+                      selected: (_value - 1.0).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 1.0);
+                        widget.onChanged(1.0);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '1.25x',
+                      selected: (_value - 1.25).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 1.25);
+                        widget.onChanged(1.25);
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '1.5x',
+                      selected: (_value - 1.5).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 1.5);
+                        widget.onChanged(1.5);
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '1.75x',
+                      selected: (_value - 1.75).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 1.75);
+                        widget.onChanged(1.75);
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: _SheetChoice(
+                      label: '2.0x',
+                      selected: (_value - 2.0).abs() < 0.01,
+                      onTap: () {
+                        setState(() => _value = 2.0);
+                        widget.onChanged(2.0);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.spaceMd),
+              Row(
+                children: [
+                  Text(
+                    'Fine Tune$statusText',
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '${_value.toStringAsFixed(2)}x',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.bold,
+                      color: AppColorScheme.accent,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.spaceXs),
+              Focus(
+                focusNode: _sliderFocusNode,
+                onKeyEvent: (node, event) {
+                  if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+                    return KeyEventResult.ignored;
+                  }
+                  final key = event.logicalKey;
+
+                  if (key == LogicalKeyboardKey.select ||
+                      key == LogicalKeyboardKey.enter ||
+                      key == LogicalKeyboardKey.gameButtonA) {
+                    setState(() {
+                      _sliderEditing = !_sliderEditing;
+                    });
+                    return KeyEventResult.handled;
+                  }
+
+                  if (_sliderEditing) {
+                    if (key == LogicalKeyboardKey.arrowLeft) {
+                      final newValue = (_value - 0.05).clamp(0.25, 3.0);
+                      final rounded = (newValue * 20).round() / 20.0;
+                      setState(() => _value = rounded);
+                      widget.onChanged(rounded);
+                      return KeyEventResult.handled;
+                    }
+                    if (key == LogicalKeyboardKey.arrowRight) {
+                      final newValue = (_value + 0.05).clamp(0.25, 3.0);
+                      final rounded = (newValue * 20).round() / 20.0;
+                      setState(() => _value = rounded);
+                      widget.onChanged(rounded);
+                      return KeyEventResult.handled;
+                    }
+                    if (key == LogicalKeyboardKey.arrowUp ||
+                        key == LogicalKeyboardKey.arrowDown ||
+                        key == LogicalKeyboardKey.escape ||
+                        key == LogicalKeyboardKey.goBack) {
+                      setState(() {
+                        _sliderEditing = false;
+                      });
+                      return KeyEventResult.handled;
+                    }
+                  } else {
+                    if (key == LogicalKeyboardKey.arrowLeft ||
+                        key == LogicalKeyboardKey.arrowRight) {
+                      return KeyEventResult.handled;
+                    }
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: ExcludeFocus(
+                  child: Slider(
+                    value: _value.clamp(0.25, 3.0),
+                    min: 0.25,
+                    max: 3.0,
+                    divisions: 55,
+                    activeColor: _sliderEditing ? AppColorScheme.accent : AppColorScheme.accent.withValues(alpha: 0.4),
+                    inactiveColor: AppColorScheme.onSurface.withValues(alpha: 0.1),
+                    onChanged: (v) {
+                      final rounded = (v * 20).round() / 20.0;
+                      setState(() => _value = rounded);
+                      widget.onChanged(rounded);
+                    },
+                  ),
                 ),
               ),
-              if (apple)
-                CupertinoButton(
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                  onPressed: () {
-                    setState(() => _value = 1.0);
-                    widget.onChanged(1.0);
-                  },
-                  child: Text(l10n.audiobookSpeedReset),
-                )
-              else
-                TextButton(
-                  onPressed: () {
-                    setState(() => _value = 1.0);
-                    widget.onChanged(1.0);
-                  },
-                  child: Text(l10n.audiobookSpeedReset),
-                ),
             ],
           ),
         ],
@@ -284,82 +503,274 @@ class _SleepSheet extends StatelessWidget {
   final VoidCallback onPickEndOfChapter;
   final VoidCallback onCancel;
 
-  static const _presets = [5, 15, 30, 45, 60];
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    return Padding(
-      padding: EdgeInsets.fromLTRB(
-        AppSpacing.spaceLg,
-        AppSpacing.spaceLg,
-        AppSpacing.spaceLg,
-        AppSpacing.spaceLg + MediaQuery.viewInsetsOf(context).bottom,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _SheetTitle(l10n.audiobookSleepTimer),
-          const SizedBox(height: AppSpacing.spaceMd),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
+
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (context, _) {
+        final titleText = controller.isActive
+            ? (controller.isPaused
+                ? 'Sleep Timer Paused — Time Remaining: ${formatAudiobookCountdown(controller.remaining)}'
+                : 'Sleep Mode Activated — Time Remaining: ${formatAudiobookCountdown(controller.remaining)}')
+            : l10n.audiobookSleepTimer;
+
+        return Padding(
+          padding: EdgeInsets.fromLTRB(
+            AppSpacing.spaceLg,
+            AppSpacing.spaceLg,
+            AppSpacing.spaceLg,
+            AppSpacing.spaceLg + MediaQuery.viewInsetsOf(context).bottom,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _SheetChoice(
-                label: l10n.audiobookSleepOff,
-                selected: controller.mode == SleepTimerMode.off,
-                onTap: () {
-                  onCancel();
-                  Navigator.of(context).maybePop();
-                },
-              ),
-              for (final m in _presets)
-                _SheetChoice(
-                  label: l10n.audiobookSleepMinutes(m),
-                  selected:
-                      controller.mode == SleepTimerMode.duration &&
-                      (controller.totalRequested.inMinutes - m).abs() < 1,
-                  onTap: () {
-                    onPickPreset(m);
-                    Navigator.of(context).maybePop();
-                  },
+              _SheetTitle(titleText),
+              const SizedBox(height: AppSpacing.spaceMd),
+              if (controller.isActive) ...[
+                Row(
+                  children: [
+                    Expanded(
+                      child: InkWell(
+                        onTap: () {
+                          if (controller.isPaused) {
+                            controller.resumeTimer();
+                          } else {
+                            controller.pauseTimer();
+                          }
+                        },
+                        borderRadius: BorderRadius.circular(8),
+                        child: Container(
+                          height: 36,
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            border: Border.all(color: AppColorScheme.accent),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                controller.isPaused ? Icons.play_arrow : Icons.pause,
+                                size: 16,
+                                color: AppColorScheme.accent,
+                              ),
+                              const SizedBox(width: 6),
+                              Text(
+                                controller.isPaused ? 'Resume Timer' : 'Pause Timer',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                  color: AppColorScheme.accent,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: InkWell(
+                        onTap: () {
+                          onCancel();
+                          Navigator.of(context).maybePop();
+                        },
+                        borderRadius: BorderRadius.circular(8),
+                        child: Container(
+                          height: 36,
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            color: Colors.red.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.stop,
+                                size: 16,
+                                color: Colors.red.withValues(alpha: 0.85),
+                              ),
+                              const SizedBox(width: 6),
+                              const Text(
+                                'Stop Timer',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                  color: Colors.redAccent,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              _SheetChoice(
-                label: l10n.audiobookSleepEndOfChapter,
-                selected: controller.mode == SleepTimerMode.endOfChapter,
-                onTap: () {
-                  onPickEndOfChapter();
-                  Navigator.of(context).maybePop();
-                },
+                const SizedBox(height: AppSpacing.spaceMd),
+              ],
+              Column(
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepEndOfChapter,
+                          selected: controller.mode == SleepTimerMode.endOfChapter,
+                          onTap: () {
+                            onPickEndOfChapter();
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepMinutes(5),
+                          selected: controller.mode == SleepTimerMode.duration &&
+                              (controller.totalRequested.inMinutes - 5).abs() < 1,
+                          onTap: () {
+                            onPickPreset(5);
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepMinutes(15),
+                          selected: controller.mode == SleepTimerMode.duration &&
+                              (controller.totalRequested.inMinutes - 15).abs() < 1,
+                          onTap: () {
+                            onPickPreset(15);
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepMinutes(30),
+                          selected: controller.mode == SleepTimerMode.duration &&
+                              (controller.totalRequested.inMinutes - 30).abs() < 1,
+                          onTap: () {
+                            onPickPreset(30);
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepMinutes(45),
+                          selected: controller.mode == SleepTimerMode.duration &&
+                              (controller.totalRequested.inMinutes - 45).abs() < 1,
+                          onTap: () {
+                            onPickPreset(45);
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepMinutes(60),
+                          selected: controller.mode == SleepTimerMode.duration &&
+                              (controller.totalRequested.inMinutes - 60).abs() < 1,
+                          onTap: () {
+                            onPickPreset(60);
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepMinutes(90),
+                          selected: controller.mode == SleepTimerMode.duration &&
+                              (controller.totalRequested.inMinutes - 90).abs() < 1,
+                          onTap: () {
+                            onPickPreset(90);
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _SheetChoice(
+                          label: l10n.audiobookSleepMinutes(120),
+                          selected: controller.mode == SleepTimerMode.duration &&
+                              (controller.totalRequested.inMinutes - 120).abs() < 1,
+                          onTap: () {
+                            onPickPreset(120);
+                            Navigator.of(context).maybePop();
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ],
           ),
-          if (controller.isActive) ...[
-            const SizedBox(height: AppSpacing.spaceMd),
-            Text(
-              l10n.audiobookSleepRemaining(
-                formatAudiobookCountdown(controller.remaining),
-              ),
-              style: TextStyle(
-                color: AppColorScheme.onSurface.withValues(alpha: 0.7),
-              ),
-            ),
-          ],
-        ],
+        );
+      },
+    );
+  }
+}
+
+Future<dynamic> showAudiobookNoteEditor({
+  required BuildContext context,
+  required String initialText,
+  required String positionLabel,
+}) {
+  if (PlatformDetection.isTV) {
+    return showDialog<dynamic>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => Dialog(
+        alignment: const Alignment(0.0, -0.6),
+        backgroundColor: AppColorScheme.surface,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        child: SizedBox(
+          width: 500,
+          child: _NoteEditorSheet(
+            initialText: initialText,
+            positionLabel: positionLabel,
+            dialogContext: ctx,
+          ),
+        ),
       ),
     );
   }
+  return _showAdaptiveSheet<dynamic>(
+    context,
+    (ctx) => _NoteEditorSheet(
+      initialText: initialText,
+      positionLabel: positionLabel,
+      dialogContext: ctx,
+    ),
+    floating: true,
+  );
 }
 
 class _NoteEditorSheet extends StatefulWidget {
   const _NoteEditorSheet({
     required this.initialText,
     required this.positionLabel,
+    this.dialogContext,
   });
 
   final String initialText;
   final String positionLabel;
+  final BuildContext? dialogContext;
 
   @override
   State<_NoteEditorSheet> createState() => _NoteEditorSheetState();
@@ -367,26 +778,82 @@ class _NoteEditorSheet extends StatefulWidget {
 
 class _NoteEditorSheetState extends State<_NoteEditorSheet> {
   late final _controller = TextEditingController(text: widget.initialText);
+  final _tvFocusNode = FocusNode();
+  final _tvFieldKey = GlobalKey<CustomTVTextFieldState>();
+  final _focusScopeNode = FocusScopeNode();
+  bool _isSubmitting = false;
+  // Set true briefly after the keyboard closes so that the hardware KeyUp event
+  // from the physical remote that closed the keyboard can't immediately activate
+  // a button (which would cause an unintended auto-submit and focus lockup).
+  bool _keyboardJustClosed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _tvFocusNode.addListener(_onTvFocusChange);
+    CustomTVTextField.isKeyboardVisibleNotifier.addListener(_onKeyboardVisibilityChange);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _tvFocusNode.requestFocus();
+    });
+  }
 
   @override
   void dispose() {
+    _tvFocusNode.removeListener(_onTvFocusChange);
+    CustomTVTextField.isKeyboardVisibleNotifier.removeListener(_onKeyboardVisibilityChange);
+    _tvFocusNode.dispose();
+    _focusScopeNode.dispose();
     _controller.dispose();
     super.dispose();
+  }
+
+  void _onTvFocusChange() {
+    if (mounted) setState(() {});
+  }
+
+  void _onKeyboardVisibilityChange() {
+    if (!mounted || _isSubmitting) return;
+    final visible = CustomTVTextField.isKeyboardVisibleNotifier.value;
+    debugPrint('[NoteEditor] keyboard visibility changed: visible=$visible isSubmitting=$_isSubmitting');
+    if (!visible) {
+      // Keep focus on the text field — do NOT move to Save button here.
+      // Moving focus to Save would cause the hardware KeyUp event from the
+      // same remote keypress that closed the keyboard to auto-activate Save.
+      _tvFocusNode.requestFocus();
+      // Block button activation briefly to absorb trailing hardware KeyUp events.
+      _keyboardJustClosed = true;
+      debugPrint('[NoteEditor] keyboardJustClosed=true — blocking buttons for 400ms');
+      Future.delayed(const Duration(milliseconds: 400), () {
+        if (mounted) {
+          debugPrint('[NoteEditor] keyboardJustClosed=false — buttons active');
+          setState(() => _keyboardJustClosed = false);
+        }
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final apple = PlatformDetection.isApple;
-    return Padding(
-      padding: EdgeInsets.fromLTRB(
-        AppSpacing.spaceLg,
-        AppSpacing.spaceLg,
-        AppSpacing.spaceLg,
-        AppSpacing.spaceLg + MediaQuery.viewInsetsOf(context).bottom,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+    final isTV = PlatformDetection.isTV;
+    final prefs = GetIt.instance<UserPreferences>();
+    final preferSystemIme = prefs.get(UserPreferences.preferSystemImeKeyboard);
+    final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
+    final bottomPadding = isTV ? AppSpacing.spaceLg : (AppSpacing.spaceLg + MediaQuery.viewInsetsOf(context).bottom);
+
+    return FocusScope(
+      node: _focusScopeNode,
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.spaceLg,
+          AppSpacing.spaceLg,
+          AppSpacing.spaceLg,
+          bottomPadding,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Row(
@@ -408,7 +875,41 @@ class _NoteEditorSheetState extends State<_NoteEditorSheet> {
             ],
           ),
           const SizedBox(height: AppSpacing.spaceMd),
-          if (apple)
+          if (isTV)
+            Focus(
+              focusNode: _tvFocusNode,
+              autofocus: true,
+              onKeyEvent: (node, event) {
+                if (_isSubmitting) return KeyEventResult.handled;
+                final key = event.logicalKey;
+                final isDown = event is KeyDownEvent;
+                if (isDown &&
+                    (key == LogicalKeyboardKey.select ||
+                        key == LogicalKeyboardKey.enter ||
+                        key == LogicalKeyboardKey.numpadEnter)) {
+                  _tvFieldKey.currentState?.openKeyboard();
+                  return KeyEventResult.handled;
+                }
+                return KeyEventResult.ignored;
+              },
+              child: CustomTVTextField(
+                key: _tvFieldKey,
+                controller: _controller,
+                isFocused: _tvFocusNode.hasFocus,
+                hint: l10n.audiobookNoteHint,
+                maxLines: 1,
+                preferSystemIme: preferSystemIme,
+                keyboardType: KeyboardType.alphabetic,
+                popParentOnKeyboardClose: false,
+                borderColor: AppColorScheme.onSurface.withValues(alpha: 0.15),
+                focusedBorderColor: focusColor,
+                onFieldSubmitted: (_) {
+                  // Do nothing — focus stays on text field (_tvFocusNode).
+                  // _onKeyboardVisibilityChange handles focus restoration.
+                },
+              ),
+            )
+          else if (apple)
             CupertinoTextField(
               controller: _controller,
               autofocus: true,
@@ -439,37 +940,119 @@ class _NoteEditorSheetState extends State<_NoteEditorSheet> {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              if (apple) ...[
-                CupertinoButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(l10n.audiobookCancel),
-                ),
-                const SizedBox(width: 8),
-                CupertinoButton.filled(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 20,
-                    vertical: 10,
-                  ),
-                  onPressed: () =>
-                      Navigator.of(context).pop(_controller.text.trim()),
-                  child: Text(l10n.audiobookSave),
-                ),
-              ] else ...[
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: Text(l10n.audiobookCancel),
-                ),
-                const SizedBox(width: 8),
-                FilledButton(
-                  onPressed: () =>
-                      Navigator.of(context).pop(_controller.text.trim()),
-                  child: Text(l10n.audiobookSave),
-                ),
-              ],
+              _SheetActionButton(
+                label: l10n.audiobookCancel,
+                onPressed: () {
+                  debugPrint('[NoteEditor] Cancel pressed: isSubmitting=$_isSubmitting keyboardJustClosed=$_keyboardJustClosed');
+                  if (_isSubmitting || _keyboardJustClosed) return;
+                  _isSubmitting = true;
+                  debugPrint('[NoteEditor] Cancel: popping dialog now');
+                  try {
+                    final targetCtx = widget.dialogContext ?? context;
+                    final canPop = Navigator.canPop(targetCtx);
+                    Navigator.pop(targetCtx, null);
+                    debugPrint('[NoteEditor] Cancel: canPop=$canPop');
+                  } catch (e, stack) {
+                    debugPrint('[NoteEditor] Cancel pop exception: $e\n$stack');
+                  }
+                },
+              ),
+              const SizedBox(width: 8),
+              _SheetActionButton(
+                label: l10n.audiobookSave,
+                onPressed: () {
+                  debugPrint('[NoteEditor] Save pressed: isSubmitting=$_isSubmitting keyboardJustClosed=$_keyboardJustClosed');
+                  if (_isSubmitting || _keyboardJustClosed) return;
+                  _isSubmitting = true;
+                  final text = _controller.text.trim();
+                  debugPrint('[NoteEditor] Save: popping dialog with text="$text"');
+                  try {
+                    final targetCtx = widget.dialogContext ?? context;
+                    final canPop = Navigator.canPop(targetCtx);
+                    Navigator.pop(targetCtx, text);
+                    debugPrint('[NoteEditor] Save: canPop=$canPop');
+                  } catch (e, stack) {
+                    debugPrint('[NoteEditor] Save pop exception: $e\n$stack');
+                  }
+                },
+                isFilled: true,
+              ),
             ],
           ),
         ],
       ),
+    ),
+  );
+}
+}
+
+class _SheetActionButton extends StatefulWidget {
+  const _SheetActionButton({
+    required this.label,
+    required this.onPressed,
+    this.isFilled = false,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final bool isFilled;
+
+  @override
+  State<_SheetActionButton> createState() => _SheetActionButtonState();
+}
+
+class _SheetActionButtonState extends State<_SheetActionButton> {
+  bool _isFocused = false;
+  bool _isHovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final focused = _isFocused || _isHovered;
+    final prefs = GetIt.instance<UserPreferences>();
+    final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
+
+    final Color backgroundColor;
+    final Color foregroundColor;
+    final Color borderColor;
+
+    if (widget.isFilled) {
+      backgroundColor = focused ? focusColor : AppColorScheme.accent;
+      foregroundColor = AppColorScheme.onAccent;
+      borderColor = focused ? Colors.white : Colors.transparent;
+    } else {
+      backgroundColor = focused ? AppColorScheme.onSurface.withValues(alpha: 0.08) : Colors.transparent;
+      foregroundColor = focused ? focusColor : AppColorScheme.onSurface.withValues(alpha: 0.8);
+      borderColor = focused ? focusColor : AppColorScheme.onSurface.withValues(alpha: 0.15);
+    }
+
+    return InkWell(
+      onTap: widget.onPressed,
+      onFocusChange: (f) => setState(() => _isFocused = f),
+      onHover: (h) => setState(() => _isHovered = h),
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        height: 38,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          border: Border.all(
+            color: borderColor,
+            width: focused ? 2.0 : 1.0,
+          ),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          widget.label,
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: foregroundColor,
+          ),
+        ),
+      ),
     );
   }
 }
+
+

--- a/lib/ui/widgets/audiobook/audiobook_sheets.dart
+++ b/lib/ui/widgets/audiobook/audiobook_sheets.dart
@@ -814,18 +814,14 @@ class _NoteEditorSheetState extends State<_NoteEditorSheet> {
   void _onKeyboardVisibilityChange() {
     if (!mounted || _isSubmitting) return;
     final visible = CustomTVTextField.isKeyboardVisibleNotifier.value;
-    debugPrint('[NoteEditor] keyboard visibility changed: visible=$visible isSubmitting=$_isSubmitting');
     if (!visible) {
-      // Keep focus on the text field — do NOT move to Save button here.
-      // Moving focus to Save would cause the hardware KeyUp event from the
-      // same remote keypress that closed the keyboard to auto-activate Save.
+      // Keep focus on the text field rather than moving to Save, so the trailing
+      // hardware KeyUp from the remote keypress that closed the keyboard cannot
+      // auto-activate a button. Block buttons briefly to absorb that KeyUp.
       _tvFocusNode.requestFocus();
-      // Block button activation briefly to absorb trailing hardware KeyUp events.
       _keyboardJustClosed = true;
-      debugPrint('[NoteEditor] keyboardJustClosed=true — blocking buttons for 400ms');
       Future.delayed(const Duration(milliseconds: 400), () {
         if (mounted) {
-          debugPrint('[NoteEditor] keyboardJustClosed=false — buttons active');
           setState(() => _keyboardJustClosed = false);
         }
       });
@@ -943,37 +939,23 @@ class _NoteEditorSheetState extends State<_NoteEditorSheet> {
               _SheetActionButton(
                 label: l10n.audiobookCancel,
                 onPressed: () {
-                  debugPrint('[NoteEditor] Cancel pressed: isSubmitting=$_isSubmitting keyboardJustClosed=$_keyboardJustClosed');
                   if (_isSubmitting || _keyboardJustClosed) return;
                   _isSubmitting = true;
-                  debugPrint('[NoteEditor] Cancel: popping dialog now');
                   try {
-                    final targetCtx = widget.dialogContext ?? context;
-                    final canPop = Navigator.canPop(targetCtx);
-                    Navigator.pop(targetCtx, null);
-                    debugPrint('[NoteEditor] Cancel: canPop=$canPop');
-                  } catch (e, stack) {
-                    debugPrint('[NoteEditor] Cancel pop exception: $e\n$stack');
-                  }
+                    Navigator.pop(widget.dialogContext ?? context, null);
+                  } catch (_) {}
                 },
               ),
               const SizedBox(width: 8),
               _SheetActionButton(
                 label: l10n.audiobookSave,
                 onPressed: () {
-                  debugPrint('[NoteEditor] Save pressed: isSubmitting=$_isSubmitting keyboardJustClosed=$_keyboardJustClosed');
                   if (_isSubmitting || _keyboardJustClosed) return;
                   _isSubmitting = true;
                   final text = _controller.text.trim();
-                  debugPrint('[NoteEditor] Save: popping dialog with text="$text"');
                   try {
-                    final targetCtx = widget.dialogContext ?? context;
-                    final canPop = Navigator.canPop(targetCtx);
-                    Navigator.pop(targetCtx, text);
-                    debugPrint('[NoteEditor] Save: canPop=$canPop');
-                  } catch (e, stack) {
-                    debugPrint('[NoteEditor] Save pop exception: $e\n$stack');
-                  }
+                    Navigator.pop(widget.dialogContext ?? context, text);
+                  } catch (_) {}
                 },
                 isFilled: true,
               ),

--- a/lib/ui/widgets/audiobook/audiobook_transport_row.dart
+++ b/lib/ui/widgets/audiobook/audiobook_transport_row.dart
@@ -68,7 +68,10 @@ class AudiobookTransportRow extends StatelessWidget {
         ),
         AudiobookFocusRing(
           focused: tvFocusIndex == 2,
-          borderRadius: BorderRadius.circular(34),
+          borderRadius: BorderRadius.circular(38),
+          borderColor: AppColorScheme.onSurface,
+          backgroundColor: Colors.transparent,
+          padding: const EdgeInsets.all(4),
           child: AudiobookPlayButton(isPlaying: isPlaying, onTap: onPlayPause),
         ),
         AudiobookFocusRing(
@@ -174,12 +177,7 @@ class AudiobookSkipButton extends StatelessWidget {
     final apple = PlatformDetection.isApple;
     final color = AppColorScheme.onSurface;
 
-    final IconData icon;
-    if (apple) {
-      icon = forward ? CupertinoIcons.goforward : CupertinoIcons.gobackward;
-    } else {
-      icon = forward ? Icons.forward_30 : Icons.replay_30;
-    }
+    final IconData icon = forward ? CupertinoIcons.goforward : CupertinoIcons.gobackward;
 
     final glyph = Stack(
       alignment: Alignment.center,

--- a/lib/ui/widgets/audiobook/chapter.dart
+++ b/lib/ui/widgets/audiobook/chapter.dart
@@ -4,3 +4,25 @@ class Chapter {
 
   const Chapter({required this.title, required this.startMs});
 }
+
+enum TimelineEventType { chapter, bookmark, note }
+
+class TimelineEvent {
+  final String id;
+  final TimelineEventType type;
+  final String title;
+  final String? content;
+  final int positionMs;
+  final DateTime date;
+  final dynamic originalObject;
+
+  const TimelineEvent({
+    required this.id,
+    required this.type,
+    required this.title,
+    this.content,
+    required this.positionMs,
+    required this.date,
+    required this.originalObject,
+  });
+}

--- a/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
+++ b/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
@@ -231,7 +231,9 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
   void _onKeyboardStateChanged() {
     if (!_keyboardController.isVisible && _isOverlayOpen.value) {
       _isOverlayOpen.value = false;
-      if (mounted && Navigator.canPop(context)) {
+      if (widget.popParentOnKeyboardClose &&
+          mounted &&
+          Navigator.canPop(context)) {
         Navigator.pop(context);
       }
     }

--- a/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
+++ b/packages/custom_tv_text_field_fork/lib/src/custom_tv_text_field.dart
@@ -231,6 +231,9 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
   void _onKeyboardStateChanged() {
     if (!_keyboardController.isVisible && _isOverlayOpen.value) {
       _isOverlayOpen.value = false;
+      if (mounted && Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
     }
     if (mounted) {
       setState(() {});
@@ -278,9 +281,19 @@ class CustomTVTextFieldState extends State<CustomTVTextField>
     }
 
     if (!_isOverlayOpen.value) {
-      final previousFocus = FocusManager.instance.primaryFocus;
-      _focusToRestoreAfterOverlay =
-          identical(previousFocus, _keyboardFocusNode) ? null : previousFocus;
+      if (widget.popParentOnKeyboardClose) {
+        // Normal case: restore the previously-focused node after the keyboard closes.
+        final previousFocus = FocusManager.instance.primaryFocus;
+        _focusToRestoreAfterOverlay =
+            identical(previousFocus, _keyboardFocusNode) ? null : previousFocus;
+      } else {
+        // Keyboard is inside a parent dialog that manages its own focus.
+        // Do NOT capture primaryFocus here — it may not have updated yet
+        // (Flutter schedules focus changes for the next frame, but openKeyboard()
+        // runs on the event queue before that frame fires). Setting null prevents
+        // whenComplete() from overriding the parent's own requestFocus() call.
+        _focusToRestoreAfterOverlay = null;
+      }
     }
 
     _keyboardController.setText(widget.controller.text);
@@ -526,9 +539,9 @@ class _FieldDisplay extends StatelessWidget {
     final borderColor = hasError
         ? Colors.redAccent
         : (widget.borderColor ?? theme.canvasColor);
-    final focusedColor =
-        widget.focusedBorderColor ??
-        (hasFocus ? (hasError ? Colors.redAccent : Colors.white) : borderColor);
+    final focusedColor = hasFocus
+        ? (widget.focusedBorderColor ?? (hasError ? Colors.redAccent : Colors.white))
+        : borderColor;
 
     return BoxDecoration(
       color: widget.fillColor ?? widget.backgroundColor,

--- a/packages/playback_emby/lib/src/emby_play_session_service.dart
+++ b/packages/playback_emby/lib/src/emby_play_session_service.dart
@@ -62,7 +62,9 @@ class EmbyPlaySessionService implements PlayerService {
     Object? reportError;
     StackTrace? reportStackTrace;
     try {
-      await _client.playbackApi.reportPlaybackStopped(report.toJson());
+      if (!_isAudiobook(mediaItem)) {
+        await _client.playbackApi.reportPlaybackStopped(report.toJson());
+      }
     } catch (error, stackTrace) {
       reportError = error;
       reportStackTrace = stackTrace;
@@ -93,6 +95,21 @@ class EmbyPlaySessionService implements PlayerService {
     StreamPlayMethod.directStream => PlayMethod.directStream,
     StreamPlayMethod.transcode => PlayMethod.transcode,
   };
+
+  bool _isAudiobook(dynamic mediaItem) {
+    if (mediaItem is Map) {
+      final type = mediaItem['Type']?.toString().toLowerCase();
+      final mediaType = mediaItem['MediaType']?.toString().toLowerCase();
+      return type == 'audiobook' || type == 'audio_book' || mediaType == 'audiobook';
+    }
+    try {
+      final type = mediaItem.type?.toString().toLowerCase();
+      final mediaType = mediaItem.mediaType?.toString().toLowerCase();
+      return type == 'audiobook' || type == 'audio_book' || mediaType == 'audiobook';
+    } catch (_) {
+      return false;
+    }
+  }
 
   @override
   void dispose() {}

--- a/packages/playback_jellyfin/lib/src/play_session_service.dart
+++ b/packages/playback_jellyfin/lib/src/play_session_service.dart
@@ -68,7 +68,9 @@ class PlaySessionService implements PlayerService {
     Object? reportError;
     StackTrace? reportStackTrace;
     try {
-      await _client.playbackApi.reportPlaybackStopped(report.toJson());
+      if (!_isAudiobook(mediaItem)) {
+        await _client.playbackApi.reportPlaybackStopped(report.toJson());
+      }
     } catch (error, stackTrace) {
       reportError = error;
       reportStackTrace = stackTrace;
@@ -99,7 +101,7 @@ class PlaySessionService implements PlayerService {
     StreamResolutionResult resolution,
     int positionTicks,
   ) {
-    if (!PlaybackExitBeacon.supported) {
+    if (!PlaybackExitBeacon.supported || _isAudiobook(mediaItem)) {
       return;
     }
     final token = _client.accessToken;
@@ -131,6 +133,21 @@ class PlaySessionService implements PlayerService {
     StreamPlayMethod.directStream => PlayMethod.directStream,
     StreamPlayMethod.transcode => PlayMethod.transcode,
   };
+
+  bool _isAudiobook(dynamic mediaItem) {
+    if (mediaItem is Map) {
+      final type = mediaItem['Type']?.toString().toLowerCase();
+      final mediaType = mediaItem['MediaType']?.toString().toLowerCase();
+      return type == 'audiobook' || type == 'audio_book' || mediaType == 'audiobook';
+    }
+    try {
+      final type = mediaItem.type?.toString().toLowerCase();
+      final mediaType = mediaItem.mediaType?.toString().toLowerCase();
+      return type == 'audiobook' || type == 'audio_book' || mediaType == 'audiobook';
+    } catch (_) {
+      return false;
+    }
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
# Pull Request

## Summary
This PR implements full "wife-approved" audiobook player view support and dedicated playback engine controls in the client app.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

1. Player View Layout
* Dual Progress Bars: Left panel features an overall full-duration seekbar showing global audiobook progress. Right panel features a high-fidelity Focused Timeline seekbar showcasing a sliding 1-hour interval around the active position.
* Focused Timeline (Sliding Window): Starts at [0, 1 hr] with the thumb on the left until reaching 30 minutes. Stays centered ([pos - 30m, pos + 30m]) during middle play. Slides to the right when less than 30 minutes remain.

2. Timeline Visual Ticks
* Visual ticks for Chapters, Bookmarks, and Notes cross vertically through/behind the slider tracks on both progress bars. Ticks on the Focused Timeline slide dynamically into view as the playback window shifts.

3. Playback Controls & Features
* Sleep Timer: Multiple options (Custom duration, End of Chapter) with automated playback suspension.
* Fine Tune speed adjustment: Integrated with D-pad focus lock on TV (locking horizontal adjust until activated by pressing Select).
* Export to CSV: Bookmarks, Notes, or All Events lists can be exported as a CSV file to the offline root path.
* Queue List: Highlights active track, simplifies spacing, and implements automated scrolling when D-pad focus moves out of the viewport.
* Notes List: Redesigned as custom 52px items with tight spacing (no separator dividers).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Build and deploy
2. Browse to audiobooks library
3. Fiddle around :)

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-02_11-57-18" src="https://github.com/user-attachments/assets/8d65bbcd-8585-473c-87b6-97b90638ed16" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-02_11-57-49" src="https://github.com/user-attachments/assets/312ec768-e553-4a6e-b84f-0772f51967e0" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
