### PR TITLE
feat(recommendations): Moonfin Recommends improvements for release

### DIFF
--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2062,66 +2062,18 @@ class RowDataSource {
           if (_getRatingLevel(candRating) > sourceRatingLevel) continue;
         }
 
-        double score = 0.0;
-
-        // Score genres (+3.0 each)
-        final cGenres = (candidate['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
-        for (final g in genres) {
-          if (cGenres.contains(g)) score += 3.0;
-        }
-
-        // Score tags (+3.0 each)
-        final cTags = (candidate['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
-        for (final t in tags) {
-          if (cTags.contains(t)) score += 3.0;
-        }
-
-        // Score people
-        final cPeople = (candidate['People'] as List?)?.map((e) => e is Map ? Map<String, dynamic>.from(e) : null).whereType<Map<String, dynamic>>().toList() ?? const <Map<String, dynamic>>[];
-        final cActors = cPeople.where((p) => p['Type'] == 'Actor').map((p) => p['Name']?.toString()).whereType<String>().toSet();
-        final cDirectors = cPeople.where((p) => p['Type'] == 'Director').map((p) => p['Name']?.toString()).whereType<String>().toSet();
-        final cWriters = cPeople.where((p) => p['Type'] == 'Writer').map((p) => p['Name']?.toString()).whereType<String>().toSet();
-
-        for (final a in actorNames) {
-          if (cActors.contains(a)) score += 5.0;
-        }
-        for (final d in directorNames) {
-          if (cDirectors.contains(d)) score += 6.0;
-        }
-        for (final w in writerNames) {
-          if (cWriters.contains(w)) score += 6.0;
-        }
-
-        // Score studios (+3.0 each)
-        final cStudios = (candidate['Studios'] as List?)?.map((e) => e is Map ? e['Name']?.toString() : e?.toString()).whereType<String>().toSet() ?? const <String>{};
-        for (final s in baseStudios) {
-          if (cStudios.contains(s)) score += 3.0;
-        }
-
-        // Score production year proximity (+2.0 if exact, +1.0 if within 3 years)
-        final candYear = candidate['ProductionYear'] as int?;
-        if (candYear != null && baseYear != null) {
-          if (candYear == baseYear) {
-            score += 2.0;
-          } else if ((candYear - baseYear).abs() <= 3) {
-            score += 1.0;
-          }
-        }
-
-        // Score similar titles / sequels (+10.0)
-        if (_isSequelOrSimilarTitle(baseItem.name, candidate['Name']?.toString() ?? '')) {
-          score += 10.0;
-        }
-
-        // Score community rating boost (+ community rating / 10.0)
-        final candCommRating = (candidate['CommunityRating'] as num?)?.toDouble();
-        if (candCommRating != null) {
-          score += candCommRating / 10.0;
-        }
-
-        if (score >= 0.0) {
-          scoredCandidates.add(MapEntry(candidate, score));
-        }
+        final score = _scoreCandidate(
+          candidate,
+          genres: genres,
+          tags: tags,
+          actorNames: actorNames,
+          directorNames: directorNames,
+          writerNames: writerNames,
+          baseStudios: baseStudios,
+          baseYear: baseYear,
+          baseName: baseItem.name,
+        );
+        scoredCandidates.add(MapEntry(candidate, score));
       }
 
       // If we have fewer than 15 items after candidate scoring and filtering, fetch filler items
@@ -2159,62 +2111,17 @@ class RowDataSource {
                 if (_getRatingLevel(candRating) > sourceRatingLevel) continue;
               }
 
-              double score = 0.0;
-
-              // Score genres (+3.0 each)
-              final cGenres = (item['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
-              for (final g in genres) {
-                if (cGenres.contains(g)) score += 3.0;
-              }
-
-              // Score tags (+3.0 each)
-              final cTags = (item['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
-              for (final t in tags) {
-                if (cTags.contains(t)) score += 3.0;
-              }
-
-              // Score people
-              final cPeople = (item['People'] as List?)?.map((e) => e is Map ? Map<String, dynamic>.from(e) : null).whereType<Map<String, dynamic>>().toList() ?? const <Map<String, dynamic>>[];
-              final cActors = cPeople.where((p) => p['Type'] == 'Actor').map((p) => p['Name']?.toString()).whereType<String>().toSet();
-              final cDirectors = cPeople.where((p) => p['Type'] == 'Director').map((p) => p['Name']?.toString()).whereType<String>().toSet();
-              final cWriters = cPeople.where((p) => p['Type'] == 'Writer').map((p) => p['Name']?.toString()).whereType<String>().toSet();
-
-              for (final a in actorNames) {
-                if (cActors.contains(a)) score += 5.0;
-              }
-              for (final d in directorNames) {
-                if (cDirectors.contains(d)) score += 6.0;
-              }
-              for (final w in writerNames) {
-                if (cWriters.contains(w)) score += 6.0;
-              }
-
-              // Score studios (+3.0 each)
-              final cStudios = (item['Studios'] as List?)?.map((e) => e is Map ? e['Name']?.toString() : e?.toString()).whereType<String>().toSet() ?? const <String>{};
-              for (final s in baseStudios) {
-                if (cStudios.contains(s)) score += 3.0;
-              }
-
-              // Score production year proximity (+2.0 if exact, +1.0 if close)
-              final candYear = item['ProductionYear'] as int?;
-              if (candYear != null && baseYear != null) {
-                if (candYear == baseYear) {
-                  score += 2.0;
-                } else if ((candYear - baseYear).abs() <= 3) {
-                  score += 1.0;
-                }
-              }
-
-              // Score similar titles / sequels (+10.0)
-              if (_isSequelOrSimilarTitle(baseItem.name, item['Name']?.toString() ?? '')) {
-                score += 10.0;
-              }
-
-              // Score community rating boost (+ community rating / 10.0)
-              final candCommRating = (item['CommunityRating'] as num?)?.toDouble();
-              if (candCommRating != null) {
-                score += candCommRating / 10.0;
-              }
+              final score = _scoreCandidate(
+                item,
+                genres: genres,
+                tags: tags,
+                actorNames: actorNames,
+                directorNames: directorNames,
+                writerNames: writerNames,
+                baseStudios: baseStudios,
+                baseYear: baseYear,
+                baseName: baseItem.name,
+              );
 
               candidatesMap[id] = item;
               scoredCandidates.add(MapEntry(item, score));
@@ -2594,28 +2501,97 @@ class RowDataSource {
     );
   }
 
-  bool _isSequelOrSimilarTitle(String titleA, String titleB) {
-    final wordsA = titleA.toLowerCase().replaceAll(RegExp(r'[^\w\s]'), '').split(RegExp(r'\s+')).where((w) => w.isNotEmpty && w.length >= 4).toSet();
-    final wordsB = titleB.toLowerCase().replaceAll(RegExp(r'[^\w\s]'), '').split(RegExp(r'\s+')).where((w) => w.isNotEmpty && w.length >= 4).toSet();
+  double _scoreCandidate(
+    Map<String, dynamic> candidate, {
+    required List<String> genres,
+    required List<String> tags,
+    required List<String> actorNames,
+    required List<String> directorNames,
+    required List<String> writerNames,
+    required List<String> baseStudios,
+    required int? baseYear,
+    required String baseName,
+  }) {
+    double score = 0.0;
 
-    // Remove common words
-    final commonWords = const {'with', 'from', 'under', 'over', 'about', 'chapter', 'part', 'movie', 'film'};
-    wordsA.removeAll(commonWords);
-    wordsB.removeAll(commonWords);
+    final cGenres = (candidate['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+    for (final g in genres) {
+      if (cGenres.contains(g)) score += 3.0;
+    }
 
-    if (wordsA.isEmpty || wordsB.isEmpty) return false;
+    final cTags = (candidate['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+    for (final t in tags) {
+      if (cTags.contains(t)) score += 3.0;
+    }
 
-    // Check if they share any word or starting prefix
-    for (final wA in wordsA) {
-      for (final wB in wordsB) {
-        if (wA == wB) return true;
-        if (wA.startsWith(wB) || wB.startsWith(wA)) {
-          return true;
-        }
+    final cPeople = (candidate['People'] as List?)?.map((e) => e is Map ? Map<String, dynamic>.from(e) : null).whereType<Map<String, dynamic>>().toList() ?? const <Map<String, dynamic>>[];
+    final cActors = cPeople.where((p) => p['Type'] == 'Actor').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+    final cDirectors = cPeople.where((p) => p['Type'] == 'Director').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+    final cWriters = cPeople.where((p) => p['Type'] == 'Writer').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+    for (final a in actorNames) {
+      if (cActors.contains(a)) score += 5.0;
+    }
+    for (final d in directorNames) {
+      if (cDirectors.contains(d)) score += 6.0;
+    }
+    for (final w in writerNames) {
+      if (cWriters.contains(w)) score += 6.0;
+    }
+
+    final cStudios = (candidate['Studios'] as List?)?.map((e) => e is Map ? e['Name']?.toString() : e?.toString()).whereType<String>().toSet() ?? const <String>{};
+    for (final s in baseStudios) {
+      if (cStudios.contains(s)) score += 3.0;
+    }
+
+    final candYear = candidate['ProductionYear'] as int?;
+    if (candYear != null && baseYear != null) {
+      if (candYear == baseYear) {
+        score += 2.0;
+      } else if ((candYear - baseYear).abs() <= 3) {
+        score += 1.0;
       }
     }
 
-    return false;
+    if (_isSequelOrSimilarTitle(baseName, candidate['Name']?.toString() ?? '')) {
+      score += 10.0;
+    }
+
+    final candCommRating = (candidate['CommunityRating'] as num?)?.toDouble();
+    if (candCommRating != null) {
+      score += candCommRating / 10.0;
+    }
+
+    return score;
+  }
+
+  bool _isSequelOrSimilarTitle(String titleA, String titleB) {
+    String normalize(String s) => s
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^\w\s]'), ' ')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
+
+    final a = normalize(titleA);
+    final b = normalize(titleB);
+    if (a.isEmpty || b.isEmpty) return false;
+
+    final shorter = a.length <= b.length ? a : b;
+    final longer = a.length <= b.length ? b : a;
+
+    // Real sequels tend to extend the base title, like "Iron Man" to
+    // "Iron Man 2" or "The Dark Knight" to "The Dark Knight Rises".
+    if (longer == shorter || longer.startsWith('$shorter ')) return true;
+
+    // Otherwise only count it when every meaningful word of the shorter title
+    // shows up in the longer one, so a single shared word like "dark" is not enough.
+    const stopWords = {'the', 'and', 'with', 'from', 'under', 'over', 'about', 'chapter', 'part', 'movie', 'film'};
+    Set<String> significant(String s) => s
+        .split(' ')
+        .where((w) => w.length >= 4 && !stopWords.contains(w))
+        .toSet();
+
+    final wordsShort = significant(shorter);
+    return wordsShort.length >= 2 && significant(longer).containsAll(wordsShort);
   }
 }
 

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -52,8 +52,12 @@ class RowDataSource {
   // Cache for local recommendations to make them practically instantaneous
   static const int _recommendationCacheMaxEntries = 64;
   static final Map<String, List<Map<String, dynamic>>> _recommendationCache = {};
+  static final Map<String, List<AggregatedItem>> _scoredRecommendationsCache = {};
 
-  static void clearRecommendationCache() => _recommendationCache.clear();
+  static void clearRecommendationCache() {
+    _recommendationCache.clear();
+    _scoredRecommendationsCache.clear();
+  }
 
   static void _cacheRecommendations(String key, List<Map<String, dynamic>> items) {
     _recommendationCache.remove(key);
@@ -1074,6 +1078,14 @@ class RowDataSource {
             fields: 'PrimaryImageAspectRatio,SortName',
           );
         } else {
+          if (row.id.startsWith('sinceYouWatched')) {
+            final cached = _scoredRecommendationsCache[row.id];
+            if (cached != null) {
+              final nextItems = cached.take(currentOffset + _defaultLimit).toList();
+              return (nextItems, cached.length);
+            }
+            return (row.items, row.totalCount);
+          }
           final underscoreIndex = row.id.indexOf('_');
           if (underscoreIndex >= 0) {
             final type = row.id.substring(0, underscoreIndex);
@@ -1852,14 +1864,18 @@ class RowDataSource {
       baseItem: baseItem,
       isLocal: isLocal,
       candidateItemTypes: candidateItemTypes,
-      limit: 15,
+      limit: 100,
     );
 
+    final rowId = 'sinceYouWatched$rowIndex';
+    _scoredRecommendationsCache[rowId] = recommendedItems;
+
     return HomeRow(
-      id: 'sinceYouWatched$rowIndex',
+      id: rowId,
       title: 'Since you watched "$baseItemName"',
       rowType: HomeRowType.latestMedia,
-      items: recommendedItems,
+      items: recommendedItems.take(15).toList(),
+      totalCount: recommendedItems.length,
     );
   }
 
@@ -1880,6 +1896,8 @@ class RowDataSource {
       final genres = (itemDetail['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
       final tags = (itemDetail['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
       final people = (itemDetail['People'] as List?)?.map((e) => e is Map ? Map<String, dynamic>.from(e) : null).whereType<Map<String, dynamic>>().toList() ?? const <Map<String, dynamic>>[];
+      final baseStudios = (itemDetail['Studios'] as List?)?.map((e) => e is Map ? e['Name']?.toString() : e?.toString()).whereType<String>().toList() ?? const <String>[];
+      final baseYear = itemDetail['ProductionYear'] as int?;
 
       final actorNames = people
           .where((p) => p['Type'] == 'Actor')
@@ -1933,8 +1951,8 @@ class RowDataSource {
               includeItemTypes: types,
               genres: genres,
               recursive: true,
-              limit: 80,
-              fields: 'Genres,Tags,People,UserData,OfficialRating',
+              limit: 40,
+              fields: 'Genres,Tags,People,UserData,OfficialRating,ProductionYear,CommunityRating,Studios',
             );
             final items = (res['Items'] as List? ?? [])
                 .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
@@ -1966,8 +1984,8 @@ class RowDataSource {
               includeItemTypes: types,
               tags: tags,
               recursive: true,
-              limit: 80,
-              fields: 'Genres,Tags,People,UserData,OfficialRating',
+              limit: 40,
+              fields: 'Genres,Tags,People,UserData,OfficialRating,ProductionYear,CommunityRating,Studios',
             );
             final items = (res['Items'] as List? ?? [])
                 .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
@@ -1984,9 +2002,9 @@ class RowDataSource {
 
       // Fetch candidates matching any directors, writers, or actors in parallel using a single combined query
       final allPersonIds = [
-        ...directorIds.take(2),
-        ...writerIds.take(2),
-        ...actorIds.take(3),
+        ...directorIds,
+        ...writerIds,
+        ...actorIds.take(10),
       ];
       if (allPersonIds.isNotEmpty) {
         futures.add(() async {
@@ -2004,8 +2022,8 @@ class RowDataSource {
               includeItemTypes: types,
               personIds: allPersonIds,
               recursive: true,
-              limit: 80,
-              fields: 'Genres,Tags,People,UserData,OfficialRating',
+              limit: 40,
+              fields: 'Genres,Tags,People,UserData,OfficialRating,ProductionYear,CommunityRating,Studios',
             );
             final items = (res['Items'] as List? ?? [])
                 .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
@@ -2023,6 +2041,7 @@ class RowDataSource {
       await Future.wait(futures);
 
       final bool effectiveIncludeWatched = includeWatched ?? prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
+      final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
       final sourceRating = baseItem.officialRating;
       final sourceRatingLevel = _getRatingLevel(sourceRating);
 
@@ -2038,21 +2057,23 @@ class RowDataSource {
         if (!effectiveIncludeWatched && isPlayed) continue;
 
         // Parental rating constraint upper bound
-        final candRating = candidate['OfficialRating'] as String?;
-        if (_getRatingLevel(candRating) > sourceRatingLevel) continue;
+        if (applyRatingCap) {
+          final candRating = candidate['OfficialRating'] as String?;
+          if (_getRatingLevel(candRating) > sourceRatingLevel) continue;
+        }
 
         double score = 0.0;
 
-        // Score genres (+2.0 each)
+        // Score genres (+3.0 each)
         final cGenres = (candidate['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
         for (final g in genres) {
-          if (cGenres.contains(g)) score += 2.0;
+          if (cGenres.contains(g)) score += 3.0;
         }
 
-        // Score tags (+1.0 each)
+        // Score tags (+3.0 each)
         final cTags = (candidate['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
         for (final t in tags) {
-          if (cTags.contains(t)) score += 1.0;
+          if (cTags.contains(t)) score += 3.0;
         }
 
         // Score people
@@ -2062,18 +2083,149 @@ class RowDataSource {
         final cWriters = cPeople.where((p) => p['Type'] == 'Writer').map((p) => p['Name']?.toString()).whereType<String>().toSet();
 
         for (final a in actorNames) {
-          if (cActors.contains(a)) score += 3.0;
+          if (cActors.contains(a)) score += 5.0;
         }
         for (final d in directorNames) {
-          if (cDirectors.contains(d)) score += 4.0;
+          if (cDirectors.contains(d)) score += 6.0;
         }
         for (final w in writerNames) {
-          if (cWriters.contains(w)) score += 4.0;
+          if (cWriters.contains(w)) score += 6.0;
         }
 
-        if (score >= 1.0) {
+        // Score studios (+3.0 each)
+        final cStudios = (candidate['Studios'] as List?)?.map((e) => e is Map ? e['Name']?.toString() : e?.toString()).whereType<String>().toSet() ?? const <String>{};
+        for (final s in baseStudios) {
+          if (cStudios.contains(s)) score += 3.0;
+        }
+
+        // Score production year proximity (+2.0 if exact, +1.0 if within 3 years)
+        final candYear = candidate['ProductionYear'] as int?;
+        if (candYear != null && baseYear != null) {
+          if (candYear == baseYear) {
+            score += 2.0;
+          } else if ((candYear - baseYear).abs() <= 3) {
+            score += 1.0;
+          }
+        }
+
+        // Score similar titles / sequels (+10.0)
+        if (_isSequelOrSimilarTitle(baseItem.name, candidate['Name']?.toString() ?? '')) {
+          score += 10.0;
+        }
+
+        // Score community rating boost (+ community rating / 10.0)
+        final candCommRating = (candidate['CommunityRating'] as num?)?.toDouble();
+        if (candCommRating != null) {
+          score += candCommRating / 10.0;
+        }
+
+        if (score >= 0.0) {
           scoredCandidates.add(MapEntry(candidate, score));
         }
+      }
+
+      // If we have fewer than 15 items after candidate scoring and filtering, fetch filler items
+      if (scoredCandidates.length < 15) {
+        try {
+          final fallbackCacheKey = '$serverId:fallback:${types.join(",")}:${genres.join(",")}';
+          final List<Map<String, dynamic>> items;
+          if (_recommendationCache.containsKey(fallbackCacheKey)) {
+            items = _recommendationCache[fallbackCacheKey]!;
+          } else {
+            final res = await _client.itemsApi.getItems(
+              includeItemTypes: types,
+              genres: genres.isNotEmpty ? genres : null,
+              recursive: true,
+              limit: 30,
+              sortBy: 'ProductionYear,SortName',
+              sortOrder: 'Descending',
+              fields: 'Genres,Tags,People,UserData,OfficialRating,ProductionYear,CommunityRating,Studios',
+            );
+            items = (res['Items'] as List? ?? [])
+                .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
+                .whereType<Map<String, dynamic>>()
+                .toList();
+            _cacheRecommendations(fallbackCacheKey, items);
+          }
+          for (final item in items) {
+            final id = item['Id']?.toString() ?? '';
+            if (id.isNotEmpty && !candidatesMap.containsKey(id) && id != baseItem.id) {
+              final userData = item['UserData'] as Map?;
+              final isPlayed = userData?['Played'] as bool? ?? false;
+              if (!effectiveIncludeWatched && isPlayed) continue;
+
+              if (applyRatingCap) {
+                final candRating = item['OfficialRating'] as String?;
+                if (_getRatingLevel(candRating) > sourceRatingLevel) continue;
+              }
+
+              double score = 0.0;
+
+              // Score genres (+3.0 each)
+              final cGenres = (item['Genres'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+              for (final g in genres) {
+                if (cGenres.contains(g)) score += 3.0;
+              }
+
+              // Score tags (+3.0 each)
+              final cTags = (item['Tags'] as List?)?.map((e) => e?.toString()).whereType<String>().toList() ?? const <String>[];
+              for (final t in tags) {
+                if (cTags.contains(t)) score += 3.0;
+              }
+
+              // Score people
+              final cPeople = (item['People'] as List?)?.map((e) => e is Map ? Map<String, dynamic>.from(e) : null).whereType<Map<String, dynamic>>().toList() ?? const <Map<String, dynamic>>[];
+              final cActors = cPeople.where((p) => p['Type'] == 'Actor').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+              final cDirectors = cPeople.where((p) => p['Type'] == 'Director').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+              final cWriters = cPeople.where((p) => p['Type'] == 'Writer').map((p) => p['Name']?.toString()).whereType<String>().toSet();
+
+              for (final a in actorNames) {
+                if (cActors.contains(a)) score += 5.0;
+              }
+              for (final d in directorNames) {
+                if (cDirectors.contains(d)) score += 6.0;
+              }
+              for (final w in writerNames) {
+                if (cWriters.contains(w)) score += 6.0;
+              }
+
+              // Score studios (+3.0 each)
+              final cStudios = (item['Studios'] as List?)?.map((e) => e is Map ? e['Name']?.toString() : e?.toString()).whereType<String>().toSet() ?? const <String>{};
+              for (final s in baseStudios) {
+                if (cStudios.contains(s)) score += 3.0;
+              }
+
+              // Score production year proximity (+2.0 if exact, +1.0 if close)
+              final candYear = item['ProductionYear'] as int?;
+              if (candYear != null && baseYear != null) {
+                if (candYear == baseYear) {
+                  score += 2.0;
+                } else if ((candYear - baseYear).abs() <= 3) {
+                  score += 1.0;
+                }
+              }
+
+              // Score similar titles / sequels (+10.0)
+              if (_isSequelOrSimilarTitle(baseItem.name, item['Name']?.toString() ?? '')) {
+                score += 10.0;
+              }
+
+              // Score community rating boost (+ community rating / 10.0)
+              final candCommRating = (item['CommunityRating'] as num?)?.toDouble();
+              if (candCommRating != null) {
+                score += candCommRating / 10.0;
+              }
+
+              candidatesMap[id] = item;
+              scoredCandidates.add(MapEntry(item, score));
+
+              // Cap the extra items to prevent bloating
+              if (scoredCandidates.length >= 30) {
+                break;
+              }
+            }
+          }
+        } catch (_) {}
       }
 
       // Sort by score desc, then by premiere date desc
@@ -2440,6 +2592,30 @@ class RowDataSource {
       rowType: HomeRowType.latestMedia,
       items: resolvedItems,
     );
+  }
+
+  bool _isSequelOrSimilarTitle(String titleA, String titleB) {
+    final wordsA = titleA.toLowerCase().replaceAll(RegExp(r'[^\w\s]'), '').split(RegExp(r'\s+')).where((w) => w.isNotEmpty && w.length >= 4).toSet();
+    final wordsB = titleB.toLowerCase().replaceAll(RegExp(r'[^\w\s]'), '').split(RegExp(r'\s+')).where((w) => w.isNotEmpty && w.length >= 4).toSet();
+
+    // Remove common words
+    final commonWords = const {'with', 'from', 'under', 'over', 'about', 'chapter', 'part', 'movie', 'film'};
+    wordsA.removeAll(commonWords);
+    wordsB.removeAll(commonWords);
+
+    if (wordsA.isEmpty || wordsB.isEmpty) return false;
+
+    // Check if they share any word or starting prefix
+    for (final wA in wordsA) {
+      for (final wB in wordsB) {
+        if (wA == wB) return true;
+        if (wA.startsWith(wB) || wB.startsWith(wA)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -220,6 +220,14 @@
   "@recommendationSystemTmdb": {
     "description": "Recommendation system option: TMDb Similarity"
   },
+  "recommendationsApplyParentalRatingCap": "Apply Parental Rating Cap?",
+  "@recommendationsApplyParentalRatingCap": {
+    "description": "Label for the toggle that controls whether similar suggestions are capped by target media parental rating"
+  },
+  "recommendationsApplyParentalRatingCapSubtitle": "Limit Moonfin Recommends suggestions by parental rating of target media",
+  "@recommendationsApplyParentalRatingCapSubtitle": {
+    "description": "Explanation under the parental rating cap setting toggle"
+  },
   "interfaceStyle": "Interface Style",
   "@interfaceStyle": {
     "description": "Label for the Automatic/Apple/Material interface style setting"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -508,6 +508,18 @@ abstract class AppLocalizations {
   /// **'TMDb Similarity'**
   String get recommendationSystemTmdb;
 
+  /// Label for the toggle that controls whether similar suggestions are capped by target media parental rating
+  ///
+  /// In en, this message translates to:
+  /// **'Apply Parental Rating Cap?'**
+  String get recommendationsApplyParentalRatingCap;
+
+  /// Explanation under the parental rating cap setting toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Limit Moonfin Recommends suggestions by parental rating of target media'**
+  String get recommendationsApplyParentalRatingCapSubtitle;
+
   /// Label for the Automatic/Apple/Material interface style setting
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -167,6 +167,14 @@ class AppLocalizationsAf extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -167,6 +167,14 @@ class AppLocalizationsAr extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -167,6 +167,14 @@ class AppLocalizationsBe extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -167,6 +167,14 @@ class AppLocalizationsBg extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -167,6 +167,14 @@ class AppLocalizationsBn extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -167,6 +167,14 @@ class AppLocalizationsCa extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -168,6 +168,14 @@ class AppLocalizationsCs extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -167,6 +167,14 @@ class AppLocalizationsCy extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -169,6 +169,14 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -167,6 +167,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => 'Oberflächen-Stil';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -169,6 +169,14 @@ class AppLocalizationsEl extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -167,6 +167,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => 'Interface Style';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -167,6 +167,14 @@ class AppLocalizationsEo extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -167,6 +167,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -168,6 +168,14 @@ class AppLocalizationsEt extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -167,6 +167,14 @@ class AppLocalizationsFa extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -169,6 +169,14 @@ class AppLocalizationsFi extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -167,6 +167,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => 'Style d\'interface';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -167,6 +167,14 @@ class AppLocalizationsGl extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -167,6 +167,14 @@ class AppLocalizationsHe extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -167,6 +167,14 @@ class AppLocalizationsHi extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -167,6 +167,14 @@ class AppLocalizationsHr extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -167,6 +167,14 @@ class AppLocalizationsHu extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -168,6 +168,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -167,6 +167,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -166,6 +166,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -167,6 +167,14 @@ class AppLocalizationsKk extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -167,6 +167,14 @@ class AppLocalizationsKn extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -166,6 +166,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -167,6 +167,14 @@ class AppLocalizationsLt extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -167,6 +167,14 @@ class AppLocalizationsLv extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -167,6 +167,14 @@ class AppLocalizationsMk extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -167,6 +167,14 @@ class AppLocalizationsMl extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -167,6 +167,14 @@ class AppLocalizationsMn extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -167,6 +167,14 @@ class AppLocalizationsNb extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -168,6 +168,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -167,6 +167,14 @@ class AppLocalizationsPa extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -168,6 +168,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -167,6 +167,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -167,6 +167,14 @@ class AppLocalizationsRo extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -167,6 +167,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -167,6 +167,14 @@ class AppLocalizationsSi extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -168,6 +168,14 @@ class AppLocalizationsSk extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -168,6 +168,14 @@ class AppLocalizationsSl extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -168,6 +168,14 @@ class AppLocalizationsSq extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -167,6 +167,14 @@ class AppLocalizationsSr extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -167,6 +167,14 @@ class AppLocalizationsSv extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -167,6 +167,14 @@ class AppLocalizationsSw extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -167,6 +167,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -167,6 +167,14 @@ class AppLocalizationsTe extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -168,6 +168,14 @@ class AppLocalizationsTh extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -168,6 +168,14 @@ class AppLocalizationsTl extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -167,6 +167,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -167,6 +167,14 @@ class AppLocalizationsUg extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -167,6 +167,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -167,6 +167,14 @@ class AppLocalizationsVi extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -166,6 +166,14 @@ class AppLocalizationsYue extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -166,6 +166,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
+  String get recommendationsApplyParentalRatingCap =>
+      'Apply Parental Rating Cap?';
+
+  @override
+  String get recommendationsApplyParentalRatingCapSubtitle =>
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
+
+  @override
   String get interfaceStyle => '';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -873,6 +873,12 @@ class UserPreferences extends ChangeNotifier {
     values: RecommendationSystemSource.values,
   );
 
+  /// Apply parental rating ceiling to Moonfin Recommends suggestions.
+  static final recommendationsApplyParentalRatingCap = Preference(
+    key: 'pref_recommendations_apply_parental_rating_cap',
+    defaultValue: true,
+  );
+
   /// Default mobile view for the Live TV guide (Now/Next list vs compact grid).
   static final epgMobileView = EnumPreference(
     key: 'pref_epg_mobile_view',

--- a/lib/ui/screens/settings/panel/libraries_category_screen.dart
+++ b/lib/ui/screens/settings/panel/libraries_category_screen.dart
@@ -1,7 +1,29 @@
 part of '../settings_side_panel.dart';
 
-class _LibrariesCategoryScreen extends StatelessWidget {
+class _LibrariesCategoryScreen extends StatefulWidget {
   const _LibrariesCategoryScreen();
+
+  @override
+  State<_LibrariesCategoryScreen> createState() => _LibrariesCategoryScreenState();
+}
+
+class _LibrariesCategoryScreenState extends State<_LibrariesCategoryScreen> {
+  late final PreferenceBinding<RecommendationSystemSource> _recSysBinding;
+
+  @override
+  void initState() {
+    super.initState();
+    _recSysBinding = PreferenceBinding(
+      GetIt.instance<PreferenceStore>(),
+      UserPreferences.recommendationSystemSource,
+    );
+  }
+
+  @override
+  void dispose() {
+    _recSysBinding.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +53,21 @@ class _LibrariesCategoryScreen extends StatelessWidget {
                     l10n.recommendationSystemTmdb,
                 },
                 onChanged: _pushPersonalizationSync,
+              ),
+              ValueListenableBuilder<RecommendationSystemSource>(
+                valueListenable: _recSysBinding,
+                builder: (context, source, _) {
+                  if (source != RecommendationSystemSource.local) {
+                    return const SizedBox.shrink();
+                  }
+                  return SwitchPreferenceTile(
+                    preference: UserPreferences.recommendationsApplyParentalRatingCap,
+                    title: 'Apply Parental Rating Cap?',
+                    subtitle: 'Limit Moonfin Recommends suggestions by parental rating of target media',
+                    icon: Icons.family_restroom,
+                    onChanged: _pushPersonalizationSync,
+                  );
+                },
               ),
               SwitchPreferenceTile(
                 preference: UserPreferences.enableFolderView,

--- a/lib/ui/screens/settings/panel/libraries_category_screen.dart
+++ b/lib/ui/screens/settings/panel/libraries_category_screen.dart
@@ -62,8 +62,8 @@ class _LibrariesCategoryScreenState extends State<_LibrariesCategoryScreen> {
                   }
                   return SwitchPreferenceTile(
                     preference: UserPreferences.recommendationsApplyParentalRatingCap,
-                    title: 'Apply Parental Rating Cap?',
-                    subtitle: 'Limit Moonfin Recommends suggestions by parental rating of target media',
+                    title: l10n.recommendationsApplyParentalRatingCap,
+                    subtitle: l10n.recommendationsApplyParentalRatingCapSubtitle,
                     icon: Icons.family_restroom,
                     onChanged: _pushPersonalizationSync,
                   );


### PR DESCRIPTION
# Pull Request

## Summary
This PR improves the new, local "Moonfin Recommends" suggestion system to increase match quality, support native lazy-loaded paging on home rows, optimize query performance, and introduce a parental rating control. Previous version didn't always return 15 results and didn't include enough similarly parameters to hone in results as much as it should have.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #689 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Expanded candidate retrieval matching parameters to fetch all directors/writers and up to 10 actors.
- Adjusted candidate scoring weights (directors/writers +6.0, actors +5.0, genres/tags/studios +3.0) and added year/community rating boosts.
- Added similar titles and sequel matching scoring logic with a +10.0 point boost.
- Implemented memories paging/lazy loading cache (`_scoredRecommendationsCache`) for home rows.
- Added a fallback query to pull same-genre/type filler items when the scored pool yields under 15 results.
- Added a unique key cache (`$serverId:fallback:...`) to optimize fallback query performance on subsequent navigation.
- Introduced `UserPreferences.recommendationsApplyParentalRatingCap` toggle to control parental ceiling checks.
- Refactored `_LibrariesCategoryScreen` to a `StatefulWidget` to display a conditional toggle tile for the rating cap.
- Optimized network query limits from 80 to 40 for candidate queries and 50 to 30 for the fallback query to improve render speed.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on AndroidTV
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings > Libraries. Confirm the "Apply Parental Rating Cap?" toggle appears only when "Recommendation System" is set to "Moonfin Recommends".
2. Open "Predator: Badlands" (PG rated) similar media details page with rating cap ON; check that R-rated items like *Predator*  are filtered out.
3. Turn the parental cap toggle OFF; verify that R-rated sequels/prequels like *Predator* bubble up to the top of the similar list due to the `+10.0` point sequel boost.
4. Scroll the "Since You Watched" home row; verify that lazy loading is smooth and paging retrieves slices of 15 from cache.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="300" alt="Shield_Screenshot_2026-07-05_14-00-14" src="https://github.com/user-attachments/assets/2b020808-3bc1-47ae-b29a-4c589e2897b2" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
