### PR TITLE
bugfix-playback: fix pre-rolls on AndroidTV

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -958,6 +958,8 @@ class Media3VideoView(
         audioPipeline.release()
         player.clearVideoSurface()
         Media3SessionController.releaseForPlayer(player)
+        // Stop and clear before releasing so the render threads unwind and the
+        // last decoded frame is dropped instead of lingering in the surface.
         player.stop()
         player.clearMediaItems()
         player.release()
@@ -1542,7 +1544,6 @@ class Media3VideoView(
             ?.trim()
             ?.lowercase()
             ?.takeIf { it.isNotEmpty() }
-        player.setPauseAtEndOfMediaItems(false)
         audioOffloadRetryAttemptedForCurrentSource = false
         stereoDownmixRetryAttemptedForCurrentSource = false
         containerFallbackAttempted = false

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -958,7 +958,14 @@ class Media3VideoView(
         audioPipeline.release()
         player.clearVideoSurface()
         Media3SessionController.releaseForPlayer(player)
+        player.stop()
+        player.clearMediaItems()
         player.release()
+
+        videoView.visibility = View.GONE
+        if (videoView is SurfaceView) {
+            (videoView as SurfaceView).holder.setFormat(android.graphics.PixelFormat.TRANSPARENT)
+        }
     }
 
     override fun dispose() {
@@ -971,6 +978,7 @@ class Media3VideoView(
             return
         }
         forceReleasePlayer()
+        containerView.removeAllViews()
         Media3Bridge.detachView(this)
     }
 
@@ -1015,7 +1023,7 @@ class Media3VideoView(
             .setMediaSourceFactory(bootMediaSourceFactory)
             .setHandleAudioBecomingNoisy(true)
             .setWakeMode(C.WAKE_MODE_NETWORK)
-            .setPauseAtEndOfMediaItems(true)
+            .setPauseAtEndOfMediaItems(false)
             .build()
             .also {
                 attachAssOverlay(assHandler)
@@ -1115,6 +1123,10 @@ class Media3VideoView(
             FrameLayout.LayoutParams.MATCH_PARENT,
             Gravity.CENTER,
         )
+        videoView.visibility = View.GONE
+        if (videoView is SurfaceView) {
+            (videoView as SurfaceView).holder.setFormat(android.graphics.PixelFormat.TRANSPARENT)
+        }
         containerView.removeView(videoView)
         videoView = newVideoView()
         containerView.addView(videoView, 0, params)
@@ -1530,7 +1542,7 @@ class Media3VideoView(
             ?.trim()
             ?.lowercase()
             ?.takeIf { it.isNotEmpty() }
-        player.setPauseAtEndOfMediaItems(currentMediaType != "audio")
+        player.setPauseAtEndOfMediaItems(false)
         audioOffloadRetryAttemptedForCurrentSource = false
         stereoDownmixRetryAttemptedForCurrentSource = false
         containerFallbackAttempted = false


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves an issue on AndroidTV where letting the credits complete at the end of a movie causes the app to freeze/go non-responsive and overlay the final frame of the preroll video.

Prior to this PR, upon finishing a movie the final frame of the pre-roll would reappear and "lock" the interface. I was able to replicate it on different movies and pre-roll combinations. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Disabled `setPauseAtEndOfMediaItems(true)` for video playback in `Media3VideoView.kt` so the player transitions directly to `STATE_ENDED` on completion, allowing native media decoders to automatically release/flush resources.
- Added `player.stop()` and `player.clearMediaItems()` inside the native `forceReleasePlayer()` method to halt background rendering threads cleanly before releasing the player.
- Set `videoView` visibility to `View.GONE` and set the surface holder's pixel format to `PixelFormat.TRANSPARENT` before detaching or releasing to prevent the final frame of the preroll from leaking in the composition layer.
- Added `containerView.removeAllViews()` to the native `dispose()` handler to ensure no stale views or surface layers are leaked.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Configure movie playback with an active preroll video.
2. Fast-forward to the end of the movie.
3. Allow the credits to complete.
4. Verify the player screen transitions cleanly back to the movie details page with responsive UI input.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
