### PR TITLE
Add jellyfin as url Keyboard Chip

### DIFF
--- a/packages/custom_tv_text_field_fork/lib/src/keyboard_controller.dart
+++ b/packages/custom_tv_text_field_fork/lib/src/keyboard_controller.dart
@@ -206,6 +206,7 @@ class CustomKeyboardState extends State<CustomKeyboard> {
           _KeyboardChip(label: 'https://', value: 'https://'),
           _KeyboardChip(label: 'http://', value: 'http://'),
           _KeyboardChip(label: 'www.', value: 'www.'),
+          _KeyboardChip(label: 'jellyfin', value: 'jellyfin'),
           _KeyboardChip(label: '.com', value: '.com'),
           _KeyboardChip(label: '.org', value: '.org'),
           _KeyboardChip(label: '.net', value: '.net'),


### PR DESCRIPTION
# Pull Request

## Summary
Add jellyfin as url Keyboard Chip

## Related Issues
Related to no issue

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added jellyfin as url keyboard chip; A lot of people hosting jellyfin might have it somewhere in their url.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [x] Not tested (explain why): Simplicity of the Change

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
