### PR TITLE
feat(book): implement Books discover browse tabs and library resume/d…

### DIFF
--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -649,10 +649,14 @@ class RowDataSource {
     );
   }
 
-  Future<HomeRow> loadLibraryResume(String parentId, String serverId) async {
+  Future<HomeRow> loadLibraryResume(
+    String parentId,
+    String serverId, {
+    List<String> includeItemTypes = const ['Video'],
+  }) async {
     final response = await _getResumeItemsWithFallback(
       parentId: parentId,
-      includeItemTypes: ['Video'],
+      includeItemTypes: includeItemTypes,
       limit: _defaultLimit,
     );
     return _buildRow(

--- a/lib/data/viewmodels/book_browse_view_model.dart
+++ b/lib/data/viewmodels/book_browse_view_model.dart
@@ -28,6 +28,18 @@ class BookBrowseViewModel extends ChangeNotifier {
   AggregatedItem? _featured;
   AggregatedItem? get featuredItem => _featured;
 
+  int _bookCount = 0;
+  int get bookCount => _bookCount;
+  int _audiobookCount = 0;
+  int get audiobookCount => _audiobookCount;
+
+  bool _isAudiobook(AggregatedItem item) {
+    final type = (item.type ?? '').toLowerCase();
+    final mediaType = (item.rawData['MediaType'] as String? ?? '')
+        .toLowerCase();
+    return type == 'audio' || type == 'audiobook' || mediaType == 'audio';
+  }
+
   int _titleCount = 0;
   int get titleCount => _titleCount;
   int _genreCount = 0;
@@ -50,7 +62,7 @@ class BookBrowseViewModel extends ChangeNotifier {
        _collectionType = collectionType;
 
   List<String> get _itemTypes =>
-      isAudiobookLibrary ? const ['AudioBook', 'Audio'] : const ['Book'];
+      isAudiobookLibrary ? const ['AudioBook', 'Audio'] : const ['Book', 'AudioBook', 'Audio'];
 
   Future<void> load() async {
     _isLoading = true;
@@ -68,7 +80,12 @@ class BookBrowseViewModel extends ChangeNotifier {
 
     try {
       final allTitle = isAudiobookLibrary ? l10n.audiobooks : l10n.books;
-      final resumeF = _dataSource.loadLibraryResume(libraryId, _serverId);
+      final resumeF = _dataSource.loadLibraryResume(
+        libraryId,
+        _serverId,
+        includeItemTypes: _itemTypes,
+      );
+      final resumeAudioF = _dataSource.loadResumeAudio(_serverId);
       final latestF = _dataSource.loadLatestMedia(
         libraryId,
         _libraryName,
@@ -103,8 +120,10 @@ class BookBrowseViewModel extends ChangeNotifier {
 
       await Future.wait([
         resumeF,
+        resumeAudioF,
         latestF,
-        ?lastPlayedF,
+        // ignore: use_null_aware_elements
+        if (lastPlayedF != null) lastPlayedF,
         favoritesF,
         genresF,
         collectionsF,
@@ -112,6 +131,7 @@ class BookBrowseViewModel extends ChangeNotifier {
       ]);
 
       final resume = await resumeF;
+      final resumeAudio = await resumeAudioF;
       final latest = await latestF;
       final lastPlayed = lastPlayedF == null ? null : await lastPlayedF;
       final favorites = await favoritesF;
@@ -119,19 +139,97 @@ class BookBrowseViewModel extends ChangeNotifier {
       final collections = await collectionsF;
       final all = await allF;
 
-      _rows = [
-        resume,
-        latest,
-        ?lastPlayed,
-        favorites,
-        genres,
-        collections,
-        all,
-      ].where((r) => r.items.isNotEmpty).toList();
+      final libraryItemIds = all.items.map((e) => e.id).toSet();
+      final libraryResumeAudio = resumeAudio.items
+          .where((item) => libraryItemIds.contains(item.id))
+          .toList();
+
+      final mergedResumeItems = [
+        ...resume.items,
+        ...libraryResumeAudio,
+      ];
+
+      final splitRows = <HomeRow>[];
+
+      void addSplit({
+        required HomeRow original,
+        required String booksId,
+        required String audiobooksId,
+        required String booksTitle,
+        required String audiobooksTitle,
+      }) {
+        final booksItems = original.items.where((item) => !_isAudiobook(item)).toList();
+        final audioItems = original.items.where((item) => _isAudiobook(item)).toList();
+
+        if (booksItems.isNotEmpty) {
+          splitRows.add(original.copyWith(
+            id: booksId,
+            title: booksTitle,
+            items: booksItems,
+            totalCount: booksItems.length,
+          ));
+        }
+        if (audioItems.isNotEmpty) {
+          splitRows.add(original.copyWith(
+            id: audiobooksId,
+            title: audiobooksTitle,
+            items: audioItems,
+            totalCount: audioItems.length,
+            isAudio: true,
+          ));
+        }
+      }
+
+      if (isAudiobookLibrary) {
+        addSplit(
+          original: latest,
+          booksId: 'recently_added_books',
+          audiobooksId: 'recently_added_audiobooks',
+          booksTitle: 'Recently Added Books',
+          audiobooksTitle: 'Recently Added Audiobooks',
+        );
+        _rows = [
+          resume,
+          ...splitRows,
+          // ignore: use_null_aware_elements
+          if (lastPlayed != null) lastPlayed,
+          favorites,
+          genres,
+          collections,
+        ].where((r) => r.items.isNotEmpty).toList();
+      } else {
+        if (mergedResumeItems.isNotEmpty) {
+          splitRows.add(resume.copyWith(
+            title: l10n.continueReading,
+            items: mergedResumeItems,
+            totalCount: mergedResumeItems.length,
+          ));
+        }
+        addSplit(
+          original: latest,
+          booksId: 'recently_added_books',
+          audiobooksId: 'recently_added_audiobooks',
+          booksTitle: 'Recently Added Books',
+          audiobooksTitle: 'Recently Added Audiobooks',
+        );
+
+        _rows = [
+          ...splitRows,
+          favorites,
+          genres,
+          collections,
+        ].where((r) => r.items.isNotEmpty).toList();
+      }
 
       _featured = resume.items.isNotEmpty
           ? resume.items.first
           : (latest.items.isNotEmpty ? latest.items.first : null);
+      
+      final booksAll = all.items.where((item) => !_isAudiobook(item)).toList();
+      final audioAll = all.items.where((item) => _isAudiobook(item)).toList();
+      _bookCount = booksAll.length;
+      _audiobookCount = audioAll.length;
+      
       _titleCount = all.totalCount > 0 ? all.totalCount : all.items.length;
       _genreCount = genres.items.length;
       _seriesCount = 0;

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -352,7 +352,11 @@ class LibraryBrowseViewModel extends ChangeNotifier {
 
     if (isBookLibrary) {
       recursive = true;
-      includeTypes = ['Book', 'Audio', 'AudioBook'];
+      if (includeItemTypes != null) {
+        includeTypes = List<String>.from(includeItemTypes!);
+      } else {
+        includeTypes = ['Book', 'Audio', 'AudioBook'];
+      }
       sortBy = 'SortName';
     } else if (isHomeVideosLibrary || isMixedContentLibrary) {
       recursive = false;
@@ -719,7 +723,17 @@ class LibraryBrowseViewModel extends ChangeNotifier {
 
   bool get isBookLibrary =>
       _collectionType == 'books' ||
-      (includeItemTypes != null && includeItemTypes!.contains('Book'));
+      _collectionType == 'audiobooks' ||
+      (includeItemTypes != null &&
+          (includeItemTypes!.contains('Book') ||
+              includeItemTypes!.contains('AudioBook') ||
+              includeItemTypes!.contains('Audio')));
+
+  bool get isAudiobookLibrary =>
+      _collectionType == 'audiobooks' ||
+      (includeItemTypes != null &&
+          (includeItemTypes!.contains('AudioBook') ||
+              includeItemTypes!.contains('Audio')));
 
   bool get isHomeVideosLibrary =>
       !isGenreBrowse &&

--- a/lib/ui/screens/browse/book_browse_screen.dart
+++ b/lib/ui/screens/browse/book_browse_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
+import 'package:playback_core/playback_core.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../../data/models/aggregated_item.dart';
@@ -9,10 +10,10 @@ import '../../../data/models/home_row.dart';
 import '../../../data/services/row_data_source.dart';
 import '../../../data/viewmodels/book_browse_view_model.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/focus/dpad_keys.dart';
 import '../../navigation/destinations.dart';
-import '../../util/home_row_title_localizer.dart';
 import '../../widgets/book/book_segmented_control.dart';
-import '../../widgets/book/book_spotlight.dart';
 import '../../widgets/book/book_stats_band.dart';
 import '../../widgets/book/discover/book_discover_tab.dart';
 import '../../widgets/focus/request_initial_focus.dart';
@@ -37,6 +38,50 @@ class BookBrowseScreen extends StatefulWidget {
 class _BookBrowseScreenState extends State<BookBrowseScreen> {
   late final BookBrowseViewModel _vm;
   int _tab = 0;
+  final _scrollController = ScrollController();
+  VoidCallback? _previousFocusContentFromNavbarCallback;
+
+  final Map<String, ScrollController> _rowControllers = {};
+  final Map<String, FocusNode> _rowFirstCardFocusNodes = {};
+
+  final _firstResumeBookFocusNode = FocusNode(debugLabel: 'FirstResumeBook');
+  final _libraryTabFocusNode = FocusNode(debugLabel: 'LibraryTab');
+  final _discoverTabFocusNode = FocusNode(debugLabel: 'DiscoverTab');
+  final _booksStatFocusNode = FocusNode(debugLabel: 'BooksStat');
+  final _audiobooksStatFocusNode = FocusNode(debugLabel: 'AudiobooksStat');
+  final _firstRecentBooksFocusNode = FocusNode(debugLabel: 'FirstRecentBooks');
+  final _firstRecentAudiobooksFocusNode = FocusNode(debugLabel: 'FirstRecentAudiobooks');
+  final _firstDiscoverFocusNode = FocusNode(debugLabel: 'FirstDiscover');
+  final _discoverSettingsFocusNode = FocusNode(debugLabel: 'DiscoverSettings');
+
+  void _onStatsBandFocusChange() {
+    if (_booksStatFocusNode.hasFocus || _audiobooksStatFocusNode.hasFocus) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          0.0,
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeOutCubic,
+        );
+      }
+    }
+  }
+
+  void _onSettingsFocusChange() {
+    if (_discoverSettingsFocusNode.hasFocus && _tab == 1 && _scrollController.hasClients) {
+      final resumeRow = _vm.rows.firstWhere(
+        (r) => r.rowType == HomeRowType.resume,
+        orElse: () => HomeRow(id: '', title: '', items: [], rowType: HomeRowType.resume),
+      );
+      final topReserve = MediaQuery.paddingOf(context).top + 56;
+      final topHeight = resumeRow.items.isNotEmpty ? (topReserve + 256.0) : topReserve;
+      final targetOffset = topHeight + 110.0;
+      _scrollController.animateTo(
+        targetOffset,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOutCubic,
+      );
+    }
+  }
 
   @override
   void initState() {
@@ -49,13 +94,56 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
     );
     _vm.addListener(_onChanged);
     _vm.load();
+
+    _booksStatFocusNode.addListener(_onStatsBandFocusChange);
+    _audiobooksStatFocusNode.addListener(_onStatsBandFocusChange);
+    _discoverSettingsFocusNode.addListener(_onSettingsFocusChange);
+
+    _previousFocusContentFromNavbarCallback =
+        NavigationLayout.focusContentFromNavbarNotifier.value;
+    NavigationLayout.focusContentFromNavbarNotifier.value =
+        _focusContentFromNavbar;
   }
 
   @override
   void dispose() {
+    _booksStatFocusNode.removeListener(_onStatsBandFocusChange);
+    _audiobooksStatFocusNode.removeListener(_onStatsBandFocusChange);
+    _discoverSettingsFocusNode.removeListener(_onSettingsFocusChange);
+    for (final controller in _rowControllers.values) {
+      controller.dispose();
+    }
+    for (final node in _rowFirstCardFocusNodes.values) {
+      node.dispose();
+    }
+    _firstResumeBookFocusNode.dispose();
+    _libraryTabFocusNode.dispose();
+    _discoverTabFocusNode.dispose();
+    _booksStatFocusNode.dispose();
+    _audiobooksStatFocusNode.dispose();
+    _firstRecentBooksFocusNode.dispose();
+    _firstRecentAudiobooksFocusNode.dispose();
+    _firstDiscoverFocusNode.dispose();
+    _discoverSettingsFocusNode.dispose();
+    _scrollController.dispose();
+    if (NavigationLayout.focusContentFromNavbarNotifier.value ==
+        _focusContentFromNavbar) {
+      NavigationLayout.focusContentFromNavbarNotifier.value =
+          _previousFocusContentFromNavbarCallback;
+    }
     _vm.removeListener(_onChanged);
     _vm.dispose();
     super.dispose();
+  }
+
+  void _focusContentFromNavbar() {
+    if (!mounted) return;
+    final resumeRow = _vm.rows.firstWhere(
+      (r) => r.rowType == HomeRowType.resume,
+      orElse: () => HomeRow(id: '', title: '', items: [], rowType: HomeRowType.resume),
+    );
+    final targetNode = resumeRow.items.isNotEmpty ? _firstResumeBookFocusNode : _libraryTabFocusNode;
+    targetNode.requestFocus();
   }
 
   void _onChanged() {
@@ -65,7 +153,7 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
   List<String> get _itemTypes =>
       _vm.isAudiobookLibrary ? const ['AudioBook', 'Audio'] : const ['Book'];
 
-  void _onItemTap(AggregatedItem item, HomeRow row) {
+  void _onItemTap(AggregatedItem item, HomeRow row) async {
     if (row.rowType == HomeRowType.genres) {
       context.push(
         Destinations.genre(
@@ -77,56 +165,255 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
       );
       return;
     }
-    _openItem(item);
-  }
 
-  void _openItem(AggregatedItem item) {
-    final type = item.type;
-    if (type == 'BoxSet') {
-      context.push(Destinations.collection(item.id));
-      return;
-    }
-    final isFolder = item.rawData['IsFolder'] as bool? ?? false;
-    if (isFolder || type == 'Folder' || type == 'CollectionFolder') {
-      context.push(Destinations.folder(item.id, serverId: item.serverId));
-      return;
-    }
-    if (type == 'Book') {
-      context.push(Destinations.book(item.id, serverId: item.serverId));
-      return;
-    }
-    context.push(Destinations.item(item.id, serverId: item.serverId));
-  }
+    if (row.rowType == HomeRowType.resume) {
+      final isAudiobook = item.type == 'AudioBook' || item.type == 'Audio';
+      if (isAudiobook) {
+        final manager = GetIt.instance<PlaybackManager>();
+        final client = GetIt.instance<MediaServerClient>();
+        final startPosition = item.playbackPosition ?? Duration.zero;
 
-  List<BookStat> _stats(AppLocalizations l10n) => [
-    BookStat(
-      label: _vm.isAudiobookLibrary ? l10n.audiobooks : l10n.books,
-      count: _vm.titleCount,
-    ),
-    BookStat(label: l10n.series, count: _vm.seriesCount),
-    BookStat(label: l10n.authors, count: _vm.authorCount),
-    BookStat(label: l10n.genres, count: _vm.genreCount),
-  ];
+        if (item.type == 'AudioBook') {
+          const audioChildFields = 'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,MediaSources,MediaSourceCount,MediaType,IndexNumber,ParentIndexNumber,Artists,AlbumArtist,Genres,Chapters';
+          bool isAudioChild(dynamic e) {
+            final childType = e is Map ? e['Type']?.toString() : null;
+            return childType == 'Audio' || childType == 'AudioBook';
+          }
 
-  void _onSeeAll(HomeRow row) {
-    if (row.rowType == HomeRowType.genres) {
-      context.push(Destinations.libraryGenresOf(widget.libraryId));
-      return;
+          try {
+            final data = await client.itemsApi.getItems(
+              parentId: item.id,
+              includeItemTypes: const ['Audio', 'AudioBook'],
+              sortBy: 'ParentIndexNumber,IndexNumber,SortName',
+              fields: audioChildFields,
+            );
+            final rawChildren = (data['Items'] as List?) ?? const [];
+            final childItems = rawChildren.where(isAudioChild).toList();
+            if (childItems.isNotEmpty) {
+              final siblings = childItems.map((i) => AggregatedItem(id: i['Id']?.toString() ?? '', serverId: item.serverId, rawData: i as Map<String, dynamic>)).toList();
+              int startIndex = 0;
+              Duration childPosition = Duration.zero;
+              final idx = siblings.indexWhere((t) => (t.playbackPosition ?? Duration.zero) > Duration.zero && !t.isPlayed);
+              if (idx >= 0) {
+                startIndex = idx;
+                childPosition = siblings[idx].playbackPosition ?? Duration.zero;
+              } else {
+                final firstUnplayed = siblings.indexWhere((t) => !t.isPlayed);
+                startIndex = firstUnplayed >= 0 ? firstUnplayed : 0;
+                childPosition = Duration.zero;
+              }
+              final playItemsFuture = manager.playItems(
+                siblings,
+                startIndex: startIndex,
+                startPosition: childPosition,
+              );
+              if (mounted) {
+                await context.push('${Destinations.audioPlayer}?isAudiobook=true');
+              }
+              await playItemsFuture;
+              if (mounted) {
+                _vm.load();
+              }
+              return;
+            }
+          } catch (_) {}
+        }
+
+        // Sibling queue for leaf audiobook
+        final parentId = item.rawData['ParentId']?.toString();
+        if (parentId != null && parentId.isNotEmpty) {
+          const audioChildFields = 'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,MediaSources,MediaSourceCount,MediaType,IndexNumber,ParentIndexNumber,Artists,AlbumArtist,Genres,Chapters';
+          bool isAudioChild(dynamic e) {
+            final childType = e is Map ? e['Type']?.toString() : null;
+            return childType == 'Audio' || childType == 'AudioBook';
+          }
+
+          try {
+            final siblingData = await client.itemsApi.getItems(
+              parentId: parentId,
+              includeItemTypes: const ['Audio', 'AudioBook'],
+              sortBy: 'ParentIndexNumber,IndexNumber,SortName',
+              fields: audioChildFields,
+            );
+            final siblingsRaw = (siblingData['Items'] as List?) ?? const [];
+            final siblings = siblingsRaw.where(isAudioChild).map((i) => AggregatedItem(id: i['Id']?.toString() ?? '', serverId: item.serverId, rawData: i as Map<String, dynamic>)).toList();
+            final startIndex = siblings.indexWhere((t) => t.id == item.id);
+            if (siblings.isNotEmpty && startIndex >= 0) {
+              final playItemsFuture = manager.playItems(
+                siblings,
+                startIndex: startIndex,
+                startPosition: startPosition,
+              );
+              if (mounted) {
+                await context.push('${Destinations.audioPlayer}?isAudiobook=true');
+              }
+              await playItemsFuture;
+              if (mounted) {
+                _vm.load();
+              }
+              return;
+            }
+          } catch (_) {}
+        }
+
+        // Default audio playback fallback
+        final playItemsFuture = manager.playItems(
+          [item],
+          startPosition: startPosition,
+        );
+        if (mounted) {
+          await context.push('${Destinations.audioPlayer}?isAudiobook=true');
+        }
+        await playItemsFuture;
+        if (mounted) {
+          _vm.load();
+        }
+        return;
+      } else {
+        // Book reader straight into reading
+        context.push(Destinations.book(item.id, serverId: item.serverId)).then((_) {
+          if (mounted) {
+            _vm.load();
+          }
+        });
+        return;
+      }
     }
+
     context.push(
-      Destinations.library(widget.libraryId, includeItemTypes: _itemTypes),
+      Destinations.itemOrPhoto(
+        item.id,
+        serverId: item.serverId,
+        type: item.type,
+      ),
+    ).then((result) {
+      if (result == true && mounted) {
+        _vm.load();
+      }
+    });
+  }
+
+  List<BookStat> _stats(AppLocalizations l10n) {
+    return [
+      BookStat(
+        label: l10n.books,
+        count: _vm.bookCount,
+        onTap: () => context.push(
+          Destinations.library(widget.libraryId, includeItemTypes: const ['Book']),
+        ),
+      ),
+      BookStat(
+        label: l10n.audiobooks,
+        count: _vm.audiobookCount,
+        onTap: () => context.push(
+          Destinations.library(widget.libraryId, includeItemTypes: const ['AudioBook', 'Audio']),
+        ),
+      ),
+      BookStat(
+        label: l10n.series,
+        count: _vm.seriesCount,
+        onTap: () => context.push(
+          Destinations.library(widget.libraryId, includeItemTypes: _itemTypes),
+        ),
+      ),
+      BookStat(
+        label: l10n.genres,
+        count: _vm.genreCount,
+        onTap: () => context.push(Destinations.libraryGenresOf(widget.libraryId)),
+      ),
+    ];
+  }
+
+  FocusNode _getFirstCardFocusNode(String rowId) {
+    if (rowId == 'recently_added_books') {
+      return _firstRecentBooksFocusNode;
+    }
+    if (rowId == 'recently_added_audiobooks') {
+      return _firstRecentAudiobooksFocusNode;
+    }
+    return _rowFirstCardFocusNodes.putIfAbsent(
+      rowId,
+      () => FocusNode(debugLabel: 'FirstCard_$rowId'),
     );
   }
 
+  void _focusRowFirstCard(String destinationRowId, FocusNode node) {
+    final controller = _rowControllers[destinationRowId];
+    if (controller != null && controller.hasClients) {
+      controller.jumpTo(0.0);
+    }
+    node.requestFocus();
+  }
+
+  KeyEventResult _handleRowKeyEvent(KeyEvent event, String rowId, int index, int totalCount) {
+    if (!event.isActionable) return KeyEventResult.ignored;
+
+    if (event.logicalKey.isLeftKey) {
+      if (index == 0) {
+        return KeyEventResult.handled;
+      }
+    } else if (event.logicalKey.isRightKey) {
+      if (index == totalCount - 1) {
+        return KeyEventResult.handled;
+      }
+    } else if (event.logicalKey.isDownKey) {
+      if (rowId == 'resume') {
+        _libraryTabFocusNode.requestFocus();
+        return KeyEventResult.handled;
+      }
+      final rows = _vm.rows;
+      final currentIdx = rows.indexWhere((r) => r.id == rowId || (rowId == 'resume' && r.rowType == HomeRowType.resume));
+      if (currentIdx >= 0 && currentIdx < rows.length - 1) {
+        final nextRow = rows[currentIdx + 1];
+        final targetNode = _getFirstCardFocusNode(nextRow.id);
+        _focusRowFirstCard(nextRow.id, targetNode);
+        return KeyEventResult.handled;
+      } else {
+        return KeyEventResult.handled; // Cap at the bottom row
+      }
+    } else if (event.logicalKey.isUpKey) {
+      if (rowId == 'resume') {
+        NavigationLayout.focusNavbarNotifier.value?.call();
+        return KeyEventResult.handled;
+      }
+      final rows = _vm.rows;
+      final currentIdx = rows.indexWhere((r) => r.id == rowId || (rowId == 'resume' && r.rowType == HomeRowType.resume));
+      if (currentIdx > 0) {
+        final prevRow = rows[currentIdx - 1];
+        final targetNode = prevRow.rowType == HomeRowType.resume
+            ? _firstResumeBookFocusNode
+            : _getFirstCardFocusNode(prevRow.id);
+        _focusRowFirstCard(prevRow.id, targetNode);
+        return KeyEventResult.handled;
+      } else {
+        // First non-resume row goes UP to the stats band
+        _booksStatFocusNode.requestFocus();
+        return KeyEventResult.handled;
+      }
+    }
+    return KeyEventResult.ignored;
+  }
+
   @override
-  Widget build(BuildContext context) =>
-      RequestInitialFocus(child: _buildContent(context));
+  Widget build(BuildContext context) {
+    final resumeRow = _vm.rows.firstWhere(
+      (r) => r.rowType == HomeRowType.resume,
+      orElse: () => HomeRow(id: '', title: '', items: [], rowType: HomeRowType.resume),
+    );
+    final targetNode = resumeRow.items.isNotEmpty ? _firstResumeBookFocusNode : _libraryTabFocusNode;
+
+    return RequestInitialFocus(
+      targetNode: targetNode,
+      child: _buildContent(context),
+    );
+  }
 
   Widget _buildContent(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColorScheme.background,
       body: NavigationLayout(
         showBackButton: true,
+        activeRoute: Destinations.bookLibrary(widget.libraryId, collectionType: widget.collectionType),
         child: _vm.isLoading
             ? Center(
                 child: CircularProgressIndicator(color: AppColorScheme.accent),
@@ -134,6 +421,7 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
             : RefreshIndicator(
                 onRefresh: _vm.refresh,
                 child: ListView(
+                  controller: _scrollController,
                   padding: const EdgeInsets.only(bottom: 120),
                   children: _buildSlivers(context),
                 ),
@@ -145,62 +433,170 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
   List<Widget> _buildSlivers(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final topReserve = MediaQuery.paddingOf(context).top + 56;
-    final featured = _vm.featuredItem;
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
+    final leftPadding = 60.0 * desktopScale;
+
+    final resumeRow = _vm.rows.firstWhere(
+      (r) => r.rowType == HomeRowType.resume,
+      orElse: () => HomeRow(id: '', title: '', items: [], rowType: HomeRowType.resume),
+    );
+    final otherRows = _vm.rows.where((r) => r.rowType != HomeRowType.resume).toList();
 
     return [
-      if (featured != null)
-        BookSpotlight(
-          eyebrow: l10n.continueReading,
-          title: featured.name,
-          subtitle: _vm.bookSubtitle(featured),
-          ctaLabel: l10n.continueReading,
-          imageUrl: _vm.bookImageUrl(featured),
-          progress: (featured.playedPercentage ?? 0) > 0
-              ? (featured.playedPercentage! / 100).clamp(0.0, 1.0)
-              : null,
-          topInset: topReserve,
-          onPrimary: () => _openItem(featured),
+      if (resumeRow.items.isNotEmpty)
+        Padding(
+          padding: EdgeInsets.only(top: topReserve),
+            child: _buildRow(resumeRow, l10n),
         )
       else
         SizedBox(height: topReserve),
-      BookStatsBand(stats: _stats(l10n)),
-      Padding(
-        padding: const EdgeInsets.fromLTRB(16, 6, 16, 10),
-        child: BookSegmentedControl(
-          labels: [l10n.library, l10n.discover],
-          selectedIndex: _tab,
-          onChanged: (v) => setState(() => _tab = v),
+      FocusTraversalGroup(
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(leftPadding, 6, leftPadding, 10),
+          child: BookSegmentedControl(
+            labels: [l10n.library, l10n.discover],
+            selectedIndex: _tab,
+            libraryFocusNode: _libraryTabFocusNode,
+            discoverFocusNode: _discoverTabFocusNode,
+            onUpPressed: () {
+              if (resumeRow.items.isNotEmpty) {
+                _firstResumeBookFocusNode.requestFocus();
+              } else {
+                NavigationLayout.focusNavbarNotifier.value?.call();
+              }
+            },
+            onLibraryDownPressed: () {
+              _booksStatFocusNode.requestFocus();
+            },
+            onDiscoverDownPressed: () {
+              _audiobooksStatFocusNode.requestFocus();
+            },
+            onChanged: (v) {
+              setState(() => _tab = v);
+              if (v == 0 && _scrollController.hasClients) {
+                _scrollController.animateTo(
+                  0.0,
+                  duration: const Duration(milliseconds: 250),
+                  curve: Curves.easeOutCubic,
+                );
+              }
+            },
+          ),
+        ),
+      ),
+      FocusTraversalGroup(
+        child: BookStatsBand(
+          stats: _stats(l10n),
+          booksFocusNode: _booksStatFocusNode,
+          audiobooksFocusNode: _audiobooksStatFocusNode,
+          onBooksUpPressed: () {
+            _libraryTabFocusNode.requestFocus();
+          },
+          onAudiobooksUpPressed: () {
+            _discoverTabFocusNode.requestFocus();
+          },
+          onBooksDownPressed: () {
+            if (_tab == 0) {
+              final hasBooksRow = _vm.rows.any((r) => r.id == 'recently_added_books');
+              final hasAudiobooksRow = _vm.rows.any((r) => r.id == 'recently_added_audiobooks');
+              if (hasBooksRow) {
+                _firstRecentBooksFocusNode.requestFocus();
+              } else if (hasAudiobooksRow) {
+                _firstRecentAudiobooksFocusNode.requestFocus();
+              }
+            } else if (_tab == 1) {
+              _discoverSettingsFocusNode.requestFocus();
+            }
+          },
+          onAudiobooksDownPressed: () {
+            if (_tab == 0) {
+              final hasBooksRow = _vm.rows.any((r) => r.id == 'recently_added_books');
+              final hasAudiobooksRow = _vm.rows.any((r) => r.id == 'recently_added_audiobooks');
+              if (hasAudiobooksRow) {
+                _firstRecentAudiobooksFocusNode.requestFocus();
+              } else if (hasBooksRow) {
+                _firstRecentBooksFocusNode.requestFocus();
+              }
+            } else if (_tab == 1) {
+              _discoverSettingsFocusNode.requestFocus();
+            }
+          },
         ),
       ),
       if (_tab == 0)
-        ..._vm.rows.map((row) => _buildRow(row, l10n))
+        ...otherRows.map((row) => _buildRow(row, l10n))
       else
         BookDiscoverTab(
           libraryId: widget.libraryId,
           isAudiobook: _vm.isAudiobookLibrary,
+          firstFocusNode: _firstDiscoverFocusNode,
+          settingsMenuFocusNode: _discoverSettingsFocusNode,
+          leftPadding: leftPadding,
+          onSettingsUpPressed: () {
+            if (_vm.isAudiobookLibrary) {
+              _audiobooksStatFocusNode.requestFocus();
+            } else {
+              _booksStatFocusNode.requestFocus();
+            }
+          },
         ),
     ];
   }
 
   Widget _buildRow(HomeRow row, AppLocalizations l10n) {
+    final isResume = row.rowType == HomeRowType.resume;
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
+    final leftPadding = 60.0 * desktopScale;
+
+    final controller = _rowControllers.putIfAbsent(
+      row.id,
+      () => ScrollController(debugLabel: 'RowScrollController_${row.id}'),
+    );
+
     return LibraryRow(
       key: ValueKey(row.id),
-      title: localizeHomeRowTitle(row: row, l10n: l10n),
-      onSeeAll: () => _onSeeAll(row),
+      title: row.title,
+      rowHeight: 256,
+      leftPadding: leftPadding,
+      scrollController: controller,
+      onSeeAll: null, // Remove all See All links from this screen
       children: [
-        for (final item in row.items)
-          MediaCard(
-            width: 132,
-            aspectRatio: 2 / 3,
-            title: item.name,
-            subtitle: _vm.bookSubtitle(item),
-            imageUrl: _vm.bookImageUrl(item),
-            itemType: item.type,
-            isFavorite: item.isFavorite,
-            isPlayed: item.isPlayed,
-            playedPercentage: item.playedPercentage,
-            onTap: () => _onItemTap(item, row),
-          ),
+        for (var i = 0; i < row.items.length; i++) ...[
+          (() {
+            final item = row.items[i];
+            final rawRatio = item.rawData['PrimaryImageAspectRatio'] as num?;
+            final fallbackRatio = (item.type == 'AudioBook' || item.type == 'Audio') ? 1.0 : 2 / 3;
+            final ratio = rawRatio != null ? rawRatio.toDouble() : fallbackRatio;
+
+            final cardExpansion = GetIt.instance<UserPreferences>()
+                .get(UserPreferences.cardFocusExpansion);
+
+            return MediaCard(
+              width: 132,
+              aspectRatio: ratio,
+              title: item.name,
+              subtitle: _vm.bookSubtitle(item),
+              imageUrl: _vm.bookImageUrl(item),
+              itemType: item.type,
+              isFavorite: item.isFavorite,
+              isPlayed: item.isPlayed,
+              playedPercentage: item.playedPercentage,
+              suppressFocusGlow: true,
+              cardFocusExpansion: cardExpansion,
+              focusNode: (isResume && i == 0)
+                  ? _firstResumeBookFocusNode
+                  : (i == 0)
+                      ? _getFirstCardFocusNode(row.id)
+                      : null,
+              onKeyEvent: (node, event) => _handleRowKeyEvent(event, isResume ? 'resume' : row.id, i, row.items.length),
+              onTap: () => _onItemTap(item, row),
+            );
+          })(),
+        ],
       ],
     );
   }

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -87,6 +87,15 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       overrideName: widget.genreName,
       includeItemTypes: widget.includeItemTypes,
     );
+    if (widget.includeItemTypes != null && widget.includeItemTypes!.isNotEmpty) {
+      if (widget.includeItemTypes!.contains('AudioBook') || widget.includeItemTypes!.contains('Audio')) {
+        _bookMediaTab = _BookMediaTab.audiobooks;
+      } else if (widget.includeItemTypes!.contains('Book')) {
+        _bookMediaTab = _BookMediaTab.books;
+      }
+    } else if (_vm.isAudiobookLibrary) {
+      _bookMediaTab = _BookMediaTab.audiobooks;
+    }
     _vm.addListener(_onChanged);
     _vm.load();
     _scrollController.addListener(_onScroll);
@@ -585,7 +594,14 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                       return AppLocalizations.of(context).albumArtists;
                     } else if (type == 'MusicArtist') {
                       return AppLocalizations.of(context).artists;
+                    } else if (type == 'AudioBook' || type == 'Audio') {
+                      return AppLocalizations.of(context).audiobooks;
+                    } else if (type == 'Book') {
+                      return AppLocalizations.of(context).books;
                     }
+                  }
+                  if (_vm.isAudiobookLibrary) {
+                    return AppLocalizations.of(context).audiobooks;
                   }
                   return _vm.libraryName;
                 }(),
@@ -604,7 +620,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                 sortBy: _vm.sortBy,
                 letterFilter: _vm.letterFilter,
                 isMusicBrowse: _vm.isMusicBrowse,
-                isBookBrowse: false,
+                isBookBrowse: _vm.isBookLibrary,
                 activeBookTab: _bookMediaTab,
                 bookOrganizeMode: _bookOrganizeMode,
                 playedFilter: _vm.playedFilter,
@@ -878,8 +894,9 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         final cellWidth =
             (constraints.maxWidth - hPad * 2 - (crossAxisCount - 1) * spacing) /
             crossAxisCount;
-        const cardRatio = 2 / 3;
-        final textHeight = 44.0 * _desktopUiScaleFactor();
+        final cardRatio = _bookMediaTab == _BookMediaTab.audiobooks ? 1.0 : 2 / 3;
+        final desktopTextScale = MediaQuery.textScalerOf(context).scale(1.0);
+        final textHeight = 44.0 * desktopTextScale;
         final childAspectRatio =
             cellWidth / (cellWidth / cardRatio + textHeight);
 
@@ -896,34 +913,34 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                     children: [
                       if (_bookOrganizeMode != _BookOrganizeMode.all)
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: Text(
-                            section.key,
-                            style: const TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.w700,
-                              color: Color(0xFFFFE6C3),
-                            ),
-                          ),
-                        ),
-                      GridView.builder(
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        itemCount: section.value.length,
-                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: crossAxisCount,
-                          crossAxisSpacing: spacing,
-                          mainAxisSpacing: 10,
-                          childAspectRatio: childAspectRatio,
-                        ),
-                        itemBuilder: (context, i) {
-                          final item = section.value[i];
-                          return MediaCard(
-                            title: item.name,
-                            subtitle: _primaryAuthor(item),
-                            imageUrl: _imageUrl(item),
-                            width: double.infinity,
-                            aspectRatio: 2 / 3,
+                           padding: const EdgeInsets.only(bottom: 8),
+                           child: Text(
+                             section.key,
+                             style: const TextStyle(
+                               fontSize: 18,
+                               fontWeight: FontWeight.w700,
+                               color: Color(0xFFFFE6C3),
+                             ),
+                           ),
+                         ),
+                       GridView.builder(
+                         shrinkWrap: true,
+                         physics: const NeverScrollableScrollPhysics(),
+                         itemCount: section.value.length,
+                         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                           crossAxisCount: crossAxisCount,
+                           crossAxisSpacing: spacing,
+                           mainAxisSpacing: 10,
+                           childAspectRatio: childAspectRatio,
+                         ),
+                         itemBuilder: (context, i) {
+                           final item = section.value[i];
+                           return MediaCard(
+                             title: item.name,
+                             subtitle: _primaryAuthor(item),
+                             imageUrl: _imageUrl(item),
+                             width: double.infinity,
+                             aspectRatio: cardRatio,
                             focusColor: _bookAccent,
                             cardFocusExpansion: _prefs.get(
                               UserPreferences.cardFocusExpansion,
@@ -2145,7 +2162,7 @@ class _BookStatusCategories extends StatelessWidget {
   }
 }
 
-class _BookFilterChip extends StatelessWidget {
+class _BookFilterChip extends StatefulWidget {
   final String label;
   final bool selected;
   final VoidCallback onTap;
@@ -2157,29 +2174,57 @@ class _BookFilterChip extends StatelessWidget {
   });
 
   @override
+  State<_BookFilterChip> createState() => _BookFilterChipState();
+}
+
+class _BookFilterChipState extends State<_BookFilterChip> with FocusStateMixin {
+  @override
   Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: AppRadius.circular(999),
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 160),
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-        decoration: BoxDecoration(
-          borderRadius: AppRadius.circular(999),
-          color: selected ? const Color(0x3332B9E8) : const Color(0x22131E33),
-          border: Border.fromBorderSide(
-            ThemeRegistry.active.borders.chipBorder.copyWith(
-              color: selected ? _bookAccent : const Color(0x556388A8),
-              width: selected ? 1.6 : 1,
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+    final focusBorderColor = showFocusBorder
+        ? focusColor
+        : (widget.selected ? _bookAccent : const Color(0x556388A8));
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (_, event) {
+          if (isActivateKey(event)) {
+            widget.onTap();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            decoration: BoxDecoration(
+              borderRadius: AppRadius.circular(999),
+              color: widget.selected ? const Color(0x3332B9E8) : const Color(0x22131E33),
+              border: Border.fromBorderSide(
+                ThemeRegistry.active.borders.chipBorder.copyWith(
+                  color: focusBorderColor,
+                  width: (widget.selected || showFocusBorder) ? 1.6 : 1,
+                ),
+              ),
             ),
-          ),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-            color: selected ? const Color(0xFFD9F2FF) : const Color(0xFFAECBE2),
+            child: Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: widget.selected ? FontWeight.w700 : FontWeight.w500,
+                color: widget.selected ? const Color(0xFFD9F2FF) : const Color(0xFFAECBE2),
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -3531,7 +3531,7 @@ class _HeaderSection extends StatelessWidget {
                     maxWidth: 350,
                   ),
           )
-        else
+        else ...[
           Text(
             item.name,
             style: Theme.of(context).textTheme.headlineLarge?.copyWith(
@@ -3544,6 +3544,29 @@ class _HeaderSection extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
             textAlign: isMobile ? TextAlign.center : null,
           ),
+          (() {
+            final author = (item.rawData['AlbumArtist'] as String?) ??
+                (item.rawData['Artists'] as List?)?.cast<String>().firstOrNull ??
+                item.seriesName;
+            if (author != null && author.isNotEmpty) {
+              return Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Align(
+                  alignment: isMobile ? Alignment.center : Alignment.centerLeft,
+                  child: Text(
+                    author,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Colors.white.withValues(alpha: 0.8),
+                      fontWeight: FontWeight.w600,
+                      shadows: _textShadows,
+                    ),
+                  ),
+                ),
+              );
+            }
+            return const SizedBox.shrink();
+          })(),
+        ],
         const SizedBox(height: 8),
         DetailMetadataRow(item: item, selectedMediaSource: selectedMediaSource),
         if (viewModel.ratings.isNotEmpty ||
@@ -3795,7 +3818,57 @@ class DetailPosterImage extends StatelessWidget {
     final w = isMobile ? 120.0 : 165.0 * desktopScale;
     final h = isMobile ? 180.0 : 248.0 * desktopScale;
 
-    if (item.primaryImageTag == null) return SizedBox(width: w, height: h);
+    if (item.primaryImageTag == null) {
+      if (item.type == 'AudioBook' || item.type == 'Audio') {
+        final audiobookPlaceholderColors = [
+          const Color(0xFFE25B45),
+          const Color(0xFF2E8B57),
+          const Color(0xFF4682B4),
+          const Color(0xFF8A2BE2),
+          const Color(0xFFD2691E),
+        ];
+        final colorIndex = item.id.hashCode.abs() % audiobookPlaceholderColors.length;
+        final accent = audiobookPlaceholderColors[colorIndex];
+        return SizedBox(
+          width: w,
+          height: h,
+          child: ClipRRect(
+            borderRadius: AppRadius.circular(8),
+            child: Container(
+              color: accent,
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const AdaptiveIcon(
+                        Icons.audiotrack,
+                        color: Colors.white70,
+                        size: 40,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        item.name,
+                        textAlign: TextAlign.center,
+                        maxLines: 4,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+      return SizedBox(width: w, height: h);
+    }
 
     return SizedBox(
       width: w,
@@ -5715,7 +5788,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           ? l10n.play
           : l10n.resume;
     } else if (hasProgress) {
-      playButtonLabel = l10n.resumeFrom(_formatResumePosition(item.playbackPosition));
+      playButtonLabel = (item.type == 'AudioBook' || item.type == 'Audio')
+          ? l10n.resume
+          : l10n.resumeFrom(_formatResumePosition(item.playbackPosition));
     } else {
       playButtonLabel = l10n.play;
     }
@@ -5850,9 +5925,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           activeColor: AppColorScheme.accent,
         ),
       _DetailActionButton(
-        label: isBook
-            ? (item.isPlayed ? l10n.finished : l10n.unread)
-            : (item.isPlayed ? l10n.watched : l10n.unwatched),
+        label: (item.type == 'AudioBook' || item.type == 'Audio')
+            ? (item.isPlayed ? 'Listened' : 'Unlistened')
+            : isBook
+                ? (item.isPlayed ? l10n.finished : l10n.unread)
+                : (item.isPlayed ? l10n.watched : l10n.unwatched),
         icon: item.isPlayed ? Icons.check_circle : Icons.check_circle_outline,
         onPressed: viewModel.togglePlayed,
         isActive: item.isPlayed,
@@ -5865,7 +5942,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         isActive: item.isFavorite,
         activeColor: const Color(0xFFFF4757),
       ),
-      if (!isBook)
+      if (!isBook && item.type != 'AudioBook' && item.type != 'Audio')
         _DetailActionButton(
           label: l10n.playlist,
           icon: Icons.playlist_add,
@@ -7489,8 +7566,24 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             final rawChildren = (data['Items'] as List?) ?? const [];
             final childItems = rawChildren.where(isAudioChild).toList();
             if (childItems.isNotEmpty) {
+              final siblings = _mapRawItemsForServer(childItems, item.serverId);
+              int startIndex = 0;
+              Duration startPosition = Duration.zero;
+              if (resume) {
+                final idx = siblings.indexWhere((t) => (t.playbackPosition ?? Duration.zero) > Duration.zero && !t.isPlayed);
+                if (idx >= 0) {
+                  startIndex = idx;
+                  startPosition = siblings[idx].playbackPosition ?? Duration.zero;
+                } else {
+                  final firstUnplayed = siblings.indexWhere((t) => !t.isPlayed);
+                  startIndex = firstUnplayed >= 0 ? firstUnplayed : 0;
+                  startPosition = Duration.zero;
+                }
+              }
               await manager.playItems(
-                _mapRawItemsForServer(childItems, item.serverId),
+                siblings,
+                startIndex: startIndex,
+                startPosition: startPosition,
               );
               break;
             }
@@ -7512,7 +7605,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               );
               final startIndex = siblings.indexWhere((t) => t.id == item.id);
               if (siblings.isNotEmpty && startIndex >= 0) {
-                await manager.playItems(siblings, startIndex: startIndex);
+                final startPosition = resume
+                    ? (item.playbackPosition ?? Duration.zero)
+                    : Duration.zero;
+                await manager.playItems(
+                  siblings,
+                  startIndex: startIndex,
+                  startPosition: startPosition,
+                );
                 break;
               }
             }
@@ -7584,7 +7684,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     await _pushPlayerRouteWhileStartingPlayback(
       context,
       destination: isAudio
-          ? Destinations.audioPlayer
+          ? (item.type == 'AudioBook' || item.type == 'Audio' || item.isAudiobook
+              ? '${Destinations.audioPlayer}?isAudiobook=true'
+              : Destinations.audioPlayer)
           : Destinations.videoPlayer,
       startupFuture: startupFuture,
     );
@@ -7627,7 +7729,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     await _pushPlayerRouteWhileStartingPlayback(
       context,
       destination: isAudio
-          ? Destinations.audioPlayer
+          ? (item.type == 'AudioBook' || item.type == 'Audio' || item.isAudiobook
+              ? '${Destinations.audioPlayer}?isAudiobook=true'
+              : Destinations.audioPlayer)
           : Destinations.videoPlayer,
       startupFuture: startupFuture,
     );

--- a/lib/ui/widgets/book/book_segmented_control.dart
+++ b/lib/ui/widgets/book/book_segmented_control.dart
@@ -1,8 +1,10 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
-import '../../../util/idiom/app_ui_idiom.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/focus/dpad_keys.dart';
+import '../../mixins/focus_state_mixin.dart';
 
 class BookSegmentedControl extends StatelessWidget {
   const BookSegmentedControl({
@@ -10,73 +12,156 @@ class BookSegmentedControl extends StatelessWidget {
     required this.labels,
     required this.selectedIndex,
     required this.onChanged,
+    this.libraryFocusNode,
+    this.discoverFocusNode,
+    this.onLibraryDownPressed,
+    this.onDiscoverDownPressed,
+    this.onUpPressed,
   });
 
   final List<String> labels;
   final int selectedIndex;
   final ValueChanged<int> onChanged;
+  final FocusNode? libraryFocusNode;
+  final FocusNode? discoverFocusNode;
+  final VoidCallback? onLibraryDownPressed;
+  final VoidCallback? onDiscoverDownPressed;
+  final VoidCallback? onUpPressed;
 
   @override
   Widget build(BuildContext context) {
-    final accent = AppColorScheme.accent;
-    final onSurface = AppColorScheme.onSurface;
-
-    if (AppUiIdiomResolver.isApple) {
-      return Align(
-        alignment: Alignment.center,
-        child: CupertinoSlidingSegmentedControl<int>(
-          groupValue: selectedIndex,
-          backgroundColor: onSurface.withValues(alpha: 0.10),
-          thumbColor: accent,
-          onValueChanged: (v) {
-            if (v != null) onChanged(v);
-          },
-          children: {
-            for (var i = 0; i < labels.length; i++)
-              i: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 18,
-                  vertical: 6,
-                ),
-                child: Text(
-                  labels[i],
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                    color: selectedIndex == i
-                        ? AppColorScheme.onAccent
-                        : onSurface,
-                  ),
-                ),
-              ),
-          },
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Expanded(
+          child: _SegmentTabButton(
+            label: labels[0],
+            selected: selectedIndex == 0,
+            onTap: () => onChanged(0),
+            focusNode: libraryFocusNode,
+            onUpPressed: onUpPressed,
+            onDownPressed: onLibraryDownPressed,
+            onRightPressed: () => discoverFocusNode?.requestFocus(),
+          ),
         ),
-      );
-    }
+        const SizedBox(width: 8),
+        Expanded(
+          child: _SegmentTabButton(
+            label: labels[1],
+            selected: selectedIndex == 1,
+            onTap: () => onChanged(1),
+            focusNode: discoverFocusNode,
+            onUpPressed: onUpPressed,
+            onDownPressed: onDiscoverDownPressed,
+            onLeftPressed: () => libraryFocusNode?.requestFocus(),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: SegmentedButton<int>(
-        segments: [
-          for (var i = 0; i < labels.length; i++)
-            ButtonSegment<int>(value: i, label: Text(labels[i])),
-        ],
-        selected: {selectedIndex},
-        showSelectedIcon: false,
-        onSelectionChanged: (s) => onChanged(s.first),
-        style: ButtonStyle(
-          backgroundColor: WidgetStateProperty.resolveWith(
-            (states) => states.contains(WidgetState.selected)
-                ? accent
-                : onSurface.withValues(alpha: 0.08),
-          ),
-          foregroundColor: WidgetStateProperty.resolveWith(
-            (states) => states.contains(WidgetState.selected)
-                ? AppColorScheme.onAccent
-                : onSurface,
-          ),
-          side: WidgetStatePropertyAll(
-            BorderSide(color: onSurface.withValues(alpha: 0.12)),
+class _SegmentTabButton extends StatefulWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final FocusNode? focusNode;
+  final VoidCallback? onUpPressed;
+  final VoidCallback? onDownPressed;
+  final VoidCallback? onLeftPressed;
+  final VoidCallback? onRightPressed;
+
+  const _SegmentTabButton({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.focusNode,
+    this.onUpPressed,
+    this.onDownPressed,
+    this.onLeftPressed,
+    this.onRightPressed,
+  });
+
+  @override
+  State<_SegmentTabButton> createState() => _SegmentTabButtonState();
+}
+
+class _SegmentTabButtonState extends State<_SegmentTabButton> with FocusStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final accentColor = AppColorScheme.accent;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        focusNode: widget.focusNode,
+        onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (_, event) {
+          if (isActivateKey(event)) {
+            widget.onTap();
+            return KeyEventResult.handled;
+          }
+          if (event.isActionable) {
+            if (event.logicalKey.isUpKey && widget.onUpPressed != null) {
+              widget.onUpPressed!();
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey.isDownKey && widget.onDownPressed != null) {
+              widget.onDownPressed!();
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey.isLeftKey) {
+              if (widget.onLeftPressed != null) {
+                widget.onLeftPressed!();
+              }
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey.isRightKey) {
+              if (widget.onRightPressed != null) {
+                widget.onRightPressed!();
+              }
+              return KeyEventResult.handled;
+            }
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.onTap,
+          behavior: HitTestBehavior.opaque,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            padding: const EdgeInsets.symmetric(vertical: 10),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(20),
+              color: widget.selected
+                  ? (isNeon ? accentColor.withValues(alpha: 0.15) : accentColor)
+                  : AppColorScheme.onSurface.withValues(alpha: 0.08),
+              border: Border.all(
+                color: showFocusBorder
+                    ? focusColor
+                    : (widget.selected && isNeon ? AppColorScheme.onSurface : Colors.transparent),
+                width: 2.0,
+              ),
+            ),
+            child: Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: widget.selected ? FontWeight.w700 : FontWeight.w500,
+                color: widget.selected
+                    ? (isNeon ? accentColor : AppColorScheme.onAccent)
+                    : AppColorScheme.onSurface,
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/ui/widgets/book/book_spotlight.dart
+++ b/lib/ui/widgets/book/book_spotlight.dart
@@ -3,9 +3,15 @@ import 'dart:ui';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import 'package:flutter/services.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
+import '../../mixins/focus_state_mixin.dart';
+import '../navigation_layout.dart';
 import 'book_glass.dart';
 
 class BookSpotlight extends StatelessWidget {
@@ -19,6 +25,7 @@ class BookSpotlight extends StatelessWidget {
     this.imageUrl,
     this.progress,
     this.topInset = 0,
+    this.focusNode,
   });
 
   final String eyebrow;
@@ -29,6 +36,7 @@ class BookSpotlight extends StatelessWidget {
   final String? imageUrl;
   final double? progress;
   final double topInset;
+  final FocusNode? focusNode;
 
   @override
   Widget build(BuildContext context) {
@@ -130,6 +138,7 @@ class BookSpotlight extends StatelessWidget {
                             apple: apple,
                             label: ctaLabel,
                             onTap: onPrimary,
+                            focusNode: focusNode,
                           ),
                         ],
                       ),
@@ -177,7 +186,7 @@ class _Cover extends StatelessWidget {
           child: imageUrl != null
               ? CachedNetworkImage(
                   imageUrl: imageUrl!,
-                  fit: BoxFit.cover,
+                  fit: BoxFit.contain,
                   errorWidget: (_, _, _) => _placeholder(),
                 )
               : _placeholder(),
@@ -230,60 +239,111 @@ class _ProgressRing extends StatelessWidget {
   }
 }
 
-class _ResumeButton extends StatelessWidget {
+class _ResumeButton extends StatefulWidget {
   const _ResumeButton({
     required this.apple,
     required this.label,
     required this.onTap,
+    this.focusNode,
   });
 
   final bool apple;
   final String label;
   final VoidCallback onTap;
+  final FocusNode? focusNode;
 
   @override
+  State<_ResumeButton> createState() => _ResumeButtonState();
+}
+
+class _ResumeButtonState extends State<_ResumeButton> with FocusStateMixin {
+  @override
   Widget build(BuildContext context) {
-    final content = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+
+    final showLabel = showFocusBorder;
+    final content = AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      padding: showLabel
+          ? const EdgeInsets.symmetric(horizontal: 16, vertical: 9)
+          : const EdgeInsets.all(9),
       child: Row(
         mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Icon(
-            apple ? CupertinoIcons.play_fill : Icons.play_arrow,
+            widget.apple ? CupertinoIcons.play_fill : Icons.play_arrow,
             size: 16,
-            color: apple ? AppColorScheme.onSurface : AppColorScheme.onAccent,
+            color: (widget.apple || showFocusBorder) ? AppColorScheme.onSurface : AppColorScheme.onAccent,
           ),
-          const SizedBox(width: 6),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w600,
-              color: apple ? AppColorScheme.onSurface : AppColorScheme.onAccent,
+          if (showLabel) ...[
+            const SizedBox(width: 6),
+            Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: (widget.apple || showFocusBorder) ? AppColorScheme.onSurface : AppColorScheme.onAccent,
+              ),
             ),
-          ),
+          ],
         ],
       ),
     );
 
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: apple
-          ? bookGlassOrSolid(
-              cornerRadius: 22,
-              blur: 18,
-              tint: AppColorScheme.accent.withValues(alpha: 0.30),
-              fallbackColor: AppColorScheme.accent,
-              child: content,
-            )
-          : DecoratedBox(
-              decoration: BoxDecoration(
-                color: AppColorScheme.accent,
-                borderRadius: AppRadius.circular(22),
-              ),
-              child: content,
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        focusNode: widget.focusNode,
+        onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (_, event) {
+          if (event is KeyDownEvent || event is KeyRepeatEvent) {
+            if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+              if (focusNavbar != null) {
+                focusNavbar();
+                return KeyEventResult.handled;
+              }
+            }
+          }
+          if (isActivateKey(event)) {
+            widget.onTap();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.onTap,
+          behavior: HitTestBehavior.opaque,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            decoration: BoxDecoration(
+              color: showFocusBorder
+                  ? AppColorScheme.onSurface.withValues(alpha: 0.1)
+                  : (widget.apple ? Colors.transparent : AppColorScheme.accent),
+              borderRadius: AppRadius.circular(22),
+              border: showFocusBorder
+                  ? Border.all(color: focusColor, width: 2.0)
+                  : Border.all(color: Colors.transparent, width: 2.0),
             ),
+            child: widget.apple && !showFocusBorder
+                ? bookGlassOrSolid(
+                    cornerRadius: 22,
+                    blur: 18,
+                    tint: AppColorScheme.accent.withValues(alpha: 0.30),
+                    fallbackColor: AppColorScheme.accent,
+                    child: content,
+                  )
+                : content,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/widgets/book/book_stats_band.dart
+++ b/lib/ui/widgets/book/book_stats_band.dart
@@ -1,25 +1,48 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import '../../../preference/user_preferences.dart';
+import '../../../util/focus/dpad_keys.dart';
+import '../../mixins/focus_state_mixin.dart';
 import '../adaptive/adaptive_glass.dart';
 
 class BookStat {
   final String label;
   final int count;
+  final VoidCallback? onTap;
 
-  const BookStat({required this.label, required this.count});
+  const BookStat({
+    required this.label,
+    required this.count,
+    this.onTap,
+  });
 }
 
 class BookStatsBand extends StatelessWidget {
-  const BookStatsBand({super.key, required this.stats});
+  const BookStatsBand({
+    super.key,
+    required this.stats,
+    this.booksFocusNode,
+    this.audiobooksFocusNode,
+    this.onBooksUpPressed,
+    this.onAudiobooksUpPressed,
+    this.onBooksDownPressed,
+    this.onAudiobooksDownPressed,
+  });
 
   final List<BookStat> stats;
+  final FocusNode? booksFocusNode;
+  final FocusNode? audiobooksFocusNode;
+  final VoidCallback? onBooksUpPressed;
+  final VoidCallback? onAudiobooksUpPressed;
+  final VoidCallback? onBooksDownPressed;
+  final VoidCallback? onAudiobooksDownPressed;
 
   @override
   Widget build(BuildContext context) {
     final visible = stats.where((s) => s.count > 0).toList();
     if (visible.isEmpty) return const SizedBox.shrink();
-    final onSurface = AppColorScheme.onSurface;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
@@ -28,38 +51,149 @@ class BookStatsBand extends StatelessWidget {
           for (var i = 0; i < visible.length; i++) ...[
             if (i > 0) const SizedBox(width: 8),
             Expanded(
-              child: adaptiveGlass(
-                cornerRadius: 12,
-                fallbackColor: onSurface.withValues(alpha: 0.06),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 9),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        '${visible[i].count}',
-                        style: TextStyle(
-                          fontSize: 17,
-                          fontWeight: FontWeight.w600,
-                          color: onSurface,
-                        ),
-                      ),
-                      const SizedBox(height: 1),
-                      Text(
-                        visible[i].label.toUpperCase(),
-                        style: TextStyle(
-                          fontSize: 9,
-                          letterSpacing: 0.6,
-                          color: onSurface.withValues(alpha: 0.5),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+              child: _BookStatCard(
+                stat: visible[i],
+                focusNode: i == 0
+                    ? booksFocusNode
+                    : (i == 1 ? audiobooksFocusNode : null),
+                onUpPressed: i == 0 ? onBooksUpPressed : onAudiobooksUpPressed,
+                onDownPressed: i == 0 ? onBooksDownPressed : onAudiobooksDownPressed,
+                onLeftPressed: (i == 1 && visible.length > 1)
+                    ? () => booksFocusNode?.requestFocus()
+                    : null,
+                onRightPressed: (i == 0 && visible.length > 1)
+                    ? () => audiobooksFocusNode?.requestFocus()
+                    : null,
               ),
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _BookStatCard extends StatefulWidget {
+  final BookStat stat;
+  final FocusNode? focusNode;
+  final VoidCallback? onUpPressed;
+  final VoidCallback? onDownPressed;
+  final VoidCallback? onLeftPressed;
+  final VoidCallback? onRightPressed;
+
+  const _BookStatCard({
+    required this.stat,
+    this.focusNode,
+    this.onUpPressed,
+    this.onDownPressed,
+    this.onLeftPressed,
+    this.onRightPressed,
+  });
+
+  @override
+  State<_BookStatCard> createState() => _BookStatCardState();
+}
+
+class _BookStatCardState extends State<_BookStatCard> with FocusStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    final onSurface = AppColorScheme.onSurface;
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+
+    Widget cardContent = Padding(
+      padding: const EdgeInsets.symmetric(vertical: 9),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '${widget.stat.count}',
+            style: TextStyle(
+              fontSize: 17,
+              fontWeight: FontWeight.w600,
+              color: onSurface,
+            ),
+          ),
+          const SizedBox(height: 1),
+          Text(
+            widget.stat.label.toUpperCase(),
+            style: TextStyle(
+              fontSize: 9,
+              letterSpacing: 0.6,
+              color: onSurface.withValues(alpha: 0.5),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (widget.stat.onTap == null) {
+      return adaptiveGlass(
+        cornerRadius: 12,
+        fallbackColor: onSurface.withValues(alpha: 0.06),
+        child: cardContent,
+      );
+    }
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        focusNode: widget.focusNode,
+        onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (_, event) {
+          if (isActivateKey(event)) {
+            widget.stat.onTap!();
+            return KeyEventResult.handled;
+          }
+          if (event.isActionable) {
+            if (event.logicalKey.isUpKey && widget.onUpPressed != null) {
+              widget.onUpPressed!();
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey.isDownKey && widget.onDownPressed != null) {
+              widget.onDownPressed!();
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey.isLeftKey) {
+              if (widget.onLeftPressed != null) {
+                widget.onLeftPressed!();
+              }
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey.isRightKey) {
+              if (widget.onRightPressed != null) {
+                widget.onRightPressed!();
+              }
+              return KeyEventResult.handled;
+            }
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.stat.onTap,
+          behavior: HitTestBehavior.opaque,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: showFocusBorder
+                  ? Border.all(color: focusColor, width: 2.0)
+                  : Border.all(color: Colors.transparent, width: 2.0),
+            ),
+            child: adaptiveGlass(
+              cornerRadius: 12,
+              fallbackColor: showFocusBorder
+                  ? onSurface.withValues(alpha: 0.15)
+                  : onSurface.withValues(alpha: 0.06),
+              child: cardContent,
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/book/discover/book_discover_tab.dart
+++ b/lib/ui/widgets/book/discover/book_discover_tab.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../../l10n/app_localizations.dart';
 import '../../../../util/platform_detection.dart';
+import '../../../../util/focus/dpad_keys.dart';
 import '../../../screens/book/discover/discover_book_detail_screen.dart';
 import '../../../screens/book/discover/librivox_authors_screen.dart';
 import '../../../screens/book/discover/librivox_book_detail_screen.dart';
@@ -19,11 +20,19 @@ const _bookAccent = bookDiscoverAccent;
 class BookDiscoverTab extends StatefulWidget {
   final String libraryId;
   final bool isAudiobook;
+  final FocusNode? firstFocusNode;
+  final FocusNode? settingsMenuFocusNode;
+  final VoidCallback? onSettingsUpPressed;
+  final double leftPadding;
 
   const BookDiscoverTab({
     super.key,
     required this.libraryId,
     required this.isAudiobook,
+    required this.leftPadding,
+    this.firstFocusNode,
+    this.settingsMenuFocusNode,
+    this.onSettingsUpPressed,
   });
 
   @override
@@ -58,6 +67,70 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
   bool _discoverAudiobookInitialized = false;
   bool _discoverAudiobookBootstrapping = false;
   final Map<String, String?> _librivoxCoverCache = {};
+  final Map<String, List<FocusNode>> _genreFocusNodesMap = {};
+  bool _isGenreSheetShowing = false;
+  bool _isAudiobookGenreSheetShowing = false;
+
+  List<FocusNode> _focusNodesForGenre(String genre, int count) {
+    return _genreFocusNodesMap.putIfAbsent(
+      genre,
+      () => List.generate(
+        count,
+        (index) => FocusNode(debugLabel: 'Discover_${genre}_$index'),
+      ),
+    );
+  }
+
+  double _calculateAdjustedCardWidth(double maxWidth, double baseCardWidth) {
+    const spacing = 12.0;
+    final n = ((maxWidth + spacing) / (baseCardWidth + spacing)).floor();
+    final count = n.clamp(1, 99);
+    return (maxWidth - (count - 1) * spacing) / count;
+  }
+
+  void _focusRow(String genre, bool goDown) {
+    final genresList = widget.isAudiobook ? _discoverAudiobookGenres : _discoverGenres;
+    final genreIndex = genresList.indexOf(genre);
+    if (genreIndex == -1) return;
+
+    final items = widget.isAudiobook
+        ? (_discoverAudiobooksByGenre[genre] ?? const [])
+        : (_discoverBooksByGenre[genre] ?? const []);
+    final hasFailed = widget.isAudiobook
+        ? _discoverAudiobookFailedGenres.contains(genre)
+        : _discoverFailedGenres.contains(genre);
+    final isLoading = widget.isAudiobook
+        ? _discoverAudiobookLoadingGenres.contains(genre)
+        : _discoverLoadingGenres.contains(genre);
+
+    if (items.isNotEmpty || hasFailed) {
+      final controller = widget.isAudiobook
+          ? _discoverAudiobookRowControllers[genre]
+          : _discoverRowControllers[genre];
+      if (controller != null && controller.hasClients) {
+        controller.jumpTo(0.0);
+      }
+
+      final isFirstRow = genreIndex == 0;
+      if (isFirstRow) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          widget.firstFocusNode?.requestFocus();
+        });
+      } else {
+        final nodes = _focusNodesForGenre(genre, items.length);
+        if (nodes.isNotEmpty) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            nodes[0].requestFocus();
+          });
+        }
+      }
+    } else if (isLoading) {
+      final nextIndex = goDown ? genreIndex + 1 : genreIndex - 1;
+      if (nextIndex >= 0 && nextIndex < genresList.length) {
+        _focusRow(genresList[nextIndex], goDown);
+      }
+    }
+  }
 
   @override
   void initState() {
@@ -78,6 +151,12 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
     for (final controller in _discoverAudiobookRowControllers.values) {
       controller.dispose();
     }
+    for (final nodesList in _genreFocusNodesMap.values) {
+      for (final node in nodesList) {
+        node.dispose();
+      }
+    }
+    _genreFocusNodesMap.clear();
     _discoverDio.close(force: true);
     super.dispose();
   }
@@ -241,121 +320,39 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
   }
 
   Future<void> _showDiscoverGenreSheet() async {
-    final temp = {..._discoverGenres};
-    final result = await showGeneralDialog<List<String>>(
-      context: context,
-      barrierDismissible: true,
-      barrierLabel: AppLocalizations.of(context).close,
-      barrierColor: Colors.black54,
-      transitionDuration: const Duration(milliseconds: 260),
-      pageBuilder: (context, _, _) => const SizedBox.shrink(),
-      transitionBuilder: (context, animation, _, _) {
-        final width = MediaQuery.of(
-          context,
-        ).size.width.clamp(320.0, 420.0).toDouble();
-        final sortedSubjects = bookDiscoverGenrePool.toList()
-          ..sort((a, b) => displayBookGenre(a).compareTo(displayBookGenre(b)));
-        return SlideTransition(
-          position: Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
-              .animate(
-                CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
-              ),
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: Material(
-              color: const Color(0xFFF0F7FF),
-              child: SizedBox(
-                width: width,
-                child: SafeArea(
-                  child: StatefulBuilder(
-                    builder: (context, setPanelState) => Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  AppLocalizations.of(
-                                    context,
-                                  ).discoverySubjects,
-                                  style: const TextStyle(
-                                    fontSize: 20,
-                                    fontWeight: FontWeight.w700,
-                                    color: Color(0xFF13233A),
-                                  ),
-                                ),
-                              ),
-                              IconButton(
-                                onPressed: () => Navigator.of(context).pop(),
-                                icon: const AdaptiveIcon(Icons.close_rounded),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            AppLocalizations.of(context).pickDiscoverySubjects,
-                            style: const TextStyle(color: Color(0xFF5C7290)),
-                          ),
-                          const SizedBox(height: 12),
-                          Expanded(
-                            child: ListView.builder(
-                              itemCount: sortedSubjects.length,
-                              itemBuilder: (context, index) {
-                                final subject = sortedSubjects[index];
-                                final selected = temp.contains(subject);
-                                return CheckboxListTile(
-                                  value: selected,
-                                  controlAffinity:
-                                      ListTileControlAffinity.leading,
-                                  activeColor: const Color(0xFF0D47A1),
-                                  checkColor: Colors.white,
-                                  side: ThemeRegistry.active.borders.chipBorder
-                                      .copyWith(
-                                        color: const Color(0xFF5C7290),
-                                        width: 2,
-                                      ),
-                                  title: Text(
-                                    displayBookGenre(subject),
-                                    style: const TextStyle(
-                                      fontWeight: FontWeight.w600,
-                                      color: Color(0xFF13233A),
-                                    ),
-                                  ),
-                                  onChanged: (value) {
-                                    setPanelState(() {
-                                      if (value == true) {
-                                        temp.add(subject);
-                                      } else if (temp.length > 1) {
-                                        temp.remove(subject);
-                                      }
-                                    });
-                                  },
-                                );
-                              },
-                            ),
-                          ),
-                          const SizedBox(height: 10),
-                          SizedBox(
-                            width: double.infinity,
-                            child: ElevatedButton(
-                              onPressed: () =>
-                                  Navigator.of(context).pop(temp.toList()),
-                              child: Text(AppLocalizations.of(context).apply),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
+    if (_isGenreSheetShowing) return;
+    _isGenreSheetShowing = true;
+    List<String>? result;
+    try {
+      final temp = {..._discoverGenres};
+      final sortedSubjects = bookDiscoverGenrePool.toList()
+        ..sort((a, b) => displayBookGenre(a).compareTo(displayBookGenre(b)));
+      result = await showGeneralDialog<List<String>>(
+        context: context,
+        barrierDismissible: true,
+        barrierLabel: AppLocalizations.of(context).close,
+        barrierColor: Colors.black54,
+        transitionDuration: const Duration(milliseconds: 260),
+        pageBuilder: (context, _, _) => _GenreDialogContent(
+          title: AppLocalizations.of(context).discoverySubjects,
+          subtitle: AppLocalizations.of(context).pickDiscoverySubjects,
+          allGenres: sortedSubjects,
+          initialSelectedGenres: temp.toList(),
+          displayFn: displayBookGenre,
+        ),
+        transitionBuilder: (context, animation, _, child) {
+          return SlideTransition(
+            position: Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
+                .animate(
+                  CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
                 ),
-              ),
-            ),
-          ),
-        );
-      },
-    );
+            child: child,
+          );
+        },
+      );
+    } finally {
+      _isGenreSheetShowing = false;
+    }
 
     if (result == null || result.isEmpty || !mounted) return;
     final sortedResult = result.toList()
@@ -551,119 +548,39 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
   }
 
   Future<void> _showAudiobookGenreSheet() async {
-    final temp = {..._discoverAudiobookGenres};
-    final l10n = AppLocalizations.of(context);
-    final result = await showGeneralDialog<List<String>>(
-      context: context,
-      barrierDismissible: true,
-      barrierLabel: l10n.closeGenrePanel,
-      barrierColor: Colors.black54,
-      transitionDuration: const Duration(milliseconds: 260),
-      pageBuilder: (context, _, _) => const SizedBox.shrink(),
-      transitionBuilder: (context, animation, _, _) {
-        final width = MediaQuery.of(
-          context,
-        ).size.width.clamp(320.0, 420.0).toDouble();
-        final sortedGenres = librivoxGenrePool.toList()..sort();
-        return SlideTransition(
-          position: Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
-              .animate(
-                CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
-              ),
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: Material(
-              color: const Color(0xFFF0F7FF),
-              child: SizedBox(
-                width: width,
-                child: SafeArea(
-                  child: StatefulBuilder(
-                    builder: (context, setPanelState) => Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  AppLocalizations.of(context).audiobookGenres,
-                                  style: const TextStyle(
-                                    fontSize: 20,
-                                    fontWeight: FontWeight.w700,
-                                    color: Color(0xFF13233A),
-                                  ),
-                                ),
-                              ),
-                              IconButton(
-                                onPressed: () => Navigator.of(context).pop(),
-                                icon: const AdaptiveIcon(Icons.close_rounded),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            AppLocalizations.of(context).pickAudiobookGenres,
-                            style: const TextStyle(color: Color(0xFF5C7290)),
-                          ),
-                          const SizedBox(height: 12),
-                          Expanded(
-                            child: ListView.builder(
-                              itemCount: sortedGenres.length,
-                              itemBuilder: (context, index) {
-                                final genre = sortedGenres[index];
-                                final selected = temp.contains(genre);
-                                return CheckboxListTile(
-                                  value: selected,
-                                  controlAffinity:
-                                      ListTileControlAffinity.leading,
-                                  activeColor: const Color(0xFF0D47A1),
-                                  checkColor: Colors.white,
-                                  side: ThemeRegistry.active.borders.chipBorder
-                                      .copyWith(
-                                        color: const Color(0xFF5C7290),
-                                        width: 2,
-                                      ),
-                                  title: Text(
-                                    genre,
-                                    style: const TextStyle(
-                                      fontWeight: FontWeight.w600,
-                                      color: Color(0xFF13233A),
-                                    ),
-                                  ),
-                                  onChanged: (value) {
-                                    setPanelState(() {
-                                      if (value == true) {
-                                        temp.add(genre);
-                                      } else if (temp.length > 1) {
-                                        temp.remove(genre);
-                                      }
-                                    });
-                                  },
-                                );
-                              },
-                            ),
-                          ),
-                          const SizedBox(height: 10),
-                          SizedBox(
-                            width: double.infinity,
-                            child: ElevatedButton(
-                              onPressed: () =>
-                                  Navigator.of(context).pop(temp.toList()),
-                              child: Text(AppLocalizations.of(context).apply),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
+    if (_isAudiobookGenreSheetShowing) return;
+    _isAudiobookGenreSheetShowing = true;
+    List<String>? result;
+    try {
+      final temp = {..._discoverAudiobookGenres};
+      final l10n = AppLocalizations.of(context);
+      final sortedGenres = librivoxGenrePool.toList()..sort();
+      result = await showGeneralDialog<List<String>>(
+        context: context,
+        barrierDismissible: true,
+        barrierLabel: l10n.closeGenrePanel,
+        barrierColor: Colors.black54,
+        transitionDuration: const Duration(milliseconds: 260),
+        pageBuilder: (context, _, _) => _GenreDialogContent(
+          title: AppLocalizations.of(context).audiobookGenres,
+          subtitle: AppLocalizations.of(context).pickAudiobookGenres,
+          allGenres: sortedGenres,
+          initialSelectedGenres: temp.toList(),
+          displayFn: (s) => s,
+        ),
+        transitionBuilder: (context, animation, _, child) {
+          return SlideTransition(
+            position: Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
+                .animate(
+                  CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
                 ),
-              ),
-            ),
-          ),
-        );
-      },
-    );
+            child: child,
+          );
+        },
+      );
+    } finally {
+      _isAudiobookGenreSheetShowing = false;
+    }
 
     if (result == null || result.isEmpty || !mounted) return;
     final sortedResult = result.toList()..sort();
@@ -692,8 +609,9 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
   Widget build(BuildContext context) {
     final isMobile =
         PlatformDetection.useMobileUi || MediaQuery.sizeOf(context).width < 600;
+    final paddingVal = isMobile ? 16.0 : widget.leftPadding;
     return Padding(
-      padding: EdgeInsets.fromLTRB(isMobile ? 16 : 60, 0, isMobile ? 16 : 60, 0),
+      padding: EdgeInsets.fromLTRB(paddingVal, 0, paddingVal, 0),
       child: widget.isAudiobook
           ? _buildAudiobookDiscoverCard(isMobile: isMobile)
           : _buildDiscoverCard(isMobile: isMobile),
@@ -703,33 +621,46 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
   Widget _buildBookIconButton({
     required IconData icon,
     required VoidCallback onTap,
-    Color backgroundColor = const Color(0x1FEAF4FF),
-    Color foregroundColor = const Color(0xFFEAF4FF),
+    Color? backgroundColor,
+    Color? foregroundColor,
+    FocusNode? focusNode,
+    VoidCallback? onUpPressed,
+    VoidCallback? onDownPressed,
   }) {
-    return InkWell(
-      borderRadius: AppRadius.circular(20),
+    return _BookIconButton(
+      icon: icon,
       onTap: onTap,
-      child: Container(
-        width: 52,
-        height: 52,
-        decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: AppRadius.circular(20),
-          border: Border.fromBorderSide(
-            ThemeRegistry.active.borders.cardBorder.copyWith(
-              color: foregroundColor.withAlpha(28),
-            ),
-          ),
-        ),
-        child: AdaptiveIcon(icon, color: foregroundColor),
-      ),
+      backgroundColor: backgroundColor,
+      foregroundColor: foregroundColor,
+      focusNode: focusNode,
+      onUpPressed: onUpPressed,
+      onDownPressed: onDownPressed,
     );
   }
 
   Widget _buildDiscoverCard({required bool isMobile}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final containerBgColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.05)
+        : const Color(0xFFEFF6FF);
+    final titleTextColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF13233A);
+    final subtitleTextColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+        : const Color(0xFF5C7290);
+    final chipBgColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.08)
+        : const Color(0xFFDDEEFF);
+    final chipFgColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF1D3654);
+
+    final innerPadding = EdgeInsets.symmetric(horizontal: isMobile ? 18.0 : 28.0);
+
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFFEFF6FF),
+        color: containerBgColor,
         borderRadius: AppRadius.circular(32),
         boxShadow: const [
           BoxShadow(
@@ -739,81 +670,85 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
           ),
         ],
       ),
-      padding: EdgeInsets.fromLTRB(
-        isMobile ? 18 : 28,
-        isMobile ? 22 : 30,
-        isMobile ? 18 : 28,
-        24,
+      padding: EdgeInsets.symmetric(
+        vertical: isMobile ? 22 : 30,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      AppLocalizations.of(context).discover,
-                      style: const TextStyle(
-                        color: Color(0xFF13233A),
-                        fontSize: 28,
-                        fontWeight: FontWeight.w700,
+          Padding(
+            padding: innerPadding,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        AppLocalizations.of(context).discover,
+                        style: TextStyle(
+                          color: titleTextColor,
+                          fontSize: 28,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      AppLocalizations.of(context).trendingTitlesOpenLibrary,
-                      style: TextStyle(
-                        color: Color(0xFF5C7290),
-                        fontSize: 14,
-                        height: 1.35,
+                      const SizedBox(height: 6),
+                      Text(
+                        AppLocalizations.of(context).trendingTitlesOpenLibrary,
+                        style: TextStyle(
+                          color: subtitleTextColor,
+                          fontSize: 14,
+                          height: 1.35,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(width: 12),
-              _buildBookIconButton(
-                icon: Icons.tune_rounded,
-                onTap: _showDiscoverGenreSheet,
-                foregroundColor: const Color(0xFF1D3654),
-                backgroundColor: const Color(0xFFE2F0FF),
-              ),
-            ],
+                const SizedBox(width: 12),
+                _buildBookIconButton(
+                  icon: Icons.tune_rounded,
+                  onTap: _showDiscoverGenreSheet,
+                  focusNode: widget.settingsMenuFocusNode,
+                  onUpPressed: widget.onSettingsUpPressed,
+                  onDownPressed: () => _focusRow(_discoverGenres.first, true),
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 16),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: _discoverGenres
-                .map(
-                  (genre) => Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 10,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFFDDEEFF),
-                      borderRadius: AppRadius.circular(999),
-                    ),
-                    child: Text(
-                      displayBookGenre(genre),
-                      style: const TextStyle(
-                        color: Color(0xFF1D3654),
-                        fontSize: 12,
-                        fontWeight: FontWeight.w700,
+          Padding(
+            padding: innerPadding,
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _discoverGenres
+                  .map(
+                    (genre) => Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: chipBgColor,
+                        borderRadius: AppRadius.circular(999),
+                      ),
+                      child: Text(
+                        displayBookGenre(genre),
+                        style: TextStyle(
+                          color: chipFgColor,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
                     ),
-                  ),
-                )
-                .toList(),
+                  )
+                  .toList(),
+            ),
           ),
           const SizedBox(height: 14),
           if (_discoverBootstrapping && !_discoverInitialized)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 28),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 28),
               child: Center(
                 child: CircularProgressIndicator(color: _bookAccent),
               ),
@@ -832,177 +767,274 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
     final rowController = _controllerForDiscoverSubject(genre);
     final canScrollRow = items.length > 2 && !isLoading;
 
-    return Padding(
-      padding: const EdgeInsets.only(top: 18),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  displayBookGenre(genre),
-                  style: const TextStyle(
-                    color: Color(0xFF13233A),
-                    fontSize: 20,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-              Text(
-                AppLocalizations.of(context).booksCount(items.length),
-                style: const TextStyle(
-                  color: Color(0xFF5C7290),
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(width: 8),
-              IconButton(
-                tooltip: AppLocalizations.of(context).scrollLeft,
-                onPressed: canScrollRow
-                    ? () => _scrollDiscoverSubjectRow(genre, -1)
-                    : null,
-                style: IconButton.styleFrom(
-                  backgroundColor: const Color(0xFF16304D),
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: const Color(0xFFD7E3F0),
-                  disabledForegroundColor: const Color(0xFF90A5BC),
-                ),
-                icon: const AdaptiveIcon(Icons.chevron_left_rounded),
-              ),
-              IconButton(
-                tooltip: AppLocalizations.of(context).scrollRight,
-                onPressed: canScrollRow
-                    ? () => _scrollDiscoverSubjectRow(genre, 1)
-                    : null,
-                style: IconButton.styleFrom(
-                  backgroundColor: const Color(0xFF16304D),
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: const Color(0xFFD7E3F0),
-                  disabledForegroundColor: const Color(0xFF90A5BC),
-                ),
-                icon: const AdaptiveIcon(Icons.chevron_right_rounded),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          if (items.isEmpty && isLoading)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 20),
-              child: Center(
-                child: CircularProgressIndicator(color: _bookAccent),
-              ),
-            )
-          else if (items.isEmpty && hasFailed)
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    AppLocalizations.of(context).couldNotLoadSubject,
-                    style: const TextStyle(color: Color(0xFF5C7290)),
-                  ),
-                ),
-                TextButton(
-                  onPressed: () => _loadDiscoverPage(genre, reset: true),
-                  child: Text(AppLocalizations.of(context).retry),
-                ),
-              ],
-            )
-          else
-            SizedBox(
-              height: 240,
-              child: ListView.separated(
-                controller: rowController,
-                scrollDirection: Axis.horizontal,
-                itemCount: items.length,
-                separatorBuilder: (_, _) => const SizedBox(width: 12),
-                itemBuilder: (context, index) => SizedBox(
-                  width: 140,
-                  child: _buildDiscoverBookCard(items[index]),
-                ),
-              ),
-            ),
-          const SizedBox(height: 8),
-          if (isLoading && items.isNotEmpty)
-            const SizedBox(
-              height: 30,
-              child: Center(
-                child: CircularProgressIndicator(
-                  strokeWidth: 2.4,
-                  color: _bookAccent,
-                ),
-              ),
-            )
-          else
-            const SizedBox(height: 4),
-        ],
-      ),
-    );
-  }
+    final isMobile =
+        PlatformDetection.useMobileUi || MediaQuery.sizeOf(context).width < 600;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final titleTextColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF13233A);
+    final subtitleTextColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+        : const Color(0xFF5C7290);
 
-  Widget _buildDiscoverBookCard(DiscoverBook item) {
-    return InkWell(
-      borderRadius: AppRadius.circular(18),
-      onTap: () => Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => DiscoverBookDetailScreen(book: item),
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: ClipRRect(
-              borderRadius: AppRadius.circular(18),
-              child: item.coverUrl == null
-                  ? Container(
-                      color: const Color(0xFF2C77B7),
-                      alignment: Alignment.center,
-                      padding: const EdgeInsets.all(10),
-                      child: const AdaptiveIcon(
-                        Icons.auto_stories_rounded,
-                        color: Colors.white,
-                        size: 30,
-                      ),
-                    )
-                  : CachedNetworkImage(
-                      imageUrl: item.coverUrl!,
-                      fit: BoxFit.cover,
-                      errorWidget: (_, _, _) => Container(
-                        color: const Color(0xFF2C77B7),
-                        alignment: Alignment.center,
-                        child: const AdaptiveIcon(
-                          Icons.auto_stories_rounded,
-                          color: Colors.white,
+    final genresList = _discoverGenres;
+    final genreIndex = genresList.indexOf(genre);
+    final isFirstRow = genreIndex == 0;
+    final isLastRow = genreIndex == genresList.length - 1;
+    final prevGenre = isFirstRow ? null : genresList[genreIndex - 1];
+    final nextGenre = isLastRow ? null : genresList[genreIndex + 1];
+
+    final innerPadding = EdgeInsets.symmetric(horizontal: isMobile ? 18.0 : 28.0);
+    final horizontalPadding = isMobile ? 18.0 : 28.0;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final viewportWidth = constraints.maxWidth - 2 * horizontalPadding;
+        final adjustedCardWidth = _calculateAdjustedCardWidth(viewportWidth, 140.0);
+        final nodes = _focusNodesForGenre(genre, items.isNotEmpty ? items.length : 1);
+
+        return Padding(
+          padding: const EdgeInsets.only(top: 18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: innerPadding,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        displayBookGenre(genre),
+                        style: TextStyle(
+                          color: titleTextColor,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w700,
                         ),
                       ),
                     ),
-            ),
+                    Text(
+                      AppLocalizations.of(context).booksCount(items.length),
+                      style: TextStyle(
+                        color: subtitleTextColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (PlatformDetection.isDesktop) ...[
+                      const SizedBox(width: 8),
+                      IconButton(
+                        tooltip: AppLocalizations.of(context).scrollLeft,
+                        onPressed: canScrollRow
+                            ? () => _scrollDiscoverSubjectRow(genre, -1)
+                            : null,
+                        style: IconButton.styleFrom(
+                          backgroundColor: isDark
+                              ? AppColorScheme.accent
+                              : const Color(0xFF16304D),
+                          foregroundColor: isDark
+                              ? AppColorScheme.onAccent
+                              : Colors.white,
+                          disabledBackgroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.1)
+                              : const Color(0xFFD7E3F0),
+                          disabledForegroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.3)
+                              : const Color(0xFF90A5BC),
+                        ),
+                        icon: const AdaptiveIcon(Icons.chevron_left_rounded),
+                      ),
+                      IconButton(
+                        tooltip: AppLocalizations.of(context).scrollRight,
+                        onPressed: canScrollRow
+                            ? () => _scrollDiscoverSubjectRow(genre, 1)
+                            : null,
+                        style: IconButton.styleFrom(
+                          backgroundColor: isDark
+                              ? AppColorScheme.accent
+                              : const Color(0xFF16304D),
+                          foregroundColor: isDark
+                              ? AppColorScheme.onAccent
+                              : Colors.white,
+                          disabledBackgroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.1)
+                              : const Color(0xFFD7E3F0),
+                          disabledForegroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.3)
+                              : const Color(0xFF90A5BC),
+                        ),
+                        icon: const AdaptiveIcon(Icons.chevron_right_rounded),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              if (items.isEmpty && isLoading)
+                Padding(
+                  padding: innerPadding,
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 20),
+                    child: Center(
+                      child: CircularProgressIndicator(color: _bookAccent),
+                    ),
+                  ),
+                )
+              else if (items.isEmpty && hasFailed)
+                Padding(
+                  padding: innerPadding,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          AppLocalizations.of(context).couldNotLoadSubject,
+                          style: TextStyle(color: subtitleTextColor),
+                        ),
+                      ),
+                      Focus(
+                        focusNode: isFirstRow ? widget.firstFocusNode : nodes[0],
+                        onKeyEvent: (node, event) {
+                          if (isActivateKey(event)) {
+                            _loadDiscoverPage(genre, reset: true);
+                            return KeyEventResult.handled;
+                          }
+                          if (event.isActionable) {
+                            if (event.logicalKey.isUpKey) {
+                              if (isFirstRow) {
+                                widget.settingsMenuFocusNode?.requestFocus();
+                              } else {
+                                _focusRow(prevGenre!, false);
+                              }
+                              return KeyEventResult.handled;
+                            }
+                            if (event.logicalKey.isDownKey && !isLastRow) {
+                              _focusRow(nextGenre!, true);
+                              return KeyEventResult.handled;
+                            }
+                          }
+                          return KeyEventResult.ignored;
+                        },
+                        child: TextButton(
+                          onPressed: () => _loadDiscoverPage(genre, reset: true),
+                          child: Text(AppLocalizations.of(context).retry),
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              else
+                SizedBox(
+                  height: 248,
+                  child: ListView.separated(
+                    padding: innerPadding.copyWith(top: 4.0, bottom: 4.0),
+                    clipBehavior: Clip.hardEdge,
+                    controller: rowController,
+                    scrollDirection: Axis.horizontal,
+                    itemCount: items.length,
+                    separatorBuilder: (_, _) => const SizedBox(width: 12),
+                    itemBuilder: (context, index) => SizedBox(
+                      width: adjustedCardWidth,
+                      child: _buildDiscoverBookCard(
+                        items[index],
+                        focusNode: (isFirstRow && index == 0) ? widget.firstFocusNode : nodes[index],
+                        onUpPressed: () {
+                          if (isFirstRow) {
+                            widget.settingsMenuFocusNode?.requestFocus();
+                          } else {
+                            _focusRow(prevGenre!, false);
+                          }
+                        },
+                        onDownPressed: isLastRow
+                            ? null
+                            : () {
+                                _focusRow(nextGenre!, true);
+                              },
+                        onLeftPressed: (index == 0)
+                            ? null
+                            : () {
+                                if (isFirstRow && index == 1) {
+                                  widget.firstFocusNode?.requestFocus();
+                                } else {
+                                  nodes[index - 1].requestFocus();
+                                }
+                              },
+                        onRightPressed: (index == items.length - 1)
+                            ? null
+                            : () => nodes[index + 1].requestFocus(),
+                      ),
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 8),
+              if (isLoading && items.isNotEmpty)
+                const SizedBox(
+                  height: 30,
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2.4,
+                      color: _bookAccent,
+                    ),
+                  ),
+                )
+              else
+                const SizedBox(height: 4),
+            ],
           ),
-          const SizedBox(height: 8),
-          HoverMarqueeText(
-            text: item.title,
-            style: const TextStyle(
-              color: Color(0xFF13233A),
-              fontWeight: FontWeight.w700,
-              fontSize: 13,
-            ),
-          ),
-          const SizedBox(height: 2),
-          HoverMarqueeText(
-            text: item.author,
-            style: const TextStyle(color: Color(0xFF5C7290), fontSize: 12),
-          ),
-        ],
-      ),
+        );
+      },
+    );
+  }
+
+  Widget _buildDiscoverBookCard(
+    DiscoverBook item, {
+    FocusNode? focusNode,
+    VoidCallback? onUpPressed,
+    VoidCallback? onDownPressed,
+    VoidCallback? onLeftPressed,
+    VoidCallback? onRightPressed,
+  }) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final titleTextColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF13233A);
+    final subtitleTextColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+        : const Color(0xFF5C7290);
+
+    return _DiscoverBookCard(
+      book: item,
+      titleTextColor: titleTextColor,
+      subtitleTextColor: subtitleTextColor,
+      focusNode: focusNode,
+      onUpPressed: onUpPressed,
+      onDownPressed: onDownPressed,
+      onLeftPressed: onLeftPressed,
+      onRightPressed: onRightPressed,
     );
   }
 
   Widget _buildAudiobookDiscoverCard({required bool isMobile}) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final containerBgColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.05)
+        : const Color(0xFFEFF6FF);
+    final titleTextColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF13233A);
+    final subtitleTextColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+        : const Color(0xFF5C7290);
+    final chipBgColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.08)
+        : const Color(0xFFDDEEFF);
+    final chipFgColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF1D3654);
+
+    final innerPadding = EdgeInsets.symmetric(horizontal: isMobile ? 18.0 : 28.0);
+
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFFEFF6FF),
+        color: containerBgColor,
         borderRadius: AppRadius.circular(32),
         boxShadow: const [
           BoxShadow(
@@ -1012,105 +1044,107 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
           ),
         ],
       ),
-      padding: EdgeInsets.fromLTRB(
-        isMobile ? 18 : 28,
-        isMobile ? 22 : 30,
-        isMobile ? 18 : 28,
-        24,
+      padding: EdgeInsets.symmetric(
+        vertical: isMobile ? 22 : 30,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      AppLocalizations.of(context).discoverAudiobooks,
-                      style: const TextStyle(
-                        color: Color(0xFF13233A),
-                        fontSize: 28,
-                        fontWeight: FontWeight.w700,
+          Padding(
+            padding: innerPadding,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        AppLocalizations.of(context).discoverAudiobooks,
+                        style: TextStyle(
+                          color: titleTextColor,
+                          fontSize: 28,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      AppLocalizations.of(context).librivoxDescription,
-                      style: const TextStyle(
-                        color: Color(0xFF5C7290),
-                        fontSize: 14,
-                        height: 1.35,
+                      const SizedBox(height: 6),
+                      Text(
+                        AppLocalizations.of(context).librivoxDescription,
+                        style: TextStyle(
+                          color: subtitleTextColor,
+                          fontSize: 14,
+                          height: 1.35,
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              _buildBookIconButton(
-                icon: Icons.people_alt_rounded,
-                onTap: () {
-                  final allBooks = _discoverAudiobooksByGenre.values
-                      .expand((b) => b)
-                      .toList();
-                  final unique = {
-                    for (final b in allBooks) b.id: b,
-                  }.values.toList();
-                  if (unique.isEmpty) return;
-                  Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (_) => LibrivoxAuthorsScreen(
-                        books: unique,
-                        coverCache: Map.unmodifiable(_librivoxCoverCache),
+                const SizedBox(width: 8),
+                _buildBookIconButton(
+                  icon: Icons.people_alt_rounded,
+                  onTap: () {
+                    final allBooks = _discoverAudiobooksByGenre.values
+                        .expand((b) => b)
+                        .toList();
+                    final unique = {
+                      for (final b in allBooks) b.id: b,
+                    }.values.toList();
+                    if (unique.isEmpty) return;
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => LibrivoxAuthorsScreen(
+                          books: unique,
+                          coverCache: Map.unmodifiable(_librivoxCoverCache),
+                        ),
                       ),
-                    ),
-                  );
-                },
-                foregroundColor: const Color(0xFF1D3654),
-                backgroundColor: const Color(0xFFE2F0FF),
-              ),
-              const SizedBox(width: 4),
-              _buildBookIconButton(
-                icon: Icons.tune_rounded,
-                onTap: _showAudiobookGenreSheet,
-                foregroundColor: const Color(0xFF1D3654),
-                backgroundColor: const Color(0xFFE2F0FF),
-              ),
-            ],
+                    );
+                  },
+                ),
+                const SizedBox(width: 4),
+                _buildBookIconButton(
+                  icon: Icons.tune_rounded,
+                  onTap: _showAudiobookGenreSheet,
+                  focusNode: widget.settingsMenuFocusNode,
+                  onUpPressed: widget.onSettingsUpPressed,
+                  onDownPressed: () => _focusRow(_discoverAudiobookGenres.first, true),
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 16),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: _discoverAudiobookGenres
-                .map(
-                  (genre) => Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 10,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFFDDEEFF),
-                      borderRadius: AppRadius.circular(999),
-                    ),
-                    child: Text(
-                      genre,
-                      style: const TextStyle(
-                        color: Color(0xFF1D3654),
-                        fontSize: 12,
-                        fontWeight: FontWeight.w700,
+          Padding(
+            padding: innerPadding,
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _discoverAudiobookGenres
+                  .map(
+                    (genre) => Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: chipBgColor,
+                        borderRadius: AppRadius.circular(999),
+                      ),
+                      child: Text(
+                        genre,
+                        style: TextStyle(
+                          color: chipFgColor,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
                     ),
-                  ),
-                )
-                .toList(),
+                  )
+                  .toList(),
+            ),
           ),
           const SizedBox(height: 14),
           if (_discoverAudiobookBootstrapping && !_discoverAudiobookInitialized)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 28),
-              child: Center(
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 28),
+              child: const Center(
                 child: CircularProgressIndicator(color: _bookAccent),
               ),
             )
@@ -1128,113 +1162,220 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
     final rowController = _controllerForAudiobookDiscoverGenre(genre);
     final canScrollRow = items.length > 2 && !isLoading;
 
-    return Padding(
-      padding: const EdgeInsets.only(top: 18),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
+    final isMobile =
+        PlatformDetection.useMobileUi || MediaQuery.sizeOf(context).width < 600;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final titleTextColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF13233A);
+    final subtitleTextColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+        : const Color(0xFF5C7290);
+
+    final genresList = _discoverAudiobookGenres;
+    final genreIndex = genresList.indexOf(genre);
+    final isFirstRow = genreIndex == 0;
+    final isLastRow = genreIndex == genresList.length - 1;
+    final prevGenre = isFirstRow ? null : genresList[genreIndex - 1];
+    final nextGenre = isLastRow ? null : genresList[genreIndex + 1];
+
+    final innerPadding = EdgeInsets.symmetric(horizontal: isMobile ? 18.0 : 28.0);
+    final horizontalPadding = isMobile ? 18.0 : 28.0;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final viewportWidth = constraints.maxWidth - 2 * horizontalPadding;
+        final adjustedCardWidth = _calculateAdjustedCardWidth(viewportWidth, 150.0);
+        final nodes = _focusNodesForGenre(genre, items.isNotEmpty ? items.length : 1);
+
+        return Padding(
+          padding: const EdgeInsets.only(top: 18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Expanded(
-                child: Text(
-                  genre,
-                  style: const TextStyle(
-                    color: Color(0xFF13233A),
-                    fontSize: 20,
-                    fontWeight: FontWeight.w700,
+              Padding(
+                padding: innerPadding,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        genre,
+                        style: TextStyle(
+                          color: titleTextColor,
+                          fontSize: 20,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      AppLocalizations.of(context).titlesCount(items.length),
+                      style: TextStyle(
+                        color: subtitleTextColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (PlatformDetection.isDesktop) ...[
+                      const SizedBox(width: 8),
+                      IconButton(
+                        tooltip: AppLocalizations.of(context).scrollLeft,
+                        onPressed: canScrollRow
+                            ? () => _scrollAudiobookDiscoverRow(genre, -1)
+                            : null,
+                        style: IconButton.styleFrom(
+                          backgroundColor: isDark
+                              ? AppColorScheme.accent
+                              : const Color(0xFF16304D),
+                          foregroundColor: isDark
+                              ? AppColorScheme.onAccent
+                              : Colors.white,
+                          disabledBackgroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.1)
+                              : const Color(0xFFD7E3F0),
+                          disabledForegroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.3)
+                              : const Color(0xFF90A5BC),
+                        ),
+                        icon: const AdaptiveIcon(Icons.chevron_left_rounded),
+                      ),
+                      IconButton(
+                        tooltip: AppLocalizations.of(context).scrollRight,
+                        onPressed: canScrollRow
+                            ? () => _scrollAudiobookDiscoverRow(genre, 1)
+                            : null,
+                        style: IconButton.styleFrom(
+                          backgroundColor: isDark
+                              ? AppColorScheme.accent
+                              : const Color(0xFF16304D),
+                          foregroundColor: isDark
+                              ? AppColorScheme.onAccent
+                              : Colors.white,
+                          disabledBackgroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.1)
+                              : const Color(0xFFD7E3F0),
+                          disabledForegroundColor: isDark
+                              ? AppColorScheme.onSurface.withValues(alpha: 0.3)
+                              : const Color(0xFF90A5BC),
+                        ),
+                        icon: const AdaptiveIcon(Icons.chevron_right_rounded),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              if (items.isEmpty && isLoading)
+                Padding(
+                  padding: innerPadding,
+                  child: const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 20),
+                    child: Center(
+                      child: CircularProgressIndicator(color: _bookAccent),
+                    ),
+                  ),
+                )
+              else if (items.isEmpty && hasFailed)
+                Padding(
+                  padding: innerPadding,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          AppLocalizations.of(context).couldNotLoadGenre,
+                          style: TextStyle(color: subtitleTextColor),
+                        ),
+                      ),
+                      Focus(
+                        focusNode: isFirstRow ? widget.firstFocusNode : nodes[0],
+                        onKeyEvent: (node, event) {
+                          if (isActivateKey(event)) {
+                            _loadAudiobookDiscoverPage(genre, reset: true);
+                            return KeyEventResult.handled;
+                          }
+                          if (event.isActionable) {
+                            if (event.logicalKey.isUpKey) {
+                              if (isFirstRow) {
+                                widget.settingsMenuFocusNode?.requestFocus();
+                              } else {
+                                _focusRow(prevGenre!, false);
+                              }
+                              return KeyEventResult.handled;
+                            }
+                            if (event.logicalKey.isDownKey && !isLastRow) {
+                              _focusRow(nextGenre!, true);
+                              return KeyEventResult.handled;
+                            }
+                          }
+                          return KeyEventResult.ignored;
+                        },
+                        child: TextButton(
+                          onPressed: () => _loadAudiobookDiscoverPage(genre, reset: true),
+                          child: Text(AppLocalizations.of(context).retry),
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              else
+                SizedBox(
+                  height: 208,
+                  child: ListView.separated(
+                    padding: innerPadding.copyWith(top: 4.0, bottom: 4.0),
+                    clipBehavior: Clip.hardEdge,
+                    controller: rowController,
+                    scrollDirection: Axis.horizontal,
+                    itemCount: items.length,
+                    separatorBuilder: (_, _) => const SizedBox(width: 12),
+                    itemBuilder: (context, index) => SizedBox(
+                      width: adjustedCardWidth,
+                      child: _buildLibrivoxBookCard(
+                        items[index],
+                        focusNode: (isFirstRow && index == 0) ? widget.firstFocusNode : nodes[index],
+                        onUpPressed: () {
+                          if (isFirstRow) {
+                            widget.settingsMenuFocusNode?.requestFocus();
+                          } else {
+                            _focusRow(prevGenre!, false);
+                          }
+                        },
+                        onDownPressed: isLastRow
+                            ? null
+                            : () {
+                                _focusRow(nextGenre!, true);
+                              },
+                        onLeftPressed: (index == 0)
+                            ? null
+                            : () {
+                                if (isFirstRow && index == 1) {
+                                  widget.firstFocusNode?.requestFocus();
+                                } else {
+                                  nodes[index - 1].requestFocus();
+                                }
+                              },
+                        onRightPressed: (index == items.length - 1)
+                            ? null
+                            : () => nodes[index + 1].requestFocus(),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-              Text(
-                AppLocalizations.of(context).titlesCount(items.length),
-                style: const TextStyle(
-                  color: Color(0xFF5C7290),
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(width: 8),
-              IconButton(
-                tooltip: AppLocalizations.of(context).scrollLeft,
-                onPressed: canScrollRow
-                    ? () => _scrollAudiobookDiscoverRow(genre, -1)
-                    : null,
-                style: IconButton.styleFrom(
-                  backgroundColor: const Color(0xFF16304D),
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: const Color(0xFFD7E3F0),
-                  disabledForegroundColor: const Color(0xFF90A5BC),
-                ),
-                icon: const AdaptiveIcon(Icons.chevron_left_rounded),
-              ),
-              IconButton(
-                tooltip: AppLocalizations.of(context).scrollRight,
-                onPressed: canScrollRow
-                    ? () => _scrollAudiobookDiscoverRow(genre, 1)
-                    : null,
-                style: IconButton.styleFrom(
-                  backgroundColor: const Color(0xFF16304D),
-                  foregroundColor: Colors.white,
-                  disabledBackgroundColor: const Color(0xFFD7E3F0),
-                  disabledForegroundColor: const Color(0xFF90A5BC),
-                ),
-                icon: const AdaptiveIcon(Icons.chevron_right_rounded),
-              ),
+              const SizedBox(height: 8),
+              if (isLoading && items.isNotEmpty)
+                const SizedBox(
+                  height: 30,
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2.4,
+                      color: _bookAccent,
+                    ),
+                  ),
+                )
+              else
+                const SizedBox(height: 4),
             ],
           ),
-          const SizedBox(height: 12),
-          if (items.isEmpty && isLoading)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 20),
-              child: Center(
-                child: CircularProgressIndicator(color: _bookAccent),
-              ),
-            )
-          else if (items.isEmpty && hasFailed)
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    AppLocalizations.of(context).couldNotLoadGenre,
-                    style: const TextStyle(color: Color(0xFF5C7290)),
-                  ),
-                ),
-                TextButton(
-                  onPressed: () =>
-                      _loadAudiobookDiscoverPage(genre, reset: true),
-                  child: Text(AppLocalizations.of(context).retry),
-                ),
-              ],
-            )
-          else
-            SizedBox(
-              height: 200,
-              child: ListView.separated(
-                controller: rowController,
-                scrollDirection: Axis.horizontal,
-                itemCount: items.length,
-                separatorBuilder: (_, _) => const SizedBox(width: 12),
-                itemBuilder: (context, index) => SizedBox(
-                  width: 150,
-                  child: _buildLibrivoxBookCard(items[index]),
-                ),
-              ),
-            ),
-          const SizedBox(height: 8),
-          if (isLoading && items.isNotEmpty)
-            const SizedBox(
-              height: 30,
-              child: Center(
-                child: CircularProgressIndicator(
-                  strokeWidth: 2.4,
-                  color: _bookAccent,
-                ),
-              ),
-            )
-          else
-            const SizedBox(height: 4),
-        ],
-      ),
+        );
+      },
     );
   }
 
@@ -1275,72 +1416,951 @@ class _BookDiscoverTabState extends State<BookDiscoverTab> {
     );
   }
 
-  Widget _buildLibrivoxBookCard(LibrivoxBook book) {
+  Widget _buildLibrivoxBookCard(
+    LibrivoxBook book, {
+    FocusNode? focusNode,
+    VoidCallback? onUpPressed,
+    VoidCallback? onDownPressed,
+    VoidCallback? onLeftPressed,
+    VoidCallback? onRightPressed,
+  }) {
     final colorIndex =
         book.id.hashCode.abs() % audiobookPlaceholderColors.length;
     final placeholderColor = audiobookPlaceholderColors[colorIndex];
     final coverUrl = _librivoxCoverCache[book.id];
-    final hasCover =
-        _librivoxCoverCache.containsKey(book.id) && coverUrl != null;
     final resolvedCover = coverUrl;
 
-    return InkWell(
-      borderRadius: AppRadius.circular(18),
-      onTap: () {
-        final allBooksById = <String, LibrivoxBook>{};
-        for (final bookList in _discoverAudiobooksByGenre.values) {
-          for (final discoveredBook in bookList) {
-            allBooksById[discoveredBook.id] = discoveredBook;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final titleTextColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF13233A);
+    final subtitleTextColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+        : const Color(0xFF5C7290);
+
+    final allBooksById = <String, LibrivoxBook>{};
+    for (final bookList in _discoverAudiobooksByGenre.values) {
+      for (final discoveredBook in bookList) {
+        allBooksById[discoveredBook.id] = discoveredBook;
+      }
+    }
+    final allBooks = allBooksById.values.toList();
+
+    return _LibrivoxBookCard(
+      book: book,
+      coverUrl: resolvedCover,
+      allBooks: allBooks,
+      coverCache: Map.of(_librivoxCoverCache),
+      placeholder: _buildAudiobookCoverPlaceholder(placeholderColor, book.formattedDuration),
+      titleTextColor: titleTextColor,
+      subtitleTextColor: subtitleTextColor,
+      focusNode: focusNode,
+      onUpPressed: onUpPressed,
+      onDownPressed: onDownPressed,
+      onLeftPressed: onLeftPressed,
+      onRightPressed: onRightPressed,
+    );
+  }
+}
+
+class _BookIconButton extends StatefulWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+  final FocusNode? focusNode;
+  final VoidCallback? onUpPressed;
+  final VoidCallback? onDownPressed;
+
+  const _BookIconButton({
+    required this.icon,
+    required this.onTap,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.focusNode,
+    this.onUpPressed,
+    this.onDownPressed,
+  });
+
+  @override
+  State<_BookIconButton> createState() => _BookIconButtonState();
+}
+
+class _BookIconButtonState extends State<_BookIconButton> {
+  bool _focused = false;
+  final FocusNode _parentFocusNode = FocusNode(debugLabel: 'BookIconButtonParent');
+
+  @override
+  void dispose() {
+    _parentFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bg = widget.backgroundColor ?? (isDark ? AppColorScheme.onSurface.withValues(alpha: 0.1) : const Color(0x1FEAF4FF));
+    final fg = widget.foregroundColor ?? (isDark ? AppColorScheme.onSurface : const Color(0xFFEAF4FF));
+
+    return Focus(
+      focusNode: _parentFocusNode,
+      onKeyEvent: (node, event) {
+        if (event.isActionable) {
+          if (event.logicalKey.isUpKey && widget.onUpPressed != null) {
+            widget.onUpPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isDownKey && widget.onDownPressed != null) {
+            widget.onDownPressed!();
+            return KeyEventResult.handled;
           }
         }
-        final allBooks = allBooksById.values.toList();
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => LibrivoxBookDetailScreen(
-              book: book,
-              coverUrl: coverUrl,
-              allBooks: allBooks,
-              coverCache: Map.of(_librivoxCoverCache),
-            ),
-          ),
-        );
+        return KeyEventResult.ignored;
       },
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: ClipRRect(
-              borderRadius: AppRadius.circular(18),
-              child: hasCover
-                  ? CachedNetworkImage(
-                      imageUrl: resolvedCover ?? '',
-                      fit: BoxFit.cover,
-                      errorWidget: (_, _, _) => _buildAudiobookCoverPlaceholder(
-                        placeholderColor,
-                        book.formattedDuration,
-                      ),
-                    )
-                  : _buildAudiobookCoverPlaceholder(
-                      placeholderColor,
-                      book.formattedDuration,
+      child: InkWell(
+        focusNode: widget.focusNode,
+        onFocusChange: (f) {
+          setState(() => _focused = f);
+        },
+        onTap: widget.onTap,
+        borderRadius: AppRadius.circular(20),
+        focusColor: Colors.transparent,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: 52,
+          height: 52,
+          decoration: BoxDecoration(
+            color: bg,
+            borderRadius: AppRadius.circular(20),
+            border: Border.all(
+              color: _focused ? AppColorScheme.accent : fg.withValues(alpha: 0.11),
+              width: 3.0,
+            ),
+          ),
+          child: Center(
+            child: AdaptiveIcon(widget.icon, color: fg),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DiscoverBookCard extends StatefulWidget {
+  final DiscoverBook book;
+  final Color titleTextColor;
+  final Color subtitleTextColor;
+  final FocusNode? focusNode;
+  final VoidCallback? onUpPressed;
+  final VoidCallback? onDownPressed;
+  final VoidCallback? onLeftPressed;
+  final VoidCallback? onRightPressed;
+
+  const _DiscoverBookCard({
+    required this.book,
+    required this.titleTextColor,
+    required this.subtitleTextColor,
+    this.focusNode,
+    this.onUpPressed,
+    this.onDownPressed,
+    this.onLeftPressed,
+    this.onRightPressed,
+  });
+
+  @override
+  State<_DiscoverBookCard> createState() => _DiscoverBookCardState();
+}
+
+class _DiscoverBookCardState extends State<_DiscoverBookCard> {
+  bool _focused = false;
+  final FocusNode _parentFocusNode = FocusNode(debugLabel: 'DiscoverCardParent');
+
+  @override
+  void initState() {
+    super.initState();
+    _focused = widget.focusNode?.hasFocus ?? false;
+    widget.focusNode?.addListener(_handleFocusChange);
+  }
+
+  @override
+  void didUpdateWidget(covariant _DiscoverBookCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.focusNode != widget.focusNode) {
+      oldWidget.focusNode?.removeListener(_handleFocusChange);
+      widget.focusNode?.addListener(_handleFocusChange);
+      _focused = widget.focusNode?.hasFocus ?? false;
+    }
+  }
+
+  @override
+  void dispose() {
+    _parentFocusNode.dispose();
+    widget.focusNode?.removeListener(_handleFocusChange);
+    super.dispose();
+  }
+
+  void _handleFocusChange() {
+    if (mounted) {
+      setState(() => _focused = widget.focusNode?.hasFocus ?? false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _parentFocusNode,
+      onKeyEvent: (node, event) {
+        if (event.isActionable) {
+          if (event.logicalKey.isUpKey && widget.onUpPressed != null) {
+            widget.onUpPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isDownKey && widget.onDownPressed != null) {
+            widget.onDownPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isLeftKey) {
+            if (widget.onLeftPressed != null) {
+              widget.onLeftPressed!();
+            }
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isRightKey) {
+            if (widget.onRightPressed != null) {
+              widget.onRightPressed!();
+            }
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: InkWell(
+        focusNode: widget.focusNode,
+        onFocusChange: (focused) {
+          if (focused) {
+            Scrollable.ensureVisible(
+              context,
+              duration: const Duration(milliseconds: 200),
+              alignment: 0.5,
+              curve: Curves.easeOutCubic,
+            );
+          }
+        },
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => DiscoverBookDetailScreen(book: widget.book),
+          ),
+        ),
+        borderRadius: AppRadius.circular(18),
+        focusColor: Colors.transparent,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
+                decoration: BoxDecoration(
+                  borderRadius: AppRadius.circular(18),
+                  border: Border.all(
+                    color: _focused ? AppColorScheme.accent : Colors.transparent,
+                    width: 3.0,
+                  ),
+                ),
+                child: ClipRRect(
+                  borderRadius: AppRadius.circular(15),
+                  child: widget.book.coverUrl == null
+                      ? Container(
+                          color: const Color(0xFF2C77B7),
+                          alignment: Alignment.center,
+                          padding: const EdgeInsets.all(10),
+                          child: const AdaptiveIcon(
+                            Icons.auto_stories_rounded,
+                            color: Colors.white,
+                            size: 30,
+                        ),
+                      )
+                      : CachedNetworkImage(
+                          imageUrl: widget.book.coverUrl!,
+                          fit: BoxFit.cover,
+                          errorWidget: (_, _, _) => Container(
+                            color: const Color(0xFF2C77B7),
+                            alignment: Alignment.center,
+                            child: const AdaptiveIcon(
+                              Icons.auto_stories_rounded,
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            HoverMarqueeText(
+              text: widget.book.title,
+              style: TextStyle(
+                color: widget.titleTextColor,
+                fontWeight: FontWeight.w700,
+                fontSize: 13,
+              ),
+            ),
+            const SizedBox(height: 2),
+            HoverMarqueeText(
+              text: widget.book.author,
+              style: TextStyle(color: widget.subtitleTextColor, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LibrivoxBookCard extends StatefulWidget {
+  final LibrivoxBook book;
+  final String? coverUrl;
+  final List<LibrivoxBook> allBooks;
+  final Map<String, String?> coverCache;
+  final Widget placeholder;
+  final Color titleTextColor;
+  final Color subtitleTextColor;
+  final FocusNode? focusNode;
+  final VoidCallback? onUpPressed;
+  final VoidCallback? onDownPressed;
+  final VoidCallback? onLeftPressed;
+  final VoidCallback? onRightPressed;
+
+  const _LibrivoxBookCard({
+    required this.book,
+    required this.coverUrl,
+    required this.allBooks,
+    required this.coverCache,
+    required this.placeholder,
+    required this.titleTextColor,
+    required this.subtitleTextColor,
+    this.focusNode,
+    this.onUpPressed,
+    this.onDownPressed,
+    this.onLeftPressed,
+    this.onRightPressed,
+  });
+
+  @override
+  State<_LibrivoxBookCard> createState() => _LibrivoxBookCardState();
+}
+
+class _LibrivoxBookCardState extends State<_LibrivoxBookCard> {
+  bool _focused = false;
+  final FocusNode _parentFocusNode = FocusNode(debugLabel: 'LibrivoxCardParent');
+
+  @override
+  void initState() {
+    super.initState();
+    _focused = widget.focusNode?.hasFocus ?? false;
+    widget.focusNode?.addListener(_handleFocusChange);
+  }
+
+  @override
+  void didUpdateWidget(covariant _LibrivoxBookCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.focusNode != widget.focusNode) {
+      oldWidget.focusNode?.removeListener(_handleFocusChange);
+      widget.focusNode?.addListener(_handleFocusChange);
+      _focused = widget.focusNode?.hasFocus ?? false;
+    }
+  }
+
+  @override
+  void dispose() {
+    _parentFocusNode.dispose();
+    widget.focusNode?.removeListener(_handleFocusChange);
+    super.dispose();
+  }
+
+  void _handleFocusChange() {
+    if (mounted) {
+      setState(() => _focused = widget.focusNode?.hasFocus ?? false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasCover = widget.coverUrl != null;
+    return Focus(
+      focusNode: _parentFocusNode,
+      onKeyEvent: (node, event) {
+        if (event.isActionable) {
+          if (event.logicalKey.isUpKey && widget.onUpPressed != null) {
+            widget.onUpPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isDownKey && widget.onDownPressed != null) {
+            widget.onDownPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isLeftKey) {
+            if (widget.onLeftPressed != null) {
+              widget.onLeftPressed!();
+            }
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isRightKey) {
+            if (widget.onRightPressed != null) {
+              widget.onRightPressed!();
+            }
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: InkWell(
+        focusNode: widget.focusNode,
+        onFocusChange: (focused) {
+          if (focused) {
+            Scrollable.ensureVisible(
+              context,
+              duration: const Duration(milliseconds: 200),
+              alignment: 0.5,
+              curve: Curves.easeOutCubic,
+            );
+          }
+        },
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => LibrivoxBookDetailScreen(
+                book: widget.book,
+                coverUrl: widget.coverUrl,
+                allBooks: widget.allBooks,
+                coverCache: widget.coverCache,
+              ),
+            ),
+          );
+        },
+        borderRadius: AppRadius.circular(18),
+        focusColor: Colors.transparent,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
+                decoration: BoxDecoration(
+                  borderRadius: AppRadius.circular(18),
+                  border: Border.all(
+                    color: _focused ? AppColorScheme.accent : Colors.transparent,
+                    width: 3.0,
+                  ),
+                ),
+                child: ClipRRect(
+                  borderRadius: AppRadius.circular(15),
+                  child: hasCover
+                      ? CachedNetworkImage(
+                          imageUrl: widget.coverUrl!,
+                          fit: BoxFit.cover,
+                          errorWidget: (_, _, _) => widget.placeholder,
+                        )
+                      : widget.placeholder,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            HoverMarqueeText(
+              text: widget.book.title,
+              style: TextStyle(
+                color: widget.titleTextColor,
+                fontWeight: FontWeight.w700,
+                fontSize: 13,
+              ),
+            ),
+            const SizedBox(height: 2),
+            HoverMarqueeText(
+              text: widget.book.authorName,
+              style: TextStyle(color: widget.subtitleTextColor, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GenreDialogContent extends StatefulWidget {
+  final String title;
+  final String subtitle;
+  final List<String> allGenres;
+  final List<String> initialSelectedGenres;
+  final String Function(String) displayFn;
+
+  const _GenreDialogContent({
+    required this.title,
+    required this.subtitle,
+    required this.allGenres,
+    required this.initialSelectedGenres,
+    required this.displayFn,
+  });
+
+  @override
+  State<_GenreDialogContent> createState() => _GenreDialogContentState();
+}
+
+class _GenreDialogContentState extends State<_GenreDialogContent> {
+  late Set<String> _selected;
+  final FocusNode _closeFocusNode = FocusNode(debugLabel: 'GenreClose');
+  final List<FocusNode> _genreFocusNodes = [];
+  final FocusNode _applyFocusNode = FocusNode(debugLabel: 'GenreApply');
+  int _lastFocusedGenreIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = {...widget.initialSelectedGenres};
+    for (int i = 0; i < widget.allGenres.length; i++) {
+      final node = FocusNode(debugLabel: 'GenreItem_$i');
+      node.addListener(() {
+        if (node.hasFocus) {
+          _lastFocusedGenreIndex = i;
+        }
+      });
+      _genreFocusNodes.add(node);
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_genreFocusNodes.isNotEmpty) {
+        _genreFocusNodes[0].requestFocus();
+      } else {
+        _applyFocusNode.requestFocus();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _closeFocusNode.dispose();
+    for (final node in _genreFocusNodes) {
+      node.dispose();
+    }
+    _applyFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final width = MediaQuery.of(context).size.width.clamp(400.0, 520.0).toDouble();
+
+    final backgroundColor = isDark
+        ? AppColorScheme.background
+        : const Color(0xFFF0F7FF);
+    final titleTextColor = isDark
+        ? AppColorScheme.onSurface
+        : const Color(0xFF13233A);
+    final subtitleTextColor = isDark
+        ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+        : const Color(0xFF5C7290);
+
+    return Align(
+      alignment: Alignment.centerRight,
+      child: Material(
+        color: backgroundColor,
+        child: SizedBox(
+          width: width,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          widget.title,
+                          style: TextStyle(
+                            fontSize: 22,
+                            fontWeight: FontWeight.w700,
+                            color: titleTextColor,
+                          ),
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          widget.subtitle,
+                          style: TextStyle(color: subtitleTextColor, fontSize: 13),
+                        ),
+                        const SizedBox(height: 16),
+                        Expanded(
+                          child: ListView.builder(
+                            itemCount: widget.allGenres.length,
+                            itemBuilder: (context, index) {
+                              final genre = widget.allGenres[index];
+                              final selected = _selected.contains(genre);
+                              final isFirst = index == 0;
+                              final isLast = index == widget.allGenres.length - 1;
+
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(vertical: 4.0),
+                                child: _GenreTile(
+                                  title: widget.displayFn(genre),
+                                  value: selected,
+                                  focusNode: _genreFocusNodes[index],
+                                  onChanged: (value) {
+                                    setState(() {
+                                      if (value == true) {
+                                        _selected.add(genre);
+                                      } else if (_selected.length > 1) {
+                                        _selected.remove(genre);
+                                      }
+                                    });
+                                  },
+                                  onUpPressed: () {
+                                    if (!isFirst) {
+                                      _genreFocusNodes[index - 1].requestFocus();
+                                    }
+                                  },
+                                  onDownPressed: () {
+                                    if (!isLast) {
+                                      _genreFocusNodes[index + 1].requestFocus();
+                                    }
+                                  },
+                                  onRightPressed: () {
+                                    if (index < 4) {
+                                      _closeFocusNode.requestFocus();
+                                    } else {
+                                      _applyFocusNode.requestFocus();
+                                    }
+                                  },
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ],
                     ),
+                  ),
+                  const SizedBox(width: 20),
+                  SizedBox(
+                    width: 80,
+                    child: Column(
+                      children: [
+                        _FocusableCloseButton(
+                          focusNode: _closeFocusNode,
+                          onPressed: () => Navigator.of(context).pop(),
+                          onDownPressed: () => _applyFocusNode.requestFocus(),
+                          onLeftPressed: () {
+                            if (_genreFocusNodes.isNotEmpty) {
+                              _genreFocusNodes[_lastFocusedGenreIndex].requestFocus();
+                            }
+                          },
+                        ),
+                        const Spacer(),
+                        _ApplyButton(
+                          focusNode: _applyFocusNode,
+                          label: AppLocalizations.of(context).apply,
+                          onPressed: () => Navigator.of(context).pop(_selected.toList()),
+                          onUpPressed: () => _closeFocusNode.requestFocus(),
+                          onLeftPressed: () {
+                            if (_genreFocusNodes.isNotEmpty) {
+                              _genreFocusNodes[_lastFocusedGenreIndex].requestFocus();
+                            }
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
-          const SizedBox(height: 8),
-          HoverMarqueeText(
-            text: book.title,
+        ),
+      ),
+    );
+  }
+}
+
+class _FocusableCloseButton extends StatefulWidget {
+  final VoidCallback onPressed;
+  final FocusNode? focusNode;
+  final VoidCallback? onDownPressed;
+  final VoidCallback? onLeftPressed;
+
+  const _FocusableCloseButton({
+    required this.onPressed,
+    this.focusNode,
+    this.onDownPressed,
+    this.onLeftPressed,
+  });
+
+  @override
+  State<_FocusableCloseButton> createState() => _FocusableCloseButtonState();
+}
+
+class _FocusableCloseButtonState extends State<_FocusableCloseButton> {
+  bool _focused = false;
+  late final FocusNode _effectiveFocusNode;
+  final FocusNode _parentFocusNode = FocusNode(debugLabel: 'CloseButtonParent');
+
+  @override
+  void initState() {
+    super.initState();
+    _effectiveFocusNode = widget.focusNode ?? FocusNode();
+    _effectiveFocusNode.addListener(_handleFocusChange);
+    _focused = _effectiveFocusNode.hasFocus;
+  }
+
+  @override
+  void dispose() {
+    _parentFocusNode.dispose();
+    if (widget.focusNode == null) {
+      _effectiveFocusNode.dispose();
+    } else {
+      _effectiveFocusNode.removeListener(_handleFocusChange);
+    }
+    super.dispose();
+  }
+
+  void _handleFocusChange() {
+    if (mounted) {
+      setState(() => _focused = _effectiveFocusNode.hasFocus);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final color = isDark ? AppColorScheme.onSurface : const Color(0xFF13233A);
+
+    return Focus(
+      focusNode: _parentFocusNode,
+      onKeyEvent: (node, event) {
+        if (event.isActionable) {
+          if (event.logicalKey.isDownKey && widget.onDownPressed != null) {
+            widget.onDownPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isLeftKey && widget.onLeftPressed != null) {
+            widget.onLeftPressed!();
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: _focused ? AppColorScheme.accent : Colors.transparent,
+            width: 2.0,
+          ),
+        ),
+        child: IconButton(
+          focusNode: _effectiveFocusNode,
+          onPressed: widget.onPressed,
+          icon: AdaptiveIcon(Icons.close_rounded, color: color),
+        ),
+      ),
+    );
+  }
+}
+
+class _GenreTile extends StatefulWidget {
+  final String title;
+  final bool value;
+  final ValueChanged<bool?> onChanged;
+  final FocusNode? focusNode;
+  final VoidCallback? onUpPressed;
+  final VoidCallback? onDownPressed;
+  final VoidCallback? onRightPressed;
+
+  const _GenreTile({
+    required this.title,
+    required this.value,
+    required this.onChanged,
+    this.focusNode,
+    this.onUpPressed,
+    this.onDownPressed,
+    this.onRightPressed,
+  });
+
+  @override
+  State<_GenreTile> createState() => _GenreTileState();
+}
+
+class _GenreTileState extends State<_GenreTile> {
+  bool _focused = false;
+  final FocusNode _parentFocusNode = FocusNode(debugLabel: 'GenreTileParent');
+
+  @override
+  void dispose() {
+    _parentFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final tileBg = _focused
+        ? (isDark ? AppColorScheme.accent.withValues(alpha: 0.15) : const Color(0xFFE3F2FD))
+        : Colors.transparent;
+    final titleColor = isDark ? AppColorScheme.onSurface : const Color(0xFF13233A);
+
+    return Focus(
+      focusNode: _parentFocusNode,
+      onKeyEvent: (node, event) {
+        if (event.isActionable) {
+          if (event.logicalKey.isUpKey && widget.onUpPressed != null) {
+            widget.onUpPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isDownKey && widget.onDownPressed != null) {
+            widget.onDownPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isRightKey && widget.onRightPressed != null) {
+            widget.onRightPressed!();
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: InkWell(
+        focusNode: widget.focusNode,
+        onFocusChange: (f) {
+          setState(() => _focused = f);
+          if (f) {
+            Scrollable.ensureVisible(
+              context,
+              duration: const Duration(milliseconds: 150),
+              alignment: 0.5,
+              curve: Curves.easeOutCubic,
+            );
+          }
+        },
+        onTap: () => widget.onChanged(!widget.value),
+        focusColor: Colors.transparent,
+        borderRadius: AppRadius.circular(12),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          decoration: BoxDecoration(
+            color: tileBg,
+            borderRadius: AppRadius.circular(12),
+            border: Border.all(
+              color: _focused ? AppColorScheme.accent : Colors.transparent,
+              width: 2.0,
+            ),
+          ),
+          child: Row(
+            children: [
+              Checkbox(
+                value: widget.value,
+                onChanged: widget.onChanged,
+                activeColor: isDark ? AppColorScheme.accent : const Color(0xFF0D47A1),
+                checkColor: Colors.white,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  widget.title,
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: titleColor,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ApplyButton extends StatefulWidget {
+  final VoidCallback onPressed;
+  final String label;
+  final FocusNode? focusNode;
+  final VoidCallback? onUpPressed;
+  final VoidCallback? onLeftPressed;
+
+  const _ApplyButton({
+    required this.onPressed,
+    required this.label,
+    this.focusNode,
+    this.onUpPressed,
+    this.onLeftPressed,
+  });
+
+  @override
+  State<_ApplyButton> createState() => _ApplyButtonState();
+}
+
+class _ApplyButtonState extends State<_ApplyButton> {
+  bool _focused = false;
+  final FocusNode _parentFocusNode = FocusNode(debugLabel: 'ApplyButtonParent');
+
+  @override
+  void dispose() {
+    _parentFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final btnColor = isDark ? AppColorScheme.accent : const Color(0xFF0D47A1);
+
+    return Focus(
+      focusNode: _parentFocusNode,
+      onKeyEvent: (node, event) {
+        if (event.isActionable) {
+          if (event.logicalKey.isUpKey && widget.onUpPressed != null) {
+            widget.onUpPressed!();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey.isLeftKey && widget.onLeftPressed != null) {
+            widget.onLeftPressed!();
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: InkWell(
+        focusNode: widget.focusNode,
+        onFocusChange: (f) => setState(() => _focused = f),
+        onTap: widget.onPressed,
+        borderRadius: AppRadius.circular(16),
+        focusColor: Colors.transparent,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: double.infinity,
+          height: 48,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: btnColor,
+            borderRadius: AppRadius.circular(16),
+            border: Border.all(
+              color: _focused ? (isDark ? Colors.white : Colors.black) : Colors.transparent,
+              width: 3.0,
+            ),
+            boxShadow: _focused
+                ? [
+                    BoxShadow(
+                      color: btnColor.withValues(alpha: 0.4),
+                      blurRadius: 12,
+                      offset: const Offset(0, 4),
+                    )
+                  ]
+                : [],
+          ),
+          child: Text(
+            widget.label,
             style: const TextStyle(
-              color: Color(0xFF13233A),
+              color: Colors.white,
               fontWeight: FontWeight.w700,
-              fontSize: 13,
+              fontSize: 16,
             ),
           ),
-          const SizedBox(height: 2),
-          HoverMarqueeText(
-            text: book.authorName,
-            style: const TextStyle(color: Color(0xFF5C7290), fontSize: 12),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/library_row.dart
+++ b/lib/ui/widgets/library_row.dart
@@ -14,6 +14,7 @@ class LibraryRow extends StatefulWidget {
   final double? rowHeight;
   final ScrollController? scrollController;
   final bool isLoading;
+  final double? leftPadding;
 
   const LibraryRow({
     super.key,
@@ -23,6 +24,7 @@ class LibraryRow extends StatefulWidget {
     this.rowHeight,
     this.scrollController,
     this.isLoading = false,
+    this.leftPadding,
   });
 
   @override
@@ -39,6 +41,9 @@ class _LibraryRowState extends State<LibraryRow> {
         .get(UserPreferences.desktopUiScale)
         .scaleFactor;
     final rowHeight = (widget.rowHeight ?? 220) * desktopScale;
+    final leftPad = widget.leftPadding ?? (20.0 * desktopScale);
+    final headerLeftPad = widget.leftPadding ?? (16.0 * desktopScale);
+
     return HorizontalScrollSection(
       title: widget.title,
       scrollController: widget.scrollController,
@@ -47,7 +52,7 @@ class _LibraryRowState extends State<LibraryRow> {
         fontWeight: FontWeight.w700,
       ),
       headerPadding: EdgeInsets.fromLTRB(
-        16 * desktopScale,
+        headerLeftPad,
         16 * desktopScale,
         8 * desktopScale,
         8 * desktopScale,
@@ -72,10 +77,11 @@ class _LibraryRowState extends State<LibraryRow> {
               )
             : hasItems
                 ? ListView.separated(
+                    clipBehavior: Clip.none,
                     controller: scrollController,
                     scrollDirection: Axis.horizontal,
                     padding: EdgeInsets.fromLTRB(
-                      20 * desktopScale,
+                      leftPad,
                       5 * desktopScale,
                       20 * desktopScale,
                       5 * desktopScale,

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -130,6 +130,7 @@ class MediaCard extends StatefulWidget {
         return 16 / 9;
       case 'MusicAlbum':
       case 'Audio':
+      case 'AudioBook':
       case 'MusicArtist':
       case 'Playlist':
       case 'Person':
@@ -309,6 +310,12 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
                 setFocused(hasFocus);
                 if (hasFocus) {
                   widget.onFocus?.call();
+                  Scrollable.ensureVisible(
+                    context,
+                    duration: const Duration(milliseconds: 200),
+                    alignment: 0.5,
+                    curve: Curves.easeOutCubic,
+                  );
                 } else {
                   widget.onFocusLost?.call();
                 }
@@ -530,7 +537,11 @@ class _CardImage extends StatelessWidget {
                   child: imageUrl != null
                       ? BoundedNetworkImage(
                           imageUrl: imageUrl!,
-                          fit: (itemType == 'Network' || itemType == 'Studio')
+                          fit: (itemType == 'Network' ||
+                                  itemType == 'Studio' ||
+                                  itemType == 'Book' ||
+                                  itemType == 'AudioBook' ||
+                                  itemType == 'Audio')
                               ? BoxFit.contain
                               : BoxFit.cover,
                           fadeInDuration: Duration.zero,
@@ -567,6 +578,63 @@ class _CardImage extends StatelessWidget {
                   )
                 else if (_showWatchedIndicator)
                   Positioned(top: 4, right: 4, child: _buildWatchedIndicator()),
+                if (playedPercentage != null && playedPercentage! > 0 && playedPercentage! < 100 && !isPlayed)
+                  Positioned.fill(
+                    child: Center(
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 150),
+                        child: (focused || hovered)
+                            ? Container(
+                                key: const ValueKey('focused_play'),
+                                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                                decoration: BoxDecoration(
+                                  color: AppColorScheme.accent,
+                                  borderRadius: AppRadius.circular(16),
+                                  boxShadow: const [
+                                    BoxShadow(
+                                      color: Colors.black38,
+                                      blurRadius: 8,
+                                      offset: Offset(0, 3),
+                                    ),
+                                  ],
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(
+                                      Icons.play_arrow,
+                                      size: 14,
+                                      color: Colors.white,
+                                    ),
+                                    const SizedBox(width: 4),
+                                    const Text(
+                                      'Resume',
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 10.5,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              )
+                            : Container(
+                                key: const ValueKey('unfocused_play'),
+                                width: 32,
+                                height: 32,
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: Colors.black.withValues(alpha: 0.5),
+                                ),
+                                child: const Icon(
+                                  Icons.play_arrow,
+                                  size: 16,
+                                  color: Colors.white,
+                                ),
+                              ),
+                      ),
+                    ),
+                  ),
                 if (playedPercentage != null && playedPercentage! > 0)
                   Positioned(
                     left: 6,

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -330,7 +330,11 @@ class _TopToolbarState extends State<TopToolbar> {
       return;
     }
     final focusContent = NavigationLayout.focusContentFromNavbarNotifier.value;
-    if (focusContent != null && widget.activeRoute == Destinations.home) {
+    final isBrowseRoute = widget.activeRoute == Destinations.home ||
+        widget.activeRoute?.startsWith('/books/') == true ||
+        widget.activeRoute?.startsWith('/music/') == true ||
+        widget.activeRoute?.startsWith('/library/') == true;
+    if (focusContent != null && isBrowseRoute) {
       focusContent();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
@@ -550,7 +554,9 @@ class _TopToolbarState extends State<TopToolbar> {
                     }
                   }
 
+                  final hasCustomFocus = NavigationLayout.focusContentFromNavbarNotifier.value != null;
                   if (widget.activeRoute != Destinations.home &&
+                      !hasCustomFocus &&
                       NavigationLayout.focusDetailsPlayButtonNotifier.value == null) {
                     final success =
                         primary.focusInDirection(TraversalDirection.down);


### PR DESCRIPTION
# Pull Request

## Summary
Some initial UI/UX ideas for the Books area to support themes, context dependent book and audiobook library separation and merging, support for browsing books, listing library shelves and the Discovery page interface on TV, and detail cards/stats.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

1.  Books Browse Tab:
    * Implemented spotlight section for books.
    * Added book stats band.
    * Implemented segmented controls for quick discover browse sorting.
2. Detail and Search Screen:
    * Implemented details page layout and browse cards designed specifically for book entities.
3. Resume Shelf support:
    * Modified RowDataSource to accept a custom includeItemTypes parameter so that book libraries can render the "Resume" category listing book-type items.
4. Library/Media Layouts: 
    * Updated LibraryRow, MediaCard, and TopToolbar to correctly identify and render book types.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Build, deploy, browse to a Books library.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
