### PR TITLE
fix-seerr: Refine Seerr Discovery page in terms of margins and traversal

### DIFF
--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -15,12 +15,13 @@ import '../../../ui/mixins/focus_state_mixin.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
 import '../../navigation/destinations.dart';
-import '../../widgets/library_row.dart';
 import '../../widgets/media_card.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/fullscreen_backdrop_switcher.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../widgets/focus/request_initial_focus.dart';
+import '../../widgets/focus/locked_focus_row.dart';
+import '../../widgets/horizontal_scroll_section.dart';
 
 const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w300';
 const _tmdbBackdropBase = 'https://image.tmdb.org/t/p/w1280';
@@ -47,6 +48,42 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       FocusNode(debugLabel: 'seerrDiscoverLoadingHold', skipTraversal: true);
   bool _initialFocusResolved = false;
   bool _isFirstRowFocused = false;
+  final Map<int, GlobalKey<LockedFocusRowState>> _rowKeys = {};
+
+  GlobalKey<LockedFocusRowState> _getRowKey(int index) {
+    return _rowKeys.putIfAbsent(index, () => GlobalKey<LockedFocusRowState>());
+  }
+
+  void _onRowLeftEdge() {
+    final prefs = GetIt.instance<UserPreferences>();
+    final navbarIsLeft = prefs.get(UserPreferences.navbarPosition) == NavbarPosition.left;
+    if (!navbarIsLeft) return;
+    final focusNavbar = NavigationLayout.focusNavbarNotifier.value;
+    if (focusNavbar != null) {
+      focusNavbar();
+    }
+  }
+
+  bool _onRowVerticalNavigation(int rowIndex, bool isUp) {
+    final targetIndex = isUp ? rowIndex - 1 : rowIndex + 1;
+    if (targetIndex >= 0 && targetIndex < _viewModel!.rows.length) {
+      final targetKey = _getRowKey(targetIndex);
+      final state = targetKey.currentState;
+      if (state != null) {
+        state.requestFocusAt(0);
+        return true;
+      }
+    } else if (isUp && targetIndex == -1) {
+      final prefs = GetIt.instance<UserPreferences>();
+      final navbarPosition = prefs.get(UserPreferences.navbarPosition);
+      if (navbarPosition == NavbarPosition.top) {
+        _restoreNavbarToNormalPosition();
+        NavigationLayout.focusNavbarNotifier.value?.call();
+      }
+      return true;
+    }
+    return false;
+  }
 
   static const _selectionDelay = Duration(milliseconds: 150);
   static const _backdropDelay = Duration(milliseconds: 200);
@@ -197,11 +234,19 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
         ? (PlatformDetection.isTV ? 95.0 : PlatformDetection.useMobileUi ? 60.0 : 80.0)
         : 0.0;
     final navbarIsLeft = navbarPosition == NavbarPosition.left;
+    final tvTopNavbarInset =
+        navbarPosition == NavbarPosition.top && PlatformDetection.isTV && !PlatformDetection.useMobileUi
+        ? 48.0
+        : 0.0;
     final rowLeftInset =
-      (navbarIsLeft && !PlatformDetection.useMobileUi) ? 56.0 : 0.0;
+        ((navbarIsLeft && !PlatformDetection.useMobileUi)
+            ? 56.0
+            : tvTopNavbarInset) +
+        (!PlatformDetection.useMobileUi ? 16.0 : 0.0);
     final infoPanelLeft =
-      (navbarIsLeft && !PlatformDetection.useMobileUi) ? 80.0 : 48.0;
-    final infoTopInset = topPad + navbarHeight + 8;
+        ((navbarIsLeft && !PlatformDetection.useMobileUi) ? 80.0 : 48.0) +
+        (!PlatformDetection.useMobileUi ? 16.0 : 0.0);
+    final infoTopInset = topPad + (navbarHeight > 0 ? navbarHeight - 12.0 : 28.0);
     return Scaffold(
       backgroundColor: AppColorScheme.background,
       body: NavigationLayout(
@@ -268,7 +313,6 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     var firstFocusableVisibleIndex = -1;
     for (var i = 0; i < rows.length; i++) {
       final row = rows[i];
-      if (row.isLoading) break;
       if (_rowHasFocusableContent(row)) {
         firstFocusableVisibleIndex = i;
         break;
@@ -279,6 +323,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       controller: _scrollController,
       padding: EdgeInsets.only(left: rowLeftInset, bottom: 32),
       itemCount: rows.length,
+      cacheExtent: 600.0,
       itemBuilder: (context, index) {
         final row = rows[index];
         if (!row.isLoading && !_rowHasFocusableContent(row)) {
@@ -286,36 +331,111 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
         }
         final isFirstFocusableRow = index == firstFocusableVisibleIndex;
         final firstNode = isFirstFocusableRow ? _initialFocusNode : null;
+        Widget rowWidget;
         if (row.isGenreRow) {
-          return _buildGenreRow(
+          rowWidget = _buildGenreRow(
             row,
+            index,
+            isFirstVisibleRow: isFirstFocusableRow,
+            autofocusFirst: isFirstFocusableRow,
+            firstFocusNode: firstNode,
+          );
+        } else if (row.isNetworkRow) {
+          rowWidget = _buildNetworkRow(
+            row,
+            index,
+            isFirstVisibleRow: isFirstFocusableRow,
+            autofocusFirst: isFirstFocusableRow,
+            firstFocusNode: firstNode,
+          );
+        } else if (row.isStudioRow) {
+          rowWidget = _buildStudioRow(
+            row,
+            index,
+            isFirstVisibleRow: isFirstFocusableRow,
+            autofocusFirst: isFirstFocusableRow,
+            firstFocusNode: firstNode,
+          );
+        } else {
+          rowWidget = _buildMediaRow(
+            row,
+            index,
             isFirstVisibleRow: isFirstFocusableRow,
             autofocusFirst: isFirstFocusableRow,
             firstFocusNode: firstNode,
           );
         }
-        if (row.isNetworkRow) {
-          return _buildNetworkRow(
-            row,
-            isFirstVisibleRow: isFirstFocusableRow,
-            autofocusFirst: isFirstFocusableRow,
-            firstFocusNode: firstNode,
-          );
-        }
-        if (row.isStudioRow) {
-          return _buildStudioRow(
-            row,
-            isFirstVisibleRow: isFirstFocusableRow,
-            autofocusFirst: isFirstFocusableRow,
-            firstFocusNode: firstNode,
-          );
-        }
-        return _buildMediaRow(
-          row,
-          index,
-          isFirstVisibleRow: isFirstFocusableRow,
-          autofocusFirst: isFirstFocusableRow,
-          firstFocusNode: firstNode,
+        return Builder(
+          builder: (rowContext) => Focus(
+            skipTraversal: true,
+            onFocusChange: (hasFocus) {
+              if (hasFocus) {
+                Scrollable.ensureVisible(
+                  rowContext,
+                  alignment: 0.0,
+                  duration: const Duration(milliseconds: 240),
+                  curve: Curves.easeInOut,
+                );
+              }
+            },
+            child: rowWidget,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildRowContainer({
+    required String title,
+    required double rowHeight,
+    required bool isLoading,
+    required bool hasItems,
+    required Widget child,
+  }) {
+    final l10n = AppLocalizations.of(context);
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
+    final showControls = hasItems && PlatformDetection.useDesktopUi;
+
+    return HorizontalScrollSection(
+      title: title,
+      titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
+        color: AppColorScheme.onSurface,
+        fontWeight: FontWeight.w700,
+      ),
+      headerPadding: EdgeInsets.fromLTRB(
+        16 * desktopScale,
+        16 * desktopScale,
+        8 * desktopScale,
+        8 * desktopScale,
+      ),
+      contentSpacing: 0,
+      showControls: showControls,
+      builder: (context, controller) {
+        return SizedBox(
+          height: (rowHeight + 10) * desktopScale,
+          child: isLoading
+              ? const Center(
+                  child: SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                )
+              : hasItems
+                  ? child
+                  : Center(
+                      child: Text(
+                        l10n.noItems,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurface
+                                  .withAlpha(128),
+                            ),
+                      ),
+                    ),
         );
       },
     );
@@ -333,49 +453,12 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       Color(GetIt.instance<UserPreferences>().get(UserPreferences.focusColor).colorValue);
     final cardExpansion =
       GetIt.instance<UserPreferences>().get(UserPreferences.cardFocusExpansion);
-    final children = <Widget>[];
-    for (var i = 0; i < row.items.length; i++) {
-      final item = row.items[i];
-      children.add(MediaCard(
-        title: item.displayTitle,
-        subtitle: _yearFromItem(item),
-        imageUrl: item.posterPath != null
-            ? '$_tmdbPosterBase${item.posterPath}'
-            : null,
-        width: 130,
-        aspectRatio: 2 / 3,
-        seerrMediaType: item.mediaType,
-        seerrStatus: item.mediaInfo?.status,
-        focusColor: focusColor,
-        cardFocusExpansion: cardExpansion,
-        suppressFocusGlow: suppressFocusGlow,
-        autofocus: autofocusFirst && i == 0,
-        focusNode: (autofocusFirst && i == 0) ? firstFocusNode : null,
-        onTap: () => _onItemTap(item),
-        onFocus: () {
-          _onItemSelected(item);
-          if (isFirstVisibleRow) {
-            _setFirstRowFocused(true);
-            _restoreNavbarToNormalPosition();
-          }
-        },
-        onFocusLost: () {
-          if (isFirstVisibleRow) {
-            _setFirstRowFocused(false);
-          }
-        },
-        onHoverStart: () => _onItemSelected(item),
-      ));
-    }
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
 
-    if (row.isLoading) {
-      children.add(const SizedBox(
-        width: 130,
-        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-      ));
-    }
-
-    return NotificationListener<ScrollNotification>(
+    final focusKey = _getRowKey(rowIndex);
+    final child = NotificationListener<ScrollNotification>(
       onNotification: (notification) {
         if (notification is ScrollUpdateNotification &&
             notification.metrics.extentAfter < 300 &&
@@ -385,150 +468,324 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
         }
         return false;
       },
-      child: LibraryRow(
-        title: row.title,
-        rowHeight: 237,
-        children: children,
+      child: LockedFocusRow<SeerrDiscoverItem>(
+        key: focusKey,
+        items: row.items,
+        hubKey: 'seerr_discover_media_${rowIndex}_${row.title}',
+        itemExtent: 130 * desktopScale,
+        itemSpacing: 12 * desktopScale,
+        height: 260 * desktopScale,
+        clipBehavior: Clip.none,
+        padding: EdgeInsets.fromLTRB(
+          20 * desktopScale,
+          5 * desktopScale,
+          20 * desktopScale,
+          5 * desktopScale,
+        ),
+        onLeftEdge: _onRowLeftEdge,
+        onVerticalNavigation: (isUp) => _onRowVerticalNavigation(rowIndex, isUp),
+        onTap: (index, item) => _onItemTap(item),
+        onIndexChanged: (index, item) {
+          _onItemSelected(item);
+          if (rowIndex == 0) {
+            _setFirstRowFocused(true);
+            _restoreNavbarToNormalPosition();
+          }
+        },
+        onFocusChange: (has) {
+          if (rowIndex == 0) {
+            _setFirstRowFocused(has);
+          }
+        },
+        autofocus: autofocusFirst,
+        focusNode: autofocusFirst ? firstFocusNode : null,
+        itemBuilder: (context, item, index, isFocused) {
+          return MediaCard(
+            title: item.displayTitle,
+            subtitle: _yearFromItem(item),
+            imageUrl: item.posterPath != null
+                ? '$_tmdbPosterBase${item.posterPath}'
+                : null,
+            width: 130,
+            aspectRatio: 2 / 3,
+            seerrMediaType: item.mediaType,
+            seerrStatus: item.mediaInfo?.status,
+            focusColor: focusColor,
+            cardFocusExpansion: cardExpansion,
+            suppressFocusGlow: suppressFocusGlow,
+            externalIsFocused: isFocused,
+            onTap: () => _onItemTap(item),
+            onFocus: () {
+              _onItemSelected(item);
+              if (rowIndex == 0) {
+                _setFirstRowFocused(true);
+                _restoreNavbarToNormalPosition();
+              }
+            },
+          );
+        },
       ),
+    );
+
+    return _buildRowContainer(
+      title: row.title,
+      rowHeight: 260,
+      isLoading: row.isLoading && row.items.isEmpty,
+      hasItems: row.items.isNotEmpty,
+      child: child,
     );
   }
 
   Widget _buildGenreRow(
-    SeerrDiscoverRow row, {
+    SeerrDiscoverRow row,
+    int rowIndex, {
     bool isFirstVisibleRow = false,
     bool autofocusFirst = false,
     FocusNode? firstFocusNode,
   }) {
     final mediaType = row.type == SeerrRowType.movieGenres ? 'movie' : 'tv';
-    final children = row.genres.indexed.map((entry) {
-      final index = entry.$1;
-      final genre = entry.$2;
-      final backdrop = genre.backdrops.isNotEmpty
-          ? '$_tmdbBackdropBase${genre.backdrops.first}'
-          : null;
-      return _GenreCard(
-        name: genre.name,
-        imageUrl: backdrop,
-        autofocus: autofocusFirst && index == 0,
-        focusNode: (autofocusFirst && index == 0) ? firstFocusNode : null,
-        onFocused: isFirstVisibleRow
-            ? () {
-                _setFirstRowFocused(true);
-                _restoreNavbarToNormalPosition();
-              }
-            : null,
-        onFocusLost: isFirstVisibleRow
-            ? () => _setFirstRowFocused(false)
-            : null,
-        onTap: () {
-          final uri = Uri(
-            path: Destinations.seerrBrowse,
-            queryParameters: {
-              'filterId': genre.id.toString(),
-              'filterName': genre.name,
-              'mediaType': mediaType,
-              'filterType': 'genre',
-            },
-          );
-          context.push(uri.toString());
-        },
-      );
-    }).toList();
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
 
-    return LibraryRow(
+    final focusKey = _getRowKey(rowIndex);
+    final child = LockedFocusRow<SeerrGenre>(
+      key: focusKey,
+      items: row.genres,
+      hubKey: 'seerr_discover_genres_${rowIndex}_${row.title}',
+      itemExtent: 180 * desktopScale,
+      itemSpacing: 12 * desktopScale,
+      height: 90 * desktopScale,
+      clipBehavior: Clip.none,
+      padding: EdgeInsets.fromLTRB(
+        20 * desktopScale,
+        5 * desktopScale,
+        20 * desktopScale,
+        5 * desktopScale,
+      ),
+      onLeftEdge: _onRowLeftEdge,
+      onVerticalNavigation: (isUp) => _onRowVerticalNavigation(rowIndex, isUp),
+      onTap: (index, genre) {
+        final uri = Uri(
+          path: Destinations.seerrBrowse,
+          queryParameters: {
+            'filterId': genre.id.toString(),
+            'filterName': genre.name,
+            'mediaType': mediaType,
+            'filterType': 'genre',
+          },
+        );
+        context.push(uri.toString());
+      },
+      onIndexChanged: (index, genre) {
+        if (rowIndex == 0) {
+          _setFirstRowFocused(true);
+          _restoreNavbarToNormalPosition();
+        }
+      },
+      onFocusChange: (has) {
+        if (rowIndex == 0) {
+          _setFirstRowFocused(has);
+        }
+      },
+      autofocus: autofocusFirst,
+      focusNode: autofocusFirst ? firstFocusNode : null,
+      itemBuilder: (context, genre, index, isFocused) {
+        final backdrop = genre.backdrops.isNotEmpty
+            ? '$_tmdbBackdropBase${genre.backdrops.first}'
+            : null;
+        return _GenreCard(
+          name: genre.name,
+          imageUrl: backdrop,
+          externalIsFocused: isFocused,
+          onTap: () {
+            final uri = Uri(
+              path: Destinations.seerrBrowse,
+              queryParameters: {
+                'filterId': genre.id.toString(),
+                'filterName': genre.name,
+                'mediaType': mediaType,
+                'filterType': 'genre',
+              },
+            );
+            context.push(uri.toString());
+          },
+        );
+      },
+    );
+
+    return _buildRowContainer(
       title: row.title,
-      rowHeight: 100,
-      children: children,
+      rowHeight: 90,
+      isLoading: row.isLoading && row.genres.isEmpty,
+      hasItems: row.genres.isNotEmpty,
+      child: child,
     );
   }
 
   Widget _buildNetworkRow(
-    SeerrDiscoverRow row, {
+    SeerrDiscoverRow row,
+    int rowIndex, {
     bool isFirstVisibleRow = false,
     bool autofocusFirst = false,
     FocusNode? firstFocusNode,
   }) {
-    final children = row.networks.indexed.map((entry) {
-      final index = entry.$1;
-      final network = entry.$2;
-      return _LogoCard(
-        name: network.name,
-        logoUrl: network.logoPath,
-        autofocus: autofocusFirst && index == 0,
-        focusNode: (autofocusFirst && index == 0) ? firstFocusNode : null,
-        onFocused: isFirstVisibleRow
-            ? () {
-                _setFirstRowFocused(true);
-                _restoreNavbarToNormalPosition();
-              }
-            : null,
-        onFocusLost: isFirstVisibleRow
-            ? () => _setFirstRowFocused(false)
-            : null,
-        onTap: () {
-          final uri = Uri(
-            path: Destinations.seerrBrowse,
-            queryParameters: {
-              'filterId': network.id.toString(),
-              'filterName': network.name,
-              'mediaType': 'tv',
-              'filterType': 'network',
-            },
-          );
-          context.push(uri.toString());
-        },
-      );
-    }).toList();
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
 
-    return LibraryRow(
+    final focusKey = _getRowKey(rowIndex);
+    final child = LockedFocusRow<SeerrNetwork>(
+      key: focusKey,
+      items: row.networks,
+      hubKey: 'seerr_discover_networks_${rowIndex}_${row.title}',
+      itemExtent: 180 * desktopScale,
+      itemSpacing: 12 * desktopScale,
+      height: 90 * desktopScale,
+      clipBehavior: Clip.none,
+      padding: EdgeInsets.fromLTRB(
+        20 * desktopScale,
+        5 * desktopScale,
+        20 * desktopScale,
+        5 * desktopScale,
+      ),
+      onLeftEdge: _onRowLeftEdge,
+      onVerticalNavigation: (isUp) => _onRowVerticalNavigation(rowIndex, isUp),
+      onTap: (index, network) {
+        final uri = Uri(
+          path: Destinations.seerrBrowse,
+          queryParameters: {
+            'filterId': network.id.toString(),
+            'filterName': network.name,
+            'mediaType': 'tv',
+            'filterType': 'network',
+          },
+        );
+        context.push(uri.toString());
+      },
+      onIndexChanged: (index, network) {
+        if (rowIndex == 0) {
+          _setFirstRowFocused(true);
+          _restoreNavbarToNormalPosition();
+        }
+      },
+      onFocusChange: (has) {
+        if (rowIndex == 0) {
+          _setFirstRowFocused(has);
+        }
+      },
+      autofocus: autofocusFirst,
+      focusNode: autofocusFirst ? firstFocusNode : null,
+      itemBuilder: (context, network, index, isFocused) {
+        return _LogoCard(
+          name: network.name,
+          logoUrl: network.logoPath,
+          externalIsFocused: isFocused,
+          onTap: () {
+            final uri = Uri(
+              path: Destinations.seerrBrowse,
+              queryParameters: {
+                'filterId': network.id.toString(),
+                'filterName': network.name,
+                'mediaType': 'tv',
+                'filterType': 'network',
+              },
+            );
+            context.push(uri.toString());
+          },
+        );
+      },
+    );
+
+    return _buildRowContainer(
       title: row.title,
-      rowHeight: 100,
-      children: children,
+      rowHeight: 90,
+      isLoading: row.isLoading && row.networks.isEmpty,
+      hasItems: row.networks.isNotEmpty,
+      child: child,
     );
   }
 
   Widget _buildStudioRow(
-    SeerrDiscoverRow row, {
+    SeerrDiscoverRow row,
+    int rowIndex, {
     bool isFirstVisibleRow = false,
     bool autofocusFirst = false,
     FocusNode? firstFocusNode,
   }) {
-    final children = row.studios.indexed.map((entry) {
-      final index = entry.$1;
-      final studio = entry.$2;
-      return _LogoCard(
-        name: studio.name,
-        logoUrl: studio.logoPath,
-        autofocus: autofocusFirst && index == 0,
-        focusNode: (autofocusFirst && index == 0) ? firstFocusNode : null,
-        onFocused: isFirstVisibleRow
-            ? () {
-                _setFirstRowFocused(true);
-                _restoreNavbarToNormalPosition();
-              }
-            : null,
-        onFocusLost: isFirstVisibleRow
-            ? () => _setFirstRowFocused(false)
-            : null,
-        onTap: () {
-          final uri = Uri(
-            path: Destinations.seerrBrowse,
-            queryParameters: {
-              'filterId': studio.id.toString(),
-              'filterName': studio.name,
-              'mediaType': 'movie',
-              'filterType': 'studio',
-            },
-          );
-          context.push(uri.toString());
-        },
-      );
-    }).toList();
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
 
-    return LibraryRow(
+    final focusKey = _getRowKey(rowIndex);
+    final child = LockedFocusRow<SeerrStudio>(
+      key: focusKey,
+      items: row.studios,
+      hubKey: 'seerr_discover_studios_${rowIndex}_${row.title}',
+      itemExtent: 180 * desktopScale,
+      itemSpacing: 12 * desktopScale,
+      height: 90 * desktopScale,
+      clipBehavior: Clip.none,
+      padding: EdgeInsets.fromLTRB(
+        20 * desktopScale,
+        5 * desktopScale,
+        20 * desktopScale,
+        5 * desktopScale,
+      ),
+      onLeftEdge: _onRowLeftEdge,
+      onVerticalNavigation: (isUp) => _onRowVerticalNavigation(rowIndex, isUp),
+      onTap: (index, studio) {
+        final uri = Uri(
+          path: Destinations.seerrBrowse,
+          queryParameters: {
+            'filterId': studio.id.toString(),
+            'filterName': studio.name,
+            'mediaType': 'movie',
+            'filterType': 'studio',
+          },
+        );
+        context.push(uri.toString());
+      },
+      onIndexChanged: (index, studio) {
+        if (rowIndex == 0) {
+          _setFirstRowFocused(true);
+          _restoreNavbarToNormalPosition();
+        }
+      },
+      onFocusChange: (has) {
+        if (rowIndex == 0) {
+          _setFirstRowFocused(has);
+        }
+      },
+      autofocus: autofocusFirst,
+      focusNode: autofocusFirst ? firstFocusNode : null,
+      itemBuilder: (context, studio, index, isFocused) {
+        return _LogoCard(
+          name: studio.name,
+          logoUrl: studio.logoPath,
+          externalIsFocused: isFocused,
+          onTap: () {
+            final uri = Uri(
+              path: Destinations.seerrBrowse,
+              queryParameters: {
+                'filterId': studio.id.toString(),
+                'filterName': studio.name,
+                'mediaType': 'movie',
+                'filterType': 'studio',
+              },
+            );
+            context.push(uri.toString());
+          },
+        );
+      },
+    );
+
+    return _buildRowContainer(
       title: row.title,
-      rowHeight: 100,
-      children: children,
+      rowHeight: 90,
+      isLoading: row.isLoading && row.studios.isEmpty,
+      hasItems: row.studios.isNotEmpty,
+      child: child,
     );
   }
 
@@ -583,25 +840,41 @@ class _InfoPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (item == null) return const SizedBox(height: 140);
+    if (item == null) return const SizedBox(height: 120);
 
     final theme = Theme.of(context);
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final shadows = [
       Shadow(
         blurRadius: 4,
-        color: AppColorScheme.scrim.withValues(alpha: 0.54),
+        color: isNeon ? Colors.black : AppColorScheme.scrim.withValues(alpha: 0.54),
       ),
+      if (isNeon)
+        const Shadow(
+          blurRadius: 10,
+          color: Colors.black,
+        ),
     ];
     final year = _SeerrDiscoverScreenState._yearFromItem(item!);
     final rating = item!.voteAverage;
     final l10n = AppLocalizations.of(context);
     final mediaType = item!.mediaType == 'tv' ? l10n.series : l10n.movie;
 
+    final secondaryColor = isNeon
+        ? AppColorScheme.onSurface
+        : AppColorScheme.onSurface.withValues(alpha: 0.7);
+    final tertiaryColor = isNeon
+        ? AppColorScheme.onSurface
+        : AppColorScheme.onSurface.withValues(alpha: 0.54);
+    final overviewColor = isNeon
+        ? AppColorScheme.onSurface
+        : AppColorScheme.onSurface.withValues(alpha: 0.8);
+
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 300),
       child: Padding(
         key: ValueKey(item!.id),
-        padding: EdgeInsets.fromLTRB(leftInset, topInset, 48, 8),
+        padding: EdgeInsets.fromLTRB(leftInset, topInset, 48, 2),
         child: SizedBox(
           width: double.infinity,
           child: Column(
@@ -618,13 +891,13 @@ class _InfoPanel extends StatelessWidget {
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
-              const SizedBox(height: 4),
+              const SizedBox(height: 2),
               Row(
                 children: [
                   if (year != null)
                     Text(year,
                         style: theme.textTheme.bodyMedium?.copyWith(
-                          color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                          color: secondaryColor,
                           shadows: shadows,
                         )),
                   if (year != null && rating != null)
@@ -638,7 +911,7 @@ class _InfoPanel extends StatelessWidget {
                         Text(
                           rating.toStringAsFixed(1),
                           style: theme.textTheme.bodyMedium?.copyWith(
-                            color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                            color: secondaryColor,
                             shadows: shadows,
                           ),
                         ),
@@ -647,20 +920,21 @@ class _InfoPanel extends StatelessWidget {
                   const SizedBox(width: 12),
                   Text(mediaType,
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: AppColorScheme.onSurface.withValues(alpha: 0.54),
+                        color: tertiaryColor,
                         shadows: shadows,
                       )),
                 ],
               ),
-              const SizedBox(height: 6),
+              const SizedBox(height: 4),
               SizedBox(
-                height: (theme.textTheme.bodySmall?.fontSize ?? 12) * 1.4 * 3,
+                height: (theme.textTheme.bodySmall?.fontSize ?? 12) * 1.4 * 3 + 8.0,
                 child: item!.overview != null && item!.overview!.isNotEmpty
                     ? Text(
                         item!.overview!,
                         style: theme.textTheme.bodySmall?.copyWith(
-                          color: AppColorScheme.onSurface.withValues(alpha: 0.8),
+                          color: overviewColor,
                           shadows: shadows,
+                          height: 1.4,
                         ),
                         maxLines: 3,
                         overflow: TextOverflow.ellipsis,
@@ -679,19 +953,13 @@ class _GenreCard extends StatefulWidget {
   final String name;
   final String? imageUrl;
   final VoidCallback? onTap;
-  final VoidCallback? onFocused;
-  final VoidCallback? onFocusLost;
-  final bool autofocus;
-  final FocusNode? focusNode;
+  final bool? externalIsFocused;
 
   const _GenreCard({
     required this.name,
     this.imageUrl,
     this.onTap,
-    this.onFocused,
-    this.onFocusLost,
-    this.autofocus = false,
-    this.focusNode,
+    this.externalIsFocused,
   });
 
   @override
@@ -704,9 +972,92 @@ class _GenreCardState extends State<_GenreCard> with FocusStateMixin {
   Widget build(BuildContext context) {
     final focusColor =
         Color(GetIt.instance<UserPreferences>().get(UserPreferences.focusColor).colorValue);
+    final externallyDriven = widget.externalIsFocused != null;
+    final effectiveFocused = widget.externalIsFocused ?? (focused || hovered);
+
+    final inner = GestureDetector(
+      onTap: widget.onTap,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setHovered(true),
+        onExit: (_) => setHovered(false),
+        child: AnimatedScale(
+          scale: effectiveFocused ? 1.05 : 1.0,
+          duration: const Duration(milliseconds: 150),
+          child: SizedBox(
+            width: 180,
+            height: 90,
+            child: ClipRRect(
+              borderRadius: AppRadius.circular(8),
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  if (widget.imageUrl != null)
+                    CachedNetworkImage(
+                      imageUrl: widget.imageUrl!,
+                      fit: BoxFit.cover,
+                      errorWidget: (_, _, _) => Container(
+                        color: AppColorScheme.surfaceVariant,
+                      ),
+                    )
+                  else
+                    Container(color: AppColorScheme.surfaceVariant),
+                  Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          AppColorScheme.scrim.withValues(alpha: 0),
+                          AppColorScheme.scrim.withValues(alpha: 0.73),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    bottom: 8,
+                    left: 8,
+                    right: 8,
+                    child: Text(
+                      widget.name,
+                      style: TextStyle(
+                        color: AppColorScheme.onSurface,
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                        shadows: [
+                          Shadow(
+                            blurRadius: 4,
+                            color: AppColorScheme.scrim,
+                          ),
+                        ],
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (effectiveFocused)
+                    Container(
+                      decoration: BoxDecoration(
+                        border: Border.fromBorderSide(
+                          ThemeRegistry.active.borders.focusBorder.copyWith(
+                            color: focusColor,
+                            width: 2,
+                          ),
+                        ),
+                        borderRadius: AppRadius.circular(8),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (externallyDriven) return inner;
+
     return Focus(
-      focusNode: widget.focusNode,
-      autofocus: widget.autofocus,
       onKeyEvent: (_, event) {
         if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
         if (event is KeyDownEvent) {
@@ -714,93 +1065,8 @@ class _GenreCardState extends State<_GenreCard> with FocusStateMixin {
         }
         return KeyEventResult.handled;
       },
-      onFocusChange: (focused) {
-        setFocused(focused);
-        if (focused) {
-          widget.onFocused?.call();
-        } else {
-          widget.onFocusLost?.call();
-        }
-      },
-      child: GestureDetector(
-        onTap: widget.onTap,
-        child: MouseRegion(
-          cursor: SystemMouseCursors.click,
-          onEnter: (_) => setHovered(true),
-          onExit: (_) => setHovered(false),
-          child: AnimatedScale(
-            scale: showFocusBorder ? 1.05 : 1.0,
-            duration: const Duration(milliseconds: 150),
-            child: SizedBox(
-              width: 180,
-              height: 90,
-              child: ClipRRect(
-                borderRadius: AppRadius.circular(8),
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    if (widget.imageUrl != null)
-                      CachedNetworkImage(
-                        imageUrl: widget.imageUrl!,
-                        fit: BoxFit.cover,
-                        errorWidget: (_, _, _) => Container(
-                          color: AppColorScheme.surfaceVariant,
-                        ),
-                      )
-                    else
-                      Container(color: AppColorScheme.surfaceVariant),
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [
-                            AppColorScheme.scrim.withValues(alpha: 0),
-                            AppColorScheme.scrim.withValues(alpha: 0.73),
-                          ],
-                        ),
-                      ),
-                    ),
-                    Positioned(
-                      bottom: 8,
-                      left: 8,
-                      right: 8,
-                      child: Text(
-                        widget.name,
-                        style: TextStyle(
-                          color: AppColorScheme.onSurface,
-                          fontWeight: FontWeight.w600,
-                          fontSize: 14,
-                          shadows: [
-                            Shadow(
-                              blurRadius: 4,
-                              color: AppColorScheme.scrim,
-                            ),
-                          ],
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    if (showFocusBorder)
-                      Container(
-                        decoration: BoxDecoration(
-                          border: Border.fromBorderSide(
-                            ThemeRegistry.active.borders.focusBorder.copyWith(
-                              color: focusColor,
-                              width: 2,
-                            ),
-                          ),
-                          borderRadius: AppRadius.circular(8),
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
+      onFocusChange: setFocused,
+      child: inner,
     );
   }
 }
@@ -809,19 +1075,13 @@ class _LogoCard extends StatefulWidget {
   final String name;
   final String? logoUrl;
   final VoidCallback? onTap;
-  final VoidCallback? onFocused;
-  final VoidCallback? onFocusLost;
-  final bool autofocus;
-  final FocusNode? focusNode;
+  final bool? externalIsFocused;
 
   const _LogoCard({
     required this.name,
     this.logoUrl,
     this.onTap,
-    this.onFocused,
-    this.onFocusLost,
-    this.autofocus = false,
-    this.focusNode,
+    this.externalIsFocused,
   });
 
   @override
@@ -834,9 +1094,71 @@ class _LogoCardState extends State<_LogoCard> with FocusStateMixin {
   Widget build(BuildContext context) {
     final focusColor =
         Color(GetIt.instance<UserPreferences>().get(UserPreferences.focusColor).colorValue);
+    final externallyDriven = widget.externalIsFocused != null;
+    final effectiveFocused = widget.externalIsFocused ?? (focused || hovered);
+
+    final inner = GestureDetector(
+      onTap: widget.onTap,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setHovered(true),
+        onExit: (_) => setHovered(false),
+        child: AnimatedScale(
+          scale: effectiveFocused ? 1.05 : 1.0,
+          duration: const Duration(milliseconds: 150),
+          child: SizedBox(
+            width: 180,
+            height: 90,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: AppColorScheme.surface,
+                borderRadius: AppRadius.circular(8),
+                border: effectiveFocused
+                    ? Border.fromBorderSide(
+                        ThemeRegistry.active.borders.focusBorder.copyWith(
+                          color: focusColor,
+                          width: 2,
+                        ),
+                      )
+                    : null,
+              ),
+              child: widget.logoUrl != null
+                  ? Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: CachedNetworkImage(
+                        imageUrl: widget.logoUrl!,
+                        fit: BoxFit.contain,
+                        errorWidget: (_, _, _) => Center(
+                          child: Text(
+                            widget.name,
+                            style: TextStyle(
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                              fontSize: 13,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ),
+                    )
+                  : Center(
+                      child: Text(
+                        widget.name,
+                        style: TextStyle(
+                          color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                          fontSize: 13,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (externallyDriven) return inner;
+
     return Focus(
-      focusNode: widget.focusNode,
-      autofocus: widget.autofocus,
       onKeyEvent: (_, event) {
         if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
         if (event is KeyDownEvent) {
@@ -844,72 +1166,8 @@ class _LogoCardState extends State<_LogoCard> with FocusStateMixin {
         }
         return KeyEventResult.handled;
       },
-      onFocusChange: (focused) {
-        setFocused(focused);
-        if (focused) {
-          widget.onFocused?.call();
-        } else {
-          widget.onFocusLost?.call();
-        }
-      },
-      child: GestureDetector(
-        onTap: widget.onTap,
-        child: MouseRegion(
-          cursor: SystemMouseCursors.click,
-          onEnter: (_) => setHovered(true),
-          onExit: (_) => setHovered(false),
-          child: AnimatedScale(
-            scale: showFocusBorder ? 1.05 : 1.0,
-            duration: const Duration(milliseconds: 150),
-            child: SizedBox(
-              width: 180,
-              height: 90,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  color: AppColorScheme.surface,
-                  borderRadius: AppRadius.circular(8),
-                  border: showFocusBorder
-                      ? Border.fromBorderSide(
-                          ThemeRegistry.active.borders.focusBorder.copyWith(
-                            color: focusColor,
-                            width: 2,
-                          ),
-                        )
-                      : null,
-                ),
-                child: widget.logoUrl != null
-                    ? Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: CachedNetworkImage(
-                          imageUrl: widget.logoUrl!,
-                          fit: BoxFit.contain,
-                          errorWidget: (_, _, _) => Center(
-                            child: Text(
-                              widget.name,
-                              style: TextStyle(
-                                color: AppColorScheme.onSurface.withValues(alpha: 0.7),
-                                fontSize: 13,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                          ),
-                        ),
-                      )
-                    : Center(
-                        child: Text(
-                          widget.name,
-                          style: TextStyle(
-                            color: AppColorScheme.onSurface.withValues(alpha: 0.7),
-                            fontSize: 13,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-              ),
-            ),
-          ),
-        ),
-      ),
+      onFocusChange: setFocused,
+      child: inner,
     );
   }
 }

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -49,9 +50,14 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
   bool _initialFocusResolved = false;
   bool _isFirstRowFocused = false;
   final Map<int, GlobalKey<LockedFocusRowState>> _rowKeys = {};
+  final Map<int, ScrollController> _rowScrollControllers = {};
 
   GlobalKey<LockedFocusRowState> _getRowKey(int index) {
     return _rowKeys.putIfAbsent(index, () => GlobalKey<LockedFocusRowState>());
+  }
+
+  ScrollController _getRowScroll(int index) {
+    return _rowScrollControllers.putIfAbsent(index, () => ScrollController());
   }
 
   void _onRowLeftEdge() {
@@ -114,6 +120,9 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     _selectionDebounce?.cancel();
     _backdropDebounce?.cancel();
     _scrollController.dispose();
+    for (final controller in _rowScrollControllers.values) {
+      controller.dispose();
+    }
     _viewModel?.removeListener(_onChanged);
     _prefs.removeListener(_onPrefsChanged);
     _initialFocusNode.removeListener(_onInitialFocusNodeChanged);
@@ -323,7 +332,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       controller: _scrollController,
       padding: EdgeInsets.only(left: rowLeftInset, bottom: 32),
       itemCount: rows.length,
-      cacheExtent: 600.0,
+      scrollCacheExtent: const ScrollCacheExtent.pixels(600.0),
       itemBuilder: (context, index) {
         final row = rows[index];
         if (!row.isLoading && !_rowHasFocusableContent(row)) {
@@ -390,6 +399,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     required double rowHeight,
     required bool isLoading,
     required bool hasItems,
+    required ScrollController scrollController,
     required Widget child,
   }) {
     final l10n = AppLocalizations.of(context);
@@ -400,6 +410,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
 
     return HorizontalScrollSection(
       title: title,
+      scrollController: scrollController,
       titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
         color: AppColorScheme.onSurface,
         fontWeight: FontWeight.w700,
@@ -472,7 +483,8 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
         key: focusKey,
         items: row.items,
         hubKey: 'seerr_discover_media_${rowIndex}_${row.title}',
-        itemExtent: 130 * desktopScale,
+        controller: _getRowScroll(rowIndex),
+        itemExtent: 130,
         itemSpacing: 12 * desktopScale,
         height: 260 * desktopScale,
         clipBehavior: Clip.none,
@@ -515,13 +527,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
             suppressFocusGlow: suppressFocusGlow,
             externalIsFocused: isFocused,
             onTap: () => _onItemTap(item),
-            onFocus: () {
-              _onItemSelected(item);
-              if (rowIndex == 0) {
-                _setFirstRowFocused(true);
-                _restoreNavbarToNormalPosition();
-              }
-            },
+            onHoverStart: () => _onItemSelected(item),
           );
         },
       ),
@@ -532,6 +538,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       rowHeight: 260,
       isLoading: row.isLoading && row.items.isEmpty,
       hasItems: row.items.isNotEmpty,
+      scrollController: _getRowScroll(rowIndex),
       child: child,
     );
   }
@@ -553,7 +560,8 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       key: focusKey,
       items: row.genres,
       hubKey: 'seerr_discover_genres_${rowIndex}_${row.title}',
-      itemExtent: 180 * desktopScale,
+      controller: _getRowScroll(rowIndex),
+      itemExtent: 180,
       itemSpacing: 12 * desktopScale,
       height: 90 * desktopScale,
       clipBehavior: Clip.none,
@@ -619,6 +627,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       rowHeight: 90,
       isLoading: row.isLoading && row.genres.isEmpty,
       hasItems: row.genres.isNotEmpty,
+      scrollController: _getRowScroll(rowIndex),
       child: child,
     );
   }
@@ -639,7 +648,8 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       key: focusKey,
       items: row.networks,
       hubKey: 'seerr_discover_networks_${rowIndex}_${row.title}',
-      itemExtent: 180 * desktopScale,
+      controller: _getRowScroll(rowIndex),
+      itemExtent: 180,
       itemSpacing: 12 * desktopScale,
       height: 90 * desktopScale,
       clipBehavior: Clip.none,
@@ -702,6 +712,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       rowHeight: 90,
       isLoading: row.isLoading && row.networks.isEmpty,
       hasItems: row.networks.isNotEmpty,
+      scrollController: _getRowScroll(rowIndex),
       child: child,
     );
   }
@@ -722,7 +733,8 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       key: focusKey,
       items: row.studios,
       hubKey: 'seerr_discover_studios_${rowIndex}_${row.title}',
-      itemExtent: 180 * desktopScale,
+      controller: _getRowScroll(rowIndex),
+      itemExtent: 180,
       itemSpacing: 12 * desktopScale,
       height: 90 * desktopScale,
       clipBehavior: Clip.none,
@@ -785,6 +797,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       rowHeight: 90,
       isLoading: row.isLoading && row.studios.isEmpty,
       hasItems: row.studios.isNotEmpty,
+      scrollController: _getRowScroll(rowIndex),
       child: child,
     );
   }


### PR DESCRIPTION
# Pull Request

## Summary
This PR implements unified spacing alignments, readability refinements, and D-pad focus traversal protection for the Seerr Discover screen under TV interfaces.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #703 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Standardized row spacing under _buildRowContainer, enforcing a consistent left-inset margin to prevent focused card border clipping.
- Increased overview description box height by +8.0 pixels to avoid clipping text descenders on the third line.
- Replaced LibraryRow in Seerr Discover screen with LockedFocusRow for proper D-pad navigation and left/right edge capping.
- Added custom D-pad vertical intercept callbacks on LockedFocusRow to explicitly snap focus to index 0 of target rows.
- Capped vertical focus at the top row for left sidebar users, preventing focus from leaking off-screen.
- Bounded card focus states to the row context using externalIsFocused on _GenreCard and _LogoCard components.
- Repositioned top description banner (_InfoPanel) higher, adjusting top insets dynamically for sidebar vs top navbar.
- Added Neon Pulse high-contrast double dropshadow text effect and height: 1.4 spacing on overview text.
- Removed unused imports and cleaned constructor parameters to resolve warnings.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Build and visit the Seerr discovery page
2. Test navigation/margins with top navbar and sidebar active.
3. Ensure there is no weird clipping.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-03_02-31-12" src="https://github.com/user-attachments/assets/6c17afd1-862c-49f6-967c-db3aead27aaf" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-03_02-26-56" src="https://github.com/user-attachments/assets/0b893c30-4949-4e0c-9f64-448cfbe8c69d" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-03_02-27-20" src="https://github.com/user-attachments/assets/e61a8053-0867-4608-8bbe-1dadac2e2b06" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
