### PR TITLE
UI - Modern Details Page Cleanup

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6092,6 +6092,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         return _DetailActionButton(
           label: widget.label,
           icon: widget.icon,
+          isPrimary: widget.isPrimary,
           onPressed: widget.onPressed,
           onLongPress: widget.onLongPress,
           onFocused: widget.onFocused,
@@ -9669,7 +9670,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                       children: [
                         Text(
                           widget.label.split('\n')[0],
-                          style: Theme.of(context).textTheme.titleSmall
+                          style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(
                                 color: fg,
                                 fontWeight: FontWeight.bold,
@@ -9679,7 +9680,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                         ),
                         Text(
                           widget.label.split('\n')[1],
-                          style: Theme.of(context).textTheme.titleSmall
+                          style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(
                                 color: fg.withValues(alpha: 0.8),
                                 fontWeight: FontWeight.bold,
@@ -9693,7 +9694,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                       widget.label,
                       maxLines: 1,
                       softWrap: false,
-                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: fg,
                         fontWeight: FontWeight.bold,
                         fontSize: 13,
@@ -9852,10 +9853,10 @@ class _DetailActionButtonState extends State<_DetailActionButton>
               const SizedBox(width: 6),
               Text(
                 widget.label,
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: labelColor,
                   fontWeight: FontWeight.bold,
-                  fontSize: 14,
+                  fontSize: 13,
                   height: 1.1,
                 ),
                 textAlign: TextAlign.center,
@@ -9949,12 +9950,12 @@ class _DetailActionButtonState extends State<_DetailActionButton>
     final activeColor = widget.isActive ? widget.activeColor : null;
     final neonAccent = widget.neonAccentColor ?? AppColorScheme.onSurface;
     final iconColor = showHighlight
-        ? (isNeon ? AppColorScheme.accent : AppColorScheme.onButtonFocused)
+        ? AppColorScheme.onButtonFocused
         : (widget.isActive
               ? (widget.activeColor ?? (isNeon ? neonAccent : Colors.white))
               : (isNeon ? neonAccent : Colors.white));
     final labelColor = showHighlight
-        ? (isNeon ? AppColorScheme.accent : AppColorScheme.onButtonFocused)
+        ? AppColorScheme.onButtonFocused
         : (isNeon ? neonAccent : Colors.white);
 
     return MouseRegion(

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -165,7 +165,7 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
   Color get _focusColor {
     final activeTheme = ThemeRegistry.active;
     if (activeTheme.id == ThemeRegistry.neonPulseId) {
-      return const Color(0xFF00E5FF);
+      return AppColorScheme.onButtonFocused;
     }
     if (activeTheme.id == ThemeRegistry.moonfinId) {
       return Colors.white;
@@ -338,14 +338,13 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
                   textAlign: TextAlign.center,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     fontSize: AppColorScheme.isPixel ? 11 : 13,
                     fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
                     color: selected
                         ? selectedTextColor
                         : onSurface.withValues(alpha: 0.75),
                     height: 1.4,
-                    fontFamily: Theme.of(context).textTheme.bodyMedium?.fontFamily,
                   ),
                 ),
               ),
@@ -568,8 +567,8 @@ class _PillTabBarState extends State<_PillTabBar> {
     return LayoutBuilder(
       builder: (context, constraints) {
         // Hug the content when it fits, cap at the available width and let the
-        // segments scroll inside when they overflow. The 6px accounts for the
-        // pane's all(3) padding.
+        // segments scroll inside when they overflow. The 16px covers the pane's
+        // all(3) padding plus a small buffer so the last segment is not clipped.
         final available = constraints.maxWidth;
         if (_widths.isEmpty || !available.isFinite) return pane;
         final content = _widths.fold<double>(0, (sum, w) => sum + w) + 16.0;

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../../../util/platform_detection.dart';
@@ -107,15 +109,20 @@ class DetailsTabBar extends StatelessWidget {
 
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          for (var i = 0; i < labels.length; i++)
-            Padding(
-              padding: const EdgeInsets.only(right: 20),
-              child: item(i),
-            ),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (var i = 0; i < labels.length; i++)
+              Padding(
+                padding: EdgeInsets.only(
+                  right: i < labels.length - 1 ? 20 : 0,
+                ),
+                child: item(i),
+              ),
+          ],
+        ),
       ),
     );
   }
@@ -154,6 +161,21 @@ class _DetailsTabItem extends StatefulWidget {
 
 class _DetailsTabItemState extends State<_DetailsTabItem> {
   bool _isFocused = false;
+
+  Color get _focusColor {
+    final activeTheme = ThemeRegistry.active;
+    if (activeTheme.id == ThemeRegistry.neonPulseId) {
+      return const Color(0xFF00E5FF);
+    }
+    if (activeTheme.id == ThemeRegistry.moonfinId) {
+      return Colors.white;
+    }
+    return Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+  }
 
   @override
   void initState() {
@@ -236,10 +258,12 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
         behavior: HitTestBehavior.opaque,
         child: Container(
           decoration: BoxDecoration(
-            borderRadius: AppRadius.circular(8),
+            borderRadius: AppColorScheme.isPixel
+                ? BorderRadius.zero
+                : AppRadius.circular(8),
             // Border is ALWAYS present with a fixed width to eliminate visual judder!
             border: Border.all(
-              color: _isFocused ? accent : Colors.transparent,
+              color: _isFocused ? _focusColor : Colors.transparent,
               width: 1.5,
             ),
           ),
@@ -252,11 +276,12 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
                 Text(
                   widget.label,
                   textAlign: TextAlign.center,
-                  style: textTheme.titleSmall?.copyWith(
+                  style: textTheme.bodyMedium?.copyWith(
                     color: (widget.isSelected || _isFocused)
                         ? AppColorScheme.onSurface
                         : muted,
                     fontWeight: FontWeight.w600,
+                    height: 1.4,
                   ),
                 ),
                 const SizedBox(height: 8),
@@ -296,21 +321,33 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
         child: GlassFocusHalo(
           focused: _isFocused,
           scale: 1.0,
-          borderRadius: BorderRadius.circular(999),
+          borderRadius: AppColorScheme.isPixel
+              ? BorderRadius.zero
+              : BorderRadius.circular(999),
           backgroundColor: Colors.transparent,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 7),
-            child: Text(
-              widget.label,
-              textAlign: TextAlign.center,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-                color: selected
-                    ? selectedTextColor
-                    : onSurface.withValues(alpha: 0.75),
+          ringColor: _focusColor,
+          child: SizedBox(
+            height: 38,
+            child: Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: AppColorScheme.isPixel ? 12 : 15,
+                ),
+                child: Text(
+                  widget.label,
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: AppColorScheme.isPixel ? 11 : 13,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    color: selected
+                        ? selectedTextColor
+                        : onSurface.withValues(alpha: 0.75),
+                    height: 1.4,
+                    fontFamily: Theme.of(context).textTheme.bodyMedium?.fontFamily,
+                  ),
+                ),
               ),
             ),
           ),
@@ -339,7 +376,7 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
       fg = AppColorScheme.onSurface.withValues(alpha: 0.6);
     }
 
-    final radius = AppRadius.circular(9);
+    final radius = AppColorScheme.isPixel ? BorderRadius.zero : AppRadius.circular(9);
 
     return Focus(
       focusNode: widget.focusNode,
@@ -365,9 +402,10 @@ class _DetailsTabItemState extends State<_DetailsTabItem> {
               child: Text(
                 widget.label,
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: fg,
                       fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                      height: 1.4,
                     ),
               ),
             ),
@@ -418,6 +456,7 @@ class _PillTabBarState extends State<_PillTabBar> {
     }
     if (oldWidget.config.selectedIndex != _config.selectedIndex) {
       _scheduleEnsureVisible();
+      _scheduleMeasure();
     }
   }
 
@@ -488,7 +527,9 @@ class _PillTabBarState extends State<_PillTabBar> {
             child: Container(
               decoration: BoxDecoration(
                 color: thumbColor,
-                borderRadius: AppRadius.circular(999),
+                borderRadius: AppColorScheme.isPixel
+                    ? BorderRadius.zero
+                    : AppRadius.circular(999),
                 border: glass
                     ? Border.all(
                         color: onSurface.withValues(alpha: 0.25),
@@ -511,12 +552,12 @@ class _PillTabBarState extends State<_PillTabBar> {
     final pane = glassPane(
       tier: glass ? GlassSettings.tier : GlassTier.solid,
       fallbackColor: onSurface.withValues(alpha: 0.08),
-      cornerRadius: 999,
+      cornerRadius: AppColorScheme.isPixel ? 0 : 999,
       sigma: 12,
       context: context,
       padding: const EdgeInsets.all(3),
       child: SizedBox(
-        height: 34,
+        height: 38,
         child: SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           child: stack,
@@ -531,7 +572,7 @@ class _PillTabBarState extends State<_PillTabBar> {
         // pane's all(3) padding.
         final available = constraints.maxWidth;
         if (_widths.isEmpty || !available.isFinite) return pane;
-        final content = _widths.fold<double>(0, (sum, w) => sum + w) + 6;
+        final content = _widths.fold<double>(0, (sum, w) => sum + w) + 16.0;
         final pillWidth = content < available ? content : available;
         return Align(
           alignment: Alignment.centerLeft,


### PR DESCRIPTION
# Pull Request

## Summary
Updates the modern details screen Play button row (typography, alignment, focus outlines, sizing) and tab bar typography, padding, line height, and contrast halos.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- item_detail_screen.dart: Neon Pulse fixes -- Swapped Play and secondary action labels to bodyMedium bold 13px, fixed isPrimary flag mapping, and applied white text highlights.
- details_tab_bar.dart: Swapped tab labels to use bodyMedium for Neon Pulse and Moonfin font families, adjusted right padding of classic tabs to 20px, increased line height to 1.4 to prevent descender clipping, and added contrast focus outlines (Cyan for Neon Pulse and White for Moonfin). This prevents issues with clipping.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Deploy and try out combinations of themes on media detail pages

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

* Moonfin:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_21-07-15" src="https://github.com/user-attachments/assets/b72acbd2-5b57-432f-b393-059ab7a5c063" />
* Neon Pulse:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_21-07-54" src="https://github.com/user-attachments/assets/18aec273-0781-4273-9328-3ee1ee492cf2" />
* Glass:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_21-14-46" src="https://github.com/user-attachments/assets/1f3c1847-8f6b-4535-8260-1518ff37fe9d" />
* 8-Bit Hero:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_21-24-27" src="https://github.com/user-attachments/assets/d29cbc92-57b6-422f-85e4-76b58b351727" />

### Inverted Selector for Tab Row (otherwise it was pink on pink/blue on blue):
* Neon Pulse:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_22-29-07" src="https://github.com/user-attachments/assets/65494b6a-5696-496b-9c07-23d2443887cb" />
* Moonfin
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-09_22-31-47" src="https://github.com/user-attachments/assets/db1108de-a4ab-434f-9b25-2f2352afd8ac" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
