### PR TITLE
add timeout for voice search permission banner

### DIFF
--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -529,7 +529,7 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
   void _showVoiceSearchError(
     String message, {
     bool showSettingsAction = false,
-  }) {
+  }) async {
     if (!mounted) return;
 
     final messenger = ScaffoldMessenger.of(context);
@@ -547,6 +547,9 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
             : null,
       ),
     );
+
+    await Future.delayed(const Duration(seconds: 5));
+    messenger.hideCurrentSnackBar();
   }
 
   KeyEventResult _onVoiceKey(FocusNode node, KeyEvent event) {

--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -534,7 +534,7 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
 
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
+    final controller = messenger.showSnackBar(
       SnackBar(
         content: Text(message),
         action: showSettingsAction
@@ -548,8 +548,10 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
       ),
     );
 
+    // A screen reader can keep the snackbar from auto-dismissing, so close this
+    // specific snackbar after a delay rather than whatever is current then.
     await Future.delayed(const Duration(seconds: 5));
-    messenger.hideCurrentSnackBar();
+    controller.close();
   }
 
   KeyEventResult _onVoiceKey(FocusNode node, KeyEvent event) {


### PR DESCRIPTION
# Pull Request

## Summary
add 5 second timeout for voice search error snackbar

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- after it makes the snackbar for voice search error, wait 5 seconds
- hide the snackbar
- make the function async so it'll accept a delay function being called

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
