### PR TITLE
enhancement-subtitle prioritization logic

### DIFF
--- a/lib/util/subtitle_track_logic.dart
+++ b/lib/util/subtitle_track_logic.dart
@@ -29,7 +29,7 @@ bool isSpecialSubtitleStream(Map<String, dynamic> stream) {
     stream['Name'] as String?,
   ].whereType<String>().map((s) => s.toLowerCase()).join(' ');
   return RegExp(
-    r'\b(commentary|director\s*commentary|commentaries|directors\s*commentary|jump\s*scare)\b',
+    r'\b(commentary|commentaries|jump\s*scare)\b',
   ).hasMatch(titleParts);
 }
 
@@ -187,37 +187,35 @@ int? computeEffectiveSubtitleIndex({
       return aEngMatch ? -1 : 1;
     }
 
-    // 1.6. Special/Commentary/Warnings check (prefer non-special over special)
+    // 1.6. Push commentary and warning tracks below normal dialogue
     final aSpecial = isSpecialSubtitleStream(streamA);
     final bSpecial = isSpecialSubtitleStream(streamB);
     if (aSpecial != bSpecial) {
       return aSpecial ? 1 : -1;
     }
 
-    // 2. SDH Match vs 3. Internal vs External depending on preferSdh
+    // 2 and 3. SDH match and internal vs external, ordered by preferSdh. With SDH
+    // on we match SDH first, with it off we keep internal tracks first so a bad
+    // external download cannot beat an internal SDH track.
     if (preferSdh) {
-      // SDH Match first
       final aSdhMatch = isSdhSubtitleStream(streamA) == preferSdh;
       final bSdhMatch = isSdhSubtitleStream(streamB) == preferSdh;
       if (aSdhMatch != bSdhMatch) {
         return aSdhMatch ? -1 : 1;
       }
 
-      // Internal vs External second
       final aInternal = !isExternalSubtitleStream(streamA);
       final bInternal = !isExternalSubtitleStream(streamB);
       if (aInternal != bInternal) {
         return aInternal ? -1 : 1;
       }
     } else {
-      // Internal vs External first
       final aInternal = !isExternalSubtitleStream(streamA);
       final bInternal = !isExternalSubtitleStream(streamB);
       if (aInternal != bInternal) {
         return aInternal ? -1 : 1;
       }
 
-      // SDH Match second
       final aSdhMatch = isSdhSubtitleStream(streamA) == preferSdh;
       final bSdhMatch = isSdhSubtitleStream(streamB) == preferSdh;
       if (aSdhMatch != bSdhMatch) {

--- a/lib/util/subtitle_track_logic.dart
+++ b/lib/util/subtitle_track_logic.dart
@@ -21,6 +21,18 @@ bool isSdhSubtitleStream(Map<String, dynamic> stream) {
   ).hasMatch(titleParts);
 }
 
+bool isSpecialSubtitleStream(Map<String, dynamic> stream) {
+  if (stream['IsCommentary'] == true) return true;
+  final titleParts = [
+    stream['DisplayTitle'] as String?,
+    stream['Title'] as String?,
+    stream['Name'] as String?,
+  ].whereType<String>().map((s) => s.toLowerCase()).join(' ');
+  return RegExp(
+    r'\b(commentary|director\s*commentary|commentaries|directors\s*commentary|jump\s*scare)\b',
+  ).hasMatch(titleParts);
+}
+
 bool shouldRenderSubtitleNatively(String? codec) {
   if (codec == null) return false;
   final normalized = codec.trim().toLowerCase();
@@ -175,18 +187,42 @@ int? computeEffectiveSubtitleIndex({
       return aEngMatch ? -1 : 1;
     }
 
-    // 2. SDH Match
-    final aSdhMatch = isSdhSubtitleStream(streamA) == preferSdh;
-    final bSdhMatch = isSdhSubtitleStream(streamB) == preferSdh;
-    if (aSdhMatch != bSdhMatch) {
-      return aSdhMatch ? -1 : 1;
+    // 1.6. Special/Commentary/Warnings check (prefer non-special over special)
+    final aSpecial = isSpecialSubtitleStream(streamA);
+    final bSpecial = isSpecialSubtitleStream(streamB);
+    if (aSpecial != bSpecial) {
+      return aSpecial ? 1 : -1;
     }
 
-    // 3. Internal vs External (internal over external)
-    final aInternal = !isExternalSubtitleStream(streamA);
-    final bInternal = !isExternalSubtitleStream(streamB);
-    if (aInternal != bInternal) {
-      return aInternal ? -1 : 1;
+    // 2. SDH Match vs 3. Internal vs External depending on preferSdh
+    if (preferSdh) {
+      // SDH Match first
+      final aSdhMatch = isSdhSubtitleStream(streamA) == preferSdh;
+      final bSdhMatch = isSdhSubtitleStream(streamB) == preferSdh;
+      if (aSdhMatch != bSdhMatch) {
+        return aSdhMatch ? -1 : 1;
+      }
+
+      // Internal vs External second
+      final aInternal = !isExternalSubtitleStream(streamA);
+      final bInternal = !isExternalSubtitleStream(streamB);
+      if (aInternal != bInternal) {
+        return aInternal ? -1 : 1;
+      }
+    } else {
+      // Internal vs External first
+      final aInternal = !isExternalSubtitleStream(streamA);
+      final bInternal = !isExternalSubtitleStream(streamB);
+      if (aInternal != bInternal) {
+        return aInternal ? -1 : 1;
+      }
+
+      // SDH Match second
+      final aSdhMatch = isSdhSubtitleStream(streamA) == preferSdh;
+      final bSdhMatch = isSdhSubtitleStream(streamB) == preferSdh;
+      if (aSdhMatch != bSdhMatch) {
+        return aSdhMatch ? -1 : 1;
+      }
     }
 
     // 4. Fancy vs Normal

--- a/test/util/subtitle_track_logic_test.dart
+++ b/test/util/subtitle_track_logic_test.dart
@@ -37,6 +37,20 @@ void main() {
       expect(isSdhSubtitleStream(stream), isFalse);
     });
   });
+  group('isSpecialSubtitleStream', () {
+    test('returns true when IsCommentary flag is true', () {
+      expect(isSpecialSubtitleStream({'IsCommentary': true}), isTrue);
+    });
+
+    test('returns true when title contains commentary/jump scare keywords', () {
+      expect(isSpecialSubtitleStream({'Title': 'Director\'s Commentary'}), isTrue);
+      expect(isSpecialSubtitleStream({'DisplayTitle': 'Jump scare warnings'}), isTrue);
+    });
+
+    test('returns false for normal tracks', () {
+      expect(isSpecialSubtitleStream({'Title': 'English (SDH)'}), isFalse);
+    });
+  });
   group('sortedSubtitleStream', () {
     test('places internal streams before external streams', () {
       final sorted = sortedSubtitleStreams(streams);
@@ -200,6 +214,86 @@ void main() {
           activeAudioLanguage: null,
         ),
         1,
+      );
+    });
+    test('prefers internal SDH track over external non-SDH track when preferSdh is false', () {
+      final customStreams = [
+        {
+          "Codec": "subrip",
+          "Language": "eng",
+          "DisplayTitle": "English - External Non-SDH",
+          "IsDefault": false,
+          "IsForced": false,
+          "IsHearingImpaired": false,
+          "IsExternal": true,
+          "Index": 1
+        },
+        {
+          "Codec": "subrip",
+          "Language": "eng",
+          "DisplayTitle": "English - Internal SDH",
+          "IsDefault": false,
+          "IsForced": false,
+          "IsHearingImpaired": true,
+          "IsExternal": false,
+          "Index": 2
+        },
+      ];
+      expect(
+        computeEffectiveSubtitleIndex(
+          subtitleStreams: customStreams,
+          selectedSubtitleIndex: null,
+          activePlaybackSubtitleIndex: null,
+          subtitleMode: SubtitleMode.always,
+          preferredLanguage: 'eng',
+          fallbackLanguage: '',
+          preferSdh: false,
+          pgsDirectPlay: true,
+          assDirectPlay: true,
+          preferredAudioLanguage: '',
+          activeAudioLanguage: null,
+        ),
+        2,
+      );
+    });
+    test('prefers normal English SDH track over English Jump scare warnings track', () {
+      final customStreams = [
+        {
+          "Codec": "subrip",
+          "Language": "eng",
+          "DisplayTitle": "Jump scare warnings",
+          "IsDefault": false,
+          "IsForced": false,
+          "IsHearingImpaired": false,
+          "IsExternal": false,
+          "Index": 1
+        },
+        {
+          "Codec": "subrip",
+          "Language": "eng",
+          "DisplayTitle": "English (SDH)",
+          "IsDefault": false,
+          "IsForced": false,
+          "IsHearingImpaired": true,
+          "IsExternal": false,
+          "Index": 2
+        },
+      ];
+      expect(
+        computeEffectiveSubtitleIndex(
+          subtitleStreams: customStreams,
+          selectedSubtitleIndex: null,
+          activePlaybackSubtitleIndex: null,
+          subtitleMode: SubtitleMode.always,
+          preferredLanguage: 'eng',
+          fallbackLanguage: '',
+          preferSdh: false,
+          pgsDirectPlay: true,
+          assDirectPlay: true,
+          preferredAudioLanguage: '',
+          activeAudioLanguage: null,
+        ),
+        2,
       );
     });
     test('falls back to English when both preferred and fallback languages are not found', () {

--- a/test/util/subtitle_track_logic_test.dart
+++ b/test/util/subtitle_track_logic_test.dart
@@ -296,6 +296,46 @@ void main() {
         2,
       );
     });
+    test('deprioritizes an English commentary track over normal English dialogue when preferSdh is true', () {
+      final customStreams = [
+        {
+          "Codec": "subrip",
+          "Language": "eng",
+          "DisplayTitle": "English Commentary",
+          "IsDefault": false,
+          "IsForced": false,
+          "IsHearingImpaired": false,
+          "IsExternal": false,
+          "Index": 1
+        },
+        {
+          "Codec": "subrip",
+          "Language": "eng",
+          "DisplayTitle": "English",
+          "IsDefault": false,
+          "IsForced": false,
+          "IsHearingImpaired": false,
+          "IsExternal": false,
+          "Index": 2
+        },
+      ];
+      expect(
+        computeEffectiveSubtitleIndex(
+          subtitleStreams: customStreams,
+          selectedSubtitleIndex: null,
+          activePlaybackSubtitleIndex: null,
+          subtitleMode: SubtitleMode.always,
+          preferredLanguage: 'eng',
+          fallbackLanguage: '',
+          preferSdh: true,
+          pgsDirectPlay: true,
+          assDirectPlay: true,
+          preferredAudioLanguage: '',
+          activeAudioLanguage: null,
+        ),
+        2,
+      );
+    });
     test('falls back to English when both preferred and fallback languages are not found', () {
       final customStreams = [
         {


### PR DESCRIPTION
# Pull Request

## Summary
Two changes to the subtitle prioritization logic that were found during testing:
1. Adjust subtitle track prioritization order when `preferSdh` is false. When SDH Preference is OFF, Moonfin will now prefer internal SDH tracks over external non-SDH tracks to protect against bad OpenSubtitles srt auto-downloads (which happen when the plugin is installed and the internal subtitles are not SRT). 
2. Special auxiliary tracks (commentary, jump scare warnings, etc.) are deprioritized compared to normal and SDH dialogue tracks in the same language. In the previous iteration, a jump scare warning track took priority over the internal SDH track, which should not happen.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #639 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Swapped the comparison order of the Internal vs External check and the SDH Match check in `computeEffectiveSubtitleIndex` when `preferSdh` is false.
- Added `isSpecialSubtitleStream` to identify auxiliary tracks (e.g. commentary, jump scare warnings) via keywords and flags.
- Incorporated a sorting step to deprioritize special tracks relative to dialogue tracks in the same language.
- Added corresponding unit tests verifying both behaviors.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Find media with multiple internal/external subtitle trakcs
2. Verify English (SDH) is preferred over Jump scare warnings or external OpenSubtitles srt tracks when SDH preference is disabled.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

* Original Logic (preferred jumpscares)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_15-05-04" src="https://github.com/user-attachments/assets/d0141e70-c109-4ffd-aa79-92f62df12c2d" />
* Fixed Logic
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_15-11-03" src="https://github.com/user-attachments/assets/b3dcc1bf-f856-4039-84f0-19fc025bcdcd" />

* Original Logic (preferred external SRT)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_15-09-42" src="https://github.com/user-attachments/assets/59680d6a-56f2-4e25-b451-a01bc51a1679" />
# Fixed Logic (prefers internal SDH)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_15-09-27" src="https://github.com/user-attachments/assets/843dfb10-11d6-446e-8d46-f719c0fe51c3" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
