### PR TITLE
Fix Android TV media session state for remote Live TV playback

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -1503,13 +1503,7 @@ class Media3VideoView(
             decoderPreferenceDirty = false
         }
 
-        // Previews must not surface a MediaSession or start the session
-        // service, and audio stays sessionless because audio_service owns the
-        // music session. The session attaches after the rebuild so it binds
-        // the live player.
-        if (!isPreview && !isAudio) {
-            Media3SessionController.attachPlayer(context, player)
-        }
+        val shouldAttachMediaSession = !isPreview && !isAudio
 
         closeExternalAudioEffectSessionIfOpen()
 
@@ -1577,7 +1571,11 @@ class Media3VideoView(
         player.skipSilenceEnabled = skipSilenceEnabled
         emitSyncDelayState()
         emitVolumeBoostState()
-        setMediaItem(startPositionMs, playWhenReady = autoPlay)
+        setMediaItem(
+            startPositionMs,
+            playWhenReady = autoPlay,
+            attachMediaSession = shouldAttachMediaSession,
+        )
         playerHasLoadedSource = true
     }
 
@@ -2465,7 +2463,11 @@ class Media3VideoView(
         }
     }
 
-    private fun setMediaItem(startPositionMs: Long, playWhenReady: Boolean) {
+    private fun setMediaItem(
+        startPositionMs: Long,
+        playWhenReady: Boolean,
+        attachMediaSession: Boolean = false,
+    ) {
         val url = currentUrl ?: return
 
         val subtitleConfigurations = externalSubtitleConfigurations.toList()
@@ -2485,6 +2487,14 @@ class Media3VideoView(
             player.play()
         } else {
             player.playWhenReady = false
+        }
+        if (attachMediaSession) {
+            // Build/advertise the Android MediaSession only after the player has
+            // a real MediaItem and playback intent. Remote PlayNow can hit this
+            // path before the fullscreen view has fully attached; advertising
+            // the session against an empty player leaves Android/Fire TV clients
+            // with STATE_NONE/stale metadata even though ExoPlayer is rendering.
+            Media3SessionController.attachPlayer(context, player)
         }
         emitState()
     }


### PR DESCRIPTION
## Summary
- Delay native Media3 session advertisement until the video player has a real media item and play intent.
- Keeps preview/audio sources sessionless, while remote-started fullscreen video/Tunarr playback advertises the session after `setMediaItem` + `play()` instead of against an empty player.

## Root cause
Remote `PlayNow` can route into the fullscreen Media3 player while the platform view/source is still being attached. Moonfin 2.2.0 advertised the Android Media3 session before the player had a media item or playback intent. Android/Fire TV media-session clients can then observe Moonfin as `STATE_NONE`/stale even while ExoPlayer renders and Jellyfin reports `IsPaused=false`.

## Test plan
- `git diff --check` passed.
- Android build/APK/device smoke not run: Hermes LXC has only ~8.6G free, below the task's ~20G disk guard for Gradle/Flutter Android builds.

## Manual verification needed after disk expansion
1. Build side-by-side beta APK for `armeabi-v7a`.
2. Install beta without touching official `org.moonfin.androidtv`.
3. Remote PlayNow a Tunarr channel to LR beta session.
4. Verify all three signals separately: TV visual playback, Jellyfin NowPlaying/IsPaused=false, and `dumpsys media_session`/HA showing Moonfin playing instead of state 0/paused.
5. Uninstall the beta so no duplicate Moonfin beta remains on LR.
