### PR TITLE
feat(settings): hide Seerr discovery rows in Home Sections when disabled

### DIFF
--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -463,6 +463,39 @@ enum SeerrRowType {
       );
 }
 
+extension SeerrRowTypeHomeSection on SeerrRowType {
+  HomeSectionType get homeSectionType => switch (this) {
+        SeerrRowType.recentRequests => HomeSectionType.seerrRecentRequests,
+        SeerrRowType.recentlyAdded => HomeSectionType.seerrRecentlyAdded,
+        SeerrRowType.trending => HomeSectionType.seerrTrending,
+        SeerrRowType.popularMovies => HomeSectionType.seerrPopularMovies,
+        SeerrRowType.movieGenres => HomeSectionType.seerrMovieGenres,
+        SeerrRowType.upcomingMovies => HomeSectionType.seerrUpcomingMovies,
+        SeerrRowType.studios => HomeSectionType.seerrStudios,
+        SeerrRowType.popularSeries => HomeSectionType.seerrPopularSeries,
+        SeerrRowType.seriesGenres => HomeSectionType.seerrSeriesGenres,
+        SeerrRowType.upcomingSeries => HomeSectionType.seerrUpcomingSeries,
+        SeerrRowType.networks => HomeSectionType.seerrNetworks,
+      };
+}
+
+extension HomeSectionTypeSeerrRow on HomeSectionType {
+  SeerrRowType? get seerrRowType => switch (this) {
+        HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
+        HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
+        HomeSectionType.seerrTrending => SeerrRowType.trending,
+        HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
+        HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
+        HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
+        HomeSectionType.seerrStudios => SeerrRowType.studios,
+        HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
+        HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
+        HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
+        HomeSectionType.seerrNetworks => SeerrRowType.networks,
+        _ => null,
+      };
+}
+
 enum ScreensaverMode { library, logo }
 
 enum ScreensaverClockMode { off, staticCorner, bouncing }

--- a/lib/preference/seerr_preferences.dart
+++ b/lib/preference/seerr_preferences.dart
@@ -97,6 +97,12 @@ class SeerrPreferences {
   Future<void> setRowsConfig(List<SeerrRowConfig> value) =>
       _store.setString(_userKey('rows_config'), SeerrRowConfig.toJsonString(value));
 
+  List<SeerrRowConfig> get homeRowsConfig =>
+      SeerrRowConfig.fromJsonString(_store.getString(_userKey('home_rows_config')) ?? '');
+
+  Future<void> setHomeRowsConfig(List<SeerrRowConfig> value) =>
+      _store.setString(_userKey('home_rows_config'), SeerrRowConfig.toJsonString(value));
+
   List<SeerrRowType> get activeRows {
     final configs = rowsConfig.where((c) => c.enabled).toList()
       ..sort((a, b) => a.order.compareTo(b.order));
@@ -159,7 +165,7 @@ class SeerrPreferences {
       'last_connection_success',
       'show_in_navigation', 'show_in_toolbar', 'show_request_status',
       'block_nsfw', 'notify_new_requests', 'notify_library_added',
-      'fetch_limit', 'rows_config',
+      'fetch_limit', 'rows_config', 'home_rows_config',
       'hd_movie_profile_id', '4k_movie_profile_id',
       'hd_tv_profile_id', '4k_tv_profile_id',
       'hd_movie_root_folder_id', '4k_movie_root_folder_id',

--- a/lib/preference/seerr_preferences.dart
+++ b/lib/preference/seerr_preferences.dart
@@ -1,6 +1,7 @@
 import 'package:jellyfin_preference/jellyfin_preference.dart';
 
 import '../auth/repositories/session_repository.dart';
+import 'home_section_config.dart';
 import 'preference_constants.dart';
 import 'seerr_row_config.dart';
 
@@ -97,11 +98,40 @@ class SeerrPreferences {
   Future<void> setRowsConfig(List<SeerrRowConfig> value) =>
       _store.setString(_userKey('rows_config'), SeerrRowConfig.toJsonString(value));
 
-  List<SeerrRowConfig> get homeRowsConfig =>
-      SeerrRowConfig.fromJsonString(_store.getString(_userKey('home_rows_config')) ?? '');
+  List<SeerrRowConfig> get homeRowsConfig {
+    final raw = _store.getString(_userKey('home_rows_config'));
+    if (raw != null && raw.isNotEmpty) {
+      return SeerrRowConfig.fromJsonString(raw);
+    }
+    // Fall back to the old home_sections_config state when this has never been
+    // saved, so upgrades keep the rows the user already chose.
+    return _homeRowsConfigFromSections();
+  }
 
   Future<void> setHomeRowsConfig(List<SeerrRowConfig> value) =>
       _store.setString(_userKey('home_rows_config'), SeerrRowConfig.toJsonString(value));
+
+  List<SeerrRowConfig> _homeRowsConfigFromSections() {
+    final sectionsJson = _store.getString('home_sections_config');
+    if (sectionsJson == null || sectionsJson.isEmpty) {
+      return SeerrRowConfig.defaults();
+    }
+    final sections = HomeSectionConfig.fromJsonString(sectionsJson);
+    return SeerrRowConfig.defaults().map((row) {
+      final idx = sections.indexWhere((s) => s.type == row.type.homeSectionType);
+      return idx >= 0 ? row.copyWith(enabled: sections[idx].enabled) : row;
+    }).toList();
+  }
+
+  bool isSeerrHomeRowEnabled(HomeSectionType type) {
+    final seerrType = type.seerrRowType;
+    if (seerrType == null || !enabled) return false;
+    final config = homeRowsConfig.firstWhere(
+      (c) => c.type == seerrType,
+      orElse: () => SeerrRowConfig(type: seerrType, enabled: true, order: 0),
+    );
+    return config.enabled;
+  }
 
   List<SeerrRowType> get activeRows {
     final configs = rowsConfig.where((c) => c.enabled).toList()

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -26,6 +26,7 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../data/utils/bounded_concurrency.dart';
 import '../../../preference/seerr_preferences.dart';
+import '../../../preference/seerr_row_config.dart';
 import '../../../data/viewmodels/seerr_discover_view_model.dart';
 import '../../../data/repositories/mdblist_repository.dart';
 import 'package:dio/dio.dart';
@@ -103,6 +104,36 @@ class HomeViewModel extends ChangeNotifier {
       HomeSectionType.audioPlaylists => true,
       _ => false,
     };
+  }
+
+  static SeerrRowType? _mapHomeSectionToSeerrRowType(HomeSectionType type) {
+    return switch (type) {
+      HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
+      HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
+      HomeSectionType.seerrTrending => SeerrRowType.trending,
+      HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
+      HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
+      HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
+      HomeSectionType.seerrStudios => SeerrRowType.studios,
+      HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
+      HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
+      HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
+      HomeSectionType.seerrNetworks => SeerrRowType.networks,
+      _ => null,
+    };
+  }
+
+  bool _isSeerrRowEnabled(HomeSectionType type) {
+    final seerrType = _mapHomeSectionToSeerrRowType(type);
+    if (seerrType == null) return false;
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    if (!seerrPrefs.enabled) return false;
+    final configs = seerrPrefs.homeRowsConfig;
+    final config = configs.firstWhere(
+      (c) => c.type == seerrType,
+      orElse: () => SeerrRowConfig(type: seerrType, enabled: true, order: 0),
+    );
+    return config.enabled;
   }
 
   static bool _isSeerrSectionType(HomeSectionType type) {
@@ -307,7 +338,7 @@ class HomeViewModel extends ChangeNotifier {
                             c.pluginSource ==
                                 HomeSectionPluginSource.playlists))) &&
                 (showAudioRows || !_isAudioSectionType(c.type)) &&
-                (showSeerrRows || !_isSeerrSectionType(c.type)) &&
+                (!_isSeerrSectionType(c.type) || (showSeerrRows && _isSeerrRowEnabled(c.type))) &&
                 (!_isTmdbSectionType(c.type) || (showTmdbRows && _isTmdbSectionEnabled(c.type))) &&
                 (c.type != HomeSectionType.radarrCalendar || _prefs.get(UserPreferences.enableRadarrCalendar)) &&
                 (c.type != HomeSectionType.sonarrCalendar || _prefs.get(UserPreferences.enableSonarrCalendar)) &&

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -26,7 +26,6 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../data/utils/bounded_concurrency.dart';
 import '../../../preference/seerr_preferences.dart';
-import '../../../preference/seerr_row_config.dart';
 import '../../../data/viewmodels/seerr_discover_view_model.dart';
 import '../../../data/repositories/mdblist_repository.dart';
 import 'package:dio/dio.dart';
@@ -104,36 +103,6 @@ class HomeViewModel extends ChangeNotifier {
       HomeSectionType.audioPlaylists => true,
       _ => false,
     };
-  }
-
-  static SeerrRowType? _mapHomeSectionToSeerrRowType(HomeSectionType type) {
-    return switch (type) {
-      HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
-      HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
-      HomeSectionType.seerrTrending => SeerrRowType.trending,
-      HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
-      HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
-      HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
-      HomeSectionType.seerrStudios => SeerrRowType.studios,
-      HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
-      HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
-      HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
-      HomeSectionType.seerrNetworks => SeerrRowType.networks,
-      _ => null,
-    };
-  }
-
-  bool _isSeerrRowEnabled(HomeSectionType type) {
-    final seerrType = _mapHomeSectionToSeerrRowType(type);
-    if (seerrType == null) return false;
-    final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    if (!seerrPrefs.enabled) return false;
-    final configs = seerrPrefs.homeRowsConfig;
-    final config = configs.firstWhere(
-      (c) => c.type == seerrType,
-      orElse: () => SeerrRowConfig(type: seerrType, enabled: true, order: 0),
-    );
-    return config.enabled;
   }
 
   static bool _isSeerrSectionType(HomeSectionType type) {
@@ -309,6 +278,7 @@ class HomeViewModel extends ChangeNotifier {
       );
       final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
       final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
+      final seerrPrefs = GetIt.instance<SeerrPreferences>();
       final showTmdbRows = _isAnyTmdbSectionEnabled();
       final showSinceYouWatched = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
       final sinceYouWatchedNum = _prefs.get(UserPreferences.sinceYouWatchedNumRows).value;
@@ -338,7 +308,7 @@ class HomeViewModel extends ChangeNotifier {
                             c.pluginSource ==
                                 HomeSectionPluginSource.playlists))) &&
                 (showAudioRows || !_isAudioSectionType(c.type)) &&
-                (!_isSeerrSectionType(c.type) || (showSeerrRows && _isSeerrRowEnabled(c.type))) &&
+                (!_isSeerrSectionType(c.type) || (showSeerrRows && seerrPrefs.isSeerrHomeRowEnabled(c.type))) &&
                 (!_isTmdbSectionType(c.type) || (showTmdbRows && _isTmdbSectionEnabled(c.type))) &&
                 (c.type != HomeSectionType.radarrCalendar || _prefs.get(UserPreferences.enableRadarrCalendar)) &&
                 (c.type != HomeSectionType.sonarrCalendar || _prefs.get(UserPreferences.enableSonarrCalendar)) &&

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -14,6 +14,8 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../preference/seerr_preferences.dart';
+import '../../../preference/seerr_row_config.dart';
 import '../../../util/extensions.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/overlay_sheet.dart';
@@ -523,6 +525,50 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     return _prefs.get(prefKey);
   }
 
+  SeerrRowType? _mapHomeSectionToSeerrRowType(HomeSectionType type) {
+    return switch (type) {
+      HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
+      HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
+      HomeSectionType.seerrTrending => SeerrRowType.trending,
+      HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
+      HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
+      HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
+      HomeSectionType.seerrStudios => SeerrRowType.studios,
+      HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
+      HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
+      HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
+      HomeSectionType.seerrNetworks => SeerrRowType.networks,
+      _ => null,
+    };
+  }
+
+  bool _isSeerrRowEnabled(HomeSectionType type) {
+    final seerrType = _mapHomeSectionToSeerrRowType(type);
+    if (seerrType == null) return false;
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    if (!seerrPrefs.enabled) return false;
+    final configs = seerrPrefs.homeRowsConfig;
+    final config = configs.firstWhere(
+      (c) => c.type == seerrType,
+      orElse: () => SeerrRowConfig(type: seerrType, enabled: true, order: 0),
+    );
+    return config.enabled;
+  }
+
+  void _disableSeerrHomeRow(HomeSectionType type) {
+    final seerrType = _mapHomeSectionToSeerrRowType(type);
+    if (seerrType == null) return;
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    final configs = List<SeerrRowConfig>.from(seerrPrefs.homeRowsConfig);
+    final idx = configs.indexWhere((c) => c.type == seerrType);
+    if (idx >= 0) {
+      configs[idx] = configs[idx].copyWith(enabled: false);
+      seerrPrefs.setHomeRowsConfig(configs);
+    } else {
+      configs.add(SeerrRowConfig(type: seerrType, enabled: false, order: configs.length));
+      seerrPrefs.setHomeRowsConfig(configs);
+    }
+  }
 
   bool _isTmdbSectionType(HomeSectionType type) {
     return type == HomeSectionType.tmdbPopularMovies ||
@@ -567,8 +613,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
         ((section.isBuiltin && _isPlaylistsSectionType(section.type)) ||
             (section.isPluginDynamic &&
                 section.pluginSource == HomeSectionPluginSource.playlists));
-    final hiddenBySeerr =
-        _isSeerrSectionType(section.type) && !showSeerrRows;
+    final hiddenBySeerr = _isSeerrSectionType(section.type) &&
+        (!showSeerrRows || !_isSeerrRowEnabled(section.type));
     final hiddenByTmdb = _isTmdbSectionType(section.type) &&
         (!showTmdbRows || !_isTmdbRowEnabled(section.type));
 
@@ -1210,6 +1256,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
   }
 
   void _toggleSection(int index, bool enabled) {
+    if (!enabled && _isSeerrSectionType(_sections[index].type)) {
+      _disableSeerrHomeRow(_sections[index].type);
+    }
     final visibleIndicesBefore = _visibleSectionIndices();
     final visibleIndex = visibleIndicesBefore.indexOf(index);
     final toggledStableId = _sections[index].stableId;

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -525,38 +525,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
     return _prefs.get(prefKey);
   }
 
-  SeerrRowType? _mapHomeSectionToSeerrRowType(HomeSectionType type) {
-    return switch (type) {
-      HomeSectionType.seerrRecentRequests => SeerrRowType.recentRequests,
-      HomeSectionType.seerrRecentlyAdded => SeerrRowType.recentlyAdded,
-      HomeSectionType.seerrTrending => SeerrRowType.trending,
-      HomeSectionType.seerrPopularMovies => SeerrRowType.popularMovies,
-      HomeSectionType.seerrMovieGenres => SeerrRowType.movieGenres,
-      HomeSectionType.seerrUpcomingMovies => SeerrRowType.upcomingMovies,
-      HomeSectionType.seerrStudios => SeerrRowType.studios,
-      HomeSectionType.seerrPopularSeries => SeerrRowType.popularSeries,
-      HomeSectionType.seerrSeriesGenres => SeerrRowType.seriesGenres,
-      HomeSectionType.seerrUpcomingSeries => SeerrRowType.upcomingSeries,
-      HomeSectionType.seerrNetworks => SeerrRowType.networks,
-      _ => null,
-    };
-  }
-
-  bool _isSeerrRowEnabled(HomeSectionType type) {
-    final seerrType = _mapHomeSectionToSeerrRowType(type);
-    if (seerrType == null) return false;
-    final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    if (!seerrPrefs.enabled) return false;
-    final configs = seerrPrefs.homeRowsConfig;
-    final config = configs.firstWhere(
-      (c) => c.type == seerrType,
-      orElse: () => SeerrRowConfig(type: seerrType, enabled: true, order: 0),
-    );
-    return config.enabled;
-  }
-
   void _disableSeerrHomeRow(HomeSectionType type) {
-    final seerrType = _mapHomeSectionToSeerrRowType(type);
+    final seerrType = type.seerrRowType;
     if (seerrType == null) return;
     final seerrPrefs = GetIt.instance<SeerrPreferences>();
     final configs = List<SeerrRowConfig>.from(seerrPrefs.homeRowsConfig);
@@ -614,7 +584,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen> {
             (section.isPluginDynamic &&
                 section.pluginSource == HomeSectionPluginSource.playlists));
     final hiddenBySeerr = _isSeerrSectionType(section.type) &&
-        (!showSeerrRows || !_isSeerrRowEnabled(section.type));
+        (!showSeerrRows ||
+            !GetIt.instance<SeerrPreferences>().isSeerrHomeRowEnabled(section.type));
     final hiddenByTmdb = _isTmdbSectionType(section.type) &&
         (!showTmdbRows || !_isTmdbRowEnabled(section.type));
 

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -830,30 +830,14 @@ class _SeerrListsScreen extends StatefulWidget {
 class _SeerrListsScreenState extends State<_SeerrListsScreen> {
   late List<SeerrRowConfig> _rows;
   final _syncService = GetIt.instance<PluginSyncService>();
+  final _seerrPrefs = GetIt.instance<SeerrPreferences>();
   final _scope = FocusScopeNode(debugLabel: 'SeerrListsScope');
   final _firstFocusNode = FocusNode(debugLabel: 'seerr_display_rows');
 
   @override
   void initState() {
     super.initState();
-    final prefs = GetIt.instance<UserPreferences>();
-    final configs = prefs.homeSectionsConfig;
-
-    _rows = SeerrRowConfig.defaults().map((defaultRow) {
-      final homeSectionType = _mapSeerrRowTypeToHomeSection(defaultRow.type);
-      if (homeSectionType != null) {
-        final config = configs.firstWhere(
-          (c) => c.type == homeSectionType,
-          orElse: () => HomeSectionConfig(
-            type: homeSectionType,
-            enabled: false,
-            order: configs.length,
-          ),
-        );
-        return defaultRow.copyWith(enabled: config.enabled);
-      }
-      return defaultRow.copyWith(enabled: false);
-    }).toList();
+    _rows = List.of(_seerrPrefs.homeRowsConfig);
   }
 
   @override
@@ -872,7 +856,25 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     }
   }
 
+  HomeSectionType? _mapSeerrRowTypeToHomeSection(SeerrRowType type) {
+    return switch (type) {
+      SeerrRowType.recentRequests => HomeSectionType.seerrRecentRequests,
+      SeerrRowType.recentlyAdded => HomeSectionType.seerrRecentlyAdded,
+      SeerrRowType.trending => HomeSectionType.seerrTrending,
+      SeerrRowType.popularMovies => HomeSectionType.seerrPopularMovies,
+      SeerrRowType.movieGenres => HomeSectionType.seerrMovieGenres,
+      SeerrRowType.upcomingMovies => HomeSectionType.seerrUpcomingMovies,
+      SeerrRowType.studios => HomeSectionType.seerrStudios,
+      SeerrRowType.popularSeries => HomeSectionType.seerrPopularSeries,
+      SeerrRowType.seriesGenres => HomeSectionType.seerrSeriesGenres,
+      SeerrRowType.upcomingSeries => HomeSectionType.seerrUpcomingSeries,
+      SeerrRowType.networks => HomeSectionType.seerrNetworks,
+    };
+  }
+
   void _saveRows() {
+    _seerrPrefs.setHomeRowsConfig(_rows);
+
     final prefs = GetIt.instance<UserPreferences>();
     final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
     var changed = false;
@@ -898,24 +900,9 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     if (changed) {
       prefs.setHomeSectionsConfig(configs);
     }
+
     _pushPersonalizationSync();
     if (mounted) setState(() {});
-  }
-
-  HomeSectionType? _mapSeerrRowTypeToHomeSection(SeerrRowType type) {
-    return switch (type) {
-      SeerrRowType.recentRequests => HomeSectionType.seerrRecentRequests,
-      SeerrRowType.recentlyAdded => HomeSectionType.seerrRecentlyAdded,
-      SeerrRowType.trending => HomeSectionType.seerrTrending,
-      SeerrRowType.popularMovies => HomeSectionType.seerrPopularMovies,
-      SeerrRowType.movieGenres => HomeSectionType.seerrMovieGenres,
-      SeerrRowType.upcomingMovies => HomeSectionType.seerrUpcomingMovies,
-      SeerrRowType.studios => HomeSectionType.seerrStudios,
-      SeerrRowType.popularSeries => HomeSectionType.seerrPopularSeries,
-      SeerrRowType.seriesGenres => HomeSectionType.seerrSeriesGenres,
-      SeerrRowType.upcomingSeries => HomeSectionType.seerrUpcomingSeries,
-      SeerrRowType.networks => HomeSectionType.seerrNetworks,
-    };
   }
 
   String _rowLabel(SeerrRowType type, AppLocalizations l10n) => switch (type) {
@@ -951,8 +938,9 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
               children: [
                 const _SectionHeader('Seerr Home Page Rows'),
                 adaptiveListSection(
-                  children: _rows.map((row) {
-                    final rowIndex = _rows.indexOf(row);
+                  children: _rows.asMap().entries.map((entry) {
+                    final rowIndex = entry.key;
+                    final row = entry.value;
                     return _SeerrRowSwitchTile(
                       focusNode: rowIndex == 0 ? _firstFocusNode : null,
                       title: _rowLabel(row.type, l10n),

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -856,22 +856,6 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     }
   }
 
-  HomeSectionType? _mapSeerrRowTypeToHomeSection(SeerrRowType type) {
-    return switch (type) {
-      SeerrRowType.recentRequests => HomeSectionType.seerrRecentRequests,
-      SeerrRowType.recentlyAdded => HomeSectionType.seerrRecentlyAdded,
-      SeerrRowType.trending => HomeSectionType.seerrTrending,
-      SeerrRowType.popularMovies => HomeSectionType.seerrPopularMovies,
-      SeerrRowType.movieGenres => HomeSectionType.seerrMovieGenres,
-      SeerrRowType.upcomingMovies => HomeSectionType.seerrUpcomingMovies,
-      SeerrRowType.studios => HomeSectionType.seerrStudios,
-      SeerrRowType.popularSeries => HomeSectionType.seerrPopularSeries,
-      SeerrRowType.seriesGenres => HomeSectionType.seerrSeriesGenres,
-      SeerrRowType.upcomingSeries => HomeSectionType.seerrUpcomingSeries,
-      SeerrRowType.networks => HomeSectionType.seerrNetworks,
-    };
-  }
-
   void _saveRows() {
     _seerrPrefs.setHomeRowsConfig(_rows);
 
@@ -879,22 +863,20 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
     var changed = false;
     for (final row in _rows) {
-      final type = _mapSeerrRowTypeToHomeSection(row.type);
-      if (type != null) {
-        final idx = configs.indexWhere((c) => c.type == type);
-        if (idx >= 0) {
-          if (configs[idx].enabled != row.enabled) {
-            configs[idx] = configs[idx].copyWith(enabled: row.enabled);
-            changed = true;
-          }
-        } else {
-          configs.add(HomeSectionConfig(
-            type: type,
-            enabled: row.enabled,
-            order: configs.length,
-          ));
+      final type = row.type.homeSectionType;
+      final idx = configs.indexWhere((c) => c.type == type);
+      if (idx >= 0) {
+        if (configs[idx].enabled != row.enabled) {
+          configs[idx] = configs[idx].copyWith(enabled: row.enabled);
           changed = true;
         }
+      } else {
+        configs.add(HomeSectionConfig(
+          type: type,
+          enabled: row.enabled,
+          order: configs.length,
+        ));
+        changed = true;
       }
     }
     if (changed) {


### PR DESCRIPTION
# Pull Request

## Summary
This PR decouples the Seerr Lists home-row configurations from the full-page Seerr discovery interface settings. It ensures Seerr discovery rows dynamically show or hide in the Home Sections configuration screen depending on their toggle status on the Seerr Lists settings page.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #732 

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Preference Decoupling**: Added `homeRowsConfig` to `SeerrPreferences` to manage Home screen Seerr rows independently from the full-page Seerr discovery page settings (`rowsConfig`).
- **Seerr Lists Integration**: Pointed the `_SeerrListsScreenState` (under Integrations -> External Home Row Lists -> Seerr Lists) to load from and save to `homeRowsConfig`.
- **Visibility Gates**: Updated `_isSeerrRowEnabled` in `home_sections_screen.dart` and `home_view_model.dart` to read from `homeRowsConfig` instead of `rowsConfig`.
- **Dynamic Unchecking Support**: Updated the toggle callbacks in `HomeSectionsScreen` (both TV and mobile) so that unchecking/disabling a Seerr row directly on the Home Sections page automatically disables it in `homeRowsConfig`, which dynamically hides it from the list.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to **Integrations -> External Home Row Lists -> Seerr Lists** and toggle rows ON or OFF.
2. Verify that toggling a row ON immediately adds it to **Home Sections** in an enabled state.
3. Verify that toggling a row OFF immediately removes it from **Home Sections**.
4. Verify that disabling/unchecking a Seerr row directly inside **Home Sections** removes it from the list and disables it on the **Seerr Lists** page.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
