### PR TITLE
bug-Fix library sorting and filtering focus accessibility on Android TV

### DIFF
--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -1050,7 +1050,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       context: context,
       useRootNavigator: false,
       builder: (_) => _FilterSortDialog(vm: _vm),
-    );
+    ).whenComplete(_restoreGridFocusAfterDialog);
   }
 
   void _showSettingsDialog(BuildContext context) {
@@ -1058,7 +1058,16 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       context: context,
       useRootNavigator: false,
       builder: (_) => _SettingsDialog(vm: _vm),
-    );
+    ).whenComplete(_restoreGridFocusAfterDialog);
+  }
+
+  // Sorting or filtering can rebuild the grid while the dialog is open, which
+  // disposes the row the dialog restores focus to. Once the dialog is gone,
+  // point focus back at a valid grid row.
+  void _restoreGridFocusAfterDialog() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) restoreGridFocusIfNeeded();
+    });
   }
 }
 
@@ -1883,7 +1892,7 @@ class _DialogCheckboxTileState extends State<_DialogCheckboxTile> with FocusStat
                   decoration: BoxDecoration(
                     borderRadius: AppRadius.circular(4),
                     border: Border.fromBorderSide(
-                      ThemeRegistry.active.borders.chipBorder.copyWith(
+                      ThemeRegistry.active.borders.focusBorder.copyWith(
                         color: widget.checked ? widget.accent : color.withValues(alpha: 0.5),
                         width: 2,
                       ),

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -1618,21 +1618,21 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                         o != LibrarySortBy.criticRating &&
                         o != LibrarySortBy.communityRating
                       )))
-              _radioTile(
+              _DialogRadioTile(
                 label: (vm.isMusicBrowse && option == LibrarySortBy.premiereDate)
                     ? 'Release Date'
                     : option.displayName,
                 selected: vm.sortBy == option,
                 trailing: vm.sortBy == option
-                    ? IconButton(
-                        icon: Icon(
+                    ? Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Icon(
                           vm.sortDirection == SortDirection.ascending
                               ? Icons.arrow_upward
                               : Icons.arrow_downward,
                           color: accent,
                           size: 18,
                         ),
-                        onPressed: () => vm.toggleSortDirection(),
                       )
                     : null,
                 onTap: () {
@@ -1642,11 +1642,12 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                     vm.setSortBy(option);
                   }
                 },
+                accent: accent,
                 onSurface: onSurface,
               ),
             Divider(color: dividerColor),
             _sectionHeader(l10n.filters, sectionColor),
-            _checkboxTile(
+            _DialogCheckboxTile(
               label: l10n.favorites,
               checked: vm.favoriteFilter,
               onTap: () => vm.setFavoriteFilter(!vm.favoriteFilter),
@@ -1660,25 +1661,25 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                 sectionColor,
               ),
               for (final status in PlayedStatusFilter.values)
-                _radioTile(
+                _DialogRadioTile(
                   label: switch (status) {
                     PlayedStatusFilter.all => l10n.all,
                     PlayedStatusFilter.watched =>
                       isBookBrowse ? l10n.readStatus : l10n.watched,
                     PlayedStatusFilter.unwatched =>
                       isBookBrowse ? l10n.unread : l10n.unwatched,
-                  },
-                  selected: vm.playedFilter == status,
-                  onTap: () => vm.setPlayedFilter(status),
-                  accent: accent,
-                  onSurface: onSurface,
-                ),
+                },
+                selected: vm.playedFilter == status,
+                onTap: () => vm.setPlayedFilter(status),
+                accent: accent,
+                onSurface: onSurface,
+              ),
             ],
             if (vm.isSeriesLibrary) ...[
               Divider(color: dividerColor),
               _sectionHeader(l10n.seriesStatus, sectionColor),
               for (final status in SeriesStatusFilter.values)
-                _radioTile(
+                _DialogRadioTile(
                   label: switch (status) {
                     SeriesStatusFilter.all => l10n.all,
                     SeriesStatusFilter.continuing => l10n.continuing,
@@ -1693,7 +1694,7 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
             if (vm.isGenreBrowse && vm.libraries.isNotEmpty) ...[
               Divider(color: dividerColor),
               _sectionHeader(l10n.library, sectionColor),
-              _radioTile(
+              _DialogRadioTile(
                 label: l10n.allLibraries,
                 selected: vm.libraryFilter == null,
                 onTap: () => vm.setLibraryFilter(null),
@@ -1701,7 +1702,7 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                 onSurface: onSurface,
               ),
               for (final lib in vm.libraries)
-                _radioTile(
+                _DialogRadioTile(
                   label: lib['Name'] as String? ?? '',
                   selected: vm.libraryFilter == lib['Id'],
                   onTap: () => vm.setLibraryFilter(lib['Id']?.toString() ?? ''),
@@ -1729,116 +1730,190 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
     );
   }
 
-  Widget _radioTile({
-    required String label,
-    required bool selected,
-    required VoidCallback onTap,
-    Widget? trailing,
-    Color? accent,
-    required Color onSurface,
-  }) {
-    final effectiveAccent = accent ?? AppColorScheme.accent;
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-        child: Row(
-          children: [
-            Container(
-              width: 18,
-              height: 18,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.fromBorderSide(
-                  ThemeRegistry.active.borders.chipBorder.copyWith(
-                    color: selected
-                        ? effectiveAccent
-                        : onSurface.withValues(alpha: 0.5),
-                    width: 2,
+}
+
+class _DialogRadioTile extends StatefulWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final Widget? trailing;
+  final Color? accent;
+  final Color onSurface;
+
+  const _DialogRadioTile({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.trailing,
+    this.accent,
+    required this.onSurface,
+  });
+
+  @override
+  State<_DialogRadioTile> createState() => _DialogRadioTileState();
+}
+
+class _DialogRadioTileState extends State<_DialogRadioTile> with FocusStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    final effectiveAccent = widget.accent ?? AppColorScheme.accent;
+    final showActive = focused || hovered;
+    final color = showActive ? focusColor : widget.onSurface;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (_, event) {
+          if (isActivateKey(event)) {
+            widget.onTap();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            color: showActive ? focusColor.withValues(alpha: 0.12) : Colors.transparent,
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            child: Row(
+              children: [
+                Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.fromBorderSide(
+                      ThemeRegistry.active.borders.focusBorder.copyWith(
+                        color: widget.selected
+                            ? effectiveAccent
+                            : color.withValues(alpha: 0.5),
+                        width: 2,
+                      ),
+                    ),
+                    color: widget.selected ? effectiveAccent : Colors.transparent,
+                  ),
+                  child: widget.selected
+                      ? Center(
+                          child: Container(
+                            width: 8,
+                            height: 8,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: widget.onSurface,
+                            ),
+                          ),
+                        )
+                      : null,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    widget.label,
+                    style: TextStyle(
+                      fontSize: 15,
+                      color: widget.selected
+                          ? color
+                          : color.withValues(alpha: 0.72),
+                    ),
                   ),
                 ),
-                color: selected ? effectiveAccent : Colors.transparent,
-              ),
-              child: selected
-                  ? Center(
-                      child: Container(
-                        width: 8,
-                        height: 8,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: onSurface,
-                        ),
-                      ),
-                    )
-                  : null,
+                if (widget.trailing != null) widget.trailing!,
+              ],
             ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                label,
-                style: TextStyle(
-                  fontSize: 15,
-                  color: selected
-                      ? onSurface
-                      : onSurface.withValues(alpha: 0.72),
-                ),
-              ),
-            ),
-            ?trailing,
-          ],
+          ),
         ),
       ),
     );
   }
+}
 
-  Widget _checkboxTile({
-    required String label,
-    required bool checked,
-    required VoidCallback onTap,
-    required Color accent,
-    required Color onSurface,
-  }) {
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-        child: Row(
-          children: [
-            Container(
-              width: 18,
-              height: 18,
-              decoration: BoxDecoration(
-                borderRadius: AppRadius.circular(4),
-                border: Border.fromBorderSide(
-                  ThemeRegistry.active.borders.chipBorder.copyWith(
-                    color: checked ? accent : onSurface.withValues(alpha: 0.5),
-                    width: 2,
+class _DialogCheckboxTile extends StatefulWidget {
+  final String label;
+  final bool checked;
+  final VoidCallback onTap;
+  final Color accent;
+  final Color onSurface;
+
+  const _DialogCheckboxTile({
+    required this.label,
+    required this.checked,
+    required this.onTap,
+    required this.accent,
+    required this.onSurface,
+  });
+
+  @override
+  State<_DialogCheckboxTile> createState() => _DialogCheckboxTileState();
+}
+
+class _DialogCheckboxTileState extends State<_DialogCheckboxTile> with FocusStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    final showActive = focused || hovered;
+    final color = showActive ? focusColor : widget.onSurface;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (_, event) {
+          if (isActivateKey(event)) {
+            widget.onTap();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            color: showActive ? focusColor.withValues(alpha: 0.12) : Colors.transparent,
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            child: Row(
+              children: [
+                Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    borderRadius: AppRadius.circular(4),
+                    border: Border.fromBorderSide(
+                      ThemeRegistry.active.borders.chipBorder.copyWith(
+                        color: widget.checked ? widget.accent : color.withValues(alpha: 0.5),
+                        width: 2,
+                      ),
+                    ),
+                    color: widget.checked ? widget.accent : Colors.transparent,
+                  ),
+                  child: widget.checked
+                      ? Center(
+                          child: Text(
+                            '✓',
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold,
+                              color: widget.onSurface,
+                            ),
+                          ),
+                        )
+                      : null,
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  widget.label,
+                  style: TextStyle(
+                    fontSize: 15,
+                    color: widget.checked ? color : color.withValues(alpha: 0.72),
                   ),
                 ),
-                color: checked ? accent : Colors.transparent,
-              ),
-              child: checked
-                  ? Center(
-                      child: Text(
-                        '✓',
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                          color: onSurface,
-                        ),
-                      ),
-                    )
-                  : null,
+              ],
             ),
-            const SizedBox(width: 12),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 15,
-                color: checked ? onSurface : onSurface.withValues(alpha: 0.72),
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );
@@ -1950,24 +2025,12 @@ class _SettingsDialogState extends State<_SettingsDialog> {
     final selected = vm.imageType == type;
     final accent = vm.isBookLibrary ? _bookAccent : _jellyfinBlue;
     final onSurface = AppColorScheme.onSurface;
-    return InkWell(
+    return _DialogRadioTile(
+      label: type.name[0].toUpperCase() + type.name.substring(1),
+      selected: selected,
       onTap: () => vm.setImageType(type),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-        child: Row(
-          children: [
-            _radioCircle(selected, accent),
-            const SizedBox(width: 12),
-            Text(
-              type.name[0].toUpperCase() + type.name.substring(1),
-              style: TextStyle(
-                fontSize: 15,
-                color: selected ? onSurface : onSurface.withValues(alpha: 0.72),
-              ),
-            ),
-          ],
-        ),
-      ),
+      accent: accent,
+      onSurface: onSurface,
     );
   }
 
@@ -1981,54 +2044,12 @@ class _SettingsDialogState extends State<_SettingsDialog> {
       PosterSize.large => AppLocalizations.of(context).large,
       PosterSize.extraLarge => AppLocalizations.of(context).extraLarge,
     };
-    return InkWell(
+    return _DialogRadioTile(
+      label: label,
+      selected: selected,
       onTap: () => vm.setPosterSize(size),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-        child: Row(
-          children: [
-            _radioCircle(selected, accent),
-            const SizedBox(width: 12),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 15,
-                color: selected ? onSurface : onSurface.withValues(alpha: 0.72),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _radioCircle(bool selected, Color accent) {
-    final onSurface = AppColorScheme.onSurface;
-    return Container(
-      width: 18,
-      height: 18,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        border: Border.fromBorderSide(
-          ThemeRegistry.active.borders.chipBorder.copyWith(
-            color: selected ? accent : onSurface.withValues(alpha: 0.5),
-            width: 2,
-          ),
-        ),
-        color: selected ? accent : Colors.transparent,
-      ),
-      child: selected
-          ? Center(
-              child: Container(
-                width: 8,
-                height: 8,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: onSurface,
-                ),
-              ),
-            )
-          : null,
+      accent: accent,
+      onSurface: onSurface,
     );
   }
 }

--- a/lib/util/focus/grid_focus_node_mixin.dart
+++ b/lib/util/focus/grid_focus_node_mixin.dart
@@ -53,7 +53,13 @@ mixin GridFocusNodeMixin<T extends StatefulWidget> on State<T> {
     if (lastFocusedGridContentVersion == gridContentVersion) return;
     final idx = lastFocusedGridIndex;
     if (idx == null) return;
-    final node = gridItemFocusNodes[idx];
+    // The grid may have shrunk, so fall back to the last available row when the
+    // remembered index no longer exists.
+    var node = gridItemFocusNodes[idx];
+    if (node == null && gridItemFocusNodes.isNotEmpty) {
+      final maxIndex = gridItemFocusNodes.keys.reduce((a, b) => a > b ? a : b);
+      node = gridItemFocusNodes[maxIndex];
+    }
     if (node != null && node.canRequestFocus) {
       node.requestFocus();
     }

--- a/lib/util/focus/grid_focus_node_mixin.dart
+++ b/lib/util/focus/grid_focus_node_mixin.dart
@@ -49,6 +49,7 @@ mixin GridFocusNodeMixin<T extends StatefulWidget> on State<T> {
   }
 
   void restoreGridFocusIfNeeded() {
+    if (ModalRoute.of(context)?.isCurrent != true) return;
     if (lastFocusedGridContentVersion == gridContentVersion) return;
     final idx = lastFocusedGridIndex;
     if (idx == null) return;


### PR DESCRIPTION
# Pull Request

## Summary
Fixes focus accessibility, D-pad navigation, and sorting/filtering bugs in the library dialogs on Android TV.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #738  
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Created stateful `_DialogRadioTile` and `_DialogCheckboxTile` widgets implementing `FocusStateMixin` and manual key activation checks (`isActivateKey(event)`) to ensure TV remote selection functions reliably.
- Updated all radio and checkbox filter/sort dialog list rows to use these widgets, giving focused rows clear border highlights and focus backgrounds.
- Removed nested focus traps in the Sort By options list by replacing the `IconButton` on the active sort option with a non-focusable `Icon`. Users can toggle sorting directions by simply clicking/pressing OK on the currently selected option.
- Added a `ModalRoute.of(context)?.isCurrent != true` check to `restoreGridFocusIfNeeded()` in `GridFocusNodeMixin` to prevent the background library grid from stealing focus when sorting popup dialogs are active.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open the Sort & Filter popup from a library page (e.g. Movies).
2. Navigate the options with the D-pad to verify that the active option has a visible border highlight.
3. Press OK on the active sort option to toggle its sort direction, and verify that the focus stays inside the popup.
4. Navigate to the Favorites filter checkbox and press OK on the remote to check and uncheck it.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Testing the various sort options/directions, as well as Favorites:

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-07_18-45-53" src="https://github.com/user-attachments/assets/8dbc5eb9-f1f1-4093-9b39-4b031c555dc2" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-07_18-46-14" src="https://github.com/user-attachments/assets/51b64b0c-bd60-4c1f-b5eb-a4c76bfcf4e1" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-07_18-46-36" src="https://github.com/user-attachments/assets/a40cdf78-e07e-4b4a-b596-072a4d9e7471" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-07_18-47-36" src="https://github.com/user-attachments/assets/31ffeb22-ede7-40f6-a529-c0f6a7fcd3c3" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
