### PR TITLE
UI/BUGFIX - Update Genres for Modern Aesthetics

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -49,7 +49,7 @@ class MultiServerRepository {
       'ParentIndexNumber,IndexNumber,Status,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,'
       'ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,'
-      'ParentLogoItemId,ParentLogoImageTag';
+      'ParentLogoItemId,ParentLogoImageTag,PrimaryImageTag,PrimaryImageAspectRatio';
   // Cap image tags to one per type (server returns all by default)
   static const _imageTypes = 'Primary,Backdrop,Thumb';
   static const _imageTypeLimit = 1;
@@ -448,7 +448,7 @@ class MultiServerRepository {
             sortOrder: sortOrder,
             recursive: true,
             limit: perServer,
-            fields: 'ItemCounts',
+            fields: 'ItemCounts,PrimaryImageAspectRatio',
             includeItemTypes: browseItemTypes,
           );
           final items = await _buildBrowsableGenresForSession(
@@ -1050,24 +1050,26 @@ class MultiServerRepository {
         genreIds: [genreId],
         includeItemTypes: includeItemTypes,
         excludeItemTypes: const ['Episode'],
-        sortBy: _defaultSortBy,
-        sortOrder: _defaultSortOrder,
+        sortBy: 'Random',
+        sortOrder: 'Ascending',
         recursive: true,
-        limit: 1,
+        limit: 10,
         fields: _fields,
         enableImageTypes: _imageTypes,
         imageTypeLimit: _imageTypeLimit,
       );
 
       final items = (response['Items'] as List?) ?? const [];
-      if (items.isEmpty) {
+      final maps = List<Map<String, dynamic>>.from(
+        items.whereType<Map>().map((item) => item.cast<String, dynamic>()),
+      );
+      if (maps.isEmpty) {
         return null;
       }
 
-      final representative = items.first;
-      if (representative is! Map) {
-        return null;
-      }
+      maps.shuffle();
+      final representative = maps[0];
+      final backdropRepresentative = maps.length > 1 ? maps[1] : null;
 
       final rawTotalCount = response['TotalRecordCount'];
       final totalCount = rawTotalCount is num
@@ -1082,8 +1084,9 @@ class MultiServerRepository {
 
       final merged = mergeGenreWithRepresentativeItem(
         genreData: genreData,
-        representativeItem: representative.cast<String, dynamic>(),
+        representativeItem: representative,
         itemCount: totalCount,
+        backdropRepresentativeItem: backdropRepresentative,
       );
       return AggregatedItem(
         id: merged['Id']?.toString() ?? '',

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -38,7 +38,7 @@ class RowDataSource {
       'ParentIndexNumber,IndexNumber,Status,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,'
       'ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,'
-      'ParentLogoItemId,ParentLogoImageTag';
+      'ParentLogoItemId,ParentLogoImageTag,PrimaryImageTag,PrimaryImageAspectRatio';
   static const _fallbackFields =
       'DateCreated,Type,UserData,OfficialRating,RunTimeTicks,ProductionYear,SeriesName,'
       'ParentIndexNumber,IndexNumber,ImageTags,BackdropImageTags,'
@@ -396,7 +396,7 @@ class RowDataSource {
         sortOrder: sortOrder,
         recursive: true,
         limit: _defaultLimit,
-        fields: 'ItemCounts',
+        fields: 'ItemCounts,PrimaryImageAspectRatio',
         includeItemTypes: browseItemTypes,
       );
     } on DioException catch (e) {
@@ -488,21 +488,23 @@ class RowDataSource {
         genreIds: [genreId],
         includeItemTypes: includeItemTypes,
         excludeItemTypes: const ['Episode'],
-        sortBy: _defaultSortBy,
-        sortOrder: _defaultSortOrder,
+        sortBy: 'Random',
+        sortOrder: 'Ascending',
         recursive: true,
-        limit: 1,
+        limit: 10,
       );
 
       final items = (response['Items'] as List?) ?? const [];
-      if (items.isEmpty) {
+      final maps = List<Map<String, dynamic>>.from(
+        items.whereType<Map>().map((item) => item.cast<String, dynamic>()),
+      );
+      if (maps.isEmpty) {
         return null;
       }
 
-      final representative = items.first;
-      if (representative is! Map) {
-        return null;
-      }
+      maps.shuffle();
+      final representative = maps[0];
+      final backdropRepresentative = maps.length > 1 ? maps[1] : null;
 
       final rawTotalCount = response['TotalRecordCount'];
       final totalCount = rawTotalCount is num
@@ -517,8 +519,9 @@ class RowDataSource {
 
       return mergeGenreWithRepresentativeItem(
         genreData: genreData,
-        representativeItem: representative.cast<String, dynamic>(),
+        representativeItem: representative,
         itemCount: totalCount,
+        backdropRepresentativeItem: backdropRepresentative,
       );
     } catch (_) {
       return null;

--- a/lib/data/utils/genre_browse_utils.dart
+++ b/lib/data/utils/genre_browse_utils.dart
@@ -1,3 +1,5 @@
+import 'package:server_core/server_core.dart';
+
 const List<String> kBrowsableGenreItemTypes = ['Movie', 'Series', 'Audio', 'MusicAlbum'];
 
 List<String> normalizeBrowsableGenreItemTypes(List<String>? includeItemTypes) {
@@ -66,46 +68,50 @@ Map<String, dynamic> mergeGenreWithRepresentativeItem({
   required Map<String, dynamic> genreData,
   required Map<String, dynamic> representativeItem,
   required int itemCount,
+  Map<String, dynamic>? backdropRepresentativeItem,
 }) {
   final merged = Map<String, dynamic>.from(genreData);
   merged['ChildCount'] = itemCount;
 
   final representativeId = representativeItem['Id']?.toString();
-  if (representativeId == null || representativeId.isEmpty) {
-    return merged;
-  }
+  if (representativeId != null && representativeId.isNotEmpty) {
+    final imageTags = representativeItem['ImageTags'];
+    String? primaryTag = representativeItem['PrimaryImageTag'] as String?;
+    if ((primaryTag == null || primaryTag.isEmpty) && imageTags is Map) {
+      final rawPrimary = imageTags['Primary'];
+      if (rawPrimary is String && rawPrimary.isNotEmpty) {
+        primaryTag = rawPrimary;
+      }
+    }
 
-  final imageTags = representativeItem['ImageTags'];
-  String? primaryTag = representativeItem['PrimaryImageTag'] as String?;
-  if ((primaryTag == null || primaryTag.isEmpty) && imageTags is Map) {
-    final rawPrimary = imageTags['Primary'];
-    if (rawPrimary is String && rawPrimary.isNotEmpty) {
-      primaryTag = rawPrimary;
+    if (primaryTag != null && primaryTag.isNotEmpty) {
+      merged['PrimaryImageItemId'] = representativeId;
+      merged['PrimaryImageTag'] = primaryTag;
     }
   }
 
-  if (primaryTag != null && primaryTag.isNotEmpty) {
-    merged['PrimaryImageItemId'] = representativeId;
-    merged['PrimaryImageTag'] = primaryTag;
-  }
-
-  if (imageTags is Map) {
-    final rawThumb = imageTags['Thumb'];
-    if (rawThumb is String && rawThumb.isNotEmpty) {
-      merged['ParentThumbItemId'] = representativeId;
-      merged['ParentThumbImageTag'] = rawThumb;
+  final backdropItem = backdropRepresentativeItem ?? representativeItem;
+  final backdropId = backdropItem['Id']?.toString();
+  if (backdropId != null && backdropId.isNotEmpty) {
+    final imageTags = backdropItem['ImageTags'];
+    if (imageTags is Map) {
+      final rawThumb = imageTags['Thumb'];
+      if (rawThumb is String && rawThumb.isNotEmpty) {
+        merged['ParentThumbItemId'] = backdropId;
+        merged['ParentThumbImageTag'] = rawThumb;
+      }
     }
-  }
 
-  final rawBackdropTags = representativeItem['BackdropImageTags'];
-  if (rawBackdropTags is List) {
-    final backdropTags = rawBackdropTags
-        .whereType<String>()
-        .where((tag) => tag.isNotEmpty)
-        .toList();
-    if (backdropTags.isNotEmpty) {
-      merged['ParentBackdropItemId'] = representativeId;
-      merged['ParentBackdropImageTags'] = backdropTags;
+    final rawBackdropTags = backdropItem['BackdropImageTags'];
+    if (rawBackdropTags is List) {
+      final backdropTags = rawBackdropTags
+          .whereType<String>()
+          .where((tag) => tag.isNotEmpty)
+          .toList();
+      if (backdropTags.isNotEmpty) {
+        merged['ParentBackdropItemId'] = backdropId;
+        merged['ParentBackdropImageTags'] = backdropTags;
+      }
     }
   }
 
@@ -117,4 +123,91 @@ int _asInt(dynamic value) {
   if (value is num) return value.toInt();
   if (value is String) return int.tryParse(value) ?? 0;
   return 0;
+}
+
+(String? imageUrl, String? backdropUrl) resolveGenreFallbackArtwork({
+  required List<Map<String, dynamic>> items,
+  required ImageApi imageApi,
+  required int maxWidth,
+}) {
+  if (items.isEmpty) {
+    return (null, null);
+  }
+
+  String? tileUrl;
+  Map<String, dynamic>? selectedItem;
+
+  // 1. Try Backdrop (always landscape)
+  for (final item in items) {
+    final bTags = item['BackdropImageTags'] as List?;
+    if (bTags != null && bTags.isNotEmpty) {
+      tileUrl = imageApi.getBackdropImageUrl(
+        item['Id']?.toString() ?? '',
+        tag: bTags.first.toString(),
+        maxWidth: maxWidth,
+      );
+      selectedItem = item;
+      break;
+    }
+  }
+
+  // 2. Try Primary if it is landscape/square
+  if (tileUrl == null) {
+    for (final item in items) {
+      final pTag = item['PrimaryImageTag'] as String?;
+      final pAr = item['PrimaryImageAspectRatio'] as num?;
+      if (pTag != null && pAr != null && pAr >= 1.0) {
+        tileUrl = imageApi.getPrimaryImageUrl(
+          item['Id']?.toString() ?? '',
+          tag: pTag,
+          maxWidth: maxWidth,
+        );
+        selectedItem = item;
+        break;
+      }
+    }
+  }
+
+  // 3. Fall back to any Primary (even portrait) if nothing else is available
+  if (tileUrl == null) {
+    for (final item in items) {
+      final pTag = item['PrimaryImageTag'] as String?;
+      if (pTag != null) {
+        tileUrl = imageApi.getPrimaryImageUrl(
+          item['Id']?.toString() ?? '',
+          tag: pTag,
+          maxWidth: maxWidth,
+        );
+        selectedItem = item;
+        break;
+      }
+    }
+  }
+
+  String? backdropUrl;
+  for (final item in items) {
+    if (item == selectedItem && items.length > 1) continue;
+    final bTags = item['BackdropImageTags'] as List?;
+    if (bTags != null && bTags.isNotEmpty) {
+      backdropUrl = imageApi.getBackdropImageUrl(
+        item['Id']?.toString() ?? '',
+        tag: bTags.first.toString(),
+        maxWidth: 960,
+      );
+      break;
+    }
+  }
+
+  if (backdropUrl == null && selectedItem != null) {
+    final bTags = selectedItem['BackdropImageTags'] as List?;
+    if (bTags != null && bTags.isNotEmpty) {
+      backdropUrl = imageApi.getBackdropImageUrl(
+        selectedItem['Id']?.toString() ?? '',
+        tag: bTags.first.toString(),
+        maxWidth: 960,
+      );
+    }
+  }
+
+  return (tileUrl, backdropUrl ?? tileUrl);
 }

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -6,6 +6,8 @@ import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart' hide ImageType;
 
+import '../../../data/models/aggregated_item.dart';
+import '../../../auth/repositories/user_repository.dart';
 import '../../../data/services/background_service.dart';
 import '../../../data/utils/genre_browse_utils.dart';
 import '../../../preference/preference_constants.dart';
@@ -18,14 +20,15 @@ import '../../widgets/fullscreen_backdrop_switcher.dart';
 import '../../widgets/genre_grid_card.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/poster_size_settings_dialog.dart';
+import '../../widgets/focus/context_menu_sheet.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
 const _horizontalPadding = 60.0;
 const _kCompactBreakpoint = 600.0;
 const _genresPageSize = 200;
-const _initialArtworkBatch = 18;
-const _backgroundArtworkConcurrency = 6;
+const _initialArtworkBatch = 12;
+const _backgroundArtworkConcurrency = 4;
 
 bool _isCompact(BuildContext context) =>
     PlatformDetection.useMobileUi ||
@@ -83,7 +86,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
           recursive: true,
           startIndex: startIndex,
           limit: _genresPageSize,
-          fields: 'ItemCounts',
+          fields: 'ItemCounts,PrimaryImageTag,ImageTags,BackdropImageTags,PrimaryImageAspectRatio',
           includeItemTypes: kBrowsableGenreItemTypes,
         );
 
@@ -97,21 +100,68 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
         if (total != null && startIndex >= total) break;
       }
 
-      _genres = items
+      final temp = items
           .map((g) {
             final data = g as Map<String, dynamic>;
             final itemCount = browsableGenreCount(
               data,
               normalizedItemTypes: kBrowsableGenreItemTypes,
             );
-            return GenreCardData(
-              id: data['Id']?.toString() ?? '',
-              name: data['Name'] as String? ?? '',
+            return (
+              data: data,
               itemCount: itemCount,
             );
           })
-          .where((genre) => genre.itemCount > 0)
+          .where((x) => x.itemCount > 0)
           .toList();
+
+      _genres = temp.map((x) {
+        final data = x.data;
+        final primaryTag = data['PrimaryImageTag'] as String?;
+        final imageTags = data['ImageTags'] as Map?;
+        final primaryAr = data['PrimaryImageAspectRatio'] as num?;
+        final backdropTags = data['BackdropImageTags'] as List?;
+
+        final customThumb = imageTags?['Thumb'] as String?;
+        final hasCustomArtwork = (primaryTag != null && primaryAr != null && primaryAr < 1.0) ||
+            (customThumb != null && customThumb.isNotEmpty);
+
+        String? imageUrl;
+        String? backdropUrl;
+
+        if (hasCustomArtwork) {
+          if (customThumb != null && customThumb.isNotEmpty) {
+            imageUrl = _client.imageApi.getThumbImageUrl(
+              data['Id']?.toString() ?? '',
+              tag: customThumb,
+              maxWidth: _genreCardRequestMaxWidth(),
+            );
+          } else if (primaryTag != null) {
+            imageUrl = _client.imageApi.getPrimaryImageUrl(
+              data['Id']?.toString() ?? '',
+              tag: primaryTag,
+              maxWidth: _genreCardRequestMaxWidth(),
+            );
+          }
+
+          if (backdropTags != null && backdropTags.isNotEmpty) {
+            backdropUrl = _client.imageApi.getBackdropImageUrl(
+              data['Id']?.toString() ?? '',
+              tag: backdropTags.first.toString(),
+              maxWidth: 960,
+            );
+          }
+        }
+
+        return GenreCardData(
+          id: data['Id']?.toString() ?? '',
+          name: data['Name'] as String? ?? '',
+          itemCount: 0,
+          imageUrl: imageUrl,
+          backdropUrl: backdropUrl,
+          isGenreFallback: !hasCustomArtwork,
+        );
+      }).toList();
     } catch (_) {}
 
     _isLoading = false;
@@ -149,12 +199,12 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
         genreIds: [genre.id],
         includeItemTypes: kBrowsableGenreItemTypes,
         excludeItemTypes: ['Episode'],
-        sortBy: 'SortName',
+        sortBy: 'Random',
         sortOrder: 'Ascending',
         recursive: true,
         limit: 4,
-        fields: 'PrimaryImageTag,ImageTags,BackdropImageTags',
-        enableImageTypes: 'Primary,Backdrop',
+        fields: 'PrimaryImageTag,ImageTags,BackdropImageTags,PrimaryImageAspectRatio',
+        enableImageTypes: 'Primary,Backdrop,Thumb',
         imageTypeLimit: 1,
       );
 
@@ -171,17 +221,23 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
       }
 
       genre.itemCount = totalCount;
-      String? imageUrl;
-      for (final raw in items) {
-        final item = raw as Map<String, dynamic>;
-        final backdropUrl = _backdropUrlFor(item);
-        genre.backdropUrl ??= backdropUrl;
-        imageUrl ??= _imageUrlFor(item, _imageType, backdropUrl: backdropUrl);
-        if (imageUrl != null && genre.backdropUrl != null) {
-          break;
-        }
+
+      if (genre.isGenreFallback) {
+        final maps = List<Map<String, dynamic>>.from(
+          items.whereType<Map>().map((item) => item.cast<String, dynamic>()),
+        );
+        maps.shuffle();
+
+        final (imageUrl, backdropUrl) = resolveGenreFallbackArtwork(
+          items: maps,
+          imageApi: _client.imageApi,
+          maxWidth: _genreCardRequestMaxWidth(),
+        );
+
+        genre.imageUrl = imageUrl;
+        genre.backdropUrl = backdropUrl;
       }
-      genre.imageUrl = imageUrl ?? genre.backdropUrl;
+
       if (!_disposed && mounted) setState(() {});
     } catch (_) {}
   }
@@ -192,78 +248,8 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
     return tags[imageType] as String?;
   }
 
-  String? _backdropUrlFor(Map<String, dynamic> item) {
-    final tags = (item['BackdropImageTags'] as List?) ?? const [];
-    if (tags.isEmpty) {
-      return null;
-    }
-    return _client.imageApi.getBackdropImageUrl(
-      item['Id']?.toString() ?? '',
-      maxWidth: BackgroundService.backdropMaxWidth,
-      tag: tags.first as String,
-    );
-  }
 
-  String? _imageUrlFor(
-    Map<String, dynamic> item,
-    ImageType imageType, {
-    String? backdropUrl,
-  }) {
-    final itemId = item['Id']?.toString() ?? '';
-    final primaryTag = item['PrimaryImageTag'] as String?;
-    final thumbTag = _tagForType(item, 'Thumb');
-    final bannerTag = _tagForType(item, 'Banner');
-    final maxWidth = _genreCardRequestMaxWidth();
-    final resolvedBackdropUrl = backdropUrl ?? _backdropUrlFor(item);
 
-    return switch (imageType) {
-      ImageType.poster =>
-        primaryTag != null
-            ? _client.imageApi.getPrimaryImageUrl(
-                itemId,
-                tag: primaryTag,
-                maxWidth: maxWidth,
-              )
-            : resolvedBackdropUrl ??
-                  (thumbTag != null
-                      ? _client.imageApi.getThumbImageUrl(
-                          itemId,
-                          tag: thumbTag,
-                          maxWidth: maxWidth,
-                        )
-                      : null),
-      ImageType.thumb =>
-        thumbTag != null
-            ? _client.imageApi.getThumbImageUrl(
-                itemId,
-                tag: thumbTag,
-                maxWidth: maxWidth,
-              )
-            : resolvedBackdropUrl ??
-                  (primaryTag != null
-                      ? _client.imageApi.getPrimaryImageUrl(
-                          itemId,
-                          tag: primaryTag,
-                          maxWidth: maxWidth,
-                        )
-                      : null),
-      ImageType.banner =>
-        bannerTag != null
-            ? _client.imageApi.getBannerImageUrl(
-                itemId,
-                tag: bannerTag,
-                maxWidth: maxWidth,
-              )
-            : resolvedBackdropUrl ??
-                  (primaryTag != null
-                      ? _client.imageApi.getPrimaryImageUrl(
-                          itemId,
-                          tag: primaryTag,
-                          maxWidth: maxWidth,
-                        )
-                      : null),
-    };
-  }
 
   int _genreCardRequestMaxWidth() {
     final requestScale = MediaQuery.devicePixelRatioOf(context).clamp(1.0, 2.0);
@@ -445,6 +431,19 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
               onTap: () => context.push(
                 Destinations.genre(genre.name, genreId: genre.id),
               ),
+              onLongPress: () {
+                final serverId = GetIt.instance<UserRepository>().currentUser?.serverId ?? '';
+                final aggregatedItem = AggregatedItem(
+                  id: genre.id,
+                  serverId: serverId,
+                  rawData: {
+                    'Type': 'Genre',
+                    'Name': genre.name,
+                    'Id': genre.id,
+                  },
+                );
+                showContextMenu(context, aggregatedItem, onChanged: () => setState(() {}));
+              },
               onHover: isMobile
                   ? null
                   : (hovering) {

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -156,7 +156,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
         return GenreCardData(
           id: data['Id']?.toString() ?? '',
           name: data['Name'] as String? ?? '',
-          itemCount: 0,
+          itemCount: x.itemCount,
           imageUrl: imageUrl,
           backdropUrl: backdropUrl,
           isGenreFallback: !hasCustomArtwork,
@@ -241,15 +241,6 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
       if (!_disposed && mounted) setState(() {});
     } catch (_) {}
   }
-
-  String? _tagForType(Map<String, dynamic> item, String imageType) {
-    final tags = item['ImageTags'];
-    if (tags is! Map) return null;
-    return tags[imageType] as String?;
-  }
-
-
-
 
   int _genreCardRequestMaxWidth() {
     final requestScale = MediaQuery.devicePixelRatioOf(context).clamp(1.0, 2.0);

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -6,7 +6,10 @@ import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart' hide ImageType;
 
+import '../../../data/models/aggregated_item.dart';
+import '../../../auth/repositories/user_repository.dart';
 import '../../../data/services/background_service.dart';
+import '../../../data/utils/genre_browse_utils.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
@@ -14,6 +17,7 @@ import '../../navigation/destinations.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/fullscreen_backdrop_switcher.dart';
 import '../../widgets/genre_grid_card.dart';
+import '../../widgets/focus/context_menu_sheet.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
@@ -21,7 +25,7 @@ const _horizontalPadding = 60.0;
 const _mobileHorizontalPadding = 16.0;
 const _kCompactBreakpoint = 600.0;
 const _initialArtworkBatch = 12;
-const _backgroundArtworkConcurrency = 6;
+const _backgroundArtworkConcurrency = 4;
 
 bool _isCompact(BuildContext context) =>
     PlatformDetection.useMobileUi ||
@@ -85,27 +89,74 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
         sortBy: 'SortName',
         sortOrder: 'Ascending',
         recursive: true,
-        fields: 'ItemCounts',
+        fields: 'ItemCounts,PrimaryImageTag,ImageTags,BackdropImageTags,PrimaryImageAspectRatio',
       );
 
       final items = (response['Items'] as List?) ?? [];
-      _genres = items.map((g) {
+      final temp = items.map((g) {
         final data = g as Map<String, dynamic>;
-        return GenreCardData(
-          id: data['Id']?.toString() ?? '',
-          name: data['Name'] as String? ?? '',
-          itemCount:
-              data['ChildCount'] as int? ??
-              (data['MovieCount'] as int? ?? 0) +
-                  (data['SeriesCount'] as int? ?? 0) +
-                  (data['AlbumCount'] as int? ?? 0) +
-                  (data['SongCount'] as int? ?? 0) +
-                  (data['ArtistCount'] as int? ?? 0) +
-                  (data['MusicVideoCount'] as int? ?? 0),
+        final count = data['ChildCount'] as int? ??
+            (data['MovieCount'] as int? ?? 0) +
+                (data['SeriesCount'] as int? ?? 0) +
+                (data['AlbumCount'] as int? ?? 0) +
+                (data['SongCount'] as int? ?? 0) +
+                (data['ArtistCount'] as int? ?? 0) +
+                (data['MusicVideoCount'] as int? ?? 0);
+        return (
+          data: data,
+          itemCount: count,
         );
       }).where((genre) {
         if (_collectionType == 'music') return true;
         return genre.itemCount > 0;
+      }).toList();
+
+      _genres = temp.map((x) {
+        final data = x.data;
+        final primaryTag = data['PrimaryImageTag'] as String?;
+        final imageTags = data['ImageTags'] as Map?;
+        final primaryAr = data['PrimaryImageAspectRatio'] as num?;
+        final backdropTags = data['BackdropImageTags'] as List?;
+
+        final customThumb = imageTags?['Thumb'] as String?;
+        final hasCustomArtwork = (primaryTag != null && primaryAr != null && primaryAr < 1.0) ||
+            (customThumb != null && customThumb.isNotEmpty);
+
+        String? imageUrl;
+        String? backdropUrl;
+
+        if (hasCustomArtwork) {
+          if (customThumb != null && customThumb.isNotEmpty) {
+            imageUrl = _client.imageApi.getThumbImageUrl(
+              data['Id']?.toString() ?? '',
+              tag: customThumb,
+              maxWidth: _genreCardRequestMaxWidth(),
+            );
+          } else if (primaryTag != null) {
+            imageUrl = _client.imageApi.getPrimaryImageUrl(
+              data['Id']?.toString() ?? '',
+              tag: primaryTag,
+              maxWidth: _genreCardRequestMaxWidth(),
+            );
+          }
+
+          if (backdropTags != null && backdropTags.isNotEmpty) {
+            backdropUrl = _client.imageApi.getBackdropImageUrl(
+              data['Id']?.toString() ?? '',
+              tag: backdropTags.first.toString(),
+              maxWidth: 960,
+            );
+          }
+        }
+
+        return GenreCardData(
+          id: data['Id']?.toString() ?? '',
+          name: data['Name'] as String? ?? '',
+          itemCount: 0,
+          imageUrl: imageUrl,
+          backdropUrl: backdropUrl,
+          isGenreFallback: !hasCustomArtwork,
+        );
       }).toList();
     } catch (_) {}
 
@@ -153,9 +204,9 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
         sortBy: 'Random',
         sortOrder: 'Ascending',
         recursive: true,
-        limit: 6,
-        fields: 'PrimaryImageTag,ImageTags,BackdropImageTags',
-        enableImageTypes: 'Primary,Backdrop',
+        limit: 4,
+        fields: 'PrimaryImageTag,ImageTags,BackdropImageTags,PrimaryImageAspectRatio',
+        enableImageTypes: 'Primary,Backdrop,Thumb',
         imageTypeLimit: 1,
       );
       final items = (response['Items'] as List?) ?? [];
@@ -169,6 +220,8 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
         }
         return;
       }
+
+      genre.itemCount = totalCount;
 
       if (_collectionType == 'music') {
         for (final raw in items) {
@@ -200,19 +253,23 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
           if (!_disposed && mounted) setState(() {});
           return;
         }
-      }
+      } else {
+        if (genre.isGenreFallback) {
+          final maps = List<Map<String, dynamic>>.from(
+            items.whereType<Map>().map((item) => item.cast<String, dynamic>()),
+          );
+          maps.shuffle();
 
-      String? imageUrl;
-      for (final raw in items) {
-        final item = raw as Map<String, dynamic>;
-        final backdropUrl = _backdropUrlFor(item);
-        genre.backdropUrl ??= backdropUrl;
-        imageUrl ??= _imageUrlFor(item, _imageType, backdropUrl: backdropUrl);
-        if (imageUrl != null && genre.backdropUrl != null) {
-          break;
+          final (imageUrl, backdropUrl) = resolveGenreFallbackArtwork(
+            items: maps,
+            imageApi: _client.imageApi,
+            maxWidth: _genreCardRequestMaxWidth(),
+          );
+
+          genre.imageUrl = imageUrl;
+          genre.backdropUrl = backdropUrl;
         }
       }
-      genre.imageUrl = imageUrl ?? genre.backdropUrl;
       if (!_disposed && mounted) setState(() {});
     } catch (_) {}
   }
@@ -223,77 +280,8 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
     return tags[imageType] as String?;
   }
 
-  String? _backdropUrlFor(Map<String, dynamic> item) {
-    final tags = (item['BackdropImageTags'] as List?) ?? const [];
-    if (tags.isEmpty) {
-      return null;
-    }
-    return _client.imageApi.getBackdropImageUrl(
-      item['Id']?.toString() ?? '',
-      maxWidth: BackgroundService.backdropMaxWidth,
-      tag: tags.first as String,
-    );
-  }
 
-  String? _imageUrlFor(
-    Map<String, dynamic> item,
-    ImageType imageType, {
-    String? backdropUrl,
-  }) {
-    final itemId = item['Id']?.toString() ?? '';
-    final primaryTag = item['PrimaryImageTag'] as String?;
-    final thumbTag = _tagForType(item, 'Thumb');
-    final bannerTag = _tagForType(item, 'Banner');
-    final maxWidth = _genreCardRequestMaxWidth();
-    final resolvedBackdropUrl = backdropUrl ?? _backdropUrlFor(item);
 
-    return switch (imageType) {
-      ImageType.poster =>
-        primaryTag != null
-            ? _client.imageApi.getPrimaryImageUrl(
-                itemId,
-                tag: primaryTag,
-                maxWidth: maxWidth,
-              )
-            : thumbTag != null
-            ? _client.imageApi.getThumbImageUrl(
-                itemId,
-                tag: thumbTag,
-                maxWidth: maxWidth,
-              )
-            : resolvedBackdropUrl,
-      ImageType.thumb =>
-        thumbTag != null
-            ? _client.imageApi.getThumbImageUrl(
-                itemId,
-                tag: thumbTag,
-                maxWidth: maxWidth,
-              )
-            : resolvedBackdropUrl ??
-                  (primaryTag != null
-                      ? _client.imageApi.getPrimaryImageUrl(
-                          itemId,
-                          tag: primaryTag,
-                          maxWidth: maxWidth,
-                        )
-                      : null),
-      ImageType.banner =>
-        bannerTag != null
-            ? _client.imageApi.getBannerImageUrl(
-                itemId,
-                tag: bannerTag,
-                maxWidth: maxWidth,
-              )
-            : resolvedBackdropUrl ??
-                  (primaryTag != null
-                      ? _client.imageApi.getPrimaryImageUrl(
-                          itemId,
-                          tag: primaryTag,
-                          maxWidth: maxWidth,
-                        )
-                      : null),
-    };
-  }
 
   int _genreCardRequestMaxWidth() {
     final requestScale = MediaQuery.devicePixelRatioOf(context).clamp(1.0, 2.0);
@@ -453,6 +441,19 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
                     includeType: _includeType,
                   ),
                 );
+              },
+              onLongPress: () {
+                final serverId = GetIt.instance<UserRepository>().currentUser?.serverId ?? '';
+                final aggregatedItem = AggregatedItem(
+                  id: genre.id,
+                  serverId: serverId,
+                  rawData: {
+                    'Type': 'Genre',
+                    'Name': genre.name,
+                    'Id': genre.id,
+                  },
+                );
+                showContextMenu(context, aggregatedItem, onChanged: () => setState(() {}));
               },
               onHover: isMobile
                   ? null

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -152,7 +152,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
         return GenreCardData(
           id: data['Id']?.toString() ?? '',
           name: data['Name'] as String? ?? '',
-          itemCount: 0,
+          itemCount: x.itemCount,
           imageUrl: imageUrl,
           backdropUrl: backdropUrl,
           isGenreFallback: !hasCustomArtwork,
@@ -273,15 +273,6 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
       if (!_disposed && mounted) setState(() {});
     } catch (_) {}
   }
-
-  String? _tagForType(Map<String, dynamic> item, String imageType) {
-    final tags = item['ImageTags'];
-    if (tags is! Map) return null;
-    return tags[imageType] as String?;
-  }
-
-
-
 
   int _genreCardRequestMaxWidth() {
     final requestScale = MediaQuery.devicePixelRatioOf(context).clamp(1.0, 2.0);

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4282,6 +4282,11 @@ class _ContentRowsState extends State<_ContentRows>
                     itemType: item.type,
                     seerrMediaType: item.seerrMediaType,
                     seerrStatus: item.seerrStatus,
+                    isGenreFallback: (row.rowType == HomeRowType.genres && row.id == 'genres') &&
+                        (() {
+                          final primaryAr = item.rawData['PrimaryImageAspectRatio'] as num?;
+                          return primaryAr == null || primaryAr >= 1.0;
+                        })(),
                     focusColor: (row.rowType == HomeRowType.genres && row.id == 'genres')
                         ? ThemeRegistry.active.borders.focusBorder.color
                         : focusColor,
@@ -4746,6 +4751,14 @@ class _ContentRowsState extends State<_ContentRows>
       );
     }
 
+    if (item.type == 'Genre' || item.type == 'MusicGenre') {
+      final primaryAr = item.rawData['PrimaryImageAspectRatio'] as num?;
+      if (primaryAr == null || primaryAr >= 1.0) {
+        final repUrl = primary(item.primaryImageItemId, item.primaryImageTagField);
+        if (repUrl != null) return repUrl;
+      }
+    }
+
     return primary(item.id, item.primaryImageTag) ??
         primary(item.primaryImageItemId, item.primaryImageTagField) ??
         primary(item.parentPrimaryImageItemId, item.parentPrimaryImageTag);
@@ -4830,6 +4843,20 @@ class _ContentRowsState extends State<_ContentRows>
     double requestScale, {
     bool isPrefetch = false,
   }) {
+    if (item.type == 'Genre' || item.type == 'MusicGenre') {
+      final parentBackdropItemId = item.parentBackdropItemId;
+      final parentBackdropTags = item.parentBackdropImageTags;
+      final maxW = (height * 16 / 9 * requestScale).toInt();
+      if (parentBackdropItemId != null && parentBackdropTags.isNotEmpty) {
+        final backdropUrl = imageApi.getBackdropImageUrl(
+          parentBackdropItemId,
+          maxWidth: maxW,
+          tag: parentBackdropTags.first,
+        );
+        if (backdropUrl != null) return backdropUrl;
+      }
+    }
+
     if (item.serverId == 'seerr') {
       if (!isPrefetch) {
         _fetchBackdropIfNeeded(item);

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4848,12 +4848,11 @@ class _ContentRowsState extends State<_ContentRows>
       final parentBackdropTags = item.parentBackdropImageTags;
       final maxW = (height * 16 / 9 * requestScale).toInt();
       if (parentBackdropItemId != null && parentBackdropTags.isNotEmpty) {
-        final backdropUrl = imageApi.getBackdropImageUrl(
+        return imageApi.getBackdropImageUrl(
           parentBackdropItemId,
           maxWidth: maxW,
           tag: parentBackdropTags.first,
         );
-        if (backdropUrl != null) return backdropUrl;
       }
     }
 

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -72,7 +72,9 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
   bool get _isLibraryFolder =>
       _item.type?.toLowerCase() == 'collectionfolder' ||
       _item.type?.toLowerCase() == 'userview' ||
-      _item.type?.toLowerCase() == 'folder';
+      _item.type?.toLowerCase() == 'folder' ||
+      _item.type?.toLowerCase() == 'genre' ||
+      _item.type?.toLowerCase() == 'musicgenre';
 
   final Map<String, ScrollController> _scrollControllers = {};
   final Map<String, FocusNode> _headerFocusNodes = {};
@@ -348,6 +350,8 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
       case 'folder':
       case 'collectionfolder':
       case 'userview':
+      case 'genre':
+      case 'musicgenre':
         return const ['Primary', 'Backdrop', 'Thumb'];
       default:
         return const ['Primary', 'Backdrop'];
@@ -618,6 +622,15 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
 
   Future<void> _fetchRemoteImages(String category) async {
     if (!mounted) return;
+    final isGenre = _item.type?.toLowerCase() == 'genre' ||
+        _item.type?.toLowerCase() == 'musicgenre';
+    if (isGenre) {
+      setState(() {
+        _remoteImages[category] = const [];
+        _loadingCategories[category] = false;
+      });
+      return;
+    }
     setState(() {
       _loadingCategories[category] = true;
       _categoryErrors[category] = null;

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -206,7 +206,12 @@ List<ItemContextAction> contextActionsFor(
 
   }
 
-  final canChangeArtwork = (isMediaType || type == 'Folder' || type == 'CollectionFolder' || type == 'UserView') &&
+  final canChangeArtwork = (isMediaType ||
+          type == 'Folder' ||
+          type == 'CollectionFolder' ||
+          type == 'UserView' ||
+          type == 'Genre' ||
+          type == 'MusicGenre') &&
       client.serverType == ServerType.jellyfin &&
       isAdminUser;
 

--- a/lib/ui/widgets/genre_grid_card.dart
+++ b/lib/ui/widgets/genre_grid_card.dart
@@ -6,6 +6,7 @@ import '../../preference/user_preferences.dart';
 import 'bounded_network_image.dart';
 import 'marquee_text.dart';
 import '../../util/focus/dpad_keys.dart';
+import '../../util/focus/key_event_utils.dart';
 import '../mixins/focus_state_mixin.dart';
 
 class GenreCardData {
@@ -14,6 +15,7 @@ class GenreCardData {
   int itemCount;
   String? imageUrl;
   String? backdropUrl;
+  bool isGenreFallback;
 
   GenreCardData({
     required this.id,
@@ -21,12 +23,14 @@ class GenreCardData {
     required this.itemCount,
     this.imageUrl,
     this.backdropUrl,
+    this.isGenreFallback = false,
   });
 }
 
 class GenreGridCard extends StatefulWidget {
   final GenreCardData genre;
   final VoidCallback onTap;
+  final VoidCallback? onLongPress;
   final ValueChanged<bool>? onHover;
   final bool centerTitle;
   final Color? focusColor;
@@ -36,6 +40,7 @@ class GenreGridCard extends StatefulWidget {
     super.key,
     required this.genre,
     required this.onTap,
+    this.onLongPress,
     this.onHover,
     this.centerTitle = false,
     this.focusColor,
@@ -47,6 +52,14 @@ class GenreGridCard extends StatefulWidget {
 }
 
 class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
+  final _selectKeyHandler = LongPressSelectKeyHandler();
+
+  @override
+  void dispose() {
+    _selectKeyHandler.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final borders = ThemeRegistry.active.borders;
@@ -82,14 +95,28 @@ class _GenreGridCardState extends State<GenreGridCard> with FocusStateMixin {
       child: Focus(
         onFocusChange: (focused) => setFocused(focused),
         onKeyEvent: (_, event) {
-          if (isActivateKey(event)) {
+          if (widget.onLongPress != null) {
+            final handlerResult = _selectKeyHandler.handleKeyEvent(
+              event,
+              onTap: widget.onTap,
+              onLongPress: () => widget.onLongPress?.call(),
+            );
+            if (handlerResult != KeyEventResult.ignored) {
+              return handlerResult;
+            }
+          } else if (isActivateKey(event)) {
             widget.onTap();
             return KeyEventResult.handled;
           }
           return KeyEventResult.ignored;
         },
         child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: widget.onTap,
+          onLongPressStart: widget.onLongPress != null
+              ? (_) => widget.onLongPress?.call()
+              : null,
+          onSecondaryTap: widget.onLongPress,
           child: AnimatedScale(
             scale: widget.cardFocusExpansion && showFocusBorder ? 1.05 : 1.0,
             duration: const Duration(milliseconds: 150),

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -46,6 +46,7 @@ class MediaCard extends StatefulWidget {
   final bool suppressFocusGlow;
   final Color? titleColor;
   final Color? subtitleColor;
+  final bool isGenreFallback;
 
   /// Extra widgets layered over the poster image (inside its clip), e.g.
   /// format badges. Position each with [Positioned].
@@ -91,6 +92,7 @@ class MediaCard extends StatefulWidget {
     this.subtitleColor,
     this.imageOverlays = const [],
     this.overlayOccupiesTopLeft = false,
+    this.isGenreFallback = false,
   });
 
   static IconData iconForType(String? type) {
@@ -256,6 +258,7 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
                   seerrStatus: widget.seerrStatus,
                   imageOverlays: widget.imageOverlays,
                   overlayOccupiesTopLeft: widget.overlayOccupiesTopLeft,
+                  isGenreFallback: widget.isGenreFallback,
                 ),
                 if (widget.title != null) ...[
                   const SizedBox(height: 6),
@@ -482,6 +485,7 @@ class _CardImage extends StatelessWidget {
   final int? seerrStatus;
   final List<Widget> imageOverlays;
   final bool overlayOccupiesTopLeft;
+  final bool isGenreFallback;
 
   const _CardImage({
     this.imageUrl,
@@ -503,6 +507,7 @@ class _CardImage extends StatelessWidget {
     this.seerrStatus,
     this.imageOverlays = const [],
     this.overlayOccupiesTopLeft = false,
+    this.isGenreFallback = false,
   });
 
   @override
@@ -560,18 +565,50 @@ class _CardImage extends StatelessWidget {
                       ? const EdgeInsets.all(8.0)
                       : EdgeInsets.zero,
                   child: imageUrl != null
-                      ? BoundedNetworkImage(
-                          imageUrl: imageUrl!,
-                          fit: (itemType == 'Network' || itemType == 'Studio')
-                              ? BoxFit.contain
-                              : BoxFit.cover,
-                          fadeInDuration: Duration.zero,
-                          scale: isCircular ? 0.8 : 0.9,
-                          maxWidth: aspectRatio > 1.2 ? 960 : 640,
-                          errorBuilder: (_, _, _) => _PlaceholderIcon(
-                            itemType: itemType,
-                            title: title,
-                          ),
+                      ? Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            BoundedNetworkImage(
+                              imageUrl: imageUrl!,
+                              fit: (itemType == 'Network' || itemType == 'Studio')
+                                  ? BoxFit.contain
+                                  : BoxFit.cover,
+                              fadeInDuration: Duration.zero,
+                              scale: isCircular ? 0.8 : 0.9,
+                              maxWidth: aspectRatio > 1.2 ? 960 : 640,
+                              errorBuilder: (_, _, _) => _PlaceholderIcon(
+                                itemType: itemType,
+                                title: title,
+                              ),
+                            ),
+                            if (isGenreFallback) ...[
+                              Container(
+                                color: Colors.black.withValues(alpha: 0.45),
+                              ),
+                              if (title != null && title!.isNotEmpty)
+                                Center(
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(12.0),
+                                    child: FittedBox(
+                                      fit: BoxFit.scaleDown,
+                                      child: Text(
+                                        title!.toUpperCase(),
+                                        textAlign: TextAlign.center,
+                                        style: TextStyle(
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.bold,
+                                          letterSpacing: 2.5,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .onSurface
+                                              .withValues(alpha: 0.9),
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ],
                         )
                       : _PlaceholderIcon(itemType: itemType, title: title),
                 ),
@@ -830,18 +867,19 @@ class _PlaceholderIcon extends StatelessWidget {
             ? Center(
                 child: Padding(
                   padding: const EdgeInsets.all(12.0),
-                  child: Text(
-                    title!.toUpperCase(),
-                    textAlign: TextAlign.center,
-                    maxLines: 3,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.bold,
-                      letterSpacing: 2.5,
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.5),
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      title!.toUpperCase(),
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: 2.5,
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withValues(alpha: 0.5),
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
# Pull Request

## Summary
This pull request implements changes to the default and custom artwork selection for Genre and MusicGenre items. It improves layout behavior, optimizes loading performance, prevents database lockups, and resolves empty/black card rendering issues on both the Home Row and Genres library page.

## Related Issues
Link related issues or tickets separated by commas.

Implements idea generated from Discord feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated logic for fallback Genre Home Rows. Specifically - use random portrait image from the genre library when unfocused, preventing landscape backdrops from getting awkwardly squished or cropped inside vertical cards. When focused, use a random backdrop instead. Both images are given a darkening overlay with the genre name overlaid.
- Added long-press and right-click support to `GenreGridCard` (supporting touch, desktop, and TV D-pad context keys). Hooked up `showContextMenu` on the All Genres and Library Genres grid screens to allow users to directly upload and manage custom genre posters, backdrops, and thumbnails. If custom art is supplied, it will take precedence over the Moonfin fallback. 
- To follow DRY principles, extracted the randomized aspect-ratio-prioritized fallback artwork selection logic into a single reusable helper function `resolveGenreFallbackArtwork` inside `genre_browse_utils.dart`, cleaning up over 140 lines of duplicate code.
- Added safety catches to prevent empty black fallback cards for genres lacking backdrops sometimes appearing.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin and verify the Home Row display of Genre cards.
2. Confirm that unfocused fallback cards display as portrait posters, and focused fallback cards expand to display landscape backdrops, both with genre labelled on top.
3. Hold select key or long press on a card on "All Genres" page to trigger Change Artwork context menu.
4. Confirm that the grid loading does not omit any genre cards due to SQLite locked query drops.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### HOME ROW UPDATE
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_10-03-03" src="https://github.com/user-attachments/assets/cc498a2f-a28c-43c9-b126-17a6ffc0b663" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_10-04-51" src="https://github.com/user-attachments/assets/af5ad0ac-0323-4e58-a131-a3624704aedb" />

### GENRE PAGE UPDATE
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_10-04-15" src="https://github.com/user-attachments/assets/58ebfc7c-43d1-4425-b1cf-cf96275cac63" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_10-11-19" src="https://github.com/user-attachments/assets/0513dce2-7de9-49ad-bcaa-1f834892e4de" />

### LONG PRESS UPDATE
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_10-14-00" src="https://github.com/user-attachments/assets/aa426c10-045b-42b6-b1dd-d68d00aa2205" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_10-17-26" src="https://github.com/user-attachments/assets/e176a460-10f2-491e-b412-f353e0deffc2" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
