### PR TITLE
Bug/atv screensaver freeze

### DIFF
--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -547,6 +547,14 @@ class Media3PlayerBackend extends PlayerBackend {
 
   Future<void> release() => _teardown('release');
 
+  Future<void> appPaused() async {
+    await _invoke<void>('appPaused');
+  }
+
+  Future<void> appResumed() async {
+    await _invoke<void>('appResumed');
+  }
+
   Future<void> _teardown(String command) async {
     await _invoke<void>(command);
     if (_isPlaying) {

--- a/lib/playback/playback_lifecycle_handler.dart
+++ b/lib/playback/playback_lifecycle_handler.dart
@@ -5,6 +5,7 @@ import 'package:playback_core/playback_core.dart';
 
 import '../data/models/aggregated_item.dart';
 import '../util/platform_detection.dart';
+import 'media3_player_backend.dart';
 
 class PlaybackLifecycleHandler with WidgetsBindingObserver {
   final PlaybackManager _manager;
@@ -46,8 +47,16 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
       case AppLifecycleState.hidden:
       case AppLifecycleState.paused:
         _saveState();
+        final backend = _manager.backend;
+        if (backend is Media3PlayerBackend) {
+          unawaited(backend.appPaused());
+        }
         break;
       case AppLifecycleState.resumed:
+        final backend = _manager.backend;
+        if (backend is Media3PlayerBackend) {
+          unawaited(backend.appResumed());
+        }
         _restoreState();
         break;
       default:

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -1269,7 +1269,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           if (_isTvLifecycleExitSuppressed()) return;
           if (_didHandleBackgroundSuspend) return;
           _didHandleBackgroundSuspend = true;
-          if (_state.isPlaying) {
+          if (_state.isPlaying && _activeMedia3Backend == null) {
             _scheduleTvBackgroundExit();
           }
           return;

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3PlayerActivity.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3PlayerActivity.kt
@@ -767,12 +767,12 @@ class Media3PlayerActivity : ComponentActivity() {
     override fun onStart() {
         super.onStart()
         if (::media3View.isInitialized) {
-            media3View.ensurePlayerAlive()
+            media3View.resumeFromBackground()
         }
     }
 
     override fun onStop() {
-        if (::media3View.isInitialized) {
+        if (::media3View.isInitialized && !media3View.isAudioPlayback()) {
             media3View.forceReleasePlayer()
         }
         super.onStop()

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3PlayerActivity.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3PlayerActivity.kt
@@ -764,6 +764,20 @@ class Media3PlayerActivity : ComponentActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        if (::media3View.isInitialized) {
+            media3View.ensurePlayerAlive()
+        }
+    }
+
+    override fun onStop() {
+        if (::media3View.isInitialized) {
+            media3View.forceReleasePlayer()
+        }
+        super.onStop()
+    }
+
     override fun onDestroy() {
         if (::media3View.isInitialized) {
             media3View.dispose()

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -438,6 +438,8 @@ class Media3VideoView(
     // composition path (see newVideoView). Previously gated to API 30+.
     private val useSurfaceView = true
     private var videoView: View = newVideoView()
+    private var lastSourceArguments: Map<*, *>? = null
+    private var lastPlaybackPositionMs: Long = 0L
 
     private fun newVideoView(): View =
         if (useSurfaceView) {
@@ -468,6 +470,20 @@ class Media3VideoView(
         container.addView(videoView, videoLayoutParams)
         container.addView(firstFrameCover, subtitleLayoutParams)
         container.addView(subtitleView, subtitleLayoutParams)
+
+        container.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                if (!isDisposedByFlutter && currentMediaType != "audio") {
+                    ensurePlayerAlive()
+                }
+            }
+
+            override fun onViewDetachedFromWindow(v: View) {
+                if (currentMediaType != "audio") {
+                    forceReleasePlayer()
+                }
+            }
+        })
     }
     private val isLowRamDevice = context.getSystemService<ActivityManager>()?.isLowRamDevice == true
     private val hasHardwareAv1Decoder by lazy { queryHardwareAv1DecoderAvailability() }
@@ -940,10 +956,20 @@ class Media3VideoView(
         applyTrackSelectorForCurrentSource()
         refreshSubtitleRendererMode()
         startTicker()
+
+        val args = lastSourceArguments
+        if (args != null) {
+            val updatedArgs = args.toMutableMap().apply {
+                this["startPositionMs"] = lastPlaybackPositionMs
+                this["autoPlay"] = false
+            }
+            setSource(updatedArgs)
+        }
     }
 
     fun forceReleasePlayer() {
         if (isPlayerReleased) return
+        lastPlaybackPositionMs = player.currentPosition
         isPlayerReleased = true
         isDisposed = true
         cancelPendingSubtitleCue(clearView = false)
@@ -1192,6 +1218,20 @@ class Media3VideoView(
                     if (isDisposedByFlutter && currentMediaType != "audio") {
                         forceReleasePlayer()
                         Media3Bridge.detachView(this)
+                    }
+                    result.success(null)
+                }
+
+                "appPaused" -> {
+                    if (currentMediaType != "audio") {
+                        forceReleasePlayer()
+                    }
+                    result.success(null)
+                }
+
+                "appResumed" -> {
+                    if (currentMediaType != "audio") {
+                        ensurePlayerAlive()
                     }
                     result.success(null)
                 }
@@ -1467,6 +1507,7 @@ class Media3VideoView(
 
     private fun setSource(arguments: Any?) {
         val args = arguments as? Map<*, *> ?: return
+        lastSourceArguments = args
         val url = args["url"]?.toString() ?: return
         val startPositionMs = (args["startPositionMs"] as? Number)?.toLong() ?: 0L
         val autoPlay = args["autoPlay"] as? Boolean ?: false

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -474,7 +474,7 @@ class Media3VideoView(
         container.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
             override fun onViewAttachedToWindow(v: View) {
                 if (!isDisposedByFlutter && currentMediaType != "audio") {
-                    ensurePlayerAlive()
+                    resumeFromBackground()
                 }
             }
 
@@ -943,7 +943,10 @@ class Media3VideoView(
     fun isPlayerLive(): Boolean = !isPlayerReleased && !isDisposedByFlutter
 
     // Rebuilds the player after another view's attachView() force-released it
-    // while this widget stayed mounted. This mirrors the init path.
+    // while this widget stayed mounted. This mirrors the init path and leaves
+    // the source alone, because the caller re-sends its own source right after
+    // (a view swap or trailer reactivation). Use resumeFromBackground when there
+    // is no incoming source to reload.
     fun ensurePlayerAlive() {
         if (!isPlayerReleased) return
         isPlayerReleased = false
@@ -956,16 +959,23 @@ class Media3VideoView(
         applyTrackSelectorForCurrentSource()
         refreshSubtitleRendererMode()
         startTicker()
-
-        val args = lastSourceArguments
-        if (args != null) {
-            val updatedArgs = args.toMutableMap().apply {
-                this["startPositionMs"] = lastPlaybackPositionMs
-                this["autoPlay"] = false
-            }
-            setSource(updatedArgs)
-        }
     }
+
+    // Rebuilds the player and reloads the last source at its paused position when
+    // the app returns from the background or the system screensaver. Only runs
+    // when the player was actually released, so a still-live view is untouched.
+    fun resumeFromBackground() {
+        if (!isPlayerReleased) return
+        ensurePlayerAlive()
+        val args = lastSourceArguments ?: return
+        val restored = args.toMutableMap().apply {
+            this["startPositionMs"] = lastPlaybackPositionMs
+            this["autoPlay"] = false
+        }
+        setSource(restored)
+    }
+
+    fun isAudioPlayback(): Boolean = currentMediaType == "audio"
 
     fun forceReleasePlayer() {
         if (isPlayerReleased) return
@@ -1231,7 +1241,7 @@ class Media3VideoView(
 
                 "appResumed" -> {
                     if (currentMediaType != "audio") {
-                        ensurePlayerAlive()
+                        resumeFromBackground()
                     }
                     result.success(null)
                 }


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves an issue on AndroidTV where returning from the system screensaver while video playback is paused causes the player to hang / deadlock with an endless spinner and unresponsive UI.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #503 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Dart Interception (`playback_lifecycle_handler.dart`)**: Intercepted the app lifecycle states in Dart. When `paused` fires, it calls `backend.appPaused()`. When `resumed` fires, it calls `backend.appResumed()`.
- **Backend API (`media3_player_backend.dart`)**: Added `appPaused()` and `appResumed()` methods to send `'appPaused'` and `'appResumed'` MethodChannel calls to the native Android side.
- **Native Controller (`Media3VideoView.kt`)**: Added handlers for `"appPaused"` and `"appResumed"` commands inside `handleControlCall`:
  - `"appPaused"` calls `forceReleasePlayer()` to cleanly release the player and free hardware decoders when the app goes to the background.
  - `"appResumed"` calls `ensurePlayerAlive()` to reconstruct the player and restore state when returning.
- **State Tracking & Restoration (`Media3VideoView.kt`)**: Tracked `lastSourceArguments` and `lastPlaybackPositionMs` so that when the player is rebuilt, it re-registers the player slot and restores playback to the exact paused position with autoplay disabled.
- **Activity Lifecycle Safety (`Media3PlayerActivity.kt`)**: Added overrides to `onStart` / `onStop` as an extra safety measure to support any potential native player activity instances.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Disable Moonfin screensaver; enable OS level screensaver
2. Pause a video on AndroidTV.
3. Wait for the system screensaver to start.
4. Dismiss the screensaver (press Back).
5. Verify the player successfully recreates, restores the exact position, and remains responsive.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### OS screensaver kicks in:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-11_12-47-38" src="https://github.com/user-attachments/assets/71750a92-afee-4f3b-aa1c-2c160e5dde47" />

### Playback can be resumed afterward:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-11_12-47-49" src="https://github.com/user-attachments/assets/0368b502-0637-4458-b0ec-0b61dc5b8fba" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
