### PR TITLE
feat: implement local and synced hide from CW and NU options

### DIFF
--- a/lib/background/watch_next_background.dart
+++ b/lib/background/watch_next_background.dart
@@ -9,6 +9,7 @@ import '../data/services/watch_next_service.dart';
 import '../di/injection.dart';
 import '../playback/car_artwork.dart';
 import '../playback/headless_session_bootstrap.dart';
+import '../preference/user_preferences.dart';
 
 Future<void> watchNextBackgroundMain() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -31,11 +32,14 @@ Future<void> watchNextBackgroundMain() async {
 
       final dataSource = RowDataSource(client);
       final rows = <HomeRow>[];
+      final prefs = GetIt.instance<UserPreferences>();
       try {
-        rows.add(await dataSource.loadResume(serverId));
+        final r = await dataSource.loadResume(serverId);
+        rows.add(r.copyWith(items: prefs.filterContinueWatching(r.items)));
       } catch (_) {}
       try {
-        rows.add(await dataSource.loadNextUp(serverId));
+        final r = await dataSource.loadNextUp(serverId);
+        rows.add(r.copyWith(items: prefs.filterNextUp(r.items)));
       } catch (_) {}
 
       await CarArtwork.instance.ensureReady();

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -986,6 +986,17 @@ class PluginSyncService extends ChangeNotifier {
 
       _applyString(
         resolved,
+        'hiddenContinueWatchingItems',
+        UserPreferences.hiddenContinueWatchingItems,
+      );
+      _applyString(
+        resolved,
+        'hiddenNextUpSeries',
+        UserPreferences.hiddenNextUpSeries,
+      );
+
+      _applyString(
+        resolved,
         'visualTheme',
         UserPreferences.visualTheme,
         enumValues: prefs.VisualThemeId.values,
@@ -1775,6 +1786,8 @@ class PluginSyncService extends ChangeNotifier {
             .map((t) => t.serializedName)
             .toList(),
       },
+      'hiddenContinueWatchingItems': _prefs.get(UserPreferences.hiddenContinueWatchingItems),
+      'hiddenNextUpSeries': _prefs.get(UserPreferences.hiddenNextUpSeries),
     };
 
     final mdblistKey = _prefs.get(UserPreferences.mdblistApiKey);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7491,6 +7491,18 @@
   "@contextMenuGoToSeries": {
     "description": "Context menu action to navigate to the parent series of an episode"
   },
+  "contextMenuHideFromContinueWatching": "Hide from Continue Watching",
+  "@contextMenuHideFromContinueWatching": {
+    "description": "Context menu action to hide an item from the Continue Watching section"
+  },
+  "contextMenuHideFromNextUp": "Hide from Next Up",
+  "@contextMenuHideFromNextUp": {
+    "description": "Context menu action to hide a show from the Next Up section"
+  },
+  "contextMenuAddToCollection": "Add to Collection",
+  "@contextMenuAddToCollection": {
+    "description": "Context menu action to add an item to a collection"
+  },
   "settingsAdministrationSubtitle": "Access the server administration panel",
   "settingsAccountSecurity": "Account & Security",
   "settingsAccountSecuritySubtitle": "Authentication, PIN code, and parental controls",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:playback_core/playback_core.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'app.dart';
+import 'data/models/aggregated_item.dart';
 import 'background/watch_next_background.dart' as watch_next_bg;
 import 'data/services/carplay_service.dart';
 import 'data/services/cast/airplay_command_bridge.dart';
@@ -414,6 +415,17 @@ void main() async {
 
   final prefs = GetIt.instance<UserPreferences>();
   WidgetsBinding.instance.addObserver(_PreferenceWriteFlushObserver(prefs));
+
+  GetIt.instance<PlaybackManager>().queueService.queueChangedStream.listen((_) {
+    final activeItem = GetIt.instance<PlaybackManager>().queueService.currentItem;
+    if (activeItem is AggregatedItem) {
+      prefs.unhideFromContinueWatching(activeItem.id);
+      if (activeItem.seriesId != null && activeItem.seriesId!.isNotEmpty) {
+        prefs.unhideFromContinueWatching(activeItem.seriesId!);
+        prefs.unhideFromNextUp(activeItem.seriesId!);
+      }
+    }
+  });
 
   // Register Theme Store themes before the active theme is resolved so a
   // store-saved theme applies on launch.

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1,8 +1,11 @@
 import 'dart:ui' as ui;
+import 'dart:convert';
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:server_core/server_core.dart' hide ImageType;
 
+import '../data/models/aggregated_item.dart';
 import '../playback/audio_capability_profile.dart';
 import '../util/idiom/app_ui_idiom.dart';
 import '../util/insecure_certificates.dart';
@@ -2153,4 +2156,157 @@ class UserPreferences extends ChangeNotifier {
     }
     notifyListeners();
   }
+
+  static final hiddenContinueWatchingItems = Preference<String>(
+    key: 'hidden_continue_watching_items',
+    defaultValue: '{}',
+  );
+
+  static final hiddenNextUpSeries = Preference<String>(
+    key: 'hidden_next_up_series',
+    defaultValue: '{}',
+  );
+
+  Map<String, String> getHiddenContinueWatchingItems() {
+    try {
+      final jsonStr = get(hiddenContinueWatchingItems);
+      final map = jsonDecode(jsonStr) as Map;
+      return map.cast<String, String>();
+    } catch (_) {
+      return {};
+    }
+  }
+
+  Future<void> hideFromContinueWatching(String id) async {
+    final items = getHiddenContinueWatchingItems();
+    items[id] = DateTime.now().toUtc().toIso8601String();
+    await set(hiddenContinueWatchingItems, jsonEncode(items));
+  }
+
+  Future<void> unhideFromContinueWatching(String id) async {
+    final items = getHiddenContinueWatchingItems();
+    if (items.remove(id) != null) {
+      await set(hiddenContinueWatchingItems, jsonEncode(items));
+    }
+  }
+
+  Map<String, String> getHiddenNextUpSeries() {
+    try {
+      final jsonStr = get(hiddenNextUpSeries);
+      final map = jsonDecode(jsonStr) as Map;
+      return map.cast<String, String>();
+    } catch (_) {
+      return {};
+    }
+  }
+
+  Future<void> hideFromNextUp(String seriesId) async {
+    final series = getHiddenNextUpSeries();
+    series[seriesId] = DateTime.now().toUtc().toIso8601String();
+    await set(hiddenNextUpSeries, jsonEncode(series));
+  }
+
+  Future<void> unhideFromNextUp(String seriesId) async {
+    final series = getHiddenNextUpSeries();
+    if (series.remove(seriesId) != null) {
+      await set(hiddenNextUpSeries, jsonEncode(series));
+    }
+  }
+
+  List<AggregatedItem> filterContinueWatching(List<AggregatedItem> items) {
+    final hidden = getHiddenContinueWatchingItems();
+    if (hidden.isEmpty) return items;
+
+    final toRemove = <String>{};
+    final result = <AggregatedItem>[];
+
+    for (final item in items) {
+      final id = item.id;
+      final seriesId = item.seriesId;
+
+      String? matchedKey;
+      if (hidden.containsKey(id)) {
+        matchedKey = id;
+      } else if (seriesId != null && hidden.containsKey(seriesId)) {
+        matchedKey = seriesId;
+      }
+
+      if (matchedKey != null) {
+        final lastPlayedStr = item.rawData['UserData']?['LastPlayedDate'] as String?;
+        if (lastPlayedStr != null && lastPlayedStr.isNotEmpty) {
+          final lastPlayed = DateTime.tryParse(lastPlayedStr);
+          final hiddenAt = DateTime.tryParse(hidden[matchedKey]!);
+          if (lastPlayed != null && hiddenAt != null && lastPlayed.isAfter(hiddenAt)) {
+            toRemove.add(matchedKey);
+            result.add(item);
+            continue;
+          }
+        }
+        continue;
+      }
+      result.add(item);
+    }
+
+    if (toRemove.isNotEmpty) {
+      unawaited(() async {
+        final current = getHiddenContinueWatchingItems();
+        var changed = false;
+        for (final k in toRemove) {
+          if (current.remove(k) != null) {
+            changed = true;
+          }
+        }
+        if (changed) {
+          await set(hiddenContinueWatchingItems, jsonEncode(current));
+        }
+      }());
+    }
+
+    return result;
+  }
+
+  List<AggregatedItem> filterNextUp(List<AggregatedItem> items) {
+    final hidden = getHiddenNextUpSeries();
+    if (hidden.isEmpty) return items;
+
+    final toRemove = <String>{};
+    final result = <AggregatedItem>[];
+
+    for (final item in items) {
+      final seriesId = item.seriesId;
+
+      if (seriesId != null && hidden.containsKey(seriesId)) {
+        final lastPlayedStr = item.rawData['UserData']?['LastPlayedDate'] as String?;
+        if (lastPlayedStr != null && lastPlayedStr.isNotEmpty) {
+          final lastPlayed = DateTime.tryParse(lastPlayedStr);
+          final hiddenAt = DateTime.tryParse(hidden[seriesId]!);
+          if (lastPlayed != null && hiddenAt != null && lastPlayed.isAfter(hiddenAt)) {
+            toRemove.add(seriesId);
+            result.add(item);
+            continue;
+          }
+        }
+        continue;
+      }
+      result.add(item);
+    }
+
+    if (toRemove.isNotEmpty) {
+      unawaited(() async {
+        final current = getHiddenNextUpSeries();
+        var changed = false;
+        for (final k in toRemove) {
+          if (current.remove(k) != null) {
+            changed = true;
+          }
+        }
+        if (changed) {
+          await set(hiddenNextUpSeries, jsonEncode(current));
+        }
+      }());
+    }
+
+    return result;
+  }
 }
+

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -108,6 +108,8 @@ class _HomeShellState extends State<_HomeShell>
   String _lastSectionsJson = '';
   bool _lastMultiServer = false;
   bool _lastMergeContinueWatchingNextUp = false;
+  String _lastHiddenCW = '{}';
+  String _lastHiddenNU = '{}';
   String _lastBlockedParentalRatings = '';
   bool _lastSeerrAvailable = false;
   bool _themeMusicRegistered = false;
@@ -150,6 +152,8 @@ class _HomeShellState extends State<_HomeShell>
     _lastMergeContinueWatchingNextUp = _userPrefs.get(
       UserPreferences.mergeContinueWatchingNextUp,
     );
+    _lastHiddenCW = _userPrefs.get(UserPreferences.hiddenContinueWatchingItems);
+    _lastHiddenNU = _userPrefs.get(UserPreferences.hiddenNextUpSeries);
     _lastBlockedParentalRatings = _userPrefs.get(
       UserPreferences.blockedParentalRatings,
     );
@@ -247,6 +251,8 @@ class _HomeShellState extends State<_HomeShell>
     final currentBlocked = _userPrefs.get(
       UserPreferences.blockedParentalRatings,
     );
+    final currentHiddenCW = _userPrefs.get(UserPreferences.hiddenContinueWatchingItems);
+    final currentHiddenNU = _userPrefs.get(UserPreferences.hiddenNextUpSeries);
     final currentEnableRadarr = _userPrefs.get(UserPreferences.enableRadarrCalendar);
     final currentEnableSonarr = _userPrefs.get(UserPreferences.enableSonarrCalendar);
     final currentMerge = _userPrefs.get(UserPreferences.mergeRadarrSonarrCalendars);
@@ -261,6 +267,8 @@ class _HomeShellState extends State<_HomeShell>
         currentMultiServer != _lastMultiServer ||
         currentMergeContinueWatchingNextUp != _lastMergeContinueWatchingNextUp ||
         currentBlocked != _lastBlockedParentalRatings ||
+        currentHiddenCW != _lastHiddenCW ||
+        currentHiddenNU != _lastHiddenNU ||
         currentEnableRadarr != _lastEnableRadarrCalendar ||
         currentEnableSonarr != _lastEnableSonarrCalendar ||
         currentMerge != _lastMergeRadarrSonarrCalendars ||
@@ -274,6 +282,8 @@ class _HomeShellState extends State<_HomeShell>
       _lastMultiServer = currentMultiServer;
       _lastMergeContinueWatchingNextUp = currentMergeContinueWatchingNextUp;
       _lastBlockedParentalRatings = currentBlocked;
+      _lastHiddenCW = currentHiddenCW;
+      _lastHiddenNU = currentHiddenNU;
       _lastEnableRadarrCalendar = currentEnableRadarr;
       _lastEnableSonarrCalendar = currentEnableSonarr;
       _lastMergeRadarrSonarrCalendars = currentMerge;
@@ -823,6 +833,9 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   int? _focusedRowIndex(FocusNode? node) {
+    if (OverlaySheetController.hasOpenSheet || SettingsPanel.isOpenNotifier.value) {
+      return _activeFocusedRowIndex;
+    }
     if (node == null) return null;
     if (identical(node, _mediaBarFocusNode)) return null;
     return _activeFocusedRowIndex;
@@ -2677,6 +2690,9 @@ class _ContentRowsState extends State<_ContentRows>
       }
     } else if (_activeFocusedRowIndex == rowIndex) {
       if (_isSidebarFocus) {
+        return;
+      }
+      if (OverlaySheetController.hasOpenSheet || SettingsPanel.isOpenNotifier.value) {
         return;
       }
       if (_activePreviewKey != null) {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -864,23 +864,20 @@ class HomeViewModel extends ChangeNotifier {
     const sortOrder = 'Ascending';
     switch (section) {
       case HomeSectionType.resume:
-        return [
-          _multiServerEnabled
-              ? await _multiServerRepo.getAggregatedResume()
-              : await _dataSource.loadResume(_serverId),
-        ];
+        final row = _multiServerEnabled
+            ? await _multiServerRepo.getAggregatedResume()
+            : await _dataSource.loadResume(_serverId);
+        return [row.copyWith(items: _prefs.filterContinueWatching(row.items))];
       case HomeSectionType.resumeAudio:
-        return [
-          _multiServerEnabled
-              ? await _multiServerRepo.getAggregatedResumeAudio()
-              : await _dataSource.loadResumeAudio(_serverId),
-        ];
+        final row = _multiServerEnabled
+            ? await _multiServerRepo.getAggregatedResumeAudio()
+            : await _dataSource.loadResumeAudio(_serverId);
+        return [row.copyWith(items: _prefs.filterContinueWatching(row.items))];
       case HomeSectionType.nextUp:
-        return [
-          _multiServerEnabled
-              ? await _multiServerRepo.getAggregatedNextUp()
-              : await _dataSource.loadNextUp(_serverId),
-        ];
+        final row = _multiServerEnabled
+            ? await _multiServerRepo.getAggregatedNextUp()
+            : await _dataSource.loadNextUp(_serverId);
+        return [row.copyWith(items: _prefs.filterNextUp(row.items))];
       case HomeSectionType.latestMedia:
         return _multiServerEnabled
             ? await _multiServerRepo.getAggregatedLatestMediaRows()
@@ -1634,11 +1631,13 @@ class HomeViewModel extends ChangeNotifier {
           }();
           final resumeRow = await resumeFuture;
           final nextUpRow = await nextUpFuture;
+          final filteredResume = _prefs.filterContinueWatching(resumeRow.items);
+          final filteredNextUp = _prefs.filterNextUp(nextUpRow?.items ?? []);
           final mergedItemsMap = <String, AggregatedItem>{};
-          for (final item in resumeRow.items) {
+          for (final item in filteredResume) {
             mergedItemsMap[item.id] = item;
           }
-          for (final item in nextUpRow?.items ?? []) {
+          for (final item in filteredNextUp) {
             mergedItemsMap.putIfAbsent(item.id, () => item);
           }
           int byLastPlayedDate(AggregatedItem a, AggregatedItem b) {
@@ -1656,11 +1655,13 @@ class HomeViewModel extends ChangeNotifier {
             _dataSource.loadResume(_serverId),
             _dataSource.loadNextUp(_serverId),
           ]);
+          final filteredResume = _prefs.filterContinueWatching(results[0].items);
+          final filteredNextUp = _prefs.filterNextUp(results[1].items);
           final mergedItemsMap = <String, AggregatedItem>{};
-          for (final item in results[0].items) {
+          for (final item in filteredResume) {
             mergedItemsMap[item.id] = item;
           }
-          for (final item in results[1].items) {
+          for (final item in filteredNextUp) {
             mergedItemsMap.putIfAbsent(item.id, () => item);
           }
           int byLastPlayedDate(AggregatedItem a, AggregatedItem b) {

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -8,6 +8,7 @@ import '../../../auth/repositories/user_repository.dart';
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/repositories/item_mutation_repository.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../preference/user_preferences.dart';
 import '../../navigation/destinations.dart';
 import '../add_to_collection_dialog.dart';
 import '../add_to_playlist_dialog.dart';
@@ -69,6 +70,47 @@ List<ItemContextAction> contextActionsFor(
         onChanged?.call();
       },
     ));
+
+    final hasProgress = item.playbackPositionTicks != null &&
+        item.playbackPositionTicks! > 0 &&
+        !item.isPlayed;
+    if (hasProgress) {
+      actions.add(ItemContextAction(
+        icon: Icons.visibility_off_outlined,
+        label: l10n.contextMenuHideFromContinueWatching,
+        onSelect: () async {
+          final prefs = GetIt.instance<UserPreferences>();
+          if (item.seriesId != null && item.seriesId!.isNotEmpty) {
+            await prefs.hideFromContinueWatching(item.seriesId!);
+          } else {
+            await prefs.hideFromContinueWatching(item.id);
+          }
+          try {
+            await client.userLibraryApi.unmarkPlayed(item.id);
+          } catch (_) {}
+          onChanged?.call();
+        },
+      ));
+    }
+
+    final isEpisode = type == 'Episode';
+    final hasSeries = item.seriesId != null && item.seriesId!.isNotEmpty;
+    if (isEpisode && hasSeries) {
+      actions.add(ItemContextAction(
+        icon: Icons.visibility_off_outlined,
+        label: l10n.contextMenuHideFromNextUp,
+        onSelect: () async {
+          final prefs = GetIt.instance<UserPreferences>();
+          await prefs.hideFromNextUp(item.seriesId!);
+          await prefs.hideFromContinueWatching(item.seriesId!);
+          try {
+            await client.userLibraryApi.unmarkPlayed(item.id);
+          } catch (_) {}
+          onChanged?.call();
+        },
+      ));
+    }
+
     actions.add(ItemContextAction(
       icon: item.isFavorite ? Icons.favorite : Icons.favorite_border,
       label: item.isFavorite
@@ -83,7 +125,7 @@ List<ItemContextAction> contextActionsFor(
     if (canManageCollections) {
       actions.add(ItemContextAction(
         icon: Icons.collections_bookmark,
-        label: '${l10n.add} ${l10n.collections}',
+        label: l10n.contextMenuAddToCollection,
         onSelect: () async {
           if (!context.mounted) return;
           final added = await AddToCollectionDialog.show(

--- a/lib/ui/widgets/focus/context_menu_sheet.dart
+++ b/lib/ui/widgets/focus/context_menu_sheet.dart
@@ -87,7 +87,7 @@ class _ActionRow extends StatelessWidget {
     return FocusableButton(
       autofocus: autofocus,
       borderRadius: 6,
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
       onPressed: () async {
         await OverlaySheetController.closeAdaptive<void>(
           context,


### PR DESCRIPTION
# Pull Request

## Summary
Implements local and server-synced "Hide from Continue Watching" and "Hide from Next Up" options for TV shows and movies on the dashboard, with optimized viewport layout and typography adjustments.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/182

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added `hiddenContinueWatchingItems` and `hiddenNextUpSeries` to `UserPreferences` with SharedPreferences mapping and auto-unhide verification triggers (upon media playback).
- Extended `PluginSyncService` settings sync payloads to push and pull settings updates with the Moonbase plugin.
- Added "Hide from Continue Watching" context action to reset the episode play progress back to 0:00 (via Jellyfin `unmarkPlayed`).
- Added "Hide from Next Up" context action to hide the series from both Next Up and Continue Watching (unmarking played to reset progress).
- Reduced vertical padding of context menu rows from 14 to 8 to avoid viewport cutoff on TVs, and preserved active row focus state when the menu overlay sheet is open.
- Fixed localization key and label from "Add Collections" to "Add to Collection".

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Long-press on a partially watched TV show episode.
2. Select "Hide from Continue Watching" to verify it leaves the dashboard and returns to Next Up at 0:00.
3. Select "Hide from Next Up" to verify it disappears from both Continue Watching and Next Up rows.
4. Verify the menu fits on screen and the active row remains visible.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-08_09-49-39" src="https://github.com/user-attachments/assets/4026b4d4-362b-4264-afd7-3942280e3603" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-08_09-51-01" src="https://github.com/user-attachments/assets/fdfac049-3278-4bb6-b880-da0d06e98b63" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
