### PR TITLE
feat(audiobook): refine audiobook UI

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7803,7 +7803,7 @@
   "audiobookQueue": "Queue",
   "audiobookTimeline": "Timeline",
   "audiobookTimelineEmpty": "Timeline is empty",
-  "audiobookWholeBook": "Whole book",
+  "audiobookWholeBook": "Whole Book",
   "audiobookWholeBookProgress": "{percent}% · {time} left",
   "@audiobookWholeBookProgress": {
     "placeholders": {"percent": {"type": "String"}, "time": {"type": "String"}}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7804,10 +7804,6 @@
   "audiobookTimeline": "Timeline",
   "audiobookTimelineEmpty": "Timeline is empty",
   "audiobookWholeBook": "Whole Book",
-  "audiobookWholeBookProgress": "{percent}% · {time} left",
-  "@audiobookWholeBookProgress": {
-    "placeholders": {"percent": {"type": "String"}, "time": {"type": "String"}}
-  },
   "audiobookFocusedTimeline": "Focused Timeline",
   "audiobookExportBookmarks": "Export Bookmarks",
   "audiobookExportNotes": "Export Notes",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15121,14 +15121,8 @@ abstract class AppLocalizations {
   /// No description provided for @audiobookWholeBook.
   ///
   /// In en, this message translates to:
-  /// **'Whole book'**
+  /// **'Whole Book'**
   String get audiobookWholeBook;
-
-  /// No description provided for @audiobookWholeBookProgress.
-  ///
-  /// In en, this message translates to:
-  /// **'{percent}% · {time} left'**
-  String audiobookWholeBookProgress(String percent, String time);
 
   /// No description provided for @audiobookFocusedTimeline.
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -8475,12 +8475,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -8421,12 +8421,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8502,12 +8502,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8547,12 +8547,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -8463,12 +8463,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8597,12 +8597,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8483,12 +8483,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8496,12 +8496,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8467,12 +8467,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8541,12 +8541,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8593,12 +8593,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8437,12 +8437,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -8459,12 +8459,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8549,12 +8549,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8484,12 +8484,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -8428,12 +8428,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8495,12 +8495,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8604,12 +8604,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8564,12 +8564,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -8363,12 +8363,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -8445,12 +8445,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -8489,12 +8489,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8532,12 +8532,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -8490,12 +8490,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8508,12 +8508,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -8272,12 +8272,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8500,12 +8500,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8515,12 +8515,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -8267,12 +8267,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8501,12 +8501,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8511,12 +8511,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8518,12 +8518,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8565,12 +8565,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8496,12 +8496,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8468,12 +8468,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8498,12 +8498,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -8448,12 +8448,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -8510,12 +8510,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8529,12 +8529,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8513,12 +8513,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8519,12 +8519,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -8455,12 +8455,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8500,12 +8500,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8497,12 +8497,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8528,12 +8528,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -8494,12 +8494,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8479,12 +8479,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8520,12 +8520,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8522,12 +8522,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8520,12 +8520,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -8414,12 +8414,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8547,12 +8547,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -8504,12 +8504,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -8475,12 +8475,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8521,12 +8521,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -8481,12 +8481,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -8224,12 +8224,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8180,12 +8180,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole book';
-
-  @override
-  String audiobookWholeBookProgress(String percent, String time) {
-    return '$percent% · $time left';
-  }
+  String get audiobookWholeBook => 'Whole Book';
 
   @override
   String get audiobookFocusedTimeline => 'Focused Timeline';

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1421,11 +1421,6 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: 0,
   );
 
-  static final audiobookShowRemaining = Preference(
-    key: 'pref_audiobook_show_remaining',
-    defaultValue: false,
-  );
-
   static final audiobookDefaultSpeed = Preference(
     key: 'pref_audiobook_default_speed',
     defaultValue: 1.0,

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:path_provider/path_provider.dart';
-
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -76,7 +74,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   AudiobookDrawerTab _drawerTab = AudiobookDrawerTab.chapters;
   bool _drawerOpen = false;
-  bool _showRemaining = false;
   bool? _localFavorite;
   String? _favoriteItemId;
 
@@ -104,7 +101,6 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   @override
   void initState() {
     super.initState();
-    _showRemaining = _prefs.get(UserPreferences.audiobookShowRemaining);
     _drawerOpen = _dpadNav;
     final savedTab = _prefs.get(UserPreferences.audiobookDrawerTab);
     _drawerTab = AudiobookDrawerTab.values.firstWhere(
@@ -516,27 +512,12 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     }
   }
 
-  String _formatRemaining(Duration position, Duration total) {
-    final remaining = total - position;
-    final speed = _state.playbackSpeed;
-    if (speed <= 0) return '-${formatAudiobookClock(remaining)}';
-    final scaled = Duration(
-      milliseconds: (remaining.inMilliseconds / speed).round(),
-    );
-    return '-${formatAudiobookClock(scaled)}';
-  }
-
   Future<void> _setDrawerTab(AudiobookDrawerTab tab) async {
     setState(() {
       _drawerTab = tab;
       _tvSubIndex = 0;
     });
     await _prefs.set(UserPreferences.audiobookDrawerTab, tab.name);
-  }
-
-  Future<void> _setShowRemaining(bool value) async {
-    setState(() => _showRemaining = value);
-    await _prefs.set(UserPreferences.audiobookShowRemaining, value);
   }
 
   Future<void> _skipBack() async {
@@ -889,11 +870,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                   notes: _notesList,
                   isTvFocused: _dpadNav &&
                       _tvArea == _AudiobookFocusArea.progress,
-                  showRemaining: _showRemaining,
                   onSeek: (d) => _manager.seekTo(d),
-                  onToggleRemaining: () => _setShowRemaining(!_showRemaining),
-                  formatPosition: formatAudiobookClock,
-                  formatRemaining: _formatRemaining,
                 ),
                 const SizedBox(height: AppSpacing.spaceXs),
                 AudiobookBookOverview(

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -70,15 +70,31 @@ class AudiobookBookOverview extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4),
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(l10n.audiobookWholeBook, style: captionStyle),
-              Text(
-                l10n.audiobookWholeBookProgress(
-                  '$percent',
-                  formatAudiobookClock(remaining),
+              Expanded(
+                child: Text(
+                  l10n.percentCompleted(percent),
+                  style: captionStyle,
+                  textAlign: TextAlign.left,
                 ),
-                style: captionStyle,
+              ),
+              Expanded(
+                child: Text(
+                  l10n.audiobookWholeBook,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontStyle: FontStyle.italic,
+                    color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  l10n.audiobookSleepRemaining(formatAudiobookClock(remaining)),
+                  style: captionStyle,
+                  textAlign: TextAlign.right,
+                ),
               ),
             ],
           ),
@@ -236,11 +252,7 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
     required this.bookmarks,
     required this.notes,
     required this.isTvFocused,
-    required this.showRemaining,
     required this.onSeek,
-    required this.onToggleRemaining,
-    required this.formatPosition,
-    required this.formatRemaining,
   });
 
   final Duration position;
@@ -249,11 +261,13 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
   final List<AudiobookBookmark> bookmarks;
   final List<AudiobookNote> notes;
   final bool isTvFocused;
-  final bool showRemaining;
   final ValueChanged<Duration> onSeek;
-  final VoidCallback onToggleRemaining;
-  final String Function(Duration) formatPosition;
-  final String Function(Duration position, Duration total) formatRemaining;
+
+  String _formatFocusedTime(Duration d) {
+    final totalMinutes = d.inMinutes;
+    final seconds = d.inSeconds.remainder(60).abs();
+    return '$totalMinutes:${seconds.toString().padLeft(2, '0')}';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -367,7 +381,10 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(formatPosition(position), style: labelStyle),
+              Text(
+                _formatFocusedTime(Duration(milliseconds: startMs.toInt())),
+                style: labelStyle,
+              ),
               Text(
                 l10n.audiobookFocusedTimeline,
                 style: TextStyle(
@@ -376,18 +393,9 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
                   color: AppColorScheme.onSurface.withValues(alpha: 0.5),
                 ),
               ),
-              InkWell(
-                onTap: onToggleRemaining,
-                borderRadius: BorderRadius.circular(6),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-                  child: Text(
-                    showRemaining
-                        ? formatRemaining(position, duration)
-                        : formatPosition(duration),
-                    style: labelStyle,
-                  ),
-                ),
+              Text(
+                _formatFocusedTime(Duration(milliseconds: endMs.toInt())),
+                style: labelStyle,
               ),
             ],
           ),

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -263,12 +263,6 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
   final bool isTvFocused;
   final ValueChanged<Duration> onSeek;
 
-  String _formatFocusedTime(Duration d) {
-    final totalMinutes = d.inMinutes;
-    final seconds = d.inSeconds.remainder(60).abs();
-    return '$totalMinutes:${seconds.toString().padLeft(2, '0')}';
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -382,7 +376,7 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                _formatFocusedTime(Duration(milliseconds: startMs.toInt())),
+                formatAudiobookClock(Duration(milliseconds: startMs.toInt())),
                 style: labelStyle,
               ),
               Text(
@@ -394,7 +388,7 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
                 ),
               ),
               Text(
-                _formatFocusedTime(Duration(milliseconds: endMs.toInt())),
+                formatAudiobookClock(Duration(milliseconds: endMs.toInt())),
                 style: labelStyle,
               ),
             ],


### PR DESCRIPTION
# Pull Request

## Summary
Refines the Audiobook Player interface's Focused Timeline and Overview layout for better slice window visualization, centered labelling, and clean percentage/remaining time positioning. Reuses existing localized translation strings.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Focused Timeline Window Limits**: Displays the start (`startMs`) and end (`endMs`) times of the zoomed 1-hour timeline slice on the left and right labels of `AudiobookZoomedProgressBar`, formatted in `MM:SS` (or `MMM:SS`).
- **Overview Bar Centering**: Centers the "Whole Book" label horizontally within `AudiobookBookOverview` using a three-column `Expanded` layout, and styles it (italic, low opacity) to match the focused timeline theme.
- **Percentage Completed**: Relocates the percentage completed to the left of the overview bar, labelled as `X% completed` via the existing `percentCompleted` translation key.
- **Remaining Time**: Relocates the remaining duration to the right of the overview bar, formatted via the existing `audiobookSleepRemaining` translation key.
- **Whole Book Capitalization**: Capitalized the 'B' in the `"Whole Book"` key in the default English translation file (`app_en.arb`) to match Focused Timeline.
- **Cleanup**: Cleaned up the unused `showRemaining` state, preference reading, unused helper methods, and unused imports in `audiobook_player_view.dart`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on NVidia Shield
- [ ] Not tested (explain why):

### Test Steps
1. Build and browse audiobook player UI

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Original:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-03_12-47-31" src="https://github.com/user-attachments/assets/10a67028-a8c2-4f81-afe8-2a9e38f5dd24" />

Update:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-03_14-15-49" src="https://github.com/user-attachments/assets/b27e7f43-d50b-4500-9ff3-d9461f6c0957" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
