### PR TITLE
fix: make calendar filter toggles apply dynamically in real-time

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -114,6 +114,16 @@ class _HomeShellState extends State<_HomeShell>
   String? _lastObservedPath;
   ModalRoute<dynamic>? _observedRoute;
 
+  bool _lastEnableRadarrCalendar = false;
+  bool _lastEnableSonarrCalendar = false;
+  bool _lastMergeRadarrSonarrCalendars = false;
+  bool _lastRadarrCalendarShowCinema = true;
+  bool _lastRadarrCalendarShowDigital = true;
+  bool _lastRadarrCalendarShowPhysical = true;
+  bool _lastRadarrCalendarShowDate = true;
+  bool _lastSonarrCalendarShowEpisodeInfo = true;
+  bool _lastSonarrCalendarShowDate = true;
+
   static const _selectionDelay = Duration(milliseconds: 150);
   static const _backdropDelay = Duration(milliseconds: 200);
 
@@ -144,6 +154,16 @@ class _HomeShellState extends State<_HomeShell>
       UserPreferences.blockedParentalRatings,
     );
     _lastSeerrAvailable = _pluginSyncService.seerrAvailable;
+    _lastEnableRadarrCalendar = _userPrefs.get(UserPreferences.enableRadarrCalendar);
+    _lastEnableSonarrCalendar = _userPrefs.get(UserPreferences.enableSonarrCalendar);
+    _lastMergeRadarrSonarrCalendars = _userPrefs.get(UserPreferences.mergeRadarrSonarrCalendars);
+    _lastRadarrCalendarShowCinema = _userPrefs.get(UserPreferences.radarrCalendarShowCinema);
+    _lastRadarrCalendarShowDigital = _userPrefs.get(UserPreferences.radarrCalendarShowDigital);
+    _lastRadarrCalendarShowPhysical = _userPrefs.get(UserPreferences.radarrCalendarShowPhysical);
+    _lastRadarrCalendarShowDate = _userPrefs.get(UserPreferences.radarrCalendarShowDate);
+    _lastSonarrCalendarShowEpisodeInfo = _userPrefs.get(UserPreferences.sonarrCalendarShowEpisodeInfo);
+    _lastSonarrCalendarShowDate = _userPrefs.get(UserPreferences.sonarrCalendarShowDate);
+
     _pluginSyncService.addListener(_onPluginSyncChanged);
     _userPrefs.addListener(_onPrefsChanged);
     _maybeRegisterThemeMusic();
@@ -227,15 +247,43 @@ class _HomeShellState extends State<_HomeShell>
     final currentBlocked = _userPrefs.get(
       UserPreferences.blockedParentalRatings,
     );
+    final currentEnableRadarr = _userPrefs.get(UserPreferences.enableRadarrCalendar);
+    final currentEnableSonarr = _userPrefs.get(UserPreferences.enableSonarrCalendar);
+    final currentMerge = _userPrefs.get(UserPreferences.mergeRadarrSonarrCalendars);
+    final currentShowCinema = _userPrefs.get(UserPreferences.radarrCalendarShowCinema);
+    final currentShowDigital = _userPrefs.get(UserPreferences.radarrCalendarShowDigital);
+    final currentShowPhysical = _userPrefs.get(UserPreferences.radarrCalendarShowPhysical);
+    final currentShowDate = _userPrefs.get(UserPreferences.radarrCalendarShowDate);
+    final currentShowEpisodeInfo = _userPrefs.get(UserPreferences.sonarrCalendarShowEpisodeInfo);
+    final currentShowSonarrDate = _userPrefs.get(UserPreferences.sonarrCalendarShowDate);
+
     if (currentJson != _lastSectionsJson ||
         currentMultiServer != _lastMultiServer ||
-        currentMergeContinueWatchingNextUp !=
-            _lastMergeContinueWatchingNextUp ||
-        currentBlocked != _lastBlockedParentalRatings) {
+        currentMergeContinueWatchingNextUp != _lastMergeContinueWatchingNextUp ||
+        currentBlocked != _lastBlockedParentalRatings ||
+        currentEnableRadarr != _lastEnableRadarrCalendar ||
+        currentEnableSonarr != _lastEnableSonarrCalendar ||
+        currentMerge != _lastMergeRadarrSonarrCalendars ||
+        currentShowCinema != _lastRadarrCalendarShowCinema ||
+        currentShowDigital != _lastRadarrCalendarShowDigital ||
+        currentShowPhysical != _lastRadarrCalendarShowPhysical ||
+        currentShowDate != _lastRadarrCalendarShowDate ||
+        currentShowEpisodeInfo != _lastSonarrCalendarShowEpisodeInfo ||
+        currentShowSonarrDate != _lastSonarrCalendarShowDate) {
       _lastSectionsJson = currentJson;
       _lastMultiServer = currentMultiServer;
       _lastMergeContinueWatchingNextUp = currentMergeContinueWatchingNextUp;
       _lastBlockedParentalRatings = currentBlocked;
+      _lastEnableRadarrCalendar = currentEnableRadarr;
+      _lastEnableSonarrCalendar = currentEnableSonarr;
+      _lastMergeRadarrSonarrCalendars = currentMerge;
+      _lastRadarrCalendarShowCinema = currentShowCinema;
+      _lastRadarrCalendarShowDigital = currentShowDigital;
+      _lastRadarrCalendarShowPhysical = currentShowPhysical;
+      _lastRadarrCalendarShowDate = currentShowDate;
+      _lastSonarrCalendarShowEpisodeInfo = currentShowEpisodeInfo;
+      _lastSonarrCalendarShowDate = currentShowSonarrDate;
+
       _viewModel.refresh();
     }
     _maybeRegisterThemeMusic();

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -2143,6 +2143,101 @@ class HomeViewModel extends ChangeNotifier {
     return null;
   }
 
+  List<AggregatedItem> _filterAndFormatRadarrItems(List<AggregatedItem> rawItems) {
+    final now = DateTime.now();
+    final showCinema = _prefs.get(UserPreferences.radarrCalendarShowCinema);
+    final showDigital = _prefs.get(UserPreferences.radarrCalendarShowDigital);
+    final showPhysical = _prefs.get(UserPreferences.radarrCalendarShowPhysical);
+    final showDate = _prefs.get(UserPreferences.radarrCalendarShowDate);
+
+    final List<AggregatedItem> filtered = [];
+
+    for (final item in rawItems) {
+      final inCinemasStr = item.rawData['InCinemas'] as String?;
+      final digitalReleaseStr = item.rawData['DigitalRelease'] as String?;
+      final physicalReleaseStr = item.rawData['PhysicalRelease'] as String?;
+
+      final inCinemas = inCinemasStr != null ? DateTime.tryParse(inCinemasStr) : null;
+      final digitalRelease = digitalReleaseStr != null ? DateTime.tryParse(digitalReleaseStr) : null;
+      final physicalRelease = physicalReleaseStr != null ? DateTime.tryParse(physicalReleaseStr) : null;
+
+      final enabledReleases = <DateTime, String>{};
+      if (showCinema && inCinemas != null && inCinemas.isAfter(now.subtract(const Duration(days: 1)))) {
+        enabledReleases[inCinemas] = 'Cinema: ';
+      }
+      if (showDigital && digitalRelease != null && digitalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
+        enabledReleases[digitalRelease] = 'Digital: ';
+      }
+      if (showPhysical && physicalRelease != null && physicalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
+        enabledReleases[physicalRelease] = 'Physical: ';
+      }
+
+      if (enabledReleases.isEmpty) continue;
+
+      final sortedDates = enabledReleases.keys.toList()..sort();
+      final targetReleaseDate = sortedDates.first;
+      final releaseType = enabledReleases[targetReleaseDate]!;
+
+      String? subtitleText;
+      if (showDate) {
+        final dateStr = _formatDateHuman(targetReleaseDate);
+        subtitleText = '$releaseType$dateStr';
+      }
+
+      final newRawData = Map<String, dynamic>.from(item.rawData);
+      newRawData['Subtitle'] = subtitleText;
+      newRawData['CalendarDate'] = targetReleaseDate.toIso8601String();
+
+      filtered.add(AggregatedItem(
+        id: item.id,
+        serverId: item.serverId,
+        rawData: newRawData,
+      ));
+    }
+
+    filtered.sort((a, b) {
+      final dateA = a.rawData['CalendarDate'] as String? ?? '';
+      final dateB = b.rawData['CalendarDate'] as String? ?? '';
+      return dateA.compareTo(dateB);
+    });
+
+    return filtered;
+  }
+
+  List<AggregatedItem> _formatSonarrItems(List<AggregatedItem> rawItems) {
+    final showDate = _prefs.get(UserPreferences.sonarrCalendarShowDate);
+    final showEpisodeInfo = _prefs.get(UserPreferences.sonarrCalendarShowEpisodeInfo);
+
+    return rawItems.map((item) {
+      final airDateUtcStr = item.rawData['CalendarDate'] as String?;
+      final airDateUtc = airDateUtcStr != null ? DateTime.tryParse(airDateUtcStr) : null;
+      if (airDateUtc == null) return item;
+
+      final sNum = item.rawData['SeasonNumber'] as String? ?? '0';
+      final eNum = item.rawData['EpisodeNumber'] as String? ?? '0';
+
+      String? subtitleText;
+      if (showDate && showEpisodeInfo) {
+        final dateStr = _formatDateHuman(airDateUtc);
+        subtitleText = 'Next Episode: $dateStr (S$sNum:E$eNum)';
+      } else if (showDate) {
+        final dateStr = _formatDateHuman(airDateUtc);
+        subtitleText = 'Next Episode: $dateStr';
+      } else if (showEpisodeInfo) {
+        subtitleText = 'Next Episode: (S$sNum:E$eNum)';
+      }
+
+      final newRawData = Map<String, dynamic>.from(item.rawData);
+      newRawData['Subtitle'] = subtitleText;
+
+      return AggregatedItem(
+        id: item.id,
+        serverId: item.serverId,
+        rawData: newRawData,
+      );
+    }).toList();
+  }
+
   Future<List<HomeRow>> _loadRadarrCalendarRow({bool forceRefresh = false}) async {
     final merge = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
     if (merge) {
@@ -2158,20 +2253,22 @@ class HomeViewModel extends ChangeNotifier {
       if (shouldFetch) {
         final fetchedItems = await _fetchRadarrCalendarFromApi();
         if (fetchedItems != null) {
-          items = fetchedItems;
-          await _saveRadarrCalendarToCache(items);
+          await _saveRadarrCalendarToCache(fetchedItems);
           await _prefs.set(UserPreferences.lastRadarrCalendarFetchTime, nowMs);
+          items = _filterAndFormatRadarrItems(fetchedItems);
         } else {
-          items = await _loadRadarrCalendarFromCache();
+          final cached = await _loadRadarrCalendarFromCache();
+          items = _filterAndFormatRadarrItems(cached);
         }
       } else {
-        items = await _loadRadarrCalendarFromCache();
+        final cached = await _loadRadarrCalendarFromCache();
+        items = _filterAndFormatRadarrItems(cached);
         if (items.isEmpty) {
           final fetchedItems = await _fetchRadarrCalendarFromApi();
           if (fetchedItems != null) {
-            items = fetchedItems;
-            await _saveRadarrCalendarToCache(items);
+            await _saveRadarrCalendarToCache(fetchedItems);
             await _prefs.set(UserPreferences.lastRadarrCalendarFetchTime, nowMs);
+            items = _filterAndFormatRadarrItems(fetchedItems);
           }
         }
       }
@@ -2210,20 +2307,22 @@ class HomeViewModel extends ChangeNotifier {
       if (shouldFetch) {
         final fetchedItems = await _fetchSonarrCalendarFromApi();
         if (fetchedItems != null) {
-          items = fetchedItems;
-          await _saveSonarrCalendarToCache(items);
+          await _saveSonarrCalendarToCache(fetchedItems);
           await _prefs.set(UserPreferences.lastSonarrCalendarFetchTime, nowMs);
+          items = _formatSonarrItems(fetchedItems);
         } else {
-          items = await _loadSonarrCalendarFromCache();
+          final cached = await _loadSonarrCalendarFromCache();
+          items = _formatSonarrItems(cached);
         }
       } else {
-        items = await _loadSonarrCalendarFromCache();
+        final cached = await _loadSonarrCalendarFromCache();
+        items = _formatSonarrItems(cached);
         if (items.isEmpty) {
           final fetchedItems = await _fetchSonarrCalendarFromApi();
           if (fetchedItems != null) {
-            items = fetchedItems;
-            await _saveSonarrCalendarToCache(items);
+            await _saveSonarrCalendarToCache(fetchedItems);
             await _prefs.set(UserPreferences.lastSonarrCalendarFetchTime, nowMs);
+            items = _formatSonarrItems(fetchedItems);
           }
         }
       }
@@ -2357,11 +2456,6 @@ class HomeViewModel extends ChangeNotifier {
 
       final results = response.data as List;
 
-      final showCinema = _prefs.get(UserPreferences.radarrCalendarShowCinema);
-      final showDigital = _prefs.get(UserPreferences.radarrCalendarShowDigital);
-      final showPhysical = _prefs.get(UserPreferences.radarrCalendarShowPhysical);
-      final showDate = _prefs.get(UserPreferences.radarrCalendarShowDate);
-
       final enrichCompleters = await mapBounded(
         results,
         5,
@@ -2383,22 +2477,21 @@ class HomeViewModel extends ChangeNotifier {
           final digitalRelease = digitalReleaseStr != null ? DateTime.tryParse(digitalReleaseStr) : null;
           final physicalRelease = physicalReleaseStr != null ? DateTime.tryParse(physicalReleaseStr) : null;
 
-          final enabledReleases = <DateTime, String>{};
-          if (showCinema && inCinemas != null && inCinemas.isAfter(now.subtract(const Duration(days: 1)))) {
-            enabledReleases[inCinemas] = 'Cinema: ';
+          final allReleases = <DateTime>[];
+          if (inCinemas != null && inCinemas.isAfter(now.subtract(const Duration(days: 1)))) {
+            allReleases.add(inCinemas);
           }
-          if (showDigital && digitalRelease != null && digitalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
-            enabledReleases[digitalRelease] = 'Digital: ';
+          if (digitalRelease != null && digitalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
+            allReleases.add(digitalRelease);
           }
-          if (showPhysical && physicalRelease != null && physicalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
-            enabledReleases[physicalRelease] = 'Physical: ';
+          if (physicalRelease != null && physicalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
+            allReleases.add(physicalRelease);
           }
 
-          if (enabledReleases.isEmpty) return null;
+          if (allReleases.isEmpty) return null;
 
-          final sortedDates = enabledReleases.keys.toList()..sort();
-          final targetReleaseDate = sortedDates.first;
-          final releaseType = enabledReleases[targetReleaseDate]!;
+          final sortedDates = allReleases..sort();
+          final defaultReleaseDate = sortedDates.first;
 
           String? posterPath;
           String? backdropPath;
@@ -2429,12 +2522,6 @@ class HomeViewModel extends ChangeNotifier {
             } catch (_) {}
           }
 
-          String? subtitleText;
-          if (showDate) {
-            final dateStr = _formatDateHuman(targetReleaseDate);
-            subtitleText = '$releaseType$dateStr';
-          }
-
           return _CalendarItemWithDate(
             item: AggregatedItem(
               id: tmdbId,
@@ -2447,12 +2534,14 @@ class HomeViewModel extends ChangeNotifier {
                 'BackdropPath': backdropPath,
                 'ProductionYear': year,
                 'SeerrMediaType': 'movie',
-                'Subtitle': subtitleText,
-                'CalendarDate': targetReleaseDate.toIso8601String(),
+                'InCinemas': inCinemasStr,
+                'DigitalRelease': digitalReleaseStr,
+                'PhysicalRelease': physicalReleaseStr,
+                'CalendarDate': defaultReleaseDate.toIso8601String(),
                 'CacheVerV2': true,
               },
             ),
-            date: targetReleaseDate,
+            date: defaultReleaseDate,
           );
         },
       );
@@ -2614,6 +2703,8 @@ class HomeViewModel extends ChangeNotifier {
                 'BackdropPath': backdropPath,
                 'SeerrMediaType': 'tv',
                 'Subtitle': subtitleText,
+                'SeasonNumber': sNum,
+                'EpisodeNumber': eNum,
                 'CalendarDate': airDateUtc.toIso8601String(),
                 'CacheVerV2': true,
               },
@@ -2724,7 +2815,9 @@ class HomeViewModel extends ChangeNotifier {
       }
 
       // 3. Merge and sort
-      final mergedItems = [...radarrItems, ...sonarrItems];
+      final filteredRadarr = _filterAndFormatRadarrItems(radarrItems);
+      final filteredSonarr = _formatSonarrItems(sonarrItems);
+      final mergedItems = [...filteredRadarr, ...filteredSonarr];
       mergedItems.sort((a, b) {
         final dateA = a.rawData['CalendarDate'] as String? ?? '';
         final dateB = b.rawData['CalendarDate'] as String? ?? '';

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -2591,8 +2591,6 @@ class HomeViewModel extends ChangeNotifier {
       }
 
       final results = response.data as List;
-      final showDate = _prefs.get(UserPreferences.sonarrCalendarShowDate);
-      final showEpisodeInfo = _prefs.get(UserPreferences.sonarrCalendarShowEpisodeInfo);
 
       final groupedEpisodes = <int, Map<String, dynamic>>{};
       for (final res in results) {
@@ -2678,18 +2676,8 @@ class HomeViewModel extends ChangeNotifier {
             } catch (_) {}
           }
 
-          String? subtitleText;
           final sNum = (episodeInfo['seasonNumber'] ?? 0).toString();
           final eNum = (episodeInfo['episodeNumber'] ?? 0).toString();
-          if (showDate && showEpisodeInfo) {
-            final dateStr = _formatDateHuman(airDateUtc);
-            subtitleText = 'Next Episode: $dateStr (S$sNum:E$eNum)';
-          } else if (showDate) {
-            final dateStr = _formatDateHuman(airDateUtc);
-            subtitleText = 'Next Episode: $dateStr';
-          } else if (showEpisodeInfo) {
-            subtitleText = 'Next Episode: (S$sNum:E$eNum)';
-          }
 
           return _CalendarItemWithDate(
             item: AggregatedItem(
@@ -2702,7 +2690,6 @@ class HomeViewModel extends ChangeNotifier {
                 'PosterPath': posterPath,
                 'BackdropPath': backdropPath,
                 'SeerrMediaType': 'tv',
-                'Subtitle': subtitleText,
                 'SeasonNumber': sNum,
                 'EpisodeNumber': eNum,
                 'CalendarDate': airDateUtc.toIso8601String(),


### PR DESCRIPTION
# Pull Request

## Summary
Fix Radarr and Sonarr upcoming calendar settings toggles (e.g. show/hide cinema, digital, physical releases, and display styles) not applying in real-time on the Home Screen calendar rows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #723 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

* Changed _fetchRadarrCalendarFromApi() to store the raw, original release date strings (inCinemas, digitalRelease, physicalRelease) in the rawData cache payload, instead of filtering at fetch-time.
* Changed _fetchSonarrCalendarFromApi() to store SeasonNumber and EpisodeNumber in rawData.
* Implemented _filterAndFormatRadarrItems() and _formatSonarrItems() to dynamically filter, resolve active release types, format subtitles, and sort calendar rows in real-time whenever they are loaded.
* Modified _onPrefsChanged() in HomeScreen state to listen to updates to all calendar preferences (such as enabling/disabling cinema, digital, and physical releases) and instantly refresh the HomeViewModel rows.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - testing on Android TV (Shield)
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> External Lists -> Upcoming Calendars.
2. Toggle "Show Upcoming Cinema Releases" off.
3. Return to the Home Screen and verify that cinema releases are hidden immediately.
4. Toggle other release types (Digital, Physical) or "Show Release Date on Home Screen?" and verify they apply instantly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Physical releases show when checked; hide went not.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
