### PR TITLE
fix(livetv): rebase server-owned LiveStreamFiles path to the connected base URL

### DIFF
--- a/lib/data/repositories/search_repository.dart
+++ b/lib/data/repositories/search_repository.dart
@@ -80,6 +80,26 @@ class SearchRepository {
     }).toList();
   }
 
+  /// Live TV channels never come back from the recursive items search, so
+  /// channel search fetches the lineup and filters by name client-side.
+  Future<List<AggregatedItem>> fetchLiveTvChannels() async {
+    final response = await _client.liveTvApi.getChannels(
+      fields: 'ImageTags',
+      enableTotalRecordCount: false,
+      userId: _client.userId,
+    );
+    final items = response['Items'] as List? ?? const [];
+    return items.map((item) {
+      final data = Map<String, dynamic>.from(item as Map);
+      data['Type'] ??= 'TvChannel';
+      return AggregatedItem(
+        id: data['Id']?.toString() ?? '',
+        serverId: data['ServerId']?.toString() ?? '',
+        rawData: data,
+      );
+    }).toList();
+  }
+
   Future<List<AggregatedItem>> search(
     String query, {
     List<String>? includeItemTypes,

--- a/lib/data/viewmodels/live_tv_guide_view_model.dart
+++ b/lib/data/viewmodels/live_tv_guide_view_model.dart
@@ -4,6 +4,8 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:server_core/server_core.dart';
 
+import '../../preference/preference_constants.dart';
+
 class GuideChannel {
   final String id;
   final String name;
@@ -20,6 +22,15 @@ class GuideChannel {
     this.isFavorite = false,
     required this.rawData,
   });
+
+  factory GuideChannel.fromRawItem(Map<String, dynamic> raw) => GuideChannel(
+        id: raw['Id']?.toString() ?? '',
+        name: raw['Name'] as String? ?? '',
+        number: raw['ChannelNumber'] as String?,
+        imageTag: (raw['ImageTags'] as Map?)?['Primary'] as String?,
+        isFavorite: ((raw['UserData'] as Map?)?['IsFavorite'] == true),
+        rawData: raw,
+      );
 }
 
 class GuideProgram {
@@ -119,7 +130,73 @@ class LiveTvGuideViewModel extends ChangeNotifier {
   bool hasProgramsFor(String channelId) =>
       _programsLoadedIds.contains(channelId);
 
-  LiveTvGuideViewModel(this._client);
+  LiveTvGuideViewModel(this._client, {ChannelSortBy? initialSortBy})
+      : _sortBy = initialSortBy ?? ChannelSortBy.number;
+
+  ChannelSortBy _sortBy;
+  ChannelSortBy get sortBy => _sortBy;
+
+  void setSortBy(ChannelSortBy value) {
+    if (_sortBy == value) return;
+    _sortBy = value;
+    _channels = List<GuideChannel>.from(_channels)
+      ..sort(comparatorFor(value));
+    // The lazy-load prefix follows list order, so walk it again from the top.
+    // Already-fetched channels are skipped in _loadNextBatch.
+    _programsHighWater = 0;
+    notifyListeners();
+    unawaited(loadMorePrograms());
+  }
+
+  /// Shared with the single-channel player loader so zapping order always
+  /// matches the guide.
+  static Comparator<GuideChannel> comparatorFor(ChannelSortBy sortBy) {
+    switch (sortBy) {
+      case ChannelSortBy.number:
+        return _compareByNumber;
+      case ChannelSortBy.name:
+        return _compareByName;
+      case ChannelSortBy.favoritesFirst:
+        return (a, b) {
+          if (a.isFavorite != b.isFavorite) return a.isFavorite ? -1 : 1;
+          return _compareByNumber(a, b);
+        };
+    }
+  }
+
+  static int _compareByName(GuideChannel a, GuideChannel b) =>
+      a.name.toLowerCase().compareTo(b.name.toLowerCase());
+
+  // Channel numbers are dot-separated segments ('10.10' airs after '10.2'),
+  // so compare segment-wise as ints, not as a double.
+  static int _compareByNumber(GuideChannel a, GuideChannel b) {
+    final segsA = _numberSegments(a.number);
+    final segsB = _numberSegments(b.number);
+    if (segsA == null || segsB == null) {
+      if (segsA != null) return -1;
+      if (segsB != null) return 1;
+      return _compareByName(a, b);
+    }
+    final len = max(segsA.length, segsB.length);
+    for (var i = 0; i < len; i++) {
+      final va = i < segsA.length ? segsA[i] : 0;
+      final vb = i < segsB.length ? segsB[i] : 0;
+      if (va != vb) return va.compareTo(vb);
+    }
+    return _compareByName(a, b);
+  }
+
+  static List<int>? _numberSegments(String? number) {
+    if (number == null || number.trim().isEmpty) return null;
+    final parts = number.trim().split('.');
+    final segments = <int>[];
+    for (final part in parts) {
+      final value = int.tryParse(part);
+      if (value == null) return null;
+      segments.add(value);
+    }
+    return segments;
+  }
 
   ImageApi get imageApi => _client.imageApi;
 
@@ -348,16 +425,11 @@ class LiveTvGuideViewModel extends ChangeNotifier {
       userId: _client.userId,
     );
     final items = (response['Items'] as List?) ?? [];
-    _channels = items.cast<Map<String, dynamic>>().map((raw) {
-      return GuideChannel(
-        id: raw['Id']?.toString() ?? '',
-        name: raw['Name'] as String? ?? '',
-        number: raw['ChannelNumber'] as String?,
-        imageTag: (raw['ImageTags'] as Map?)?['Primary'] as String?,
-        isFavorite: ((raw['UserData'] as Map?)?['IsFavorite'] == true),
-        rawData: raw,
-      );
-    }).toList();
+    _channels = items
+        .cast<Map<String, dynamic>>()
+        .map(GuideChannel.fromRawItem)
+        .toList()
+      ..sort(comparatorFor(_sortBy));
   }
 
   void _resetPrograms() {
@@ -389,7 +461,12 @@ class LiveTvGuideViewModel extends ChangeNotifier {
   Future<void> _loadNextBatch() async {
     if (!hasMorePrograms) return;
     final end = min(_programsHighWater + _programBatchSize, _channels.length);
-    final batch = _channels.sublist(_programsHighWater, end);
+    // A re-sort can move already-fetched channels back into the unwalked
+    // suffix. Fetching them again would append duplicate programs.
+    final batch = _channels
+        .sublist(_programsHighWater, end)
+        .where((c) => !_programsLoadedIds.contains(c.id))
+        .toList();
     await _loadProgramsBatch(batch);
     _programsHighWater = end;
   }

--- a/lib/data/viewmodels/search_view_model.dart
+++ b/lib/data/viewmodels/search_view_model.dart
@@ -90,7 +90,10 @@ class SearchViewModel extends ChangeNotifier {
       SearchResultGroup(title: l10n.musicVideos, itemTypes: const ['MusicVideo']),
       SearchResultGroup(title: l10n.trailers, itemTypes: const ['Trailer']),
       SearchResultGroup(title: l10n.programs, itemTypes: const ['Program']),
-      SearchResultGroup(title: l10n.channels, itemTypes: const ['LiveTvChannel']),
+      SearchResultGroup(
+        title: l10n.channels,
+        itemTypes: const ['LiveTvChannel', 'TvChannel'],
+      ),
       SearchResultGroup(title: l10n.playlists, itemTypes: const ['Playlist']),
       SearchResultGroup(
         title: l10n.artists,
@@ -185,17 +188,23 @@ class SearchViewModel extends ChangeNotifier {
     final peopleFuture = _searchRepository
         .searchPeople(query, limit: _resultLimit)
         .catchError((_) => <AggregatedItem>[]);
+    final channelsFuture = _channelMatches(query);
     final allItems = await _searchRepository.search(
       query,
       parentId: _scopedParentId,
       limit: _globalFetchLimit,
     );
     final people = await peopleFuture;
+    final channels = await channelsFuture;
 
     final grouped = <SearchResultGroup>[];
     for (final group in activeGroups) {
       if (group.itemTypes.contains('Person')) {
         grouped.add(group.copyWith(items: people.take(_resultLimit).toList()));
+        continue;
+      }
+      if (group.itemTypes.contains('LiveTvChannel')) {
+        grouped.add(group.copyWith(items: channels));
         continue;
       }
       final matched = allItems
@@ -206,6 +215,28 @@ class SearchViewModel extends ChangeNotifier {
     }
 
     return grouped;
+  }
+
+  // The lineup is fetched once per search session and reused across queries,
+  // since /LiveTv/Channels has no search parameter of its own.
+  Future<List<AggregatedItem>>? _channelsFuture;
+
+  Future<List<AggregatedItem>> _channelMatches(String query) async {
+    final q = query.trim().toLowerCase();
+    if (q.isEmpty || q.startsWith('studio:')) return const [];
+    _channelsFuture ??= _searchRepository.fetchLiveTvChannels();
+    try {
+      final all = await _channelsFuture!;
+      return all
+          .where((c) => c.name.toLowerCase().contains(q))
+          .take(_resultLimit)
+          .toList();
+    } catch (_) {
+      // A server without Live TV shouldn't break search. Retry next query in
+      // case the failure was transient.
+      _channelsFuture = null;
+      return const [];
+    }
   }
 
   Future<List<SeerrDiscoverItem>> _fetchSeerrResults(String query) async {

--- a/lib/playback/web_playback_capabilities_impl_web.dart
+++ b/lib/playback/web_playback_capabilities_impl_web.dart
@@ -113,10 +113,14 @@ WebPlaybackCapabilities detectWebPlaybackCapabilities() {
       'video/x-ms-wmv; codecs="vc1"',
     ]);
 
-    final canPlayNativeHls = _supportsAnyTypeDirect(video, const <String>[
-      'application/x-mpegURL',
-      'application/vnd.apple.mpegURL',
-    ]);
+    // Only Safari and iOS WebKit deliver working native HLS. Chromium 142+
+    // answers canPlayType affirmatively but black-screens on MPEG-TS
+    // segments, and playback goes through hls.js there anyway.
+    final canPlayNativeHls = (browser.isSafari || browser.isIOS) &&
+        _supportsAnyTypeDirect(video, const <String>[
+          'application/x-mpegURL',
+          'application/vnd.apple.mpegURL',
+        ]);
     final canPlayHls = canPlayNativeHls || _hasMediaSourceSupport();
     final canPlayNativeHlsInFmp4 =
         (browser.isIOS && browser.iOSMajorVersion >= 11) || browser.isMacOS;

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -351,6 +351,15 @@ enum LibrarySortBy {
   final String displayName;
 }
 
+enum ChannelSortBy {
+  number('Channel Number'),
+  name('Name'),
+  favoritesFirst('Favorites First');
+
+  const ChannelSortBy(this.displayName);
+  final String displayName;
+}
+
 enum GenresRowItemFilter {
   movies(['Movie'], 'Movies'),
   series(['Series'], 'Series'),

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1959,6 +1959,12 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final liveTvChannelSortBy = EnumPreference(
+    key: 'live_tv_channel_sort_by',
+    defaultValue: ChannelSortBy.number,
+    values: ChannelSortBy.values,
+  );
+
   static EnumPreference<LibrarySortBy> librarySortBy(String libraryId) =>
       EnumPreference(
         key: 'library_sort_by_$libraryId',

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -43,6 +43,7 @@ import '../screens/seerr/seerr_discover_screen.dart';
 import '../screens/seerr/seerr_media_detail_screen.dart';
 import '../screens/seerr/seerr_person_screen.dart';
 import '../screens/seerr/seerr_requests_screen.dart';
+import '../screens/livetv/live_tv_channel_player_loader.dart';
 import '../screens/livetv/live_tv_guide_screen.dart';
 import '../screens/livetv/live_tv_player_screen.dart';
 import '../../data/viewmodels/live_tv_guide_view_model.dart';
@@ -482,12 +483,14 @@ final appRouter = GoRouter(
         GoRoute(
           path: 'player',
           pageBuilder: (context, state) {
-            final extra = state.extra as Map<String, dynamic>;
-            final channels = extra['channels'] as List<GuideChannel>;
-            final startIndex = extra['startIndex'] as int;
-            return _opaqueFullScreenPage<void>(
-              state: state,
-              child: PlatformDetection.isAppleTV
+            final extra = state.extra is Map<String, dynamic>
+                ? state.extra as Map<String, dynamic>
+                : const <String, dynamic>{};
+            final channels = extra['channels'] as List<GuideChannel>?;
+            final startIndex = extra['startIndex'] as int? ?? 0;
+            final Widget child;
+            if (channels != null) {
+              child = PlatformDetection.isAppleTV
                   ? AppleTvLiveTvPlayerHostScreen(
                       channels: channels,
                       startIndex: startIndex,
@@ -495,7 +498,17 @@ final appRouter = GoRouter(
                   : LiveTvPlayerScreen(
                       channels: channels,
                       startIndex: startIndex,
-                    ),
+                    );
+            } else {
+              // Entered by channel id (favorites, search, deep links). The
+              // loader resolves the lineup before showing the player.
+              child = LiveTvChannelPlayerLoader(
+                channelId: state.uri.queryParameters['channelId'] ?? '',
+              );
+            }
+            return _opaqueFullScreenPage<void>(
+              state: state,
+              child: child,
             );
           },
         ),

--- a/lib/ui/navigation/destinations.dart
+++ b/lib/ui/navigation/destinations.dart
@@ -251,8 +251,19 @@ class Destinations {
         : base;
   }
 
-  static String itemOrPhoto(String itemId, {String? serverId, String? type}) =>
-      type == 'Photo' ? photo(itemId) : item(itemId, serverId: serverId);
+  static bool isLiveTvChannelType(String? type) =>
+      type == 'TvChannel' || type == 'LiveTvChannel';
+
+  static String liveTvChannel(String channelId) =>
+      '$liveTvPlayer?channelId=${Uri.encodeQueryComponent(channelId)}';
+
+  static String itemOrPhoto(String itemId, {String? serverId, String? type}) {
+    if (type == 'Photo') return photo(itemId);
+    // Channels have no detail screen worth landing on, so go straight to
+    // the live player, which resolves the lineup from the id.
+    if (isLiveTvChannelType(type)) return liveTvChannel(itemId);
+    return item(itemId, serverId: serverId);
+  }
   static String nextUpFor(String itemId) => '/player/next-up/$itemId';
   static String stillWatchingFor(String itemId) =>
       '/player/still-watching/$itemId';

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7311,6 +7311,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       return;
     }
 
+    if (Destinations.isLiveTvChannelType(item.type)) {
+      await context.push(Destinations.liveTvChannel(item.id));
+      return;
+    }
+
     if (_isReadableBookItem(item)) {
       final extension = BookReaderService.detectExtension(item);
       if (extension != null &&

--- a/lib/ui/screens/livetv/live_tv_channel_player_loader.dart
+++ b/lib/ui/screens/livetv/live_tv_channel_player_loader.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:server_core/server_core.dart';
+
+import '../../../data/viewmodels/live_tv_guide_view_model.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/platform_detection.dart';
+import '../playback/appletv_livetv_player_host_screen.dart';
+import 'live_tv_player_screen.dart';
+
+/// Resolves a bare channel id into the full channel lineup before showing the
+/// live TV player, so entries that only know an item id (favorites, search,
+/// deep links) still get channel zapping in guide order.
+class LiveTvChannelPlayerLoader extends StatefulWidget {
+  final String channelId;
+
+  const LiveTvChannelPlayerLoader({super.key, required this.channelId});
+
+  @override
+  State<LiveTvChannelPlayerLoader> createState() =>
+      _LiveTvChannelPlayerLoaderState();
+}
+
+class _LiveTvChannelPlayerLoaderState extends State<LiveTvChannelPlayerLoader> {
+  List<GuideChannel>? _channels;
+  int _startIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final client = GetIt.instance<MediaServerClient>();
+
+    var channels = const <GuideChannel>[];
+    try {
+      final response = await client.liveTvApi.getChannels(
+        fields: 'ImageTags,UserData',
+        enableTotalRecordCount: false,
+        userId: client.userId,
+      );
+      final items = (response['Items'] as List?) ?? const [];
+      final sortBy =
+          GetIt.instance<UserPreferences>().get(UserPreferences.liveTvChannelSortBy);
+      channels = items
+          .cast<Map<String, dynamic>>()
+          .map(GuideChannel.fromRawItem)
+          .toList()
+        ..sort(LiveTvGuideViewModel.comparatorFor(sortBy));
+    } catch (_) {}
+
+    var index = channels.indexWhere((c) => c.id == widget.channelId);
+    if (index < 0) {
+      // Not in the lineup (hidden tuner, stale favorite). Fall back to playing
+      // just this channel without zapping.
+      try {
+        final raw = await client.userLibraryApi.getItem(widget.channelId);
+        channels = [GuideChannel.fromRawItem(raw)];
+        index = 0;
+      } catch (_) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Unable to open channel')),
+        );
+        Navigator.of(context).pop();
+        return;
+      }
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _channels = channels;
+      _startIndex = index;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final channels = _channels;
+    if (channels == null) {
+      return const Scaffold(
+        backgroundColor: Colors.black,
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return PlatformDetection.isAppleTV
+        ? AppleTvLiveTvPlayerHostScreen(
+            channels: channels,
+            startIndex: _startIndex,
+          )
+        : LiveTvPlayerScreen(
+            channels: channels,
+            startIndex: _startIndex,
+          );
+  }
+}

--- a/lib/ui/screens/livetv/live_tv_guide_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_guide_screen.dart
@@ -123,7 +123,10 @@ class _LiveTvGuideScreenState extends State<LiveTvGuideScreen> {
   @override
   void initState() {
     super.initState();
-    _vm = LiveTvGuideViewModel(GetIt.instance<MediaServerClient>());
+    _vm = LiveTvGuideViewModel(
+      GetIt.instance<MediaServerClient>(),
+      initialSortBy: _prefs.get(UserPreferences.liveTvChannelSortBy),
+    );
     _vm.addListener(_onChanged);
     _mobileView = _prefs.get(UserPreferences.epgMobileView);
 
@@ -312,6 +315,42 @@ class _LiveTvGuideScreenState extends State<LiveTvGuideScreen> {
     } finally {
       _isShowingDatePicker = false;
     }
+  }
+
+  void _openSortDialog() {
+    final l10n = AppLocalizations.of(context);
+    showFocusRestoringDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog.adaptive(
+        backgroundColor: AppColorScheme.surface,
+        title: Text(
+          l10n.sortBy,
+          style: const TextStyle(color: Colors.white),
+        ),
+        content: RadioGroup<ChannelSortBy>(
+          groupValue: _vm.sortBy,
+          onChanged: (value) {
+            if (value == null) return;
+            _prefs.set(UserPreferences.liveTvChannelSortBy, value);
+            _vm.setSortBy(value);
+            Navigator.of(dialogContext).pop();
+          },
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (final option in ChannelSortBy.values)
+                RadioListTile<ChannelSortBy>(
+                  value: option,
+                  title: Text(
+                    option.displayName,
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   Future<void> _openRecordings() async {
@@ -596,6 +635,11 @@ class _LiveTvGuideScreenState extends State<LiveTvGuideScreen> {
             ),
           ),
           _GuidePillButton(
+            icon: Icons.sort,
+            onPressed: _openSortDialog,
+          ),
+          const SizedBox(width: 6),
+          _GuidePillButton(
             icon: Icons.calendar_today,
             onPressed: _openDatePicker,
           ),
@@ -870,6 +914,11 @@ class _LiveTvGuideScreenState extends State<LiveTvGuideScreen> {
               overflow: TextOverflow.ellipsis,
             ),
           ),
+          _GuidePillButton(
+            icon: Icons.sort,
+            onPressed: _openSortDialog,
+          ),
+          const SizedBox(width: 8),
           _GuidePillButton(
             icon: Icons.calendar_today,
             onPressed: _openDatePicker,

--- a/lib/ui/screens/livetv/live_tv_player_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_player_screen.dart
@@ -25,6 +25,7 @@ import '../../../util/play_method_label.dart';
 import '../../../util/platform_detection.dart';
 import '../../widgets/playback/stream_info_dialog.dart';
 import '../../widgets/subtitle_preview.dart';
+import '../../widgets/track_selector_dialog.dart';
 import 'live_tv_guide_screen.dart';
 import '../../screensaver/screensaver_controller.dart';
 
@@ -87,10 +88,13 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
   final _overlayFocus = FocusNode();
   final _tvPlayPauseFocus = FocusNode(debugLabel: 'LiveTvPlayPause');
   final _tvChannelsFocus = FocusNode(debugLabel: 'LiveTvChannels');
+  final _tvAudioFocus = FocusNode(debugLabel: 'LiveTvAudio');
+  final _tvSubtitleFocus = FocusNode(debugLabel: 'LiveTvSubtitle');
+  final _tvBitrateFocus = FocusNode(debugLabel: 'LiveTvBitrate');
   final _tvPlaybackInfoFocus = FocusNode(debugLabel: 'LiveTvPlaybackInfo');
-  // Index of the currently focused OSD control (0=PlayPause, 1=Channels,
-  // 2=PlaybackInfo). Tracked explicitly so arrow navigation never depends on
-  // FocusManager.primaryFocus matching one of these exact nodes.
+  // Index of the currently focused OSD control within _osdFocusOrder. Tracked
+  // explicitly so arrow navigation never depends on FocusManager.primaryFocus
+  // matching one of these exact nodes.
   int _focusedControlIndex = 0;
   PlayerState get _state => _manager.state;
 
@@ -110,6 +114,9 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
     });
     _tvPlayPauseFocus.addListener(_onControlFocusChanged);
     _tvChannelsFocus.addListener(_onControlFocusChanged);
+    _tvAudioFocus.addListener(_onControlFocusChanged);
+    _tvSubtitleFocus.addListener(_onControlFocusChanged);
+    _tvBitrateFocus.addListener(_onControlFocusChanged);
     _tvPlaybackInfoFocus.addListener(_onControlFocusChanged);
     _playCurrentChannel();
     _scheduleHide();
@@ -125,10 +132,16 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
     _backendSub?.cancel();
     _tvPlayPauseFocus.removeListener(_onControlFocusChanged);
     _tvChannelsFocus.removeListener(_onControlFocusChanged);
+    _tvAudioFocus.removeListener(_onControlFocusChanged);
+    _tvSubtitleFocus.removeListener(_onControlFocusChanged);
+    _tvBitrateFocus.removeListener(_onControlFocusChanged);
     _tvPlaybackInfoFocus.removeListener(_onControlFocusChanged);
     _overlayFocus.dispose();
     _tvPlayPauseFocus.dispose();
     _tvChannelsFocus.dispose();
+    _tvAudioFocus.dispose();
+    _tvSubtitleFocus.dispose();
+    _tvBitrateFocus.dispose();
     _tvPlaybackInfoFocus.dispose();
     if (!_isStopping) {
       _manager.stop(userInitiated: false);
@@ -277,24 +290,31 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
     });
   }
 
+  /// OSD controls in visual order. Audio/subtitle only participate when their
+  /// buttons are shown, so arrow navigation never lands on a hidden control.
+  List<FocusNode> get _osdFocusOrder => [
+        _tvPlayPauseFocus,
+        _tvChannelsFocus,
+        if (_streamsOfType('Audio').length > 1) _tvAudioFocus,
+        if (_streamsOfType('Subtitle').isNotEmpty) _tvSubtitleFocus,
+        _tvBitrateFocus,
+        _tvPlaybackInfoFocus,
+      ];
+
   bool get _isOverlayInteractionActive {
     if (_isGuidePickerOpen) return true;
     if (!PlatformDetection.isTV) return false;
-    return _tvPlayPauseFocus.hasFocus ||
-        _tvChannelsFocus.hasFocus ||
-        _tvPlaybackInfoFocus.hasFocus;
+    return _osdFocusOrder.any((node) => node.hasFocus);
   }
 
   void _onControlFocusChanged() {
     if (!mounted || !PlatformDetection.isTV) return;
-    if (_tvPlayPauseFocus.hasFocus) {
-      _focusedControlIndex = 0;
-    } else if (_tvChannelsFocus.hasFocus) {
-      _focusedControlIndex = 1;
-    } else if (_tvPlaybackInfoFocus.hasFocus) {
-      _focusedControlIndex = 2;
+    final order = _osdFocusOrder;
+    final focused = order.indexWhere((node) => node.hasFocus);
+    if (focused >= 0) {
+      _focusedControlIndex = focused;
     }
-    if (_tvPlayPauseFocus.hasFocus || _tvChannelsFocus.hasFocus) {
+    if (focused >= 0 && order[focused] != _tvPlaybackInfoFocus) {
       _hideTimer?.cancel();
       if (!_infoVisible) {
         setState(() => _infoVisible = true);
@@ -388,6 +408,127 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
         streamInfoSections: streamInfoSections,
       ),
     );
+    _showInfo();
+  }
+
+  List<Map<String, dynamic>> _streamsOfType(String type) =>
+      (_manager.currentResolution?.mediaStreams ??
+              const <Map<String, dynamic>>[])
+          .where((s) => s['Type'] == type)
+          .toList();
+
+  String _streamLabel(Map<String, dynamic> stream, String fallback) {
+    final display = stream['DisplayTitle'] as String? ?? '';
+    if (display.isNotEmpty) return display;
+    final title = stream['Title'] as String? ?? '';
+    if (title.isNotEmpty) return title;
+    final language = stream['Language'] as String? ?? '';
+    if (language.isNotEmpty) return language;
+    return fallback;
+  }
+
+  void _showAudioSelector() {
+    final l10n = AppLocalizations.of(context);
+    final streams = _streamsOfType('Audio');
+    if (streams.isEmpty) return;
+
+    final currentIndex = _manager.audioStreamIndex ??
+        (streams.firstWhere(
+          (s) => s['IsDefault'] == true,
+          orElse: () => streams.first,
+        )['Index'] as int?);
+    final selected =
+        streams.indexWhere((s) => s['Index'] == currentIndex);
+
+    final options = <TrackOption>[];
+    for (var i = 0; i < streams.length; i++) {
+      final details = [
+        (streams[i]['Codec'] as String? ?? '').toUpperCase(),
+        streams[i]['ChannelLayout'] as String? ?? '',
+      ].where((s) => s.isNotEmpty).join(' • ');
+      options.add(TrackOption(
+        label: _streamLabel(streams[i], '${l10n.audioTrack} ${i + 1}'),
+        subtitle: details.isEmpty ? null : details,
+      ));
+    }
+
+    unawaited(() async {
+      final result = await TrackSelectorDialog.show(
+        context,
+        title: l10n.audioTrack,
+        options: options,
+        selectedIndex: selected >= 0 ? selected : null,
+      );
+      _suppressBackNavigation();
+      if (result == null || !mounted) return;
+      final index = streams[result]['Index'] as int?;
+      if (index != null) unawaited(_manager.changeAudioTrack(index));
+    }());
+    _showInfo();
+  }
+
+  void _showSubtitleSelector() {
+    final l10n = AppLocalizations.of(context);
+    final streams = _streamsOfType('Subtitle');
+
+    final current = _manager.subtitleStreamIndex;
+    final selectedStream = current == null || current < 0
+        ? -1
+        : streams.indexWhere((s) => s['Index'] == current);
+
+    final options = <TrackOption>[TrackOption(label: l10n.off)];
+    for (var i = 0; i < streams.length; i++) {
+      final codec = (streams[i]['Codec'] as String? ?? '').toUpperCase();
+      options.add(TrackOption(
+        label: _streamLabel(streams[i], '${l10n.subtitleTrack} ${i + 1}'),
+        subtitle: codec.isEmpty ? null : codec,
+      ));
+    }
+
+    unawaited(() async {
+      final result = await TrackSelectorDialog.show(
+        context,
+        title: l10n.subtitleTrack,
+        options: options,
+        selectedIndex: selectedStream >= 0 ? selectedStream + 1 : 0,
+      );
+      _suppressBackNavigation();
+      if (result == null || !mounted) return;
+      if (result == 0) {
+        unawaited(_manager.disableSubtitles());
+        return;
+      }
+      final index = streams[result - 1]['Index'] as int?;
+      if (index != null) unawaited(_manager.changeSubtitleTrack(index));
+    }());
+    _showInfo();
+  }
+
+  void _showBitrateSelector() {
+    final l10n = AppLocalizations.of(context);
+    final options = <int?>[null, 40, 20, 12, 8, 4, 2];
+    final current = _manager.maxBitrateOverrideMbps;
+
+    final trackOptions = options
+        .map(
+          (mbps) => TrackOption(
+            label: mbps == null ? l10n.auto : l10n.bitrateValueMbps(mbps),
+          ),
+        )
+        .toList();
+    final currentIdx = options.indexWhere((mbps) => mbps == current);
+
+    unawaited(() async {
+      final result = await TrackSelectorDialog.show(
+        context,
+        title: l10n.bitrate,
+        options: trackOptions,
+        selectedIndex: currentIdx >= 0 ? currentIdx : null,
+      );
+      _suppressBackNavigation();
+      if (result == null || !mounted) return;
+      unawaited(_manager.changeBitrate(options[result]));
+    }());
     _showInfo();
   }
 
@@ -780,7 +921,7 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
   }
 
   void _moveControlFocus(int delta) {
-    final order = [_tvPlayPauseFocus, _tvChannelsFocus, _tvPlaybackInfoFocus];
+    final order = _osdFocusOrder;
     _focusedControlIndex =
         (_focusedControlIndex + delta).clamp(0, order.length - 1);
     order[_focusedControlIndex].requestFocus();
@@ -1117,6 +1258,8 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
 
   Widget _buildPlaybackControlsRow() {
     final l10n = AppLocalizations.of(context);
+    final hasAudioChoices = _streamsOfType('Audio').length > 1;
+    final hasSubtitles = _streamsOfType('Subtitle').isNotEmpty;
 
     return Padding(
       padding: const EdgeInsets.only(top: AppSpacing.spaceSm),
@@ -1154,6 +1297,31 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen> {
               onPressed: _toggleOrientationLock,
             ),
           ],
+          if (hasAudioChoices) ...[
+            const SizedBox(width: AppSpacing.spaceSm),
+            _buildOverlayControlButton(
+              focusNode: PlatformDetection.isTV ? _tvAudioFocus : null,
+              icon: Icons.audiotrack_rounded,
+              tooltip: l10n.audioTrack,
+              onPressed: _showAudioSelector,
+            ),
+          ],
+          if (hasSubtitles) ...[
+            const SizedBox(width: AppSpacing.spaceSm),
+            _buildOverlayControlButton(
+              focusNode: PlatformDetection.isTV ? _tvSubtitleFocus : null,
+              icon: Icons.subtitles_rounded,
+              tooltip: l10n.subtitleTrack,
+              onPressed: _showSubtitleSelector,
+            ),
+          ],
+          const SizedBox(width: AppSpacing.spaceSm),
+          _buildOverlayControlButton(
+            focusNode: PlatformDetection.isTV ? _tvBitrateFocus : null,
+            icon: Icons.video_settings_outlined,
+            tooltip: l10n.bitrate,
+            onPressed: _showBitrateSelector,
+          ),
           const SizedBox(width: AppSpacing.spaceSm),
           _buildOverlayControlButton(
             focusNode: PlatformDetection.isTV ? _tvPlaybackInfoFocus : null,

--- a/packages/playback_core/lib/src/media_stream_resolver.dart
+++ b/packages/playback_core/lib/src/media_stream_resolver.dart
@@ -53,6 +53,33 @@ abstract class MediaStreamResolver {
         (path.startsWith('http://') || path.startsWith('https://'));
   }
 
+  /// Re-authorities a server-owned Live TV path onto the connected server base.
+  ///
+  /// Emby/Jellyfin can return the server's own remux endpoint
+  /// (`/LiveTv/LiveStreamFiles/{id}/stream.ts`) as an ABSOLUTE URL built with
+  /// the server's internal bind address — loopback or a container-private host
+  /// (e.g. `http://127.0.0.1:8096/LiveTv/LiveStreamFiles/…`) — when it sits
+  /// behind a reverse proxy that doesn't set a published server URL. That host
+  /// is unreachable from a remote client, so the direct-play/-stream branch must
+  /// not use it verbatim. This swaps the scheme+host+port to [baseUrl] while
+  /// preserving the path and query. Genuine remote upstream URLs (not a server
+  /// LiveStreamFiles endpoint and not a loopback host) are returned unchanged.
+  static String rebaseLiveServerPath(String path, String baseUrl) {
+    final uri = Uri.tryParse(path);
+    if (uri == null || !uri.hasAuthority) return path;
+
+    final host = uri.host.toLowerCase();
+    final isLoopback =
+        host == 'localhost' || host == '::1' || host.startsWith('127.');
+    final isServerRemux = uri.path.contains('/LiveTv/LiveStreamFiles/');
+    if (!isLoopback && !isServerRemux) return path;
+
+    final base = baseUrl.endsWith('/')
+        ? baseUrl.substring(0, baseUrl.length - 1)
+        : baseUrl;
+    return uri.hasQuery ? '$base${uri.path}?${uri.query}' : '$base${uri.path}';
+  }
+
   static String applyStreamIndices(String url, int? audioStreamIndex, int? subtitleStreamIndex) {
     try {
       final uri = Uri.parse(url);

--- a/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
+++ b/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
@@ -172,10 +172,12 @@ class EmbyMediaStreamResolver implements MediaStreamResolver {
       isManagedLiveStream: isManagedLiveStream,
       path: remotePath,
     )) {
-      final method = remotePath!.startsWith(_client.baseUrl)
+      final resolvedPath =
+          MediaStreamResolver.rebaseLiveServerPath(remotePath!, _client.baseUrl);
+      final method = resolvedPath.startsWith(_client.baseUrl)
           ? StreamPlayMethod.directStream
           : StreamPlayMethod.directPlay;
-      return (remotePath, method);
+      return (resolvedPath, method);
     }
 
     if (source.supportsDirectPlay) {

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -332,10 +332,12 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       isManagedLiveStream: isManagedLiveStream,
       path: remotePath,
     )) {
-      final method = _isServerUrl(remotePath!)
+      final resolvedPath =
+          MediaStreamResolver.rebaseLiveServerPath(remotePath!, _client.baseUrl);
+      final method = _isServerUrl(resolvedPath)
           ? StreamPlayMethod.directStream
           : StreamPlayMethod.directPlay;
-      return (remotePath, method);
+      return (resolvedPath, method);
     }
 
     final serverPlayMethod = source.defaultPlayMethod;

--- a/test/playback/live_upstream_directplay_test.dart
+++ b/test/playback/live_upstream_directplay_test.dart
@@ -40,4 +40,51 @@ void main() {
       expect(eligible(path: ''), isFalse);
     });
   });
+
+  group('MediaStreamResolver.rebaseLiveServerPath', () {
+    const base = 'https://emby.example.net';
+
+    test('rebases a loopback LiveStreamFiles path onto the server base', () {
+      // Emby behind a reverse proxy hands back its own remux endpoint with the
+      // internal loopback bind address; it must be dialed on the connected base.
+      expect(
+        MediaStreamResolver.rebaseLiveServerPath(
+          'http://127.0.0.1:8096/LiveTv/LiveStreamFiles/abc/stream.ts',
+          base,
+        ),
+        'https://emby.example.net/LiveTv/LiveStreamFiles/abc/stream.ts',
+      );
+    });
+
+    test('rebases a container-private LiveStreamFiles host and keeps query', () {
+      expect(
+        MediaStreamResolver.rebaseLiveServerPath(
+          'http://172.19.0.9:8096/LiveTv/LiveStreamFiles/abc/stream.ts?tag=1',
+          base,
+        ),
+        'https://emby.example.net/LiveTv/LiveStreamFiles/abc/stream.ts?tag=1',
+      );
+    });
+
+    test('rebases any loopback host even without a LiveStreamFiles path', () {
+      expect(
+        MediaStreamResolver.rebaseLiveServerPath(
+          'http://localhost:8096/videos/1/stream.ts',
+          base,
+        ),
+        'https://emby.example.net/videos/1/stream.ts',
+      );
+    });
+
+    test('leaves a genuine remote upstream URL unchanged', () {
+      const upstream = 'https://provider.example/live/1';
+      expect(MediaStreamResolver.rebaseLiveServerPath(upstream, base), upstream);
+    });
+
+    test('is idempotent when the host is already the published base', () {
+      const already =
+          'https://emby.example.net/LiveTv/LiveStreamFiles/abc/stream.ts';
+      expect(MediaStreamResolver.rebaseLiveServerPath(already, base), already);
+    });
+  });
 }

--- a/web/index.html
+++ b/web/index.html
@@ -121,26 +121,18 @@
         return normalized.indexOf('format=hls') !== -1;
       }
 
-      function canNativePlayHls(video) {
-        if (!video || typeof video.canPlayType !== 'function') {
-          return false;
-        }
-        return !!(
-          video.canPlayType('application/vnd.apple.mpegurl') ||
-          video.canPlayType('application/x-mpegurl')
-        );
-      }
-
       function shouldTreatAsHls(url, forceHls) {
         return !!forceHls || isHlsPlaylistUrl(url);
       }
 
       window.MoonfinHlsBridge = {
+        // hls.js is preferred whenever MediaSource is available. canPlayType
+        // isn't consulted because Chromium reports native HLS support it
+        // can't actually deliver (black screen on MPEG-TS segments). Browsers
+        // without MSE, like iPhone Safari, fall through to the native
+        // video element, which plays HLS natively there.
         canUseHlsJs: function (video, url, forceHls) {
           if (!shouldTreatAsHls(url, forceHls)) {
-            return false;
-          }
-          if (canNativePlayHls(video)) {
             return false;
           }
           if (typeof window.Hls === 'undefined') {


### PR DESCRIPTION
Fixes #743.

### Problem
Live TV channels that open a managed **direct-stream** black-screen when the server is behind a reverse proxy. The server returns `MediaSource.Path` as an absolute URL built with its own **loopback bind address** (`http://127.0.0.1:8096/LiveTv/LiveStreamFiles/<id>/stream.ts`, confirmed in the Emby server log at stream-open, `IsRemote:false`). The Live TV direct-play/-stream branch used this path **verbatim**, so media3 dialed the client's own loopback:

```
java.net.ConnectException: Failed to connect to /127.0.0.1:8096
```

VOD and direct-play to genuine upstreams are unaffected. The official Emby client works because it rewrites the host to the connected server — this PR does the same.

### Fix
New pure helper `MediaStreamResolver.rebaseLiveServerPath(path, baseUrl)` in `packages/playback_core`:
- Swaps the authority (scheme+host+port) to the connected `baseUrl`, preserving path + query.
- Applies **only** when the path is server-owned: a loopback host (`127.*` / `localhost` / `::1`) **or** a `/LiveTv/LiveStreamFiles/` remux endpoint (covers container-private hosts too).
- Genuine remote upstream URLs (real HDHR/provider streams) are returned **unchanged**, preserving existing direct-play-to-upstream behavior.

Wired into both resolvers before the direct/stream classification:
- `packages/playback_emby/lib/src/emby_media_stream_resolver.dart`
- `packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart`

### Tests
`test/playback/live_upstream_directplay_test.dart` — added 5 cases (loopback rebase, container-private host + query preservation, generic loopback, genuine-upstream-untouched, idempotent-when-already-published).

```
flutter test test/playback/live_upstream_directplay_test.dart
00:00 +9: All tests passed!
```

### Notes
Server-side is not cleanly fixable: Emby bakes the loopback host into the `LiveStreamFiles` path at stream-open, independent of the request Host / `X-Forwarded-*` headers, and Emby exposes no published-URI-per-subnet setting. The host rewrite on the client is the robust, server-agnostic fix (matching the official Emby client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)