### PR TITLE
adjust sidebar gradient based on opacity setting

### DIFF
--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -641,7 +641,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
 
   Widget _buildTvLayout() {
     final overlayColor = _overlayColor();
-    final opacity = _overlayOpacity();
+    final opacity = _overlayOpacity() ?? 0.0;
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     final desktopHoverRail =
         (PlatformDetection.isDesktop || (PlatformDetection.isWeb && !PlatformDetection.useMobileUi)) && !PlatformDetection.isTV;
@@ -682,11 +682,19 @@ class _LeftSidebarState extends State<LeftSidebar> {
                                 end: Alignment.centerRight,
                                 colors: [
                                   overlayColor.withValues(
-                                    alpha: math.max(opacity, 0.7),
+                                    alpha: math.pow(opacity, 0.25) as double,
                                   ),
                                   overlayColor.withValues(
-                                    alpha: math.max(opacity, 0.5),
+                                    alpha: opacity,
                                   ),
+                                  overlayColor.withValues(
+                                    alpha: math.pow(opacity, 2.0) as double,
+                                  ),
+                                  overlayColor.withValues(
+                                    alpha: math.pow(opacity, 4.0) as double,
+                                  ),
+                                  if (opacity < 1)
+                                    Colors.transparent,
                                 ],
                               ),
                               border: isNeon
@@ -701,27 +709,6 @@ class _LeftSidebarState extends State<LeftSidebar> {
                                           ),
                                     )
                                   : null,
-                            ),
-                          ),
-                        if (!AppColorScheme.isGlass)
-                          Positioned(
-                            left: _kExpandedBackdropWidthTV,
-                            top: 0,
-                            bottom: 0,
-                            child: Container(
-                              width: _kBackdropEdgeBlendWidthTV,
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  begin: Alignment.centerLeft,
-                                  end: Alignment.centerRight,
-                                  colors: [
-                                    overlayColor.withValues(
-                                      alpha: math.max(opacity, 0.5),
-                                    ),
-                                    Colors.transparent,
-                                  ],
-                                ),
-                              ),
                             ),
                           ),
                       ],


### PR DESCRIPTION
# Pull Request

## Summary
Radical Muffin Man, you and I have been compromising for too long. We should both be happy. 

It's become clear to me that you like more gradient on your sidebar, whereas I prefer a solid sidebar. To compromise, you pushed the gradient out so most of the sidebar would follow the opacity, and then the edge would drop off in a gradient. 

My new proposal is this: let the opacity define the gradient. 100% opacity? No gradient. 90%? Slight gradient at the edge. 50%? Complete gradient. 0%? Completely transparent (below 50 is not even currently supported on core tv/desktop, it stops at 50%)

This way I could set 100% and have a solid sidebar, and you could do 50 or 75% and have more of a gradient that you like. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Adjust gradient calculation for sidebar
- 
- 

## Platform
- [X] Android TV
- [ ] iOS
- [X] tvOS
- [X] Web
- [X] macOS
- [X] Windows
- [X] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Tested on desktop and TV
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="2780" height="1470" alt="Screenshot_20260711_151141" src="https://github.com/user-attachments/assets/5f8dcb13-299d-4407-975b-9ff1e0c09577" />
<img width="2780" height="1470" alt="Screenshot_20260711_151058" src="https://github.com/user-attachments/assets/6453bcc5-1536-4bb7-97ec-933f122e100a" />
<img width="2780" height="1470" alt="Screenshot_20260711_151046" src="https://github.com/user-attachments/assets/c071783c-da9f-40b3-a155-bf736c3aacb8" />
<img width="2780" height="1470" alt="Screenshot_20260711_151025" src="https://github.com/user-attachments/assets/a35fb19d-740b-4d6b-b52e-e6c614768d1d" />
<img width="2780" height="1470" alt="Screenshot_20260711_151004" src="https://github.com/user-attachments/assets/82b3c972-de5f-4952-98d3-f5feee8e6c24" />
<img width="4000" height="3000" alt="20260711_151805" src="https://github.com/user-attachments/assets/1e0e44ba-961e-4a15-8061-684f1c2a330d" />
<img width="4000" height="3000" alt="20260711_151828" src="https://github.com/user-attachments/assets/deb2b4f9-1f19-467d-87fa-f29d626be0e6" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
