### PR TITLE
add moonbase seerr label to few more places

### DIFF
--- a/lib/preference/seerr_preferences.dart
+++ b/lib/preference/seerr_preferences.dart
@@ -43,6 +43,13 @@ class SeerrPreferences {
   Future<void> setMoonfinDisplayName(String value) =>
       _store.setString(_userKey('moonfin_display_name'), value);
 
+  /// Label for the Seerr integration: the moonbase display name when one is set,
+  /// otherwise [fallback] (typically l10n.seerr).
+  String labelOrDefault(String fallback) {
+    final name = moonfinDisplayName.trim();
+    return name.isNotEmpty ? name : fallback;
+  }
+
   String get moonfinVariant => normalizeVariant(_store.getString(_userKey('moonfin_variant')));
   bool get isSeerrVariant => moonfinVariant == 'seerr';
   Future<void> setMoonfinVariant(String value) =>

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -2615,10 +2615,9 @@ class _DetailContentState extends State<_DetailContent> {
     final seerrAppearancesFocusNode = hasSeerrAppearances
         ? _sectionFocusNode('detailPersonSeerrAppearances')
         : null;
-    final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
-    final seerrLabel = seerrDisplayName.isNotEmpty
-        ? seerrDisplayName
-        : l10n.seerr;
+    final seerrLabel = GetIt.instance<SeerrPreferences>().labelOrDefault(
+      l10n.seerr,
+    );
 
     return [
       if (!useSplit) ...[

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -34,6 +34,7 @@ import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../preference/seerr_preferences.dart';
 import '../../../ui/mixins/focus_state_mixin.dart';
 import '../../../auth/repositories/user_repository.dart';
 import '../../../util/focus/key_event_utils.dart';
@@ -2614,6 +2615,10 @@ class _DetailContentState extends State<_DetailContent> {
     final seerrAppearancesFocusNode = hasSeerrAppearances
         ? _sectionFocusNode('detailPersonSeerrAppearances')
         : null;
+    final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
+    final seerrLabel = seerrDisplayName.isNotEmpty
+        ? seerrDisplayName
+        : l10n.seerr;
 
     return [
       if (!useSplit) ...[
@@ -2711,7 +2716,7 @@ class _DetailContentState extends State<_DetailContent> {
             if (hasSeerrButton) ...[
               const SizedBox(width: 16),
               _DetailActionButton(
-                label: l10n.seerr,
+                label: seerrLabel,
                 iconBuilder: (size, color) =>
                     SeerrIcon(size: size, color: color),
                 onPressed: () {

--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -975,10 +975,9 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
     if (_selectedTab >= tabCount) _selectedTab = tabCount - 1;
 
     final l10n = AppLocalizations.of(context);
-    final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
-    final seerrLabel = seerrDisplayName.isNotEmpty
-    ? seerrDisplayName
-    : l10n.seerr;
+    final seerrLabel = GetIt.instance<SeerrPreferences>().labelOrDefault(
+      l10n.seerr,
+    );
     final totalCount =
         _vm.results.fold<int>(0, (s, g) => s + g.items.length) +
         _vm.seerrResults.length;
@@ -987,7 +986,7 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
       for (final group in _vm.results)
         '${localizeSearchGroupTitle(group.title, l10n)}: ${group.items.length}',
       if (_vm.seerrResults.isNotEmpty)
-        '${seerrLabel}: ${_vm.seerrResults.length}',
+        '$seerrLabel: ${_vm.seerrResults.length}',
     ];
 
     final isMobile = PlatformDetection.useMobileUi;
@@ -1190,10 +1189,9 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
     }
     if (hasSeerr) {
       final cardWidth = 108.0;
-      final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
-      final seerrLabel = seerrDisplayName.isNotEmpty
-      ? seerrDisplayName
-      : l10n.seerr;
+      final seerrLabel = GetIt.instance<SeerrPreferences>().labelOrDefault(
+        l10n.seerr,
+      );
       rows.add(
         LibraryRow(
           key: _allRowKey(groups.length),

--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -18,6 +18,7 @@ import '../../../data/services/voice_search_controller.dart';
 import '../../../data/viewmodels/search_view_model.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../preference/seerr_preferences.dart';
 import '../../navigation/destinations.dart';
 import '../../../util/platform_detection.dart';
 import '../../../util/focus/dpad_keys.dart';
@@ -974,6 +975,10 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
     if (_selectedTab >= tabCount) _selectedTab = tabCount - 1;
 
     final l10n = AppLocalizations.of(context);
+    final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
+    final seerrLabel = seerrDisplayName.isNotEmpty
+    ? seerrDisplayName
+    : l10n.seerr;
     final totalCount =
         _vm.results.fold<int>(0, (s, g) => s + g.items.length) +
         _vm.seerrResults.length;
@@ -982,7 +987,7 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
       for (final group in _vm.results)
         '${localizeSearchGroupTitle(group.title, l10n)}: ${group.items.length}',
       if (_vm.seerrResults.isNotEmpty)
-        '${l10n.seerr}: ${_vm.seerrResults.length}',
+        '${seerrLabel}: ${_vm.seerrResults.length}',
     ];
 
     final isMobile = PlatformDetection.useMobileUi;
@@ -1185,10 +1190,14 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
     }
     if (hasSeerr) {
       final cardWidth = 108.0;
+      final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
+      final seerrLabel = seerrDisplayName.isNotEmpty
+      ? seerrDisplayName
+      : l10n.seerr;
       rows.add(
         LibraryRow(
           key: _allRowKey(groups.length),
-          title: l10n.seerr,
+          title: seerrLabel,
           rowHeight: cardWidth / (2 / 3) + 56,
           children: [
             for (var c = 0; c < _vm.seerrResults.length; c++)

--- a/lib/ui/screens/settings/panel/integrations_screen.dart
+++ b/lib/ui/screens/settings/panel/integrations_screen.dart
@@ -22,10 +22,9 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
-    final seerrLabel = seerrDisplayName.isNotEmpty
-    ? seerrDisplayName
-    : l10n.seerr;
+    final seerrLabel = GetIt.instance<SeerrPreferences>().labelOrDefault(
+      l10n.seerr,
+    );
     return withCleanSettingsTypography(
       context,
       Scaffold(

--- a/lib/ui/screens/settings/panel/integrations_screen.dart
+++ b/lib/ui/screens/settings/panel/integrations_screen.dart
@@ -22,6 +22,10 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final seerrDisplayName = GetIt.instance<SeerrPreferences>().moonfinDisplayName.trim();
+    final seerrLabel = seerrDisplayName.isNotEmpty
+    ? seerrDisplayName
+    : l10n.seerr;
     return withCleanSettingsTypography(
       context,
       Scaffold(
@@ -60,7 +64,7 @@ class _IntegrationsScreenState extends State<_IntegrationsScreen> {
                       width: 24,
                       height: 24,
                     ),
-                    title: Text(l10n.seerr),
+                    title: Text(seerrLabel),
                     subtitle: Text(l10n.mediaRequestIntegration),
                     onTap: () =>
                         context.pushSettingsScreen(const SeerrConfigScreen()),

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -426,10 +426,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     final seerrAvailable =
         _syncService.pluginAvailable && _syncService.seerrEnabled;
     final showSeerrSettings = seerrAvailable && _seerrPrefs.enabled;
-    final seerrDisplayName = _seerrPrefs.moonfinDisplayName.trim();
-    final seerrLabel = seerrDisplayName.isNotEmpty
-    ? seerrDisplayName
-    : l10n.seerr;
+    final seerrLabel = _seerrPrefs.labelOrDefault(l10n.seerr);
 
     return RequestInitialFocus(
       targetNode: _enableSeerrFocusNode,

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -426,13 +426,17 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     final seerrAvailable =
         _syncService.pluginAvailable && _syncService.seerrEnabled;
     final showSeerrSettings = seerrAvailable && _seerrPrefs.enabled;
+    final seerrDisplayName = _seerrPrefs.moonfinDisplayName.trim();
+    final seerrLabel = seerrDisplayName.isNotEmpty
+    ? seerrDisplayName
+    : l10n.seerr;
 
     return RequestInitialFocus(
       targetNode: _enableSeerrFocusNode,
       child: Scaffold(
         appBar: buildSettingsAppBar(
           context,
-          Text(l10n.seerr),
+          Text(seerrLabel),
           actions: showSeerrSettings
               ? [
                   IconButton(

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -763,10 +763,7 @@ class _LeftSidebarState extends State<LeftSidebar> {
         _prefs.get(UserPreferences.syncPlayEnabled) &&
         _prefs.get(UserPreferences.showSyncPlayButton);
     final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final seerrDisplayName = seerrPrefs.moonfinDisplayName.trim();
-    final seerrNavLabel = seerrDisplayName.isNotEmpty
-      ? seerrDisplayName
-      : (seerrPrefs.isSeerrVariant ? l10n.seerr : l10n.seerr);
+    final seerrNavLabel = seerrPrefs.labelOrDefault(l10n.seerr);
     final clockBehavior = _prefs.get(UserPreferences.clockBehavior);
     final showClock =
         clockBehavior == ClockBehavior.always ||

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -241,10 +241,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
 
     if (_seerrEnabled()) {
       final seerrPrefs = GetIt.instance<SeerrPreferences>();
-      final displayName = seerrPrefs.moonfinDisplayName.trim();
-      final label = displayName.isNotEmpty
-          ? displayName
-          : (seerrPrefs.isSeerrVariant ? l10n.seerr : l10n.seerr);
+      final label = seerrPrefs.labelOrDefault(l10n.seerr);
       actions.add(
         _BottomNavAction(
           iconBuilder: (size, color) => seerrPrefs.isSeerrVariant

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -807,10 +807,7 @@ class _TopToolbarState extends State<TopToolbar> {
     final showSeerr = _prefs.get(UserPreferences.showSeerrButton) &&
         GetIt.instance<PluginSyncService>().seerrAvailable;
     final l10n = AppLocalizations.of(context);
-    final seerrDisplayName = seerrPrefs.moonfinDisplayName.trim();
-    final seerrNavLabel = seerrDisplayName.isNotEmpty
-      ? seerrDisplayName
-      : (seerrPrefs.isSeerrVariant ? l10n.seerr : l10n.seerr);
+    final seerrNavLabel = seerrPrefs.labelOrDefault(l10n.seerr);
     // Desktop/macOS keeps the dropdown; inline fan-out is only used where
     // horizontal scroll is natural (TV d-pad or touch).
     final useInlineLibraries =


### PR DESCRIPTION
# Pull Request

## Summary
Currently the moonbase set Seerr label only applies to the navbar. This PR extends it mainly to search, but also anywhere else that currently uses l10n.seerr as the text/label. 

There are more places deep in settings that say "seerr" hardcoded within the name, but that would require localization changes. I can look into that if you want, I just didn't feel it was worthwhile for something that deep into settings lol

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #777 
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [X Other (describe): label change

## Changes Made
List the key changes included in this PR.

- if moonbase seerr display name was set and non null/empty, use that displayname
- otherwise, just use l10n.seerr like before 
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
Before (ignore the back button placement, this screenshot is from an earlier build while I was working on the search screen stuff, point is this is what shows currently):
<img width="1950" height="1432" alt="Screenshot_20260711_214630" src="https://github.com/user-attachments/assets/7c4c9baf-370e-4e93-9804-c2498347c863" />

After (ooh, nice, fancy):
<img width="2770" height="1459" alt="Screenshot_20260711_213903" src="https://github.com/user-attachments/assets/250f11d0-03db-4982-9c03-fcbcef674706" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
