### PR TITLE
UI Bug - Fix modern home rows bleed-through

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1250,7 +1250,10 @@ class _ContentRowsState extends State<_ContentRows>
         item.type == 'MusicVideo';
   }
 
-  static String _previewKeyFor(AggregatedItem item) {
+  static String _previewKeyFor(AggregatedItem item, [int? rowIndex]) {
+    if (rowIndex != null) {
+      return '${item.serverId}:${item.id}:$rowIndex';
+    }
     return '${item.serverId}:${item.id}';
   }
 
@@ -1273,8 +1276,12 @@ class _ContentRowsState extends State<_ContentRows>
     return null;
   }
 
-  void _schedulePreview(AggregatedItem item, {required Duration delay}) {
-    final previewKey = _previewKeyFor(item);
+  void _schedulePreview(
+    AggregatedItem item, {
+    required Duration delay,
+    int? rowIndex,
+  }) {
+    final previewKey = _previewKeyFor(item, rowIndex);
     if (_activePreviewKey == previewKey) {
       return;
     }
@@ -1315,8 +1322,8 @@ class _ContentRowsState extends State<_ContentRows>
         _isHomeRouteActive();
   }
 
-  void _stopPreviewFor(AggregatedItem item) {
-    final previewKey = _previewKeyFor(item);
+  void _stopPreviewFor(AggregatedItem item, [int? rowIndex]) {
+    final previewKey = _previewKeyFor(item, rowIndex);
     _previewDelayTimer?.cancel();
     _previewDelayTimer = null;
     if (_activePreviewKey == previewKey && mounted) {
@@ -3993,7 +4000,7 @@ class _ContentRowsState extends State<_ContentRows>
           }
           final canPreview = _supportsEpisodePreview(item);
           if (!PlatformDetection.useMobileUi && canPreview) {
-            _schedulePreview(item, delay: _previewStartDelay);
+            _schedulePreview(item, delay: _previewStartDelay, rowIndex: rowIndex);
           } else {
             _finishSharedPreview();
           }
@@ -4029,7 +4036,7 @@ class _ContentRowsState extends State<_ContentRows>
           late final double ar;
           late final double width;
           late final String? imageUrl;
-          final previewKey = _previewKeyFor(item);
+          final previewKey = _previewKeyFor(item, rowIndex);
           final isV2MobileTouch = isRowsV2 && PlatformDetection.useMobileUi;
           final isV2MouseHover = isRowsV2 && !PlatformDetection.useMobileUi;
           final isTouchFocused =
@@ -4286,7 +4293,7 @@ class _ContentRowsState extends State<_ContentRows>
                         }
                       }
                       if (!PlatformDetection.useMobileUi && canPreview) {
-                        _schedulePreview(item, delay: _previewStartDelay);
+                        _schedulePreview(item, delay: _previewStartDelay, rowIndex: rowIndex);
                       } else {
                         _finishSharedPreview();
                       }
@@ -4298,7 +4305,7 @@ class _ContentRowsState extends State<_ContentRows>
                         }
                         _finishSharedPreview();
                       } else {
-                        _stopPreviewFor(item);
+                        _stopPreviewFor(item, rowIndex);
                       }
                     },
                     onLongPress: () => showContextMenu(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4363,7 +4363,9 @@ class _ContentRowsState extends State<_ContentRows>
                         ? _buildV2ExtendedSection(
                             ctx,
                             item,
-                            previewKey,
+                            // Ratings are cached under the global item key, so
+                            // look them up without the row index.
+                            _previewKeyFor(item),
                             cardWidth: width,
                             extendedWidth: v2ExtendedWidth,
                             isAudioRow: row.isAudio,


### PR DESCRIPTION

# Pull Request

## Summary
This PR resolves the "bleed through" behavior where interacting with a card on a modern row (V2) triggers the expansion and video preview activation of identical media items displayed on other rows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #736 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated static helper `_previewKeyFor` in `home_screen.dart` to accept an optional `rowIndex`. If provided, it appends the row index to form a unique, row-specific key (`${serverId}:${id}:${rowIndex}`).
- Updated `_schedulePreview` and `_stopPreviewFor` methods to accept `rowIndex` and pass it down.
- Passed `rowIndex` into these calls in `_buildMediaRow` (during index changes, hover events, and taps).
- Left ratings prefetching (`_primeV2FocusedRatings`) using the global item ID so the ratings database request cache is still shared across all rows.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Focus a card in a modern row that also exists on another row (e.g. playlist row and recently added row).
2. Verify that the focused item transitions to landscape and expands only on the active row, while remaining portrait on the other row.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
