### PR TITLE
feat(seerr): adjust Seerr people links and fallback profile image

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -10,6 +10,7 @@ import '../services/row_data_source.dart';
 import '../repositories/item_mutation_repository.dart';
 import '../repositories/mdblist_repository.dart';
 import '../repositories/tmdb_repository.dart';
+import '../repositories/seerr_repository.dart';
 import '../utils/playlist_utils.dart';
 import '../../util/episode_playability.dart';
 import '../services/plugin_sync_service.dart';
@@ -39,6 +40,9 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   AggregatedItem? _item;
   AggregatedItem? get item => _item;
+
+  String? _localPersonId;
+  String? get localPersonId => _localPersonId;
 
   int? _selectedAudioIndex;
   int? get selectedAudioIndex => _selectedAudioIndex;
@@ -201,12 +205,74 @@ class ItemDetailViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final data = await _client.itemsApi.getItem(itemId, mediaSourceId: mediaSourceId);
-      _item = AggregatedItem(
-        id: itemId,
-        serverId: _serverId ?? _client.baseUrl,
-        rawData: data,
-      );
+      if (itemId.startsWith('tmdb:')) {
+        final tmdbId = itemId.substring(5);
+        final seerrRepo = await GetIt.instance.getAsync<SeerrRepository>();
+        await seerrRepo.ensureInitialized();
+        final tmdbIdInt = int.tryParse(tmdbId);
+        if (tmdbIdInt == null) throw Exception('Invalid TMDB ID');
+        final seerrPerson = await seerrRepo.getPersonDetails(tmdbIdInt);
+
+        final rawData = {
+          'Name': seerrPerson.name,
+          'Overview': seerrPerson.biography,
+          'ProviderIds': {'Tmdb': tmdbId},
+          'Type': 'Person',
+          'PrimaryImageTag': seerrPerson.profilePath,
+          'ProfilePath': seerrPerson.profilePath,
+          'PremiereDate': seerrPerson.birthday,
+          'EndDate': seerrPerson.deathday,
+        };
+
+        _item = AggregatedItem(
+          id: itemId,
+          serverId: _serverId ?? _client.baseUrl,
+          rawData: rawData,
+        );
+
+        try {
+          final localPeople = await _client.itemsApi.getPersons(
+            searchTerm: seerrPerson.name,
+            limit: 20,
+            fields: 'ProviderIds',
+          );
+          final itemsList = (localPeople['Items'] as List? ?? [])
+              .map((e) => e is Map ? Map<String, dynamic>.from(e) : null)
+              .whereType<Map<String, dynamic>>()
+              .toList();
+          for (final localItem in itemsList) {
+            final localPIds = localItem['ProviderIds'] as Map?;
+            if (localPIds?['Tmdb']?.toString() == tmdbId) {
+              _localPersonId = localItem['Id']?.toString();
+              break;
+            }
+          }
+        } catch (_) {}
+
+        if (_localPersonId != null) {
+          try {
+            final localData = await _client.itemsApi.getItem(_localPersonId!);
+            final mergedData = Map<String, dynamic>.from(localData);
+            if (mergedData['Overview'] == null ||
+                (mergedData['Overview'] as String).isEmpty) {
+              mergedData['Overview'] = seerrPerson.biography;
+            }
+            mergedData['ProfilePath'] = seerrPerson.profilePath;
+            _item = AggregatedItem(
+              id: _localPersonId!,
+              serverId: _serverId ?? _client.baseUrl,
+              rawData: mergedData,
+            );
+          } catch (_) {}
+        }
+      } else {
+        final data = await _client.itemsApi.getItem(itemId, mediaSourceId: mediaSourceId);
+        _item = AggregatedItem(
+          id: itemId,
+          serverId: _serverId ?? _client.baseUrl,
+          rawData: data,
+        );
+      }
       _lyrics = LyricsData.empty;
       final prefs = GetIt.instance<UserPreferences>();
       final savedSubIndex = prefs.getItemSubtitleStreamIndex(itemId);
@@ -861,8 +927,14 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   Future<void> _loadFilmography() async {
     try {
+      final localId = _localPersonId ?? (itemId.startsWith('tmdb:') ? null : itemId);
+      if (localId == null) {
+        _filmography = const [];
+        notifyListeners();
+        return;
+      }
       final data = await _client.itemsApi.getItems(
-        personIds: [itemId],
+        personIds: [localId],
         includeItemTypes: ['Movie', 'Series', 'MusicVideo', 'Episode'],
         sortBy: 'PremiereDate',
         sortOrder: 'Descending',

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -9,6 +9,7 @@ import '../../data/services/connectivity_service.dart';
 import '../../di/injection.dart';
 import '../../playback/external_player_policy.dart';
 import '../../preference/user_preferences.dart';
+import '../../preference/preference_constants.dart';
 import '../../syncplay/syncplay_manager.dart';
 import '../../util/platform_detection.dart';
 import '../screens/auth/emby_connect_screen.dart';
@@ -718,6 +719,13 @@ final appRouter = GoRouter(
       path: Destinations.seerrPersonDetail,
       builder: (context, state) {
         final personId = state.pathParameters['personId']!;
+        final prefs = GetIt.instance<UserPreferences>();
+        if (prefs.get(UserPreferences.detailScreenStyle) == DetailScreenStyle.modern) {
+          return ItemDetailScreen(
+            key: ValueKey('tmdb:$personId'),
+            itemId: 'tmdb:$personId',
+          );
+        }
         return SeerrPersonScreen(personId: personId);
       },
     ),

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -993,12 +993,17 @@ class _DetailContentState extends State<_DetailContent> {
     final topOffset = safeTop + 80.0;
 
     String? imageUrl;
-    if (item.primaryImageTag != null) {
+    if (item.primaryImageTag != null && !item.id.startsWith('tmdb:')) {
       imageUrl = viewModel.imageApi.getPrimaryImageUrl(
         item.id,
         maxHeight: 400,
         tag: item.primaryImageTag,
       );
+    } else {
+      final profilePath = item.rawData['ProfilePath'] as String?;
+      if (profilePath != null && profilePath.isNotEmpty) {
+        imageUrl = 'https://image.tmdb.org/t/p/w500$profilePath';
+      }
     }
 
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
@@ -11936,12 +11941,17 @@ class PersonHeader extends StatelessWidget {
     final isMobile = _isCompact(context);
     final safeTop = MediaQuery.of(context).padding.top;
     String? imageUrl;
-    if (item.primaryImageTag != null) {
+    if (item.primaryImageTag != null && !item.id.startsWith('tmdb:')) {
       imageUrl = imageApi.getPrimaryImageUrl(
         item.id,
         maxHeight: 400,
         tag: item.primaryImageTag,
       );
+    } else {
+      final profilePath = item.rawData['ProfilePath'] as String?;
+      if (profilePath != null && profilePath.isNotEmpty) {
+        imageUrl = 'https://image.tmdb.org/t/p/w500$profilePath';
+      }
     }
 
     final avatarRadius = isMobile ? 60.0 : 80.0;

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3795,8 +3795,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   String? _imageUrl(AggregatedItem item) {
     final tag = item.primaryImageTag;
-    if (tag == null) return null;
-    return _vm.imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
+    if (tag != null && !item.id.startsWith('tmdb:')) {
+      return _vm.imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
+    }
+    final profilePath = item.rawData['ProfilePath'] as String?;
+    if (profilePath != null && profilePath.isNotEmpty) {
+      return 'https://image.tmdb.org/t/p/w500$profilePath';
+    }
+    return null;
   }
 
   void _selectTab(int index) {


### PR DESCRIPTION
# Pull Request

## Summary
When Detail Screen Style is set to "Modern", redirects Seerr-specific person details page routing from Seerr Discovery pages to the unified local Person details screen to match Details 2.0 behavior, and implements fallback TMDB profile image resolution for people not present in the local Jellyfin library.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #686 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [X] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Routing Mapping**: Updated GoRouter builder for `Destinations.seerrPersonDetail` (`/seerr/person/:personId`) to return `ItemDetailScreen` instead of `SeerrPersonScreen` to route to unified details.
- **Virtual Person Loading**: Extended `ItemDetailViewModel`'s `load()` method to detect `tmdb:` prefixed IDs, retrieve person metadata via `SeerrRepository`, and construct virtual `AggregatedItem`s containing biography, dates, and profile paths.
- **Jellyfin Local Person Linkage**: Queried the local Jellyfin server by person name using the `/Persons` endpoint to check for matching TMDB provider IDs. If a match is found, links the unified details layout to the local Person's library ID to populate local filmography and contributions.
- **Fallback Profile Image Resolution**: Updated fallback image rendering in `_buildStaticPersonProfilePanel` and `PersonHeader` in `item_detail_screen.dart`, as well as `_imageUrl` in `modern_detail_content.dart`, to fetch profile photos directly from TMDB (`https://image.tmdb.org/t/p/w500$profilePath`) if the person lacks a local primary image or is a virtual entry.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV/NVidia Shield
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the Seerr Discovery tab and open a media details page.
2. Click on a cast member card (e.g., Eric Nam).
3. Verify that the unified `ItemDetailScreen` loads correctly, displaying the biography, birthday/age, TMDB profile avatar image, and Appearances (Seerr) filmography.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Cast member linked from Seerr details page who exists in local library (has local Movies links):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-05_15-04-28" src="https://github.com/user-attachments/assets/6feeb014-e366-4436-8c47-381332b3ac8e" />

Cast member linked from Seerr details page who does NOT exist in local library (only Seerr links):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-05_15-25-07" src="https://github.com/user-attachments/assets/4d206ab1-4172-4a77-9cb5-7633c7109847" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
