### PR TITLE
feat(windows): configure custom WebView2 user data folder in AppData and bypass unique origin localStorage restrictions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:audio_session/audio_session.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:get_it/get_it.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:playback_core/playback_core.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -13,6 +15,7 @@ import 'data/services/cast/airplay_command_bridge.dart';
 import 'data/services/download_notification_service.dart';
 import 'data/services/media_server_client_factory.dart';
 import 'data/services/storage_path_service.dart';
+import 'util/webview_environment.dart';
 import 'data/services/theme_store_service.dart';
 import 'di/injection.dart';
 import 'playback/appletv_audio_now_playing_feeder.dart';
@@ -304,6 +307,16 @@ class _PreferenceWriteFlushObserver with WidgetsBindingObserver {
 void main() async {
   configureHttpOverrides();
   WidgetsFlutterBinding.ensureInitialized();
+
+  if (!PlatformDetection.isWeb && PlatformDetection.isWindows) {
+    try {
+      final appDataDir = await getApplicationSupportDirectory();
+      final customPath = '${appDataDir.path}\\WebView2Data';
+      gWebViewEnvironment = await WebViewEnvironment.create(
+        settings: WebViewEnvironmentSettings(userDataFolder: customPath),
+      );
+    } catch (_) {}
+  }
 
   if (PlatformDetection.isAppleTV) {
     ErrorWidget.builder = (FlutterErrorDetails details) {

--- a/lib/ui/screens/admin/plugins/plugin_web_settings_screen.dart
+++ b/lib/ui/screens/admin/plugins/plugin_web_settings_screen.dart
@@ -1,4 +1,6 @@
+import 'dart:collection';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -8,6 +10,8 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 import '../../../../l10n/app_localizations.dart';
 import '../../../../util/platform_detection.dart';
+import '../../../../util/insecure_certificates.dart';
+import '../../../../util/webview_environment.dart';
 import '../widgets/admin_form_styles.dart';
 
 class PluginWebSettingsScreen extends StatefulWidget {
@@ -334,6 +338,42 @@ class _PluginWebSettingsScreenState extends State<PluginWebSettingsScreen> {
 </body></html>''';
   }
 
+  String _buildCredentialsJs() {
+    final payload = <String, dynamic>{
+      'Servers': <Map<String, dynamic>>[
+        <String, dynamic>{
+          'Id': widget.serverId,
+          'Name': widget.serverName,
+          'Url': _normalizedServerBaseUrl,
+          'ManualAddress': _normalizedServerBaseUrl,
+          'AccessToken': widget.accessToken,
+          'UserId': widget.userId ?? '',
+          'DateLastAccessed': DateTime.now().millisecondsSinceEpoch,
+          'LastConnectionMode': 1,
+        },
+      ],
+    };
+
+    final payloadLiteral = jsonEncode(payload);
+    return '''(() => {
+  try {
+    const credentials = $payloadLiteral;
+    const s = JSON.stringify(credentials);
+    const keys = [
+      'jellyfin_credentials',
+      'jellyfin_credentials_v2',
+      'jellyfin_credentials_v3',
+      'jellyfin-credentials',
+      'emby_credentials',
+    ];
+    for (const k of keys) {
+      localStorage.setItem(k, s);
+      sessionStorage.setItem(k, s);
+    }
+  } catch (_) {}
+})();''';
+  }
+
   Future<void> _openExternalUri(Uri uri) async {
     await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
@@ -515,18 +555,31 @@ class _PluginWebSettingsScreenState extends State<PluginWebSettingsScreen> {
   Widget _buildInAppWebView() {
     return InAppWebView(
       key: const ValueKey('plugin-webview-inapp'),
+      webViewEnvironment: gWebViewEnvironment,
       initialSettings: InAppWebViewSettings(
         javaScriptEnabled: true,
         domStorageEnabled: true,
+        isInspectable: true,
       ),
-      initialData: InAppWebViewInitialData(
-        data: _buildBootstrapHtml(_currentUrl),
-        baseUrl: WebUri.uri(_serverBaseUri.resolve('/web/')),
-        mimeType: 'text/html',
-        encoding: 'utf-8',
-      ),
+      initialUrlRequest: URLRequest(url: WebUri.uri(_currentUrl)),
+      initialUserScripts: UnmodifiableListView<UserScript>([
+        UserScript(
+          source: _buildCredentialsJs(),
+          injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+        ),
+      ]),
       onWebViewCreated: (controller) {
         _inAppController = controller;
+      },
+      onReceivedServerTrustAuthRequest: (controller, challenge) async {
+        if (gAllowSelfSignedCertificates) {
+          return ServerTrustAuthResponse(
+            action: ServerTrustAuthResponseAction.PROCEED,
+          );
+        }
+        return ServerTrustAuthResponse(
+          action: ServerTrustAuthResponseAction.CANCEL,
+        );
       },
       shouldOverrideUrlLoading: (controller, navigationAction) async {
         final targetUri = navigationAction.request.url?.uriValue;

--- a/lib/ui/screens/playback/book_reader_screen.dart
+++ b/lib/ui/screens/playback/book_reader_screen.dart
@@ -13,6 +13,7 @@ import 'package:rar/rar.dart';
 import 'package:server_core/server_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:pdfrx/pdfrx.dart';
+import '../../../util/webview_environment.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
@@ -27,6 +28,7 @@ import '../../../data/services/book_reader_service.dart';
 import '../../../data/services/media_server_client_factory.dart';
 import '../../../data/services/reader_settings_store.dart';
 import '../../../util/platform_detection.dart';
+import '../../../util/insecure_certificates.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../l10n/current_app_localizations.dart';
 import '../../widgets/adaptive/sf_symbol.dart';
@@ -2724,6 +2726,7 @@ class _BookReaderScreenState extends State<BookReaderScreen>
 
     final webView = InAppWebView(
       key: ValueKey<String>(isEpub ? 'epub-web' : 'reader-web'),
+      webViewEnvironment: gWebViewEnvironment,
       initialData: isEpub
           ? InAppWebViewInitialData(
               data:
@@ -2756,6 +2759,16 @@ class _BookReaderScreenState extends State<BookReaderScreen>
           : null,
       onWebViewCreated: (controller) {
         _webController = controller;
+      },
+      onReceivedServerTrustAuthRequest: (controller, challenge) async {
+        if (gAllowSelfSignedCertificates) {
+          return ServerTrustAuthResponse(
+            action: ServerTrustAuthResponseAction.PROCEED,
+          );
+        }
+        return ServerTrustAuthResponse(
+          action: ServerTrustAuthResponseAction.CANCEL,
+        );
       },
       onProgressChanged: (controller, progress) {
         if (!mounted) return;

--- a/lib/ui/screens/playback/game_emulator_screen.dart
+++ b/lib/ui/screens/playback/game_emulator_screen.dart
@@ -12,6 +12,8 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import '../../widgets/adaptive/adaptive_glass.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../util/platform_detection.dart';
+import '../../../util/insecure_certificates.dart';
+import '../../../util/webview_environment.dart';
 
 /// Full-screen EmulatorJS host. Loads the Moonbase plugin's player shell in a WebView, streams
 /// the ROM from the user's server, and syncs the save state on exit. Includes a native,
@@ -555,6 +557,7 @@ class _GameEmulatorScreenState extends State<GameEmulatorScreen> {
             else
               InAppWebView(
                 key: const ValueKey('game-emulator-webview'),
+                webViewEnvironment: gWebViewEnvironment,
                 initialUrlRequest: URLRequest(url: WebUri(_playerUrl!)),
                 initialUserScripts: _userScripts.isEmpty
                     ? null
@@ -572,6 +575,16 @@ class _GameEmulatorScreenState extends State<GameEmulatorScreen> {
                   controller.addJavaScriptHandler(
                     handlerName: 'moonfinPlayer',
                     callback: _onPlayerMessage,
+                  );
+                },
+                onReceivedServerTrustAuthRequest: (controller, challenge) async {
+                  if (gAllowSelfSignedCertificates) {
+                    return ServerTrustAuthResponse(
+                      action: ServerTrustAuthResponseAction.PROCEED,
+                    );
+                  }
+                  return ServerTrustAuthResponse(
+                    action: ServerTrustAuthResponseAction.CANCEL,
                   );
                 },
               ),

--- a/lib/util/webview_environment.dart
+++ b/lib/util/webview_environment.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+WebViewEnvironment? gWebViewEnvironment;


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the embedded browser loading screen/blank screen in the Windows desktop app when accessing Jellyfin plugin settings. This is achieved by initializing a custom WebView2 `WebViewEnvironment` mapped to a user-writable path (`AppData`) to resolve permission access errors when installed in Program Files, and loading settings via a direct target origin request with user-script credentials injection at document start to bypass unique-origin `localStorage` security errors. This error impacts 3 areas of the app: plugin settings, the Game Emulator, and the Book Reader. This PR should fix all 3.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **WebView Environment Setup:** Created a global configuration in `lib/util/webview_environment.dart` and initialized it inside `main()` on Windows to bind WebView2's userDataFolder to the user's local AppData support folder.
- **Settings Screen Navigation & Authentication:** Replaced `initialData` (bootstrap iframe fallback URL) with direct origin loading using `initialUrlRequest` and primed Jellyfin credentials via `UserScript` injection at document start.
- **SSL/TLS Validation & Security Bypass:** Handled self-signed certificate challenges in `onReceivedServerTrustAuthRequest` across all app WebViews (plugin settings, book reader, and game emulator) to honor the user's `gAllowSelfSignedCertificates` preference.
- **WebView2 Data Parity:** Passed `webViewEnvironment: gWebViewEnvironment` to all `InAppWebView` instances in the app.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code - but changes only impact the Windows Desktop client

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Install the updated package on a Windows machine in a restricted folder (`C:\Program Files\Moonfin`).
2. Run the application as a standard user.
3. Open the "Plugins" page and click "Settings" on the Moonfin plugin.
4. Verify that the settings page renders fully and is functional without a perpetual loading spinner or blank background.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="2500" height="1016" alt="2026-07-04_12-45-21_moonfin" src="https://github.com/user-attachments/assets/a9af9808-7e82-4c38-b691-3d723764247c" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
