### PR TITLE
hide audio button on details page if there is only 1 track

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5520,9 +5520,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       item,
       selectedSource,
     ).where((s) => s['Type'] == 'Audio').toList();
-    if (streams.length > 1) {
-      _showAudioSelector(context, streams);
-    }
+    _showAudioSelector(context, streams);
   }
 
   void _openSubtitleSelector(BuildContext context, AggregatedItem item) {

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5511,18 +5511,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     return _mediaStreamsForItem(item, selectedSource);
   }
 
-  void _openAudioSelector(BuildContext context, AggregatedItem item) {
-    final selectedSource = selectedMediaSourceForItem(
-      item,
-      widget.selectedMediaSourceId,
-    );
-    final streams = _streamsForTrackSelectors(
-      item,
-      selectedSource,
-    ).where((s) => s['Type'] == 'Audio').toList();
-    _showAudioSelector(context, streams);
-  }
-
   void _openSubtitleSelector(BuildContext context, AggregatedItem item) {
     final selectedSource = selectedMediaSourceForItem(
       item,
@@ -5678,6 +5666,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final subtitleStreams = mediaStreams
         .where((s) => s['Type'] == 'Subtitle')
         .toList();
+    final audioStreams = _streamsForTrackSelectors(item, selectedSource)
+        .where((s) => s['Type'] == 'Audio')
+        .toList();
 
     final canShowDownloadActions =
         _isDownloadable(item.type) &&
@@ -5809,11 +5800,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           activeColor: const Color(0xFF4CAF50),
         ),
       if (isPlayableVideo) ...[
-        _DetailActionButton(
-          label: l10n.audio,
-          icon: Icons.audiotrack,
-          onPressed: () => _openAudioSelector(context, item),
-        ),
+        if (audioStreams.length > 1)
+          _DetailActionButton(
+            label: l10n.audio,
+            icon: Icons.audiotrack,
+            onPressed: () => _showAudioSelector(context, audioStreams),
+          ),
         _DetailActionButton(
           label: l10n.subtitles,
           icon: Icons.subtitles,


### PR DESCRIPTION
# Pull Request

## Summary
No need for users to change audio tracks if there's only 1 track. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes discord-LB1
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- get audio streams list during build() instead of a separate openAudioSelector function
- wrap audio button with if(streams.length > 1)
- have audio button onpressed call showAudioSelector directly, bypassing the unnecessary openAudioSelector function

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to media with only 1 audio track - no button
2. Go to media with more audio tracks - button
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="1080" height="2204" alt="Screenshot_20260705_142507" src="https://github.com/user-attachments/assets/c68ef462-a6f1-46b0-809c-31cf0b557236" />
<img width="1080" height="2204" alt="Screenshot_20260705_142521" src="https://github.com/user-attachments/assets/4642d5cc-8cf7-40df-90a5-a557f3c5b279" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
