### PR TITLE
fix: Playback Info Labelling Logic

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3369,6 +3369,22 @@
   "@transcodingAudio": {
     "description": "Label for audio-only transcode playback method"
   },
+  "directStreamRemux": "Direct Stream (Remux)",
+  "@directStreamRemux": {
+    "description": "Play method label for direct stream with remuxing"
+  },
+  "transcodingBitrateOrResolution": "Transcoding (Bitrate or Resolution)",
+  "@transcodingBitrateOrResolution": {
+    "description": "Play method label for transcoding due to bitrate or resolution"
+  },
+  "transcodingVideoAndAudio": "Transcoding (Video & Audio)",
+  "@transcodingVideoAndAudio": {
+    "description": "Play method label for transcoding both video and audio"
+  },
+  "transcodingVideo": "Transcoding (Video)",
+  "@transcodingVideo": {
+    "description": "Play method label for transcoding video"
+  },
   "autoServerDefault": "Auto (Server Default)",
   "@autoServerDefault": {
     "description": "Option: auto server default"

--- a/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
@@ -14,6 +14,7 @@ import '../../../playback/appletv_mpv_backend.dart';
 import '../../../playback/appletv_preview_player.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../util/play_method_label.dart';
 import '../livetv/live_tv_guide_screen.dart';
 import '../../theme/app_theme_controller.dart';
 
@@ -514,9 +515,11 @@ class _AppleTvLiveTvPlayerHostScreenState
     final videoStream = streams.where((s) => s['Type'] == 'Video').firstOrNull;
     final audioStream = pickStream('Audio', _manager.audioStreamIndex);
 
-    final playMethod = resolution != null
-        ? _prettyPlayMethod(resolution.playMethod.name)
-        : 'Unknown';
+    final playMethod = playbackMethodLabel(
+          l10n: AppLocalizations.of(context),
+          playMethod: resolution?.playMethod,
+          transcodingReasons: resolution?.transcodingReasons ?? const [],
+        );
     final container = (resolution?.container ?? '').trim().toUpperCase().isEmpty
         ? 'Unknown'
         : (resolution?.container ?? '').trim().toUpperCase();
@@ -572,18 +575,7 @@ class _AppleTvLiveTvPlayerHostScreenState
     return sections;
   }
 
-  String _prettyPlayMethod(String name) {
-    switch (name) {
-      case 'directPlay':
-        return 'Direct Play';
-      case 'directStream':
-        return 'Direct Stream (Remux)';
-      case 'transcode':
-        return 'Transcode';
-      default:
-        return name;
-    }
-  }
+
 
   void _pushMetadata() {
     final backend = _backend;

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -22,6 +22,8 @@ import '../../theme/app_theme_controller.dart';
 import '../../screensaver/screensaver_controller.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../util/play_method_label.dart';
 
 class AppleTvPlayerHostScreen extends StatefulWidget {
   const AppleTvPlayerHostScreen({super.key});
@@ -207,18 +209,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     }
   }
 
-  String _prettyPlayMethod(String name) {
-    switch (name) {
-      case 'directPlay':
-        return 'Direct Play';
-      case 'directStream':
-        return 'Direct Stream (Remux)';
-      case 'transcode':
-        return 'Transcode';
-      default:
-        return name;
-    }
-  }
+
 
   Map<String, dynamic>? _rawDataForQueueItem(dynamic item) {
     if (item is AggregatedItem) return item.rawData;
@@ -396,7 +387,11 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
       rowEntry('File Name', fileName()),
       rowEntry(
         'Play Method',
-        res != null ? _prettyPlayMethod(res.playMethod.name) : 'Unknown',
+        playbackMethodLabel(
+          l10n: AppLocalizations.of(context),
+          playMethod: res?.playMethod,
+          transcodingReasons: res?.transcodingReasons ?? const [],
+        ),
       ),
       if (res != null && res.transcodingReasons.isNotEmpty)
         rowEntry('Transcode Reasons', res.transcodingReasons.join(', ')),

--- a/lib/util/play_method_label.dart
+++ b/lib/util/play_method_label.dart
@@ -8,7 +8,7 @@ const Set<String> _bitrateOrResolutionReasons = <String>{
   'videobitrateexceedslimit',
   'bitratelimitexceeded',
   'containerbitratenotsupported',
-  'resolutionnotsupported',
+  'videoresolutionnotsupported',
   'audiobitratenotsupported',
 };
 

--- a/lib/util/play_method_label.dart
+++ b/lib/util/play_method_label.dart
@@ -2,12 +2,20 @@ import 'package:playback_core/playback_core.dart';
 
 import '../l10n/app_localizations.dart';
 
-const Set<String> _videoReEncodeReasons = <String>{
+const Set<String> _bitrateOrResolutionReasons = <String>{
+  'videobitratenotsupported',
+  'containerbitrateexceedslimit',
+  'videobitrateexceedslimit',
+  'bitratelimitexceeded',
+  'containerbitratenotsupported',
+  'resolutionnotsupported',
+  'audiobitratenotsupported',
+};
+
+const Set<String> _videoCodecReasons = <String>{
   'videocodecnotsupported',
   'videoprofilenotsupported',
   'videolevelnotsupported',
-  'videoresolutionnotsupported',
-  'videobitratenotsupported',
   'videoframeratenotsupported',
   'videorangenotsupported',
   'videorangetypenotsupported',
@@ -15,6 +23,14 @@ const Set<String> _videoReEncodeReasons = <String>{
   'anamorphicvideonotsupported',
   'interlacedvideonotsupported',
   'refframesnotsupported',
+};
+
+const Set<String> _audioCodecReasons = <String>{
+  'audiocodecnotsupported',
+  'audiochannelsnotsupported',
+  'audioprofilenotsupported',
+  'audiosampleratenotsupported',
+  'audiobitdepthnotsupported',
 };
 
 String playbackMethodLabel({
@@ -26,17 +42,34 @@ String playbackMethodLabel({
   final lowerReasons = transcodingReasons
       .map((e) => e.toLowerCase())
       .toList(growable: false);
-  final isRemux =
-      playMethod == StreamPlayMethod.transcode &&
-      !lowerReasons.any(_videoReEncodeReasons.contains);
 
   if (playMethod != null) {
-    return switch (playMethod) {
-      StreamPlayMethod.directPlay => l10n.directPlay,
-      StreamPlayMethod.directStream => l10n.directStream,
-      StreamPlayMethod.transcode when isRemux => l10n.transcodingAudio,
-      StreamPlayMethod.transcode => l10n.transcoding,
-    };
+    if (playMethod == StreamPlayMethod.directPlay) {
+      return l10n.directPlay;
+    }
+    if (playMethod == StreamPlayMethod.directStream) {
+      return '${l10n.directStream} (Remux)';
+    }
+    if (playMethod == StreamPlayMethod.transcode) {
+      final isBitrateOrRes = lowerReasons.any(_bitrateOrResolutionReasons.contains);
+      final hasVideoCodec = lowerReasons.any(_videoCodecReasons.contains);
+      final hasAudioCodec = lowerReasons.any(_audioCodecReasons.contains);
+
+      final base = l10n.transcoding;
+      if (isBitrateOrRes) {
+        return '$base (Bitrate or Resolution)';
+      } else if (hasVideoCodec && hasAudioCodec) {
+        return '$base (Video & Audio)';
+      } else if (hasVideoCodec) {
+        return '$base (Video)';
+      } else if (hasAudioCodec) {
+        return l10n.transcodingAudio.isNotEmpty
+            ? l10n.transcodingAudio
+            : '$base (Audio)';
+      } else {
+        return base;
+      }
+    }
   }
 
   return switch (fallbackPlayMethod) {

--- a/lib/util/play_method_label.dart
+++ b/lib/util/play_method_label.dart
@@ -48,26 +48,23 @@ String playbackMethodLabel({
       return l10n.directPlay;
     }
     if (playMethod == StreamPlayMethod.directStream) {
-      return '${l10n.directStream} (Remux)';
+      return l10n.directStreamRemux;
     }
     if (playMethod == StreamPlayMethod.transcode) {
       final isBitrateOrRes = lowerReasons.any(_bitrateOrResolutionReasons.contains);
       final hasVideoCodec = lowerReasons.any(_videoCodecReasons.contains);
       final hasAudioCodec = lowerReasons.any(_audioCodecReasons.contains);
 
-      final base = l10n.transcoding;
       if (isBitrateOrRes) {
-        return '$base (Bitrate or Resolution)';
+        return l10n.transcodingBitrateOrResolution;
       } else if (hasVideoCodec && hasAudioCodec) {
-        return '$base (Video & Audio)';
+        return l10n.transcodingVideoAndAudio;
       } else if (hasVideoCodec) {
-        return '$base (Video)';
+        return l10n.transcodingVideo;
       } else if (hasAudioCodec) {
-        return l10n.transcodingAudio.isNotEmpty
-            ? l10n.transcodingAudio
-            : '$base (Audio)';
+        return l10n.transcodingAudio;
       } else {
-        return base;
+        return l10n.transcoding;
       }
     }
   }

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -110,7 +110,22 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       source,
       isAudio: isAudio,
       enableDirectPlay: enableDirectPlay,
+      maxStreamingBitrate: maxStreamingBitrate,
     );
+
+    final reasons = List<String>.from(source.transcodingReasons);
+    if (playMethod == StreamPlayMethod.transcode) {
+      final mediaBitrate = source.bitrate;
+      if (maxStreamingBitrate != null &&
+          mediaBitrate != null &&
+          mediaBitrate > maxStreamingBitrate) {
+        final lowerReasons = reasons.map((r) => r.toLowerCase()).toSet();
+        if (!lowerReasons.contains('videobitratenotsupported') &&
+            !lowerReasons.contains('containerbitrateexceedslimit')) {
+          reasons.add('VideoBitrateNotSupported');
+        }
+      }
+    }
 
     if (playMethod == StreamPlayMethod.transcode || playMethod == StreamPlayMethod.directStream) {
       url = MediaStreamResolver.applyStreamIndices(url, audioStreamIndex, subtitleStreamIndex);
@@ -173,7 +188,7 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       externalSubtitles: authedSubs,
       mediaStreams: source.mediaStreams,
       selectedAudioStreamIndex: source.defaultAudioStreamIndex,
-      transcodingReasons: source.transcodingReasons,
+      transcodingReasons: reasons,
       hybridAudioUrl: hybridAudioUrl,
     );
   }
@@ -294,6 +309,7 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
     PlaybackMediaSource source, {
     bool isAudio = false,
     bool enableDirectPlay = true,
+    int? maxStreamingBitrate,
   }) {
     final remotePath = source.path;
     final isManagedLiveStream =
@@ -322,6 +338,62 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       return (remotePath, method);
     }
 
+    final serverPlayMethod = source.defaultPlayMethod;
+    if (serverPlayMethod != null) {
+      if (serverPlayMethod == PlayMethod.directPlay && source.supportsDirectPlay) {
+        if (isAudio) {
+          return (
+            _buildDirectPlayAudioUrl(itemId, source),
+            StreamPlayMethod.directPlay,
+          );
+        }
+        return (
+          _client.playbackApi.getStreamUrl(itemId, mediaSourceId: source.id, liveStreamId: source.liveStreamId),
+          StreamPlayMethod.directPlay,
+        );
+      }
+      if (serverPlayMethod == PlayMethod.directStream && source.supportsDirectStream && source.directStreamUrl != null) {
+        var dsUrl = '${_client.baseUrl}${source.directStreamUrl}';
+        if (source.liveStreamId != null) {
+          dsUrl = '$dsUrl${dsUrl.contains('?') ? '&' : '?'}LiveStreamId=${Uri.encodeComponent(source.liveStreamId!)}';
+        }
+        return (dsUrl, StreamPlayMethod.directStream);
+      }
+      if (serverPlayMethod == PlayMethod.transcode && source.supportsTranscoding && source.transcodingUrl != null) {
+        var tcUrl = '${_client.baseUrl}${source.transcodingUrl}';
+        if (source.liveStreamId != null) {
+          tcUrl = '$tcUrl${tcUrl.contains('?') ? '&' : '?'}LiveStreamId=${Uri.encodeComponent(source.liveStreamId!)}';
+        }
+        return (tcUrl, StreamPlayMethod.transcode);
+      }
+    }
+
+    const videoReEncodeReasons = <String>{
+      'videocodecnotsupported',
+      'videoprofilenotsupported',
+      'videolevelnotsupported',
+      'videoresolutionnotsupported',
+      'videobitratenotsupported',
+      'videoframeratenotsupported',
+      'videorangenotsupported',
+      'videorangetypenotsupported',
+      'videobitdepthnotsupported',
+      'anamorphicvideonotsupported',
+      'interlacedvideonotsupported',
+      'refframesnotsupported',
+      'containerbitrateexceedslimit',
+      'videobitrateexceedslimit',
+      'bitratelimitexceeded',
+      'containerbitratenotsupported',
+      'resolutionnotsupported',
+    };
+    final lowerReasons = source.transcodingReasons.map((e) => e.toLowerCase()).toSet();
+    var requiresVideoTranscode = lowerReasons.any(videoReEncodeReasons.contains);
+    final mediaBitrate = source.bitrate;
+    if (maxStreamingBitrate != null && mediaBitrate != null && mediaBitrate > maxStreamingBitrate) {
+      requiresVideoTranscode = true;
+    }
+
     if (source.supportsDirectPlay && isAudio) {
       return (
         _buildDirectPlayAudioUrl(itemId, source),
@@ -335,7 +407,7 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
         StreamPlayMethod.directPlay,
       );
     }
-    if (source.supportsDirectStream && source.directStreamUrl != null) {
+    if (source.supportsDirectStream && source.directStreamUrl != null && !requiresVideoTranscode) {
       var dsUrl = '${_client.baseUrl}${source.directStreamUrl}';
       if (source.liveStreamId != null) {
         dsUrl = '$dsUrl${dsUrl.contains('?') ? '&' : '?'}LiveStreamId=${Uri.encodeComponent(source.liveStreamId!)}';

--- a/packages/server_core/lib/src/models/playback_models.dart
+++ b/packages/server_core/lib/src/models/playback_models.dart
@@ -152,6 +152,9 @@ class PlaybackMediaSource {
                 ?.cast<Map<String, dynamic>>() ??
             const [],
         defaultAudioStreamIndex: json['DefaultAudioStreamIndex'] as int?,
+        defaultPlayMethod: json['PlayMethod'] != null
+            ? PlayMethod.fromServerString(json['PlayMethod'] as String?)
+            : null,
         transcodingReasons: _parseTranscodingReasons(json),
       );
 


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves issues with incorrect play method labelling in the Playback Information sheet when transcoding. It updates the resolver to correctly select the transcoding play method when the cap is exceeded, injects the missing `VideoBitrateNotSupported` reason in the resolver, and restructures the labels to prioritize limit caps over codec incompatibilities. This also resolves non-English locales showing empty strings instead of the proper transcoding labels in certain instances (e.g., when transcoding is due to the audio stream).

## Related Issues
Link related issues or tickets separated by commas.

Related to Discord feedback

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

1. **Jellyfin Resolver Video Transcode Check**: Updated `_resolveStreamUrl` in `jellyfin_media_stream_resolver.dart` to identify if video transcoding is required. If the media's original bitrate exceeds the streaming cap, it forces video transcoding, bypassing the `directStream` selection and resolving to `StreamPlayMethod.transcode`.
2. **Dynamic Bitrate Limit Reason Appending**: Updated `resolve()` in the resolver to check if the stream resolved to transcode and if the original media bitrate exceeds the cap. If so, it appends the missing `VideoBitrateNotSupported` reason to the transcoding reasons list before passing it to `StreamResolutionResult`.
3. **Prioritized Transcode Reason Labels**: Restructured `playbackMethodLabel` in `play_method_label.dart` to evaluate transcode reasons by priority, showing `"Transcoding (Bitrate or Resolution)"` if a bitrate limit is active, and falling back to codec incompatibilities or a generic `"Transcoding"` string otherwise. See the following flowchart for the labelling logic:

<img width="1313" height="1886" alt="diagram-1783479267605" src="https://github.com/user-attachments/assets/28acd359-57f2-4692-8a0e-162dd3b6c779" />

4. **Unified Player Experience**: Replaced the platform-specific `_prettyPlayMethod` layout string mapping on Apple TV screens (`appletv_player_host_screen.dart` and `appletv_livetv_player_host_screen.dart`) with the unified, localized `playbackMethodLabel` utility. Removed the unused helper methods.
6. **Localization-Friendliness**: If a language doesn't have an explicit translation for `transcodingAudio`, it falls back to dynamically building it using the base translated `l10n.transcoding` + ` (Audio)` instead of displaying an empty string. If the community translation is added in the future, it is automatically prioritized.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a movie with a video bitrate over 2 Mbps.
2. Open playback settings and change the streaming quality cap to 2 Mbps.
3. Open the Playback Information sheet and verify that the Play Method displays `"Transcoding (Bitrate or Resolution)"`.
4. Open a video that is incompatible on the player and notice the transcoding reason adjusts accordingly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

DIRECT PLAY:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-07_19-36-26" src="https://github.com/user-attachments/assets/58cf5a1f-d9a1-43df-ae65-de41fc89dbca" />

TRANSCODING DOWN TO 2 Mbps:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-07_19-47-30" src="https://github.com/user-attachments/assets/65241bcf-5e6a-4d66-b507-650fc62a7cd9" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
