### PR TITLE
feat: add Extras/Special Features support for TV shows

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1232,6 +1232,34 @@
   "@extras": {
     "description": "Tab label for special features / extras"
   },
+  "behindTheScenes": "Behind the Scenes",
+  "@behindTheScenes": {
+    "description": "Tab label for behind the scenes special features"
+  },
+  "deletedScenes": "Deleted Scenes",
+  "@deletedScenes": {
+    "description": "Tab label for deleted scenes special features"
+  },
+  "featurettes": "Featurettes",
+  "@featurettes": {
+    "description": "Tab label for featurettes special features"
+  },
+  "interviews": "Interviews",
+  "@interviews": {
+    "description": "Tab label for interviews special features"
+  },
+  "scenes": "Scenes",
+  "@scenes": {
+    "description": "Tab label for scenes special features"
+  },
+  "shorts": "Shorts",
+  "@shorts": {
+    "description": "Tab label for shorts special features"
+  },
+  "trailers": "Trailers",
+  "@trailers": {
+    "description": "Tab label for trailers special features"
+  },
   "timeRemaining": "{time} remaining",
   "@timeRemaining": {
     "description": "Label showing remaining playback time, e.g. '42m remaining'",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1834,6 +1834,48 @@ abstract class AppLocalizations {
   /// **'Extras'**
   String get extras;
 
+  /// Tab label for behind the scenes special features
+  ///
+  /// In en, this message translates to:
+  /// **'Behind the Scenes'**
+  String get behindTheScenes;
+
+  /// Tab label for deleted scenes special features
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted Scenes'**
+  String get deletedScenes;
+
+  /// Tab label for featurettes special features
+  ///
+  /// In en, this message translates to:
+  /// **'Featurettes'**
+  String get featurettes;
+
+  /// Tab label for interviews special features
+  ///
+  /// In en, this message translates to:
+  /// **'Interviews'**
+  String get interviews;
+
+  /// Tab label for scenes special features
+  ///
+  /// In en, this message translates to:
+  /// **'Scenes'**
+  String get scenes;
+
+  /// Tab label for shorts special features
+  ///
+  /// In en, this message translates to:
+  /// **'Shorts'**
+  String get shorts;
+
+  /// Tab label for trailers special features
+  ///
+  /// In en, this message translates to:
+  /// **'Trailers'**
+  String get trailers;
+
   /// Label showing remaining playback time, e.g. '42m remaining'
   ///
   /// In en, this message translates to:
@@ -14301,12 +14343,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Videos'**
   String get videos;
-
-  /// No description provided for @trailers.
-  ///
-  /// In en, this message translates to:
-  /// **'Trailers'**
-  String get trailers;
 
   /// No description provided for @programs.
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -924,6 +924,27 @@ class AppLocalizationsAf extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Sleepwaens';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8018,9 +8039,6 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get videos => 'Video\'s';
-
-  @override
-  String get trailers => 'Sleepwaens';
 
   @override
   String get programs => 'Programme';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -914,6 +914,27 @@ class AppLocalizationsAr extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'مقطورات';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7967,9 +7988,6 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videos => 'فيديوهات';
-
-  @override
-  String get trailers => 'مقطورات';
 
   @override
   String get programs => 'البرامج';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -920,6 +920,27 @@ class AppLocalizationsBe extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Трэйлеры';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8046,9 +8067,6 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get videos => 'Відэа';
-
-  @override
-  String get trailers => 'Трэйлеры';
 
   @override
   String get programs => 'Праграмы';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -919,6 +919,27 @@ class AppLocalizationsBg extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Трейлъри';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8091,9 +8112,6 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get videos => 'Видеоклипове';
-
-  @override
-  String get trailers => 'Трейлъри';
 
   @override
   String get programs => 'програми';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -917,6 +917,27 @@ class AppLocalizationsBn extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'ট্রেলার';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8006,9 +8027,6 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get videos => 'ভিডিও';
-
-  @override
-  String get trailers => 'ট্রেলার';
 
   @override
   String get programs => 'প্রোগ্রাম';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -931,6 +931,27 @@ class AppLocalizationsCa extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Remolcs';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8139,9 +8160,6 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get videos => 'Vídeos';
-
-  @override
-  String get trailers => 'Remolcs';
 
   @override
   String get programs => 'Programes';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -922,6 +922,27 @@ class AppLocalizationsCs extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Přívěsy';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8025,9 +8046,6 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get videos => 'videa';
-
-  @override
-  String get trailers => 'Přívěsy';
 
   @override
   String get programs => 'Programy';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -923,6 +923,27 @@ class AppLocalizationsCy extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trelars';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8039,9 +8060,6 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get videos => 'Fideos';
-
-  @override
-  String get trailers => 'Trelars';
 
   @override
   String get programs => 'Rhaglenni';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -918,6 +918,27 @@ class AppLocalizationsDa extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailere';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8011,9 +8032,6 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get videos => 'Videoer';
-
-  @override
-  String get trailers => 'Trailere';
 
   @override
   String get programs => 'Programmer';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -931,6 +931,27 @@ class AppLocalizationsDe extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Anhänger';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8083,9 +8104,6 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Anhänger';
 
   @override
   String get programs => 'Programme';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -929,6 +929,27 @@ class AppLocalizationsEl extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Ρυμουλκούμενα';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8136,9 +8157,6 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get videos => 'Βίντεο';
-
-  @override
-  String get trailers => 'Ρυμουλκούμενα';
 
   @override
   String get programs => 'Προγράμματα';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -918,6 +918,27 @@ class AppLocalizationsEn extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7983,9 +8004,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videos => 'Videos';
 
   @override
-  String get trailers => 'Trailers';
-
-  @override
   String get programs => 'Programs';
 
   @override
@@ -9598,6 +9616,9 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String endsAt(String time) {
     return 'Ends at $time';
   }
+
+  @override
+  String get trailers => 'Trailers';
 
   @override
   String endsIn(String time) {
@@ -16608,9 +16629,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -919,6 +919,27 @@ class AppLocalizationsEo extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Antaŭfilmoj';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8003,9 +8024,6 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get videos => 'Videoj';
-
-  @override
-  String get trailers => 'Antaŭfilmoj';
 
   @override
   String get programs => 'Programoj';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -926,6 +926,27 @@ class AppLocalizationsEs extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Remolques';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8095,9 +8116,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videos => 'Vídeos';
 
   @override
-  String get trailers => 'Remolques';
-
-  @override
   String get programs => 'Programas';
 
   @override
@@ -9719,6 +9737,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String endsAt(String time) {
     return 'Termina en $time';
   }
+
+  @override
+  String get trailers => 'Remolques';
 
   @override
   String endsIn(String time) {
@@ -16878,9 +16899,6 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get videos => 'Vídeos';
 
   @override
-  String get trailers => 'Remolques';
-
-  @override
   String get programs => 'Programas';
 
   @override
@@ -18210,6 +18228,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String endsAt(String time) {
     return 'Termina en $time';
   }
+
+  @override
+  String get trailers => 'Remolques';
 
   @override
   String endsIn(String time) {
@@ -25358,9 +25379,6 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
 
   @override
   String get videos => 'Vídeos';
-
-  @override
-  String get trailers => 'Remolques';
 
   @override
   String get programs => 'Programas';
@@ -26694,6 +26712,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   }
 
   @override
+  String get trailers => 'Remolques';
+
+  @override
   String endsIn(String time) {
     return '';
   }
@@ -33840,9 +33861,6 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
 
   @override
   String get videos => 'Vídeos';
-
-  @override
-  String get trailers => 'Remolques';
 
   @override
   String get programs => 'Programas';
@@ -35176,6 +35194,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   }
 
   @override
+  String get trailers => 'Remolques';
+
+  @override
   String endsIn(String time) {
     return '';
   }
@@ -42322,9 +42343,6 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
 
   @override
   String get videos => 'Vídeos';
-
-  @override
-  String get trailers => 'Remolques';
 
   @override
   String get programs => 'Programas';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -922,6 +922,27 @@ class AppLocalizationsEt extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Haagised';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8026,9 +8047,6 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get videos => 'Videod';
-
-  @override
-  String get trailers => 'Haagised';
 
   @override
   String get programs => 'Programmid';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -918,6 +918,27 @@ class AppLocalizationsFa extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'تریلرها';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7974,9 +7995,6 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get videos => 'ویدیوها';
-
-  @override
-  String get trailers => 'تریلرها';
 
   @override
   String get programs => 'برنامه ها';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -924,6 +924,27 @@ class AppLocalizationsFi extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Perävaunut';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8039,9 +8060,6 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get videos => 'Videot';
-
-  @override
-  String get trailers => 'Perävaunut';
 
   @override
   String get programs => 'Ohjelmat';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -931,6 +931,27 @@ class AppLocalizationsFr extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Remorques';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8144,9 +8165,6 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get videos => 'Vidéos';
-
-  @override
-  String get trailers => 'Remorques';
 
   @override
   String get programs => 'Programmes';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -929,6 +929,27 @@ class AppLocalizationsGl extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8110,9 +8131,6 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -909,6 +909,27 @@ class AppLocalizationsHe extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7909,9 +7930,6 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -918,6 +918,27 @@ class AppLocalizationsHi extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7991,9 +8012,6 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -920,6 +920,27 @@ class AppLocalizationsHr extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8035,9 +8056,6 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -923,6 +923,27 @@ class AppLocalizationsHu extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8078,9 +8099,6 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -925,6 +925,27 @@ class AppLocalizationsId extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailer';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8032,9 +8053,6 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get videos => 'Video';
-
-  @override
-  String get trailers => 'Trailer';
 
   @override
   String get programs => 'Program';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -924,6 +924,27 @@ class AppLocalizationsIt extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8054,9 +8075,6 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -896,6 +896,27 @@ class AppLocalizationsJa extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7818,9 +7839,6 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -922,6 +922,27 @@ class AppLocalizationsKk extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8046,9 +8067,6 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -924,6 +924,27 @@ class AppLocalizationsKn extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8061,9 +8082,6 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -896,6 +896,27 @@ class AppLocalizationsKo extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7813,9 +7834,6 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -919,6 +919,27 @@ class AppLocalizationsLt extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Priekabos';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8045,9 +8066,6 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get videos => 'Vaizdo įrašai';
-
-  @override
-  String get trailers => 'Priekabos';
 
   @override
   String get programs => 'Programos';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -923,6 +923,27 @@ class AppLocalizationsLv extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Piekabes';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8055,9 +8076,6 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get videos => 'Videoklipi';
-
-  @override
-  String get trailers => 'Piekabes';
 
   @override
   String get programs => 'Programmas';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -923,6 +923,27 @@ class AppLocalizationsMk extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8064,9 +8085,6 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -925,6 +925,27 @@ class AppLocalizationsMl extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'ട്രെയിലറുകൾ';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8108,9 +8129,6 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get videos => 'വീഡിയോകൾ';
-
-  @override
-  String get trailers => 'ട്രെയിലറുകൾ';
 
   @override
   String get programs => 'പ്രോഗ്രാമുകൾ';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -921,6 +921,27 @@ class AppLocalizationsMn extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8042,9 +8063,6 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -920,6 +920,27 @@ class AppLocalizationsNb extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8014,9 +8035,6 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -924,6 +924,27 @@ class AppLocalizationsNl extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8044,9 +8065,6 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -920,6 +920,27 @@ class AppLocalizationsPa extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7994,9 +8015,6 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -923,6 +923,27 @@ class AppLocalizationsPl extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8056,9 +8077,6 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -923,6 +923,27 @@ class AppLocalizationsPt extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Reboques';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8074,9 +8095,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videos => 'Vídeos';
 
   @override
-  String get trailers => 'Reboques';
-
-  @override
   String get programs => 'Programas';
 
   @override
@@ -9692,6 +9710,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String endsAt(String time) {
     return 'Termina em $time';
   }
+
+  @override
+  String get trailers => 'Trailers';
 
   @override
   String endsIn(String time) {
@@ -16794,9 +16815,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get videos => 'Videos';
 
   @override
-  String get trailers => 'Trailers';
-
-  @override
   String get programs => 'Programas';
 
   @override
@@ -18119,6 +18137,9 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String endsAt(String time) {
     return 'Termina em $time';
   }
+
+  @override
+  String get trailers => 'Trailers';
 
   @override
   String endsIn(String time) {
@@ -25240,9 +25261,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get videos => 'Vídeos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programas';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -922,6 +922,27 @@ class AppLocalizationsRo extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8059,9 +8080,6 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -923,6 +923,27 @@ class AppLocalizationsRu extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8065,9 +8086,6 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -916,6 +916,27 @@ class AppLocalizationsSi extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8001,9 +8022,6 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -924,6 +924,27 @@ class AppLocalizationsSk extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8046,9 +8067,6 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -923,6 +923,27 @@ class AppLocalizationsSl extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8043,9 +8064,6 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -927,6 +927,27 @@ class AppLocalizationsSq extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8074,9 +8095,6 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -920,6 +920,27 @@ class AppLocalizationsSr extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8040,9 +8061,6 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -919,6 +919,27 @@ class AppLocalizationsSv extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8025,9 +8046,6 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -928,6 +928,27 @@ class AppLocalizationsSw extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8066,9 +8087,6 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -925,6 +925,27 @@ class AppLocalizationsTa extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8068,9 +8089,6 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -923,6 +923,27 @@ class AppLocalizationsTe extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'ట్రైలర్స్';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8063,9 +8084,6 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get videos => 'వీడియోలు';
-
-  @override
-  String get trailers => 'ట్రైలర్స్';
 
   @override
   String get programs => 'కార్యక్రమాలు';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -915,6 +915,27 @@ class AppLocalizationsTh extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'รถพ่วง';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7960,9 +7981,6 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get videos => 'วิดีโอ';
-
-  @override
-  String get trailers => 'รถพ่วง';
 
   @override
   String get programs => 'โปรแกรม';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -926,6 +926,27 @@ class AppLocalizationsTl extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8093,9 +8114,6 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -921,6 +921,27 @@ class AppLocalizationsTr extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Fragmanlar';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8047,9 +8068,6 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get videos => 'Videolar';
-
-  @override
-  String get trailers => 'Fragmanlar';
 
   @override
   String get programs => 'Programlar';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -919,6 +919,27 @@ class AppLocalizationsUg extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8021,9 +8042,6 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -919,6 +919,27 @@ class AppLocalizationsUk extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Трейлери';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8065,9 +8086,6 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get videos => 'Відео';
-
-  @override
-  String get trailers => 'Трейлери';
 
   @override
   String get programs => 'Програми';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -925,6 +925,27 @@ class AppLocalizationsVi extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Xe kéo';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -8024,9 +8045,6 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get videos => 'Video';
-
-  @override
-  String get trailers => 'Xe kéo';
 
   @override
   String get programs => 'Chương trình';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -892,6 +892,27 @@ class AppLocalizationsYue extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => 'Trailers';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7772,9 +7793,6 @@ class AppLocalizationsYue extends AppLocalizations {
   String get videos => 'Videos';
 
   @override
-  String get trailers => 'Trailers';
-
-  @override
   String get programs => 'Programs';
 
   @override
@@ -9355,6 +9373,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String endsAt(String time) {
     return '结束于$time';
   }
+
+  @override
+  String get trailers => 'Trailers';
 
   @override
   String endsIn(String time) {
@@ -16193,9 +16214,6 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get videos => 'Videos';
 
   @override
-  String get trailers => 'Trailers';
-
-  @override
   String get programs => 'Programs';
 
   @override
@@ -17486,6 +17504,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String endsAt(String time) {
     return 'Ends at $time';
   }
+
+  @override
+  String get trailers => 'Trailers';
 
   @override
   String endsIn(String time) {
@@ -24321,9 +24342,6 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -891,6 +891,27 @@ class AppLocalizationsZh extends AppLocalizations {
   String get extras => 'Extras';
 
   @override
+  String get behindTheScenes => 'Behind the Scenes';
+
+  @override
+  String get deletedScenes => 'Deleted Scenes';
+
+  @override
+  String get featurettes => 'Featurettes';
+
+  @override
+  String get interviews => 'Interviews';
+
+  @override
+  String get scenes => 'Scenes';
+
+  @override
+  String get shorts => 'Shorts';
+
+  @override
+  String get trailers => '预告片';
+
+  @override
   String timeRemaining(String time) {
     return '$time remaining';
   }
@@ -7740,9 +7761,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get videos => '视频';
 
   @override
-  String get trailers => '预告片';
-
-  @override
   String get programs => '节目';
 
   @override
@@ -9312,6 +9330,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String endsAt(String time) {
     return 'Ends at $time';
   }
+
+  @override
+  String get trailers => 'Trailers';
 
   @override
   String endsIn(String time) {
@@ -16147,9 +16168,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get videos => 'Videos';
-
-  @override
-  String get trailers => 'Trailers';
 
   @override
   String get programs => 'Programs';

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -560,6 +560,14 @@ class _DetailContentState extends State<_DetailContent> {
     debugLabel: 'albumPlayButton',
   );
   final Map<String, FocusNode> _trackFocusNodes = <String, FocusNode>{};
+  final Map<String, FocusNode> _featureFocusNodes = <String, FocusNode>{};
+
+  FocusNode _featureFocusNodeFor(String categoryKey) {
+    return _featureFocusNodes.putIfAbsent(
+      categoryKey,
+      () => FocusNode(debugLabel: 'detailFeatureRow_$categoryKey'),
+    );
+  }
 
   FocusNode _getTrackFocusNode(String trackId) {
     return _trackFocusNodes.putIfAbsent(
@@ -980,6 +988,10 @@ class _DetailContentState extends State<_DetailContent> {
       node.dispose();
     }
     _trackFocusNodes.clear();
+    for (final node in _featureFocusNodes.values) {
+      node.dispose();
+    }
+    _featureFocusNodes.clear();
     _nextEpisodeFocusNode.dispose();
     _seriesNextUpFocusNode.dispose();
     super.dispose();
@@ -1583,7 +1595,19 @@ class _DetailContentState extends State<_DetailContent> {
   List<Widget> _buildMovieContent(BuildContext context, AggregatedItem item) {
     final l10n = AppLocalizations.of(context);
     final hasChapters = item.chapters.isNotEmpty;
-    final hasFeatures = viewModel.features.isNotEmpty;
+
+    final groupedFeatures = <String, List<AggregatedItem>>{};
+    for (final f in viewModel.features) {
+      final cat = _getExtraCategory(f);
+      groupedFeatures.putIfAbsent(cat, () => []).add(f);
+    }
+    final presentCategories = extraCategoriesOrder
+        .where((cat) => groupedFeatures[cat]?.isNotEmpty == true)
+        .toList();
+    final hasFeatures = presentCategories.isNotEmpty;
+    final firstFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.first) : null;
+    final lastFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.last) : null;
+
     final hasCast = viewModel.actors.isNotEmpty;
     final hasCollection = viewModel.parentCollectionItems.isNotEmpty;
     final hasSimilar = viewModel.similar.isNotEmpty;
@@ -1603,10 +1627,10 @@ class _DetailContentState extends State<_DetailContent> {
     final movieDownTarget = hasChapters
         ? _firstChapterFocusNode
         : (hasFeatures
-              ? _firstFeatureFocusNode
+              ? firstFeatureNode!
               : (castFocusNode ?? collectionFocusNode ?? similarFocusNode));
     final chapterFeatureLastNode = hasFeatures
-        ? _firstFeatureFocusNode
+        ? lastFeatureNode!
         : (hasChapters
               ? _firstChapterFocusNode
               : (metadataFocusNode ?? actionButtonsFocusNode));
@@ -1735,7 +1759,19 @@ class _DetailContentState extends State<_DetailContent> {
     final hasSeasons = viewModel.seasons.isNotEmpty;
     final hasCast = viewModel.actors.isNotEmpty;
     final hasSimilar = viewModel.similar.isNotEmpty;
-    final hasFeatures = viewModel.features.isNotEmpty;
+
+    final groupedFeatures = <String, List<AggregatedItem>>{};
+    for (final f in viewModel.features) {
+      final cat = _getExtraCategory(f);
+      groupedFeatures.putIfAbsent(cat, () => []).add(f);
+    }
+    final presentCategories = extraCategoriesOrder
+        .where((cat) => groupedFeatures[cat]?.isNotEmpty == true)
+        .toList();
+    final hasFeatures = presentCategories.isNotEmpty;
+    final firstFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.first) : null;
+    final lastFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.last) : null;
+
     final hasNextUp = viewModel.nextUp != null;
     final seriesNextUpFocusNode = hasNextUp ? _seriesNextUpFocusNode : null;
     final seasonsFocusNode = hasSeasons
@@ -1919,7 +1955,7 @@ class _DetailContentState extends State<_DetailContent> {
                   seriesNextUpFocusNode ??
                   metadataFocusNode ??
                   actionButtonsFocusNode,
-              downTarget: hasFeatures ? _firstFeatureFocusNode : null,
+              downTarget: hasFeatures ? firstFeatureNode : null,
               itemCount: viewModel.similar.length,
               consumeDownWhenNoTarget: !hasFeatures,
             ),
@@ -1982,7 +2018,19 @@ class _DetailContentState extends State<_DetailContent> {
   List<Widget> _buildEpisodeContent(BuildContext context, AggregatedItem item) {
     final l10n = AppLocalizations.of(context);
     final hasChapters = item.chapters.isNotEmpty;
-    final hasFeatures = viewModel.features.isNotEmpty;
+
+    final groupedFeatures = <String, List<AggregatedItem>>{};
+    for (final f in viewModel.features) {
+      final cat = _getExtraCategory(f);
+      groupedFeatures.putIfAbsent(cat, () => []).add(f);
+    }
+    final presentCategories = extraCategoriesOrder
+        .where((cat) => groupedFeatures[cat]?.isNotEmpty == true)
+        .toList();
+    final hasFeatures = presentCategories.isNotEmpty;
+    final firstFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.first) : null;
+    final lastFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.last) : null;
+
     final hasSeasonEpisodes = viewModel.episodes.isNotEmpty;
     final hasCast = viewModel.actors.isNotEmpty;
     final hasSimilar = viewModel.similar.isNotEmpty;
@@ -2019,9 +2067,9 @@ class _DetailContentState extends State<_DetailContent> {
         similarFocusNode;
     final episodeDownTarget = hasChapters
         ? _firstChapterFocusNode
-        : (hasFeatures ? _firstFeatureFocusNode : chapterFeatureNextNode);
+        : (hasFeatures ? firstFeatureNode! : chapterFeatureNextNode);
     final chapterFeatureLastNode = hasFeatures
-        ? _firstFeatureFocusNode
+        ? lastFeatureNode!
         : (hasChapters
               ? _firstChapterFocusNode
               : (metadataFocusNode ?? actionButtonsFocusNode));
@@ -2238,15 +2286,27 @@ class _DetailContentState extends State<_DetailContent> {
   }) {
     final l10n = AppLocalizations.of(context);
     final hasChapters = item.chapters.isNotEmpty;
-    final hasFeatures = viewModel.features.isNotEmpty;
-    final chapterDownTarget = hasFeatures
-        ? _firstFeatureFocusNode
-        : nextSectionFocusNode;
-    final featureUpTarget = hasChapters ? _firstChapterFocusNode : null;
 
-    return [
-      if (hasChapters) ...[
-        const SizedBox(height: 32),
+    final groupedFeatures = <String, List<AggregatedItem>>{};
+    for (final f in viewModel.features) {
+      final cat = _getExtraCategory(f);
+      groupedFeatures.putIfAbsent(cat, () => []).add(f);
+    }
+
+    final presentCategories = extraCategoriesOrder
+        .where((cat) => groupedFeatures[cat]?.isNotEmpty == true)
+        .toList();
+    final hasFeatures = presentCategories.isNotEmpty;
+
+    final chapterDownTarget = hasFeatures
+        ? _featureFocusNodeFor(presentCategories.first)
+        : nextSectionFocusNode;
+
+    final List<Widget> widgets = [];
+
+    if (hasChapters) {
+      widgets.add(const SizedBox(height: 32));
+      widgets.add(
         HorizontalScrollSection(
           title: l10n.chapters,
           builder: (_, ctrl) => DetailChaptersRow(
@@ -2268,31 +2328,48 @@ class _DetailContentState extends State<_DetailContent> {
             ),
           ),
         ),
-      ],
-      if (hasFeatures) ...[
-        const SizedBox(height: 32),
+      );
+    }
+
+    for (int i = 0; i < presentCategories.length; i++) {
+      final cat = presentCategories[i];
+      final items = groupedFeatures[cat]!;
+      final focusNode = _featureFocusNodeFor(cat);
+
+      final upTarget = (i == 0)
+          ? (hasChapters ? _firstChapterFocusNode : prevSectionFocusNode)
+          : _featureFocusNodeFor(presentCategories[i - 1]);
+
+      final downTarget = (i == presentCategories.length - 1)
+          ? nextSectionFocusNode
+          : _featureFocusNodeFor(presentCategories[i + 1]);
+
+      widgets.add(const SizedBox(height: 32));
+      widgets.add(
         HorizontalScrollSection(
-          title: l10n.features,
+          title: getExtraCategoryLabel(cat, l10n),
           builder: (_, ctrl) => DetailFeaturesRow(
-            items: viewModel.features,
+            items: items,
             imageApi: viewModel.imageApi,
             prefs: prefs,
             onItemLongPress: _showItemContextMenu,
             scrollController: _trackSectionScrollController(
-              _firstFeatureFocusNode,
+              focusNode,
               ctrl,
             ),
-            firstItemFocusNode: _firstFeatureFocusNode,
+            firstItemFocusNode: focusNode,
             onItemKeyEvent: _buildVerticalRowHandler(
-              sourceFocusNode: _firstFeatureFocusNode,
-              upTarget: featureUpTarget ?? prevSectionFocusNode,
-              downTarget: nextSectionFocusNode,
-              itemCount: viewModel.features.length,
+              sourceFocusNode: focusNode,
+              upTarget: upTarget,
+              downTarget: downTarget,
+              itemCount: items.length,
             ),
           ),
         ),
-      ],
-    ];
+      );
+    }
+
+    return widgets;
   }
 
   List<Widget> _buildPersonContent(BuildContext context, AggregatedItem item) {
@@ -14137,4 +14214,92 @@ class _PersonDisplaySettingsDialogState
 }
 
 typedef PersonDisplaySettingsDialog = _PersonDisplaySettingsDialog;
+
+const extraCategoriesOrder = [
+  'extras',
+  'behindTheScenes',
+  'deletedScenes',
+  'featurettes',
+  'interviews',
+  'scenes',
+  'shorts',
+  'trailers',
+];
+
+String _getExtraCategory(AggregatedItem item) {
+  final extraType = item.rawData['ExtraType'] as String?;
+  if (extraType == null) return 'extras';
+  switch (extraType) {
+    case 'BehindTheScenes':
+      return 'behindTheScenes';
+    case 'DeletedScene':
+      return 'deletedScenes';
+    case 'Featurette':
+      return 'featurettes';
+    case 'Interview':
+      return 'interviews';
+    case 'Scene':
+      return 'scenes';
+    case 'Short':
+      return 'shorts';
+    case 'Trailer':
+      return 'trailers';
+    default:
+      return 'extras';
+  }
+}
+
+String getExtraCategoryLabel(String key, AppLocalizations l10n) {
+  switch (key) {
+    case 'behindTheScenes':
+      try {
+        return l10n.behindTheScenes;
+      } catch (_) {
+        return 'Behind the Scenes';
+      }
+    case 'deletedScenes':
+      try {
+        return l10n.deletedScenes;
+      } catch (_) {
+        return 'Deleted Scenes';
+      }
+    case 'featurettes':
+      try {
+        return l10n.featurettes;
+      } catch (_) {
+        return 'Featurettes';
+      }
+    case 'interviews':
+      try {
+        return l10n.interviews;
+      } catch (_) {
+        return 'Interviews';
+      }
+    case 'scenes':
+      try {
+        return l10n.scenes;
+      } catch (_) {
+        return 'Scenes';
+      }
+    case 'shorts':
+      try {
+        return l10n.shorts;
+      } catch (_) {
+        return 'Shorts';
+      }
+    case 'trailers':
+      try {
+        return l10n.trailers;
+      } catch (_) {
+        return 'Trailers';
+      }
+    case 'extras':
+    default:
+      try {
+        return l10n.extras;
+      } catch (_) {
+        return 'Extras';
+      }
+  }
+}
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1598,7 +1598,7 @@ class _DetailContentState extends State<_DetailContent> {
 
     final groupedFeatures = <String, List<AggregatedItem>>{};
     for (final f in viewModel.features) {
-      final cat = _getExtraCategory(f);
+      final cat = getExtraCategory(f);
       groupedFeatures.putIfAbsent(cat, () => []).add(f);
     }
     final presentCategories = extraCategoriesOrder
@@ -1762,7 +1762,7 @@ class _DetailContentState extends State<_DetailContent> {
 
     final groupedFeatures = <String, List<AggregatedItem>>{};
     for (final f in viewModel.features) {
-      final cat = _getExtraCategory(f);
+      final cat = getExtraCategory(f);
       groupedFeatures.putIfAbsent(cat, () => []).add(f);
     }
     final presentCategories = extraCategoriesOrder
@@ -1770,7 +1770,6 @@ class _DetailContentState extends State<_DetailContent> {
         .toList();
     final hasFeatures = presentCategories.isNotEmpty;
     final firstFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.first) : null;
-    final lastFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.last) : null;
 
     final hasNextUp = viewModel.nextUp != null;
     final seriesNextUpFocusNode = hasNextUp ? _seriesNextUpFocusNode : null;
@@ -2021,7 +2020,7 @@ class _DetailContentState extends State<_DetailContent> {
 
     final groupedFeatures = <String, List<AggregatedItem>>{};
     for (final f in viewModel.features) {
-      final cat = _getExtraCategory(f);
+      final cat = getExtraCategory(f);
       groupedFeatures.putIfAbsent(cat, () => []).add(f);
     }
     final presentCategories = extraCategoriesOrder
@@ -2289,7 +2288,7 @@ class _DetailContentState extends State<_DetailContent> {
 
     final groupedFeatures = <String, List<AggregatedItem>>{};
     for (final f in viewModel.features) {
-      final cat = _getExtraCategory(f);
+      final cat = getExtraCategory(f);
       groupedFeatures.putIfAbsent(cat, () => []).add(f);
     }
 
@@ -14214,92 +14213,4 @@ class _PersonDisplaySettingsDialogState
 }
 
 typedef PersonDisplaySettingsDialog = _PersonDisplaySettingsDialog;
-
-const extraCategoriesOrder = [
-  'extras',
-  'behindTheScenes',
-  'deletedScenes',
-  'featurettes',
-  'interviews',
-  'scenes',
-  'shorts',
-  'trailers',
-];
-
-String _getExtraCategory(AggregatedItem item) {
-  final extraType = item.rawData['ExtraType'] as String?;
-  if (extraType == null) return 'extras';
-  switch (extraType) {
-    case 'BehindTheScenes':
-      return 'behindTheScenes';
-    case 'DeletedScene':
-      return 'deletedScenes';
-    case 'Featurette':
-      return 'featurettes';
-    case 'Interview':
-      return 'interviews';
-    case 'Scene':
-      return 'scenes';
-    case 'Short':
-      return 'shorts';
-    case 'Trailer':
-      return 'trailers';
-    default:
-      return 'extras';
-  }
-}
-
-String getExtraCategoryLabel(String key, AppLocalizations l10n) {
-  switch (key) {
-    case 'behindTheScenes':
-      try {
-        return l10n.behindTheScenes;
-      } catch (_) {
-        return 'Behind the Scenes';
-      }
-    case 'deletedScenes':
-      try {
-        return l10n.deletedScenes;
-      } catch (_) {
-        return 'Deleted Scenes';
-      }
-    case 'featurettes':
-      try {
-        return l10n.featurettes;
-      } catch (_) {
-        return 'Featurettes';
-      }
-    case 'interviews':
-      try {
-        return l10n.interviews;
-      } catch (_) {
-        return 'Interviews';
-      }
-    case 'scenes':
-      try {
-        return l10n.scenes;
-      } catch (_) {
-        return 'Scenes';
-      }
-    case 'shorts':
-      try {
-        return l10n.shorts;
-      } catch (_) {
-        return 'Shorts';
-      }
-    case 'trailers':
-      try {
-        return l10n.trailers;
-      } catch (_) {
-        return 'Trailers';
-      }
-    case 'extras':
-    default:
-      try {
-        return l10n.extras;
-      } catch (_) {
-        return 'Extras';
-      }
-  }
-}
 

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -659,16 +659,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final tabs = _tabsFor(_vm.item!, l10n);
       if (tabIndex >= 0 && tabIndex < tabs.length) {
         final label = tabs[tabIndex].label;
-        bool isExtraLabel = false;
+        String? extraCat;
         for (final cat in extraCategoriesOrder) {
           if (label == getExtraCategoryLabel(cat, l10n)) {
-            _featuresFirstFocusNodes[cat]?.requestFocus();
-            isExtraLabel = true;
+            extraCat = cat;
             break;
           }
         }
-        if (isExtraLabel) {
-          // Handled
+        if (extraCat != null) {
+          _featuresFirstFocusNodes[extraCat]?.requestFocus();
         } else if (label == l10n.cast) {
           _castFirstFocusNode.requestFocus();
         } else if (label == l10n.crewSection) {
@@ -735,7 +734,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     final groupedFeatures = <String, List<AggregatedItem>>{};
     for (final f in _vm.features) {
-      final cat = _getExtraCategory(f);
+      final cat = getExtraCategory(f);
       groupedFeatures.putIfAbsent(cat, () => []).add(f);
     }
 
@@ -745,7 +744,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       if (items != null && items.isNotEmpty) {
         extraTabs.add(_ModernTab(
           getExtraCategoryLabel(cat, l10n),
-          (context, item) => _extrasTab(context, item, items),
+          (context, item) => _extrasTab(context, item, items, _featuresFirstFocusNodes[cat]),
         ));
       }
     }
@@ -2064,7 +2063,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  Widget _extrasTab(BuildContext context, AggregatedItem item, List<AggregatedItem> items) => SizedBox(
+  Widget _extrasTab(BuildContext context, AggregatedItem item, List<AggregatedItem> items, FocusNode? firstItemFocusNode) => SizedBox(
         height: 200,
         child: Focus(
           canRequestFocus: false,
@@ -2086,6 +2085,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             items: items,
             imageApi: _vm.imageApi,
             prefs: widget.prefs,
+            firstItemFocusNode: firstItemFocusNode,
           ),
         ),
       );
@@ -4240,7 +4240,7 @@ const extraCategoriesOrder = [
   'trailers',
 ];
 
-String _getExtraCategory(AggregatedItem item) {
+String getExtraCategory(AggregatedItem item) {
   final extraType = item.rawData['ExtraType'] as String?;
   if (extraType == null) return 'extras';
   switch (extraType) {
@@ -4266,53 +4266,21 @@ String _getExtraCategory(AggregatedItem item) {
 String getExtraCategoryLabel(String key, AppLocalizations l10n) {
   switch (key) {
     case 'behindTheScenes':
-      try {
-        return l10n.behindTheScenes;
-      } catch (_) {
-        return 'Behind the Scenes';
-      }
+      return l10n.behindTheScenes;
     case 'deletedScenes':
-      try {
-        return l10n.deletedScenes;
-      } catch (_) {
-        return 'Deleted Scenes';
-      }
+      return l10n.deletedScenes;
     case 'featurettes':
-      try {
-        return l10n.featurettes;
-      } catch (_) {
-        return 'Featurettes';
-      }
+      return l10n.featurettes;
     case 'interviews':
-      try {
-        return l10n.interviews;
-      } catch (_) {
-        return 'Interviews';
-      }
+      return l10n.interviews;
     case 'scenes':
-      try {
-        return l10n.scenes;
-      } catch (_) {
-        return 'Scenes';
-      }
+      return l10n.scenes;
     case 'shorts':
-      try {
-        return l10n.shorts;
-      } catch (_) {
-        return 'Shorts';
-      }
+      return l10n.shorts;
     case 'trailers':
-      try {
-        return l10n.trailers;
-      } catch (_) {
-        return 'Trailers';
-      }
+      return l10n.trailers;
     case 'extras':
     default:
-      try {
-        return l10n.extras;
-      } catch (_) {
-        return 'Extras';
-      }
+      return l10n.extras;
   }
 }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -129,6 +129,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   final FocusNode _personSeerrCrewCreditsFirstFocusNode = FocusNode(debugLabel: 'personSeerrCrewCreditsFirst');
   final Map<String, FocusNode> _boxSetHeadingFocusNodes = {};
   final Map<String, FocusNode> _boxSetRowFirstFocusNodes = {};
+  final Map<String, FocusNode> _featuresFirstFocusNodes = {};
   late final ScrollController _scrollController = ScrollController();
   String? _seriesLogoTag;
   String? _seriesLogoId;
@@ -455,6 +456,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _gridFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _moviesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _seriesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+
+    for (final cat in extraCategoriesOrder) {
+      final node = FocusNode(debugLabel: 'modernFeatureFirst_$cat');
+      node.onKeyEvent = leftToSidebarHandler;
+      _featuresFirstFocusNodes[cat] = node;
+    }
     _collectionSortFocusNode.onKeyEvent = (node, event) {
       if (event is KeyDownEvent) {
         if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
@@ -573,6 +580,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     for (final node in _boxSetRowFirstFocusNodes.values) {
       node.dispose();
     }
+    for (final node in _featuresFirstFocusNodes.values) {
+      node.dispose();
+    }
+    _featuresFirstFocusNodes.clear();
     super.dispose();
   }
 
@@ -648,7 +659,17 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final tabs = _tabsFor(_vm.item!, l10n);
       if (tabIndex >= 0 && tabIndex < tabs.length) {
         final label = tabs[tabIndex].label;
-        if (label == l10n.cast) {
+        bool isExtraLabel = false;
+        for (final cat in extraCategoriesOrder) {
+          if (label == getExtraCategoryLabel(cat, l10n)) {
+            _featuresFirstFocusNodes[cat]?.requestFocus();
+            isExtraLabel = true;
+            break;
+          }
+        }
+        if (isExtraLabel) {
+          // Handled
+        } else if (label == l10n.cast) {
           _castFirstFocusNode.requestFocus();
         } else if (label == l10n.crewSection) {
           _crewFirstFocusNode.requestFocus();
@@ -711,7 +732,23 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final hasCrew = _vm.directors.isNotEmpty || _vm.writers.isNotEmpty;
     final hasStudios = item.studios.isNotEmpty;
     final hasSimilar = _vm.similar.isNotEmpty;
-    final hasFeatures = _vm.features.isNotEmpty;
+
+    final groupedFeatures = <String, List<AggregatedItem>>{};
+    for (final f in _vm.features) {
+      final cat = _getExtraCategory(f);
+      groupedFeatures.putIfAbsent(cat, () => []).add(f);
+    }
+
+    final List<_ModernTab> extraTabs = [];
+    for (final cat in extraCategoriesOrder) {
+      final items = groupedFeatures[cat];
+      if (items != null && items.isNotEmpty) {
+        extraTabs.add(_ModernTab(
+          getExtraCategoryLabel(cat, l10n),
+          (context, item) => _extrasTab(context, item, items),
+        ));
+      }
+    }
 
     final cast = _ModernTab(l10n.cast, _castTab);
     final crew = _ModernTab(l10n.crewSection, _crewTab);
@@ -730,7 +767,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasStudios) studios,
           if (item.chapters.isNotEmpty) chapters,
           details,
-          if (hasFeatures) _ModernTab(l10n.extras, _extrasTab),
+          ...extraTabs,
           if (hasSimilar) similar,
         ];
       case 'Season':
@@ -741,7 +778,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCrew) crew,
           if (hasStudios) studios,
           if (item.chapters.isNotEmpty) chapters,
-          if (hasFeatures) _ModernTab(l10n.extras, _extrasTab),
+          ...extraTabs,
         ];
       case 'Episode':
         return [
@@ -752,6 +789,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasStudios) studios,
           if (item.chapters.isNotEmpty) chapters,
           details,
+          ...extraTabs,
           if (hasSimilar) similar,
         ];
       case 'MusicAlbum':
@@ -898,7 +936,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasStudios) studios,
           if (item.chapters.isNotEmpty) chapters,
           details,
-          if (hasFeatures) _ModernTab(l10n.extras, _extrasTab),
+          ...extraTabs,
           if (hasSimilar) similar,
         ];
     }
@@ -2026,7 +2064,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  Widget _extrasTab(BuildContext context, AggregatedItem item) => SizedBox(
+  Widget _extrasTab(BuildContext context, AggregatedItem item, List<AggregatedItem> items) => SizedBox(
         height: 200,
         child: Focus(
           canRequestFocus: false,
@@ -2045,7 +2083,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             return KeyEventResult.ignored;
           },
           child: DetailFeaturesRow(
-            items: _vm.features,
+            items: items,
             imageApi: _vm.imageApi,
             prefs: widget.prefs,
           ),
@@ -4188,5 +4226,93 @@ class _DetailsContainerState extends State<_DetailsContainer> with FocusStateMix
             : widget.child,
       ),
     );
+  }
+}
+
+const extraCategoriesOrder = [
+  'extras',
+  'behindTheScenes',
+  'deletedScenes',
+  'featurettes',
+  'interviews',
+  'scenes',
+  'shorts',
+  'trailers',
+];
+
+String _getExtraCategory(AggregatedItem item) {
+  final extraType = item.rawData['ExtraType'] as String?;
+  if (extraType == null) return 'extras';
+  switch (extraType) {
+    case 'BehindTheScenes':
+      return 'behindTheScenes';
+    case 'DeletedScene':
+      return 'deletedScenes';
+    case 'Featurette':
+      return 'featurettes';
+    case 'Interview':
+      return 'interviews';
+    case 'Scene':
+      return 'scenes';
+    case 'Short':
+      return 'shorts';
+    case 'Trailer':
+      return 'trailers';
+    default:
+      return 'extras';
+  }
+}
+
+String getExtraCategoryLabel(String key, AppLocalizations l10n) {
+  switch (key) {
+    case 'behindTheScenes':
+      try {
+        return l10n.behindTheScenes;
+      } catch (_) {
+        return 'Behind the Scenes';
+      }
+    case 'deletedScenes':
+      try {
+        return l10n.deletedScenes;
+      } catch (_) {
+        return 'Deleted Scenes';
+      }
+    case 'featurettes':
+      try {
+        return l10n.featurettes;
+      } catch (_) {
+        return 'Featurettes';
+      }
+    case 'interviews':
+      try {
+        return l10n.interviews;
+      } catch (_) {
+        return 'Interviews';
+      }
+    case 'scenes':
+      try {
+        return l10n.scenes;
+      } catch (_) {
+        return 'Scenes';
+      }
+    case 'shorts':
+      try {
+        return l10n.shorts;
+      } catch (_) {
+        return 'Shorts';
+      }
+    case 'trailers':
+      try {
+        return l10n.trailers;
+      } catch (_) {
+        return 'Trailers';
+      }
+    case 'extras':
+    default:
+      try {
+        return l10n.extras;
+      } catch (_) {
+        return 'Extras';
+      }
   }
 }


### PR DESCRIPTION
# Pull Request

## Summary
Current testing build did not have proper navigation link on Season pages to open the Extras tag. This PR fixes that as well as adds support for TV show and season-level extras/special features categorized by category subfolders/Jellyfin ExtraType (Extras, Behind the Scenes, Deleted Scenes, Featurettes, Interviews, Scenes, Shorts, Trailers) in both modern (tabbed) and standard (row-based) detail views at the Season 00 level, as well as within actual seasons. Also fixes D-pad navigation/focus transitions for modern tab contents for each category.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes tester feedback from Discord
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Added category translations (behindTheScenes, deletedScenes, featurettes, interviews, scenes, shorts, trailers) to lib/l10n/app_en.arb.
* Updated item_detail_screen.dart to group features by category and display them in separate horizontal sections, linking FocusNodes sequentially so directional D-pad navigation flows correctly.
* Updated modern_detail_content.dart to categorize features into distinct labeled tabs if relevant extras folder contents are present.
* Fixed D-pad navigation logic inside modern_detail_content.dart to properly map focus requests down from the tab bar header into the active extras/special features rows.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Android TV with standard Season 00 structure. Requires tester feedback for more complex special feature structures.
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a TV Series or Season that contains subfolder extras (e.g. Season 01/behind the scenes, Season 01/deleted scenes, etc.).
2. Verify that extras are grouped and labeled under separate tabs (in modern layout) or separate horizontal scroll rows (in standard layout).
3. Verify that D-Pad navigation correctly cycles between all extra sections and navigates correctly from the tab bar down to the extra cards.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
