### PR TITLE
Bugfix - Fix artwork selector navigation on TVs

### DIFF
--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -1566,6 +1566,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
               focusNode: _gridBackFocusNode,
               borderRadius: 8,
               suppressFocusGlow: true,
+              semanticLabel: l10n.back,
               onSelect: () {
                 final categoryToFocus = _focusedCategory;
                 setState(() {
@@ -1651,11 +1652,10 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
                 res,
               ) {
                 final selected = _selectedResolution == res;
-                final index = ['All', 'High (1080p+)', 'Medium (720p)', 'Low (<720p)'].indexOf(res);
                 return Padding(
                   padding: const EdgeInsets.only(right: 8),
                   child: FocusableWrapper(
-                    focusNode: index == 0 ? _firstResolutionFocusNode : null,
+                    focusNode: res == 'All' ? _firstResolutionFocusNode : null,
                     borderRadius: 16,
                     suppressFocusGlow: true,
                     onSelect: () {
@@ -1664,7 +1664,8 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
                       });
                     },
                     onNavigateUp: () => _gridBackFocusNode.requestFocus(),
-                    onNavigateDown: () => _getFirstCardFocusNode(category).requestFocus(),
+                    onNavigateDown: () =>
+                        _getFirstCardFocusNode(category).requestFocus(),
                     child: ExcludeFocus(
                       child: ChoiceChip(
                         label: Text(_getResolutionDisplayName(res, l10n)),

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -68,6 +68,8 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
   final FocusNode _closeFocusNode = FocusNode();
   final FocusNode _seriesFocusNode = FocusNode();
   final FocusNode _seasonFocusNode = FocusNode();
+  final FocusNode _gridBackFocusNode = FocusNode();
+  final FocusNode _firstResolutionFocusNode = FocusNode();
 
   bool get _isLibraryFolder =>
       _item.type?.toLowerCase() == 'collectionfolder' ||
@@ -186,6 +188,8 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
     _closeFocusNode.dispose();
     _seriesFocusNode.dispose();
     _seasonFocusNode.dispose();
+    _gridBackFocusNode.dispose();
+    _firstResolutionFocusNode.dispose();
     for (final controller in _scrollControllers.values) {
       controller.dispose();
     }
@@ -1090,7 +1094,9 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
   }
 
   void _handleNavigateDownFromFilters() {
-    if (_supportedCategories.isNotEmpty) {
+    if (_focusedCategory != null) {
+      _gridBackFocusNode.requestFocus();
+    } else if (_supportedCategories.isNotEmpty) {
       _getHeaderFocusNode(_supportedCategories[0]).requestFocus();
     }
   }
@@ -1556,9 +1562,11 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
         Row(
           children: [
             const SizedBox(width: 8),
-            IconButton(
-              icon: const Icon(Icons.arrow_back),
-              onPressed: () {
+            FocusableWrapper(
+              focusNode: _gridBackFocusNode,
+              borderRadius: 8,
+              suppressFocusGlow: true,
+              onSelect: () {
                 final categoryToFocus = _focusedCategory;
                 setState(() {
                   _focusedCategory = null;
@@ -1569,6 +1577,13 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
                   });
                 }
               },
+              onNavigateUp: () => _getFirstFilterFocusNode().requestFocus(),
+              onNavigateDown: () => _firstResolutionFocusNode.requestFocus(),
+              onNavigateRight: () => _closeFocusNode.requestFocus(),
+              child: const Padding(
+                padding: EdgeInsets.all(8),
+                child: Icon(Icons.arrow_back),
+              ),
             ),
             const SizedBox(width: 8),
             Text(
@@ -1636,33 +1651,48 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
                 res,
               ) {
                 final selected = _selectedResolution == res;
+                final index = ['All', 'High (1080p+)', 'Medium (720p)', 'Low (<720p)'].indexOf(res);
                 return Padding(
                   padding: const EdgeInsets.only(right: 8),
-                  child: ChoiceChip(
-                    label: Text(_getResolutionDisplayName(res, l10n)),
-                    selected: selected,
-                    onSelected: (val) {
-                      if (val) {
-                        setState(() {
-                          _selectedResolution = res;
-                        });
-                      }
+                  child: FocusableWrapper(
+                    focusNode: index == 0 ? _firstResolutionFocusNode : null,
+                    borderRadius: 16,
+                    suppressFocusGlow: true,
+                    onSelect: () {
+                      setState(() {
+                        _selectedResolution = res;
+                      });
                     },
-                    selectedColor: AppColorScheme.onSurface.withValues(
-                      alpha: 0.2,
-                    ),
-                    backgroundColor: AppColorScheme.onSurface.withValues(
-                      alpha: 0.06,
-                    ),
-                    labelStyle: TextStyle(
-                      color: selected
-                          ? AppColorScheme.onSurface
-                          : AppColorScheme.onSurface.withValues(alpha: 0.5),
-                      fontSize: 12,
-                    ),
-                    side: BorderSide.none,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: AppRadius.circular(16),
+                    onNavigateUp: () => _gridBackFocusNode.requestFocus(),
+                    onNavigateDown: () => _getFirstCardFocusNode(category).requestFocus(),
+                    child: ExcludeFocus(
+                      child: ChoiceChip(
+                        label: Text(_getResolutionDisplayName(res, l10n)),
+                        selected: selected,
+                        onSelected: (val) {
+                          if (val) {
+                            setState(() {
+                              _selectedResolution = res;
+                            });
+                          }
+                        },
+                        selectedColor: AppColorScheme.onSurface.withValues(
+                          alpha: 0.2,
+                        ),
+                        backgroundColor: AppColorScheme.onSurface.withValues(
+                          alpha: 0.06,
+                        ),
+                        labelStyle: TextStyle(
+                          color: selected
+                              ? AppColorScheme.onSurface
+                              : AppColorScheme.onSurface.withValues(alpha: 0.5),
+                          fontSize: 12,
+                        ),
+                        side: BorderSide.none,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: AppRadius.circular(16),
+                        ),
+                      ),
                     ),
                   ),
                 );
@@ -1682,11 +1712,19 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
             ),
             itemCount: totalCount,
             itemBuilder: (context, i) {
+              final isFirst = (i == 0);
+              final cardNode = isFirst ? _getFirstCardFocusNode(category) : null;
+
               if (i < currentCount) {
                 if (currentTags.isEmpty) {
                   return Align(
                     alignment: Alignment.topCenter,
-                    child: _buildCurrentCard(category, null, dims),
+                    child: _buildCurrentCard(
+                      category,
+                      null,
+                      dims,
+                      focusNode: cardNode,
+                    ),
                   );
                 }
                 return Align(
@@ -1696,6 +1734,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
                     currentTags[i],
                     dims,
                     imageIndex: category == 'Backdrop' ? i : null,
+                    focusNode: cardNode,
                   ),
                 );
               }
@@ -1715,6 +1754,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
                   remoteImage,
                   dims,
                   isActionLoading,
+                  focusNode: cardNode,
                 ),
               );
             },


### PR DESCRIPTION
# Pull Request

## Summary
Fixes D-pad focus traversal inside the Change Artwork dialog on TVs, ensuring focus doesn't get trapped in the top filters row when the grid view is active.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Declared and disposed `_gridBackFocusNode` and `_firstResolutionFocusNode`.
- Updated `_handleNavigateDownFromFilters()` to request focus on the back button (`_gridBackFocusNode`) instead of list categories when the grid view is active.
- Wrapped the grid view back button in a `FocusableWrapper` with `_gridBackFocusNode`.
- Wrapped each resolution `ChoiceChip` inside a `FocusableWrapper` (with `ExcludeFocus` on the inner chip) to make it focusable on TV, linking the first chip to `_firstResolutionFocusNode`.
- Passed `_getFirstCardFocusNode(category)` to the first card in the grid view builder so focus navigates correctly to the grid.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on Android TV
- [ ] Not tested (explain why):

### Test Steps
1. Open the Change Artwork selector dialog on an Android TV device.
2. Select a category (e.g. Poster) to open its grid view.
3. Focus on the top row of filters (Sources, Language, Clear All).
4. Press DOWN on the D-pad and verify focus moves to the grid back button, then to the resolution chips, and finally down to the grid cards.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_02-07-37" src="https://github.com/user-attachments/assets/c01316b4-5db8-4457-973c-0f5e098b02cf" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
