### PR TITLE
remove formatting tags from item descriptions

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -11370,8 +11370,9 @@ class _OverviewText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final prunedText = text.replaceAll(RegExp(r'<\/?([a-z][a-z0-9]*)\b[^>]*>'), '');
     return ExpandableBiography(
-      text: text,
+      text: prunedText,
       toggleFocusNode: focusNode,
       onArrowUp: onArrowUp,
       onArrowDown: onArrowDown,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3099,7 +3099,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final isSeason = item.type == 'Season';
     final logoTag = item.logoImageTag ?? (isEpisode ? item.seriesLogoImageTag : null);
     final logoId = logoTag != null ? (item.logoImageTag != null ? item.id : item.seriesId) : null;
-    final overview = item.overview?.trim();
+    final overview = item.overview?.trim().replaceAll(RegExp(r'<\/?([a-z][a-z0-9]*)\b[^>]*>'), '');
     final hideTitleAndLogo = _landscape && _buildUpNext(context, item) != null;
     final hasUpNext = _landscape && _buildUpNext(context, item) != null;
     final showRatings = isEpisode


### PR DESCRIPTION
# Pull Request

## Summary
Prune the formatting tags from overview dext on details pages

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #751 
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- use regex string replace to remove any part of the overview text that looks like a `<tag>`
- do the same thing for classic and modern detail screen
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
Before:
<img width="1080" height="2340" alt="Screenshot_20260709_190004" src="https://github.com/user-attachments/assets/d33ce6be-c291-4c6d-8a4a-4417e66815d5" />

After:
<img width="1080" height="2340" alt="Screenshot_20260709_192832" src="https://github.com/user-attachments/assets/6d983fde-569d-4dca-bfa9-ba36272c7ce6" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
