### PR TITLE
UI ENHANCEMENT: GAME CHANGING DIVIDING UI PR

### DIFF
--- a/lib/ui/widgets/settings/settings_panel.dart
+++ b/lib/ui/widgets/settings/settings_panel.dart
@@ -104,7 +104,20 @@ class SettingsPanel extends StatelessWidget {
             )
           : panel;
     } else {
-      content = body;
+      final navBorder = ThemeRegistry.active.borders.navBorder;
+      if (navBorder != null) {
+        content = DecoratedBox(
+          position: DecorationPosition.foreground,
+          decoration: BoxDecoration(
+            border: Border(
+              left: navBorder,
+            ),
+          ),
+          child: body,
+        );
+      } else {
+        content = body;
+      }
     }
     return Align(
       alignment: Alignment.centerRight,


### PR DESCRIPTION
# Pull Request

## Summary
Add a theme-colored divider line to the Settings panel left edge. This divider is visible in Neon Pulse (pink) and 8-Bit Hero (gray-blue) themes, separating the drawer from the main UI content, and persists when navigating into sub-settings screen views.

## Related Issues
Link related issues or tickets separated by commas.

- Closes # My kid's need for keeping things separate
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified settings_panel.dart to wrap the standard settings drawer layout inside a DecoratedBox with position: DecorationPosition.foreground and a left border matching the theme's active navBorder specification.
- Using the foreground painting position ensures that the border is drawn on top of the child view stack, preventing it from being covered by the solid Scaffold backgrounds of the Settings drawer screens.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open the Settings panel from the left sidebar.
2. Confirm that a vertical line in the theme colorway (e.g. pink for Neon Pulse) is visible on the left edge of the panel.
3. Navigate into a settings screen (such as App Theme) and confirm the line remains visible.
4. Switch between Neon Pulse and other themes (like Moonfin/Glass) to verify visual consistency.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### THE BEFORETIMES
<img width="2560" height="1555" alt="2026-07-10_19-33-57_moonfin" src="https://github.com/user-attachments/assets/e6cdd11f-e262-4900-9c23-91c85f9cb4fc" />

### THE ENLIGHTENMENT
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_20-21-02" src="https://github.com/user-attachments/assets/587469d8-7f18-475d-a28f-fafa6ef220cf" />

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-10_20-20-41" src="https://github.com/user-attachments/assets/ae3a617d-f9a7-466b-8ce9-d3708cf500f8" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
