### PR TITLE
bugfix - Fix Screensaver Library Art Mode database timeout

### DIFF
--- a/lib/ui/screensaver/screensaver_content_service.dart
+++ b/lib/ui/screensaver/screensaver_content_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
 
@@ -33,60 +35,56 @@ class ScreensaverContentService {
       final viewsResponse = await client.userViewsApi.getUserViews();
       final views = (viewsResponse['Items'] as List? ?? [])
           .cast<Map<String, dynamic>>();
+      // Movie and TV libraries by type, plus mixed-content libraries that
+      // report no CollectionType. Non-media views just return nothing.
       final targetLibraries = views.where((view) {
         final type = view['CollectionType'] as String? ?? '';
-        return type == 'movies' || type == 'tvshows';
+        return type == 'movies' || type == 'tvshows' || type.isEmpty;
       }).toList();
 
-      final List<Map<String, dynamic>> rawItems = [];
-
-      final random = DateTime.now().millisecondsSinceEpoch;
+      final random = Random();
       final sortByOptions = ['DateCreated', 'CommunityRating'];
       final sortOrderOptions = ['Descending', 'Ascending'];
+      final sortBy = sortByOptions[random.nextInt(sortByOptions.length)];
+      final sortOrder =
+          sortOrderOptions[random.nextInt(sortOrderOptions.length)];
+      final startIndex = [0, 30, 60, 90][random.nextInt(4)];
 
-      final sortBy = sortByOptions[random % sortByOptions.length];
-      final sortOrder = sortOrderOptions[(random ~/ 2) % sortOrderOptions.length];
-      final startIndex = [0, 30, 60, 90][(random ~/ 4) % 4];
-
+      final rawItems = <Map<String, dynamic>>[];
       if (targetLibraries.isNotEmpty) {
-        for (final lib in targetLibraries) {
-          final libId = lib['Id'] as String;
-          try {
-            final response = await client.itemsApi.getItems(
-              parentId: libId,
-              includeItemTypes: ['Movie', 'Series'],
-              sortBy: sortBy,
-              sortOrder: sortOrder,
-              recursive: true,
-              startIndex: startIndex,
-              limit: _batchSize,
-              fields: 'ImageTags,BackdropImageTags,OfficialRating',
-              enableTotalRecordCount: false,
-              enableImageTypes: 'Backdrop,Logo',
-              maxOfficialRating: maxAge == 'any' ? null : maxAge,
-              hasParentalRating: requireRating ? true : null,
-            );
-            final items = (response['Items'] as List? ?? [])
-                .cast<Map<String, dynamic>>();
-            rawItems.addAll(items);
-          } catch (_) {}
+        final results = await Future.wait(
+          targetLibraries.map((lib) async {
+            final libId = lib['Id'] as String?;
+            if (libId == null) return <Map<String, dynamic>>[];
+            try {
+              return await _fetchItems(
+                client,
+                parentId: libId,
+                sortBy: sortBy,
+                sortOrder: sortOrder,
+                startIndex: startIndex,
+                maxAge: maxAge,
+                requireRating: requireRating,
+              );
+            } catch (_) {
+              return <Map<String, dynamic>>[];
+            }
+          }),
+        );
+        for (final result in results) {
+          rawItems.addAll(result);
         }
       } else {
-        final response = await client.itemsApi.getItems(
-          includeItemTypes: ['Movie', 'Series'],
-          sortBy: sortBy,
-          sortOrder: sortOrder,
-          recursive: true,
-          limit: _batchSize,
-          fields: 'ImageTags,BackdropImageTags,OfficialRating',
-          enableTotalRecordCount: false,
-          enableImageTypes: 'Backdrop,Logo',
-          maxOfficialRating: maxAge == 'any' ? null : maxAge,
-          hasParentalRating: requireRating ? true : null,
+        rawItems.addAll(
+          await _fetchItems(
+            client,
+            sortBy: sortBy,
+            sortOrder: sortOrder,
+            startIndex: startIndex,
+            maxAge: maxAge,
+            requireRating: requireRating,
+          ),
         );
-        final items = (response['Items'] as List? ?? [])
-            .cast<Map<String, dynamic>>();
-        rawItems.addAll(items);
       }
 
       rawItems.shuffle();
@@ -103,7 +101,45 @@ class ScreensaverContentService {
     } catch (_) {
       return const [];
     }
-  }  ScreensaverItem? _toItem(
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchItems(
+    MediaServerClient client, {
+    String? parentId,
+    required String sortBy,
+    required String sortOrder,
+    required int startIndex,
+    required String maxAge,
+    required bool requireRating,
+  }) async {
+    Future<List<Map<String, dynamic>>> query(int start) async {
+      final response = await client.itemsApi.getItems(
+        parentId: parentId,
+        includeItemTypes: ['Movie', 'Series'],
+        sortBy: sortBy,
+        sortOrder: sortOrder,
+        recursive: true,
+        startIndex: start,
+        limit: _batchSize,
+        fields: 'ImageTags,BackdropImageTags,OfficialRating',
+        enableTotalRecordCount: false,
+        enableImageTypes: 'Backdrop,Logo',
+        maxOfficialRating: maxAge == 'any' ? null : maxAge,
+        hasParentalRating: requireRating ? true : null,
+      );
+      return (response['Items'] as List? ?? []).cast<Map<String, dynamic>>();
+    }
+
+    final items = await query(startIndex);
+    // A random offset can overshoot a small library and return nothing, so
+    // retry from the start to avoid an empty batch.
+    if (items.isEmpty && startIndex > 0) {
+      return query(0);
+    }
+    return items;
+  }
+
+  ScreensaverItem? _toItem(
     MediaServerClient client,
     Map<String, dynamic> raw, {
     required bool requireRating,

--- a/lib/ui/screensaver/screensaver_content_service.dart
+++ b/lib/ui/screensaver/screensaver_content_service.dart
@@ -30,20 +30,67 @@ class ScreensaverContentService {
     final maxAge = _prefs.get(UserPreferences.screensaverMaxAgeRating);
     final requireRating = _prefs.get(UserPreferences.screensaverRequireRating);
     try {
-      final response = await client.itemsApi.getItems(
-        includeItemTypes: ['Movie', 'Series'],
-        sortBy: 'Random',
-        sortOrder: 'Descending',
-        recursive: true,
-        limit: _batchSize,
-        fields: 'ImageTags,BackdropImageTags,OfficialRating',
-        enableTotalRecordCount: false,
-        enableImageTypes: 'Backdrop,Logo',
-        maxOfficialRating: maxAge == 'any' ? null : maxAge,
-        hasParentalRating: requireRating ? true : null,
-      );
-      final rawItems = (response['Items'] as List? ?? [])
+      final viewsResponse = await client.userViewsApi.getUserViews();
+      final views = (viewsResponse['Items'] as List? ?? [])
           .cast<Map<String, dynamic>>();
+      final targetLibraries = views.where((view) {
+        final type = view['CollectionType'] as String? ?? '';
+        return type == 'movies' || type == 'tvshows';
+      }).toList();
+
+      final List<Map<String, dynamic>> rawItems = [];
+
+      final random = DateTime.now().millisecondsSinceEpoch;
+      final sortByOptions = ['DateCreated', 'CommunityRating'];
+      final sortOrderOptions = ['Descending', 'Ascending'];
+
+      final sortBy = sortByOptions[random % sortByOptions.length];
+      final sortOrder = sortOrderOptions[(random ~/ 2) % sortOrderOptions.length];
+      final startIndex = [0, 30, 60, 90][(random ~/ 4) % 4];
+
+      if (targetLibraries.isNotEmpty) {
+        for (final lib in targetLibraries) {
+          final libId = lib['Id'] as String;
+          try {
+            final response = await client.itemsApi.getItems(
+              parentId: libId,
+              includeItemTypes: ['Movie', 'Series'],
+              sortBy: sortBy,
+              sortOrder: sortOrder,
+              recursive: true,
+              startIndex: startIndex,
+              limit: _batchSize,
+              fields: 'ImageTags,BackdropImageTags,OfficialRating',
+              enableTotalRecordCount: false,
+              enableImageTypes: 'Backdrop,Logo',
+              maxOfficialRating: maxAge == 'any' ? null : maxAge,
+              hasParentalRating: requireRating ? true : null,
+            );
+            final items = (response['Items'] as List? ?? [])
+                .cast<Map<String, dynamic>>();
+            rawItems.addAll(items);
+          } catch (_) {}
+        }
+      } else {
+        final response = await client.itemsApi.getItems(
+          includeItemTypes: ['Movie', 'Series'],
+          sortBy: sortBy,
+          sortOrder: sortOrder,
+          recursive: true,
+          limit: _batchSize,
+          fields: 'ImageTags,BackdropImageTags,OfficialRating',
+          enableTotalRecordCount: false,
+          enableImageTypes: 'Backdrop,Logo',
+          maxOfficialRating: maxAge == 'any' ? null : maxAge,
+          hasParentalRating: requireRating ? true : null,
+        );
+        final items = (response['Items'] as List? ?? [])
+            .cast<Map<String, dynamic>>();
+        rawItems.addAll(items);
+      }
+
+      rawItems.shuffle();
+
       final items = <ScreensaverItem>[];
       for (final raw in rawItems) {
         final item = _toItem(client, raw, requireRating: requireRating);
@@ -51,13 +98,12 @@ class ScreensaverContentService {
           items.add(item);
         }
       }
-      return items;
+
+      return items.take(_batchSize).toList();
     } catch (_) {
       return const [];
     }
-  }
-
-  ScreensaverItem? _toItem(
+  }  ScreensaverItem? _toItem(
     MediaServerClient client,
     Map<String, dynamic> raw, {
     required bool requireRating,


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the screensaver "Library Art" mode failing to display artwork due to server-side query timeouts on large or slower servers.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated `ScreensaverContentService.loadBatch` to fetch top-level library folders using `getUserViews()` first.
- Filtered views of type `movies` and `tvshows` to obtain library-specific `ParentId` constraints.
- Switched from slow `SortBy=Random` database queries to index-backed fast sorting methods (`DateCreated` and `CommunityRating`) with randomized sorting orders and starting index offsets.
- Combined the retrieved items, shuffled them locally in-memory, and returned the desired batch size.
- Added a fallback to a server-wide query if no target movie/show libraries are found.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV/Shiedld
- [ ] Not tested (explain why):

### Test Steps
1. Enable Screensaver -> Library Art mode in Settings.
2. Verify that the screensaver successfully downloads and displays slideshow backdrops and logos from the media libraries without timing out or failing.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_03-12-33" src="https://github.com/user-attachments/assets/c86aa512-df37-4c09-ba04-f2b0ae833e06" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
