### PR TITLE
Feature/episode rating home

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4097,7 +4097,55 @@ class _ContentRowsState extends State<_ContentRows>
                 color: subtitleColor,
                 shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
               );
-              cardSubtitleWidget = Column(
+
+              Widget? ratingWidget;
+              final enableEpisodeRatings = widget.prefs.get(UserPreferences.enableEpisodeRatings);
+              if (enableEpisodeRatings) {
+                final ratingVal = item.communityRating;
+                if (ratingVal != null && ratingVal > 0) {
+                  final displayVal = ratingVal <= 10.0 ? ratingVal * 10 : ratingVal;
+                  final ratingText = '${displayVal.toInt()}%';
+                  final ratingColor = isNeon
+                      ? AppColorScheme.accent
+                      : const Color(0xFF00B0FF); // matching TMDb theme color or active neon color
+                  ratingWidget = Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: ratingColor.withValues(alpha: 0.15),
+                      border: Border.all(
+                        color: ratingColor.withValues(alpha: 0.8),
+                        width: 1.5,
+                      ),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Image.asset(
+                          'assets/icons/ratings/tmdb.png',
+                          height: 18,
+                          filterQuality: FilterQuality.medium,
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          ratingText,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                            height: 1.1,
+                            shadows: [
+                              Shadow(blurRadius: 4, color: Colors.black54)
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+              }
+
+              final infoColumn = Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
@@ -4116,6 +4164,20 @@ class _ContentRowsState extends State<_ContentRows>
                   ),
                 ],
               );
+
+              if (ratingWidget != null) {
+                cardSubtitleWidget = Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ratingWidget,
+                    const SizedBox(width: 8),
+                    Expanded(child: infoColumn),
+                  ],
+                );
+              } else {
+                cardSubtitleWidget = infoColumn;
+              }
             } else {
               cardSubtitle = episodeInfo ?? item.name;
               cardSubtitleWidget = null;
@@ -4319,7 +4381,7 @@ class _ContentRowsState extends State<_ContentRows>
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (hasAnyRating)
+                    if (hasAnyRating && item.type != 'Episode')
                       RatingsRow(
                         ratings: additionalRatings,
                         communityRating: item.communityRating,


### PR DESCRIPTION
# Pull Request

## Summary
Add TMDb user rating (community rating) for TV episodes on the Home Screen V2 layout rows. 

## Related Issues
Link related issues or tickets separated by commas.

Tester feedback.

- Closes #homescreen 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Created a custom TMDb rating pill for `Episode` items on the Home Screen inside V2 row subtitle builder, matching the Episode details page style (displaying the official TMDb icon asset and percentage value, e.g. `79%`).
- Structured the `cardSubtitleWidget` inside `home_screen.dart` to place the rating pill to the left of the 2 lines of info (Season/Episode title and release year/runtime/genres), centering them vertically.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV (Shield)
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the Home Screen with V2 rows enabled.
2. Focus on an episode card in Continue Watching or Next Up row.
3. Verify the rating pill is rendered directly to the left of the 2-line metadata column.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="1984" height="1570" alt="Shield_Screenshot_2026-07-05_20-58-32" src="https://github.com/user-attachments/assets/3fe453fc-5b33-4097-8c89-95ff0df83108" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
