### PR TITLE
Home Sections Auto-Sort and Cleanup

### DIFF
--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -14,6 +14,7 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../util/extensions.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/poster_size_settings_dialog.dart';
@@ -597,9 +598,13 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   List<int> _visibleSectionIndices() {
     final visible = <int>[];
     final mergeEnabled = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
+    final mergeCalendarsEnabled = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
     for (var i = 0; i < _sections.length; i++) {
       if (_isHiddenByRowVisibilityGates(_sections[i])) continue;
       if (mergeEnabled && _sections[i].type == HomeSectionType.nextUp) {
+        continue;
+      }
+      if (mergeCalendarsEnabled && _sections[i].type == HomeSectionType.sonarrCalendar) {
         continue;
       }
       visible.add(i);
@@ -614,14 +619,26 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     _mediaBarConfig = all
         .where((s) => s.type == HomeSectionType.mediaBar)
         .firstOrNull;
-    _sections = all.where((s) => s.type != HomeSectionType.mediaBar).toList();
+    _sections = all.where((s) => s.type != HomeSectionType.mediaBar).toList()
+        ..sort((a, b) => a.order.compareTo(b.order));
     final addedBuiltins = _ensureBuiltinSectionsPresent();
     _mergeDiscoveredPluginSections();
+
+    final beforeIds = _sections.map((s) => s.stableId).toList();
+    _sortSectionsEnabledAboveDisabled();
+    var orderChanged = false;
+    for (var i = 0; i < beforeIds.length; i++) {
+      if (beforeIds[i] != _sections[i].stableId) {
+        orderChanged = true;
+        break;
+      }
+    }
+
     // _enforceMergeAdjacency reorders _focusNodes in lockstep with _sections,
     // so the nodes must exist before it runs.
     _rebuildFocusNodes();
     _enforceMergeAdjacency();
-    if (addedBuiltins) {
+    if (addedBuiltins || orderChanged) {
       _persistSections(pushSync: false);
     }
     _refreshPluginSections();
@@ -677,11 +694,23 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         final mergedPlaylistSections = _mergePlaylistSections(
           discoveredPlaylists,
         );
+
+        final beforeIds = _sections.map((s) => s.stableId).toList();
+        _sortSectionsEnabledAboveDisabled();
+        var sortChanged = false;
+        for (var i = 0; i < beforeIds.length; i++) {
+          if (beforeIds[i] != _sections[i].stableId) {
+            sortChanged = true;
+            break;
+          }
+        }
+
         changed =
             mergedPluginSections ||
             mergedCollectionSections ||
             mergedGenreSections ||
-            mergedPlaylistSections;
+            mergedPlaylistSections ||
+            sortChanged;
         _rebuildFocusNodes();
       });
       if (changed) {
@@ -1166,8 +1195,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         targetContext,
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOut,
-        alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        alignment: 0.5,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
       );
       return;
     }
@@ -1178,22 +1207,79 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     });
   }
 
-  void _enforceMergeAdjacency() {
-    final merge = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
-    if (!merge) return;
-    final resumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
-    final nextUpIdx = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
-    if (resumeIdx < 0 || nextUpIdx < 0) return;
-    if ((resumeIdx - nextUpIdx).abs() == 1) return;
+  void _sortSectionsEnabledAboveDisabled() {
+    _sections = _sections.sortedEnabledAboveDisabled((s) => s.enabled);
+  }
+
+  void _toggleSection(int index, bool enabled) {
+    final visibleIndicesBefore = _visibleSectionIndices();
+    final visibleIndex = visibleIndicesBefore.indexOf(index);
+
+    final nodeMap = <String, FocusNode>{};
+    for (var i = 0; i < _sections.length; i++) {
+      nodeMap[_sections[i].stableId] = _focusNodes[i];
+    }
 
     setState(() {
-      final nextUpItem = _sections.removeAt(nextUpIdx);
-      final nextUpNode = _focusNodes.removeAt(nextUpIdx);
+      _sections[index] = _sections[index].copyWith(enabled: enabled);
+      _sortSectionsEnabledAboveDisabled();
+      _enforceMergeAdjacency();
 
-      final newResumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
-      _sections.insert(newResumeIdx + 1, nextUpItem);
-      _focusNodes.insert(newResumeIdx + 1, nextUpNode);
+      final newNodes = <FocusNode>[];
+      for (final section in _sections) {
+        final node = nodeMap[section.stableId];
+        if (node != null) {
+          newNodes.add(node);
+        } else {
+          newNodes.add(FocusNode(debugLabel: 'home_section_new'));
+        }
+      }
+      _focusNodes.clear();
+      _focusNodes.addAll(newNodes);
     });
+
+    _save();
+
+    final visibleIndicesAfter = _visibleSectionIndices();
+    if (visibleIndex >= 0 && visibleIndicesAfter.isNotEmpty) {
+      final targetVisibleIndex = visibleIndex.clamp(0, visibleIndicesAfter.length - 1);
+      final targetActualIndex = visibleIndicesAfter[targetVisibleIndex];
+      _focusSectionAndEnsureVisible(targetActualIndex);
+    }
+  }
+
+  void _enforceMergeAdjacency() {
+    final merge = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
+    if (merge) {
+      final resumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
+      final nextUpIdx = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
+      if (resumeIdx >= 0 && nextUpIdx >= 0 && (resumeIdx - nextUpIdx).abs() != 1) {
+        setState(() {
+          final nextUpItem = _sections.removeAt(nextUpIdx);
+          final nextUpNode = _focusNodes.removeAt(nextUpIdx);
+
+          final newResumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
+          _sections.insert(newResumeIdx + 1, nextUpItem);
+          _focusNodes.insert(newResumeIdx + 1, nextUpNode);
+        });
+      }
+    }
+
+    final mergeCalendars = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
+    if (mergeCalendars) {
+      final radarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.radarrCalendar);
+      final sonarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.sonarrCalendar);
+      if (radarrIdx >= 0 && sonarrIdx >= 0 && (radarrIdx - sonarrIdx).abs() != 1) {
+        setState(() {
+          final sonarrItem = _sections.removeAt(sonarrIdx);
+          final sonarrNode = _focusNodes.removeAt(sonarrIdx);
+
+          final newRadarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.radarrCalendar);
+          _sections.insert(newRadarrIdx + 1, sonarrItem);
+          _focusNodes.insert(newRadarrIdx + 1, sonarrNode);
+        });
+      }
+    }
     _save();
   }
 
@@ -1205,12 +1291,32 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     final merge = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
     final resumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
     final nextUpIdx = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
-
     final isMergeActive = merge && resumeIdx >= 0 && nextUpIdx >= 0 && (resumeIdx - nextUpIdx).abs() == 1;
+
+    final mergeCalendars = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
+    final radarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.radarrCalendar);
+    final sonarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.sonarrCalendar);
+    final isMergeCalendarsActive = mergeCalendars && radarrIdx >= 0 && sonarrIdx >= 0 && (radarrIdx - sonarrIdx).abs() == 1;
 
     setState(() {
       if (isMergeActive && (fromIndex == resumeIdx || fromIndex == nextUpIdx)) {
         final first = resumeIdx < nextUpIdx ? resumeIdx : nextUpIdx;
+        final item1 = _sections.removeAt(first);
+        final node1 = _focusNodes.removeAt(first);
+        final item2 = _sections.removeAt(first);
+        final node2 = _focusNodes.removeAt(first);
+
+        var targetIndex = toIndex;
+        if (targetIndex > first) {
+          targetIndex -= 1;
+        }
+
+        _sections.insert(targetIndex, item1);
+        _focusNodes.insert(targetIndex, node1);
+        _sections.insert(targetIndex + 1, item2);
+        _focusNodes.insert(targetIndex + 1, node2);
+      } else if (isMergeCalendarsActive && (fromIndex == radarrIdx || fromIndex == sonarrIdx)) {
+        final first = radarrIdx < sonarrIdx ? radarrIdx : sonarrIdx;
         final item1 = _sections.removeAt(first);
         final node1 = _focusNodes.removeAt(first);
         final item2 = _sections.removeAt(first);
@@ -1233,6 +1339,12 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
             targetIndex = first + 2;
           }
         }
+        if (isMergeCalendarsActive) {
+          final first = radarrIdx < sonarrIdx ? radarrIdx : sonarrIdx;
+          if (targetIndex == first + 1) {
+            targetIndex = first + 2;
+          }
+        }
 
         final item = _sections.removeAt(fromIndex);
         final node = _focusNodes.removeAt(fromIndex);
@@ -1246,6 +1358,13 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       var focusIndex = toIndex;
       if (isMergeActive && (fromIndex == resumeIdx || fromIndex == nextUpIdx)) {
         final first = resumeIdx < nextUpIdx ? resumeIdx : nextUpIdx;
+        var targetIndex = toIndex;
+        if (targetIndex > first) {
+          targetIndex -= 1;
+        }
+        focusIndex = targetIndex;
+      } else if (isMergeCalendarsActive && (fromIndex == radarrIdx || fromIndex == sonarrIdx)) {
+        final first = radarrIdx < sonarrIdx ? radarrIdx : sonarrIdx;
         var targetIndex = toIndex;
         if (targetIndex > first) {
           targetIndex -= 1;
@@ -1402,8 +1521,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
               onPressed: () {
                 setState(() {
                   _sections = HomeSectionConfig.defaults();
+                  _sortSectionsEnabledAboveDisabled();
                   _rebuildFocusNodes();
-                  _setMergeContinueWatchingNextUp(
+                   _setMergeContinueWatchingNextUp(
                     UserPreferences.mergeContinueWatchingNextUp.defaultValue,
                     pushSync: false,
                   );
@@ -1469,7 +1589,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
             setState(() {});
           },
         ),
-        const Divider(),
+
       ],
     );
   }
@@ -1559,14 +1679,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                               ),
                               onTap: isEmpty
                                   ? null
-                                  : () {
-                                      setState(() {
-                                        _sections[sectionIndex] = section.copyWith(
-                                          enabled: !section.enabled,
-                                        );
-                                      });
-                                      _save();
-                                    },
+                                  : () => _toggleSection(sectionIndex, !section.enabled),
                             ),
                           ),
                           const Divider(height: 1, color: Color(0xFF00F0FF), indent: 16, endIndent: 16),
@@ -1599,14 +1712,120 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                               ),
                               onTap: isNextUpEmpty
                                   ? null
-                                  : () {
-                                      setState(() {
-                                        _sections[nextUpIndex] = nextUpSection.copyWith(
-                                          enabled: !nextUpSection.enabled,
-                                        );
-                                      });
-                                      _save();
-                                    },
+                                  : () => _toggleSection(nextUpIndex, !nextUpSection.enabled),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    // Centered unified drag handle
+                    Padding(
+                      padding: const EdgeInsets.only(right: 16),
+                      child: ReorderableDragStartListener(
+                        index: index,
+                        child: const Icon(
+                          Icons.drag_handle,
+                          color: Color(0xFF00F0FF), // Neon cyan handle
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+        }
+
+        final mergeCalendarsEnabled = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
+        final isMergedCalendars = mergeCalendarsEnabled && section.type == HomeSectionType.radarrCalendar;
+
+        if (isMergedCalendars) {
+          final sonarrIndex = _sections.indexWhere((s) => s.type == HomeSectionType.sonarrCalendar);
+          if (sonarrIndex >= 0) {
+            final sonarrSection = _sections[sonarrIndex];
+            final isSonarrEmpty = _emptySectionIds.contains(sonarrSection.stableId);
+
+            return Padding(
+              key: const ValueKey('merged_radarr_sonarr_calendars'),
+              padding: _kHomeSectionTileOuterPadding,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerLow.withValues(alpha: 0.82),
+                  borderRadius: AppRadius.circular(_kHomeSectionTileRadius),
+                  border: Border.all(
+                    color: const Color(0xFF00F0FF), // Neon cyan border
+                    width: 1.5,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          // 1. Radarr Calendar Tile
+                          Opacity(
+                            opacity: isEmpty ? 0.45 : 1.0,
+                            child: ListTile(
+                              focusColor: Colors.transparent,
+                              hoverColor: Colors.transparent,
+                              contentPadding: const EdgeInsets.only(left: 16, right: 8, top: 4, bottom: 4),
+                              minLeadingWidth: 44,
+                              horizontalTitleGap: 14,
+                              leading: buildSettingsLeadingIconShell(
+                                context,
+                                icon: Icon(
+                                  (section.enabled && !isEmpty)
+                                      ? Icons.check_box
+                                      : Icons.check_box_outline_blank,
+                                ),
+                                focused: false,
+                                iconColor: AppColorScheme.onSurface.withValues(alpha: 0.78),
+                              ),
+                              title: Text(
+                                _labelFor(section, l10n),
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: kCleanSettingsFontFamily,
+                                ),
+                              ),
+                              onTap: isEmpty
+                                  ? null
+                                  : () => _toggleSection(sectionIndex, !section.enabled),
+                            ),
+                          ),
+                          const Divider(height: 1, color: Color(0xFF00F0FF), indent: 16, endIndent: 16),
+                          // 2. Sonarr Calendar Tile
+                          Opacity(
+                            opacity: isSonarrEmpty ? 0.45 : 1.0,
+                            child: ListTile(
+                              focusColor: Colors.transparent,
+                              hoverColor: Colors.transparent,
+                              contentPadding: const EdgeInsets.only(left: 16, right: 8, top: 4, bottom: 4),
+                              minLeadingWidth: 44,
+                              horizontalTitleGap: 14,
+                              leading: buildSettingsLeadingIconShell(
+                                context,
+                                icon: Icon(
+                                  (sonarrSection.enabled && !isSonarrEmpty)
+                                      ? Icons.check_box
+                                      : Icons.check_box_outline_blank,
+                                ),
+                                focused: false,
+                                iconColor: AppColorScheme.onSurface.withValues(alpha: 0.78),
+                              ),
+                              title: Text(
+                                _labelFor(sonarrSection, l10n),
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: kCleanSettingsFontFamily,
+                                ),
+                              ),
+                              onTap: isSonarrEmpty
+                                  ? null
+                                  : () => _toggleSection(sonarrIndex, !sonarrSection.enabled),
                             ),
                           ),
                         ],
@@ -1736,14 +1955,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                                       : null))),
                 onTap: isEmpty
                     ? null
-                    : () {
-                        setState(() {
-                          _sections[sectionIndex] = section.copyWith(
-                            enabled: !section.enabled,
-                          );
-                        });
-                        _save();
-                      },
+                    : () => _toggleSection(sectionIndex, !section.enabled),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -1778,6 +1990,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         final section = _sections[sectionIndex];
         final isEmpty = _emptySectionIds.contains(section.stableId);
         final mergeEnabled = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
+        final mergeCalendarsEnabled = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
 
         if (mergeEnabled && section.type == HomeSectionType.resume) {
           final nextUpIndex = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
@@ -1786,6 +1999,20 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
               context,
               sectionIndex,
               nextUpIndex,
+              l10n,
+              visibleIndex == 0,
+              visibleIndex == visibleIndices.length - 1,
+            );
+          }
+        }
+
+        if (mergeCalendarsEnabled && section.type == HomeSectionType.radarrCalendar) {
+          final sonarrIndex = _sections.indexWhere((s) => s.type == HomeSectionType.sonarrCalendar);
+          if (sonarrIndex >= 0) {
+            return _buildMergedTvTile(
+              context,
+              sectionIndex,
+              sonarrIndex,
               l10n,
               visibleIndex == 0,
               visibleIndex == visibleIndices.length - 1,
@@ -1812,12 +2039,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           isFirst: visibleIndex == 0,
           isLast: visibleIndex == visibleIndices.length - 1,
           isEmpty: isEmpty,
-          onToggle: (enabled) {
-            setState(() {
-              _sections[sectionIndex] = section.copyWith(enabled: enabled);
-            });
-            _save();
-          },
+          onToggle: (enabled) => _toggleSection(sectionIndex, enabled),
           onMoveUp: () {
             if (visibleIndex == 0) return;
             _moveSection(
@@ -1908,12 +2130,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                   isLast: isLast,
                   autofocus: isFirst,
                   showArrows: resumeFocused || (!resumeFocused && !nextUpFocused),
-                  onToggle: (enabled) {
-                    setState(() {
-                      _sections[resumeSectionIndex] = resumeSection.copyWith(enabled: enabled);
-                    });
-                    _save();
-                  },
+                  onToggle: (enabled) => _toggleSection(resumeSectionIndex, enabled),
                   onMoveUp: () {
                     if (isFirst) return;
                     final visibleIndices = _visibleSectionIndices();
@@ -1944,12 +2161,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
                   isFirst: isFirst,
                   isLast: isLast,
                   showArrows: nextUpFocused,
-                  onToggle: (enabled) {
-                    setState(() {
-                      _sections[nextUpSectionIndex] = nextUpSection.copyWith(enabled: enabled);
-                    });
-                    _save();
-                  },
+                  onToggle: (enabled) => _toggleSection(nextUpSectionIndex, enabled),
                   onMoveUp: () {
                     if (isFirst) return;
                     final visibleIndices = _visibleSectionIndices();
@@ -2000,8 +2212,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
               context,
               duration: const Duration(milliseconds: 120),
               curve: Curves.easeOut,
-              alignment: 0.2,
-              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+              alignment: 0.5,
+              alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
             );
           });
         }
@@ -2253,8 +2465,8 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
               context,
               duration: const Duration(milliseconds: 120),
               curve: Curves.easeOut,
-              alignment: 0.2,
-              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+              alignment: 0.5,
+              alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
             );
           });
         }

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1182,28 +1182,26 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     _persistSections(pushSync: true);
   }
 
-  void _focusSectionAndEnsureVisible(int index, {int attempt = 0}) {
+  void _focusSectionAndEnsureVisible(int index) {
     if (!mounted || index < 0 || index >= _focusNodes.length) return;
     final node = _focusNodes[index];
     if (!node.hasFocus) {
       node.requestFocus();
     }
 
-    final targetContext = _focusNodes[index].context;
-    if (targetContext != null) {
+    // Defer the scroll until the reorder rebuild commits, so the target row's
+    // context exists.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || index < 0 || index >= _focusNodes.length) return;
+      final targetContext = _focusNodes[index].context;
+      if (targetContext == null) return;
       Scrollable.ensureVisible(
         targetContext,
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOut,
-        alignment: 0.5,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+        alignment: 0.2,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
       );
-      return;
-    }
-
-    if (attempt >= 3) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _focusSectionAndEnsureVisible(index, attempt: attempt + 1);
     });
   }
 
@@ -1214,6 +1212,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   void _toggleSection(int index, bool enabled) {
     final visibleIndicesBefore = _visibleSectionIndices();
     final visibleIndex = visibleIndicesBefore.indexOf(index);
+    final toggledStableId = _sections[index].stableId;
 
     final nodeMap = <String, FocusNode>{};
     for (var i = 0; i < _sections.length; i++) {
@@ -1240,28 +1239,37 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
 
     _save();
 
+    // Keep focus on the neighbor that slid into the toggled row's visible slot
+    // so the viewport stays put. If the toggled row didn't vacate its slot (it
+    // was the last visible row), step to the previous neighbor instead.
     final visibleIndicesAfter = _visibleSectionIndices();
     if (visibleIndex >= 0 && visibleIndicesAfter.isNotEmpty) {
-      final targetVisibleIndex = visibleIndex.clamp(0, visibleIndicesAfter.length - 1);
+      var targetVisibleIndex = visibleIndex.clamp(0, visibleIndicesAfter.length - 1);
+      final toggledActualAfter = _sections.indexWhere((s) => s.stableId == toggledStableId);
+      final toggledVisibleAfter = visibleIndicesAfter.indexOf(toggledActualAfter);
+      if (toggledVisibleAfter == targetVisibleIndex && targetVisibleIndex > 0) {
+        targetVisibleIndex -= 1;
+      }
       final targetActualIndex = visibleIndicesAfter[targetVisibleIndex];
       _focusSectionAndEnsureVisible(targetActualIndex);
     }
   }
 
+  /// Mutates [_sections] and [_focusNodes] in place. Callers own the surrounding
+  /// setState and persistence so this can run inside another setState without
+  /// re-entrancy or double saving.
   void _enforceMergeAdjacency() {
     final merge = _prefs.get(UserPreferences.mergeContinueWatchingNextUp);
     if (merge) {
       final resumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
       final nextUpIdx = _sections.indexWhere((s) => s.type == HomeSectionType.nextUp);
       if (resumeIdx >= 0 && nextUpIdx >= 0 && (resumeIdx - nextUpIdx).abs() != 1) {
-        setState(() {
-          final nextUpItem = _sections.removeAt(nextUpIdx);
-          final nextUpNode = _focusNodes.removeAt(nextUpIdx);
+        final nextUpItem = _sections.removeAt(nextUpIdx);
+        final nextUpNode = _focusNodes.removeAt(nextUpIdx);
 
-          final newResumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
-          _sections.insert(newResumeIdx + 1, nextUpItem);
-          _focusNodes.insert(newResumeIdx + 1, nextUpNode);
-        });
+        final newResumeIdx = _sections.indexWhere((s) => s.type == HomeSectionType.resume);
+        _sections.insert(newResumeIdx + 1, nextUpItem);
+        _focusNodes.insert(newResumeIdx + 1, nextUpNode);
       }
     }
 
@@ -1270,17 +1278,14 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
       final radarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.radarrCalendar);
       final sonarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.sonarrCalendar);
       if (radarrIdx >= 0 && sonarrIdx >= 0 && (radarrIdx - sonarrIdx).abs() != 1) {
-        setState(() {
-          final sonarrItem = _sections.removeAt(sonarrIdx);
-          final sonarrNode = _focusNodes.removeAt(sonarrIdx);
+        final sonarrItem = _sections.removeAt(sonarrIdx);
+        final sonarrNode = _focusNodes.removeAt(sonarrIdx);
 
-          final newRadarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.radarrCalendar);
-          _sections.insert(newRadarrIdx + 1, sonarrItem);
-          _focusNodes.insert(newRadarrIdx + 1, sonarrNode);
-        });
+        final newRadarrIdx = _sections.indexWhere((s) => s.type == HomeSectionType.radarrCalendar);
+        _sections.insert(newRadarrIdx + 1, sonarrItem);
+        _focusNodes.insert(newRadarrIdx + 1, sonarrNode);
       }
     }
-    _save();
   }
 
   void _moveSection(int fromIndex, int toIndex) {
@@ -1584,9 +1589,11 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
           onChanged: (value) {
             _setMergeContinueWatchingNextUp(value);
             if (value) {
-              _enforceMergeAdjacency();
+              setState(_enforceMergeAdjacency);
+              _save();
+            } else {
+              setState(() {});
             }
-            setState(() {});
           },
         ),
 
@@ -2212,8 +2219,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
               context,
               duration: const Duration(milliseconds: 120),
               curve: Curves.easeOut,
-              alignment: 0.5,
-              alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+              alignment: 0.2,
+              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
             );
           });
         }
@@ -2465,8 +2472,8 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
               context,
               duration: const Duration(milliseconds: 120),
               curve: Curves.easeOut,
-              alignment: 0.5,
-              alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+              alignment: 0.2,
+              alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
             );
           });
         }

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -7,6 +7,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../util/extensions.dart';
 import '../../../util/platform_detection.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
@@ -94,18 +95,18 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
     final enabled = csv.split(',').where((s) => s.isNotEmpty).toList();
 
     final items = <_RatingItem>[];
-    for (final key in enabled) {
-      if (_allSources.contains(key)) {
-        items.add(_RatingItem(key: key, enabled: true));
-      }
-    }
-    final addedKeys = items.map((i) => i.key).toSet();
     for (final key in _allSources) {
-      if (!addedKeys.contains(key)) {
-        items.add(_RatingItem(key: key, enabled: false));
-      }
+      items.add(_RatingItem(key: key, enabled: enabled.contains(key)));
     }
-    _items = items;
+    items.sort((a, b) {
+      final indexA = enabled.indexOf(a.key);
+      final indexB = enabled.indexOf(b.key);
+      if (indexA == -1 && indexB == -1) return 0;
+      if (indexA == -1) return 1;
+      if (indexB == -1) return -1;
+      return indexA.compareTo(indexB);
+    });
+    _items = items.sortedEnabledAboveDisabled((i) => i.enabled);
     _rebuildFocusNodes();
   }
 
@@ -216,10 +217,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
                   ).colorScheme.onSurface.withValues(alpha: 0.7),
                 ),
               ),
-              onToggle: (enabled) {
-                setState(() => item.enabled = enabled);
-                _save();
-              },
+              onToggle: (enabled) => _toggleRatingItem(index, enabled),
               onMoveUp: () => _moveItemTo(index, index - 1),
               onMoveDown: () => _moveItemTo(index, index + 1),
             );
@@ -253,15 +251,66 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
                 const Icon(Icons.arrow_right, size: 18),
             ],
           ),
-          onToggle: (enabled) {
-            setState(() => item.enabled = enabled);
-            _save();
-          },
+          onToggle: (enabled) => _toggleRatingItem(itemIndex, enabled),
           onMoveUp: () => _moveItemTo(itemIndex, itemIndex - 1),
           onMoveDown: () => _moveItemTo(itemIndex, itemIndex + 1),
         );
       },
     );
+  }
+
+  void _toggleRatingItem(int index, bool enabled) {
+    final nodeMap = <String, FocusNode>{};
+    for (var i = 0; i < _items.length; i++) {
+      nodeMap[_items[i].key] = _focusNodes[i];
+    }
+
+    setState(() {
+      _items[index].enabled = enabled;
+      _items = _items.sortedEnabledAboveDisabled((i) => i.enabled);
+
+      final newNodes = <FocusNode>[];
+      for (final item in _items) {
+        final node = nodeMap[item.key];
+        if (node != null) {
+          newNodes.add(node);
+        } else {
+          newNodes.add(FocusNode(debugLabel: 'rating_new'));
+        }
+      }
+      _focusNodes.clear();
+      _focusNodes.addAll(newNodes);
+    });
+
+    _save();
+
+    final targetIndex = index.clamp(0, _items.length - 1);
+    _focusItemAndEnsureVisible(targetIndex);
+  }
+
+  void _focusItemAndEnsureVisible(int index, {int attempt = 0}) {
+    if (!mounted || index < 0 || index >= _focusNodes.length) return;
+    final node = _focusNodes[index];
+    if (!node.hasFocus) {
+      node.requestFocus();
+    }
+
+    final targetContext = _focusNodes[index].context;
+    if (targetContext != null) {
+      Scrollable.ensureVisible(
+        targetContext,
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOut,
+        alignment: 0.5,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+      );
+      return;
+    }
+
+    if (attempt >= 3) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusItemAndEnsureVisible(index, attempt: attempt + 1);
+    });
   }
 
   void _moveItemTo(int index, int newIndex) {
@@ -334,8 +383,8 @@ class _ReorderableTileState extends State<_ReorderableTile> {
         context,
         duration: const Duration(milliseconds: 120),
         curve: Curves.easeOut,
-        alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        alignment: 0.5,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
       );
     });
   }

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -98,6 +98,8 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
     for (final key in _allSources) {
       items.add(_RatingItem(key: key, enabled: enabled.contains(key)));
     }
+    // Sorting by position in the enabled CSV already yields enabled-first
+    // (disabled keys resolve to -1 and sink to the bottom) in saved order.
     items.sort((a, b) {
       final indexA = enabled.indexOf(a.key);
       final indexB = enabled.indexOf(b.key);
@@ -106,7 +108,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
       if (indexB == -1) return -1;
       return indexA.compareTo(indexB);
     });
-    _items = items.sortedEnabledAboveDisabled((i) => i.enabled);
+    _items = items;
     _rebuildFocusNodes();
   }
 
@@ -260,6 +262,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
   }
 
   void _toggleRatingItem(int index, bool enabled) {
+    final toggledKey = _items[index].key;
     final nodeMap = <String, FocusNode>{};
     for (var i = 0; i < _items.length; i++) {
       nodeMap[_items[i].key] = _focusNodes[i];
@@ -284,32 +287,34 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
 
     _save();
 
-    final targetIndex = index.clamp(0, _items.length - 1);
+    // Keep focus on the neighbor that slid into the toggled row's old slot so
+    // the viewport stays put. If the item didn't move (it was the last row),
+    // step to the previous neighbor instead.
+    final newIndex = _items.indexWhere((i) => i.key == toggledKey);
+    final targetIndex = (newIndex == index && index > 0) ? index - 1 : index;
     _focusItemAndEnsureVisible(targetIndex);
   }
 
-  void _focusItemAndEnsureVisible(int index, {int attempt = 0}) {
+  void _focusItemAndEnsureVisible(int index) {
     if (!mounted || index < 0 || index >= _focusNodes.length) return;
     final node = _focusNodes[index];
     if (!node.hasFocus) {
       node.requestFocus();
     }
 
-    final targetContext = _focusNodes[index].context;
-    if (targetContext != null) {
+    // Defer the scroll until the reorder rebuild commits, so the target row's
+    // context exists.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || index < 0 || index >= _focusNodes.length) return;
+      final targetContext = _focusNodes[index].context;
+      if (targetContext == null) return;
       Scrollable.ensureVisible(
         targetContext,
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOut,
-        alignment: 0.5,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+        alignment: 0.2,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
       );
-      return;
-    }
-
-    if (attempt >= 3) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _focusItemAndEnsureVisible(index, attempt: attempt + 1);
     });
   }
 
@@ -383,8 +388,8 @@ class _ReorderableTileState extends State<_ReorderableTile> {
         context,
         duration: const Duration(milliseconds: 120),
         curve: Curves.easeOut,
-        alignment: 0.5,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+        alignment: 0.2,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
       );
     });
   }

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -13,6 +13,7 @@ import '../../../preference/preference_constants.dart';
 import '../../../preference/seerr_preferences.dart';
 import '../../../preference/seerr_row_config.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../util/extensions.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
 import 'package:moonfin_design/moonfin_design.dart';
@@ -51,7 +52,19 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     super.initState();
     _syncService = GetIt.instance<PluginSyncService>();
     _seerrPrefs = GetIt.instance<SeerrPreferences>();
-    _rows = List.of(_seerrPrefs.rowsConfig);
+    _rows = List.of(_seerrPrefs.rowsConfig)..sort((a, b) => a.order.compareTo(b.order));
+    final beforeTypes = _rows.map((r) => r.type).toList();
+    _sortRowsEnabledAboveDisabled();
+    var orderChanged = false;
+    for (var i = 0; i < beforeTypes.length; i++) {
+      if (beforeTypes[i] != _rows[i].type) {
+        orderChanged = true;
+        break;
+      }
+    }
+    if (orderChanged) {
+      _saveRows();
+    }
     _rebuildFocusNodes();
     _syncService.addListener(_onSyncStateChanged);
     _loadSeerrStatus(showLoading: true);
@@ -104,7 +117,8 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
   void _onSyncStateChanged() {
     if (!mounted) return;
     setState(() {
-      _rows = List.of(_seerrPrefs.rowsConfig);
+      _rows = List.of(_seerrPrefs.rowsConfig)..sort((a, b) => a.order.compareTo(b.order));
+      _sortRowsEnabledAboveDisabled();
       _rebuildFocusNodes();
     });
     _loadSeerrStatus();
@@ -234,9 +248,68 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     await _loadSeerrStatus(showLoading: true);
   }
 
+  void _sortRowsEnabledAboveDisabled() {
+    _rows = _rows.sortedEnabledAboveDisabled((r) => r.enabled);
+  }
+
+  void _toggleSeerrRow(int index, bool enabled) {
+    final nodeMap = <SeerrRowType, FocusNode>{};
+    for (var i = 0; i < _rows.length; i++) {
+      nodeMap[_rows[i].type] = _focusNodes[i];
+    }
+
+    setState(() {
+      _rows[index] = _rows[index].copyWith(enabled: enabled);
+      _sortRowsEnabledAboveDisabled();
+
+      final newNodes = <FocusNode>[];
+      for (final row in _rows) {
+        final node = nodeMap[row.type];
+        if (node != null) {
+          newNodes.add(node);
+        } else {
+          newNodes.add(FocusNode(debugLabel: 'seerr_row_new'));
+        }
+      }
+      _focusNodes.clear();
+      _focusNodes.addAll(newNodes);
+    });
+
+    _saveRows();
+
+    final targetIndex = index.clamp(0, _rows.length - 1);
+    _focusRowAndEnsureVisible(targetIndex);
+  }
+
+  void _focusRowAndEnsureVisible(int index, {int attempt = 0}) {
+    if (!mounted || index < 0 || index >= _focusNodes.length) return;
+    final node = _focusNodes[index];
+    if (!node.hasFocus) {
+      node.requestFocus();
+    }
+
+    final targetContext = _focusNodes[index].context;
+    if (targetContext != null) {
+      Scrollable.ensureVisible(
+        targetContext,
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOut,
+        alignment: 0.5,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+      );
+      return;
+    }
+
+    if (attempt >= 3) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusRowAndEnsureVisible(index, attempt: attempt + 1);
+    });
+  }
+
   Future<void> _resetRows() async {
     setState(() {
       _rows = SeerrRowConfig.defaults();
+      _sortRowsEnabledAboveDisabled();
       _rebuildFocusNodes();
     });
     await _saveRows();
@@ -470,12 +543,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
                 const Icon(Icons.arrow_right, size: 18),
             ],
           ),
-          onToggle: (enabled) {
-            setState(() {
-              _rows[rowIndex] = row.copyWith(enabled: enabled);
-            });
-            _saveRows();
-          },
+          onToggle: (enabled) => _toggleSeerrRow(rowIndex, enabled),
           onMoveUp: () => _moveSeerrRowTo(rowIndex, rowIndex - 1),
           onMoveDown: () => _moveSeerrRowTo(rowIndex, rowIndex + 1),
         );
@@ -535,12 +603,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
                           color: colorScheme.onSurfaceVariant,
                         ),
                       ),
-                onToggle: (enabled) {
-                  setState(() {
-                    _rows[rowIndex] = row.copyWith(enabled: enabled);
-                  });
-                  _saveRows();
-                },
+                onToggle: (enabled) => _toggleSeerrRow(rowIndex, enabled),
                 onMoveUp: () => _moveSeerrRowTo(rowIndex, rowIndex - 1),
                 onMoveDown: () => _moveSeerrRowTo(rowIndex, rowIndex + 1),
               );
@@ -1535,8 +1598,8 @@ class _SeerrReorderableTileState extends State<_SeerrReorderableTile> {
         context,
         duration: const Duration(milliseconds: 120),
         curve: Curves.easeOut,
-        alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        alignment: 0.5,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
       );
     });
   }

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -253,6 +253,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
   }
 
   void _toggleSeerrRow(int index, bool enabled) {
+    final toggledType = _rows[index].type;
     final nodeMap = <SeerrRowType, FocusNode>{};
     for (var i = 0; i < _rows.length; i++) {
       nodeMap[_rows[i].type] = _focusNodes[i];
@@ -277,32 +278,34 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
 
     _saveRows();
 
-    final targetIndex = index.clamp(0, _rows.length - 1);
+    // Keep focus on the neighbor that slid into the toggled row's old slot so
+    // the viewport stays put. If the row didn't move (it was the last row),
+    // step to the previous neighbor instead.
+    final newIndex = _rows.indexWhere((r) => r.type == toggledType);
+    final targetIndex = (newIndex == index && index > 0) ? index - 1 : index;
     _focusRowAndEnsureVisible(targetIndex);
   }
 
-  void _focusRowAndEnsureVisible(int index, {int attempt = 0}) {
+  void _focusRowAndEnsureVisible(int index) {
     if (!mounted || index < 0 || index >= _focusNodes.length) return;
     final node = _focusNodes[index];
     if (!node.hasFocus) {
       node.requestFocus();
     }
 
-    final targetContext = _focusNodes[index].context;
-    if (targetContext != null) {
+    // Defer the scroll until the reorder rebuild commits, so the target row's
+    // context exists.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || index < 0 || index >= _focusNodes.length) return;
+      final targetContext = _focusNodes[index].context;
+      if (targetContext == null) return;
       Scrollable.ensureVisible(
         targetContext,
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOut,
-        alignment: 0.5,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+        alignment: 0.2,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
       );
-      return;
-    }
-
-    if (attempt >= 3) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _focusRowAndEnsureVisible(index, attempt: attempt + 1);
     });
   }
 
@@ -1598,8 +1601,8 @@ class _SeerrReorderableTileState extends State<_SeerrReorderableTile> {
         context,
         duration: const Duration(milliseconds: 120),
         curve: Curves.easeOut,
-        alignment: 0.5,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+        alignment: 0.2,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
       );
     });
   }

--- a/lib/util/extensions.dart
+++ b/lib/util/extensions.dart
@@ -19,3 +19,14 @@ extension DurationExtensions on Duration {
         '${seconds.toString().padLeft(2, '0')}';
   }
 }
+
+extension ListExtensions<T> on List<T> {
+  /// Pulls all items matching [test] (enabled) above items that don't (disabled),
+  /// preserving their relative order.
+  List<T> sortedEnabledAboveDisabled(bool Function(T) test) {
+    final enabled = where(test).toList();
+    final disabled = where((x) => !test(x)).toList();
+    return [...enabled, ...disabled];
+  }
+}
+


### PR DESCRIPTION
# Pull Request

## Summary
Using DRY, implements auto-sorting of enabled settings rows above disabled settings rows for three UI screens: Ratings sources, Seerr Discovery, and Home Sections. It also integrates Sonarr/Radarr calendar merging on the Home Sections screen and ensures the focus indicator stays on screen when moving items up/down.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added a generic extension `sortedEnabledAboveDisabled` on `List<T>` inside `lib/util/extensions.dart` to cleanly partition and merge list structures.
- Updated Ratings Sources, Seerr Discovery, and Home Sections screens to auto-sort enabled rows above disabled rows upon toggle and initial load.
- Re-anchored focus on the active visible index when lists rearrange or items hide to prevent focus indicators from disappearing.
- Refactored `Scrollable.ensureVisible` on all three screens to center-align the viewport on the focused item, ensuring the viewport follows the focus indicator when moving items.
- Implemented support to read `UserPreferences.mergeRadarrSonarrCalendars` configured on the Upcoming Calendars settings screen. When enabled, Sonarr's row is hidden from the visible list and Radarr's row renders as a unified double-row tile in both TV and non-TV layouts, supporting block movement.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Testing completed on Android TV/Shield
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Ratings Sources, Seerr Discovery, or Home Sections settings.
2. Toggle any settings row to verify immediate reordering (enabled rows go to the top, disabled to the bottom).
3. Move items up or down past visible screen bounds and check that the viewport follows the focus indicator (keeping it centered).
4. Turn on "Merge Sonarr and Radarr Calendars" in Upcoming Calendars settings.
5. Verify that in Home Sections settings, the Sonarr/Radarr calendar rows are merged into a single tile and behave as a single block.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Previous behaviour would leave checked sections at the bottom of the list:
<img width="826" height="1436" alt="2026-07-06_22-01-06_Antigravity_IDE" src="https://github.com/user-attachments/assets/c710cbe6-f45d-4ec1-9025-7beb1b079d4d" />

Now they are put into a "checked" area and the Radarr/Sonarr calendar can appear merged:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-06_23-23-35" src="https://github.com/user-attachments/assets/d09ab6b9-4cc2-44aa-ae92-22e86245b506" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
