### PR TITLE
feat-ui - Add Show Technical Details option to Details screens

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1742,7 +1742,9 @@ class PluginSyncService extends ChangeNotifier {
           _prefs.get(UserPreferences.recommendationSystemSource).name,
       'detailScreenStyle': _prefs.get(UserPreferences.detailScreenStyle).name,
       'detailExpandedTabs': _prefs.get(UserPreferences.detailExpandedTabs),
-      'detailShowTechnicalDetails': _prefs.get(UserPreferences.detailShowTechnicalDetails),
+      'detailShowTechnicalDetails': _prefs.get(
+        UserPreferences.detailShowTechnicalDetails,
+      ),
       'homeImageTypeContinueWatching': _prefs
           .get(UserPreferences.homeRowImageType(prefs.HomeSectionType.resume))
           .name,

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1081,6 +1081,11 @@ class PluginSyncService extends ChangeNotifier {
       );
       _applyBool(
         resolved,
+        'detailShowTechnicalDetails',
+        UserPreferences.detailShowTechnicalDetails,
+      );
+      _applyBool(
+        resolved,
         'fullScreenRows',
         UserPreferences.fullScreenRows,
       );
@@ -1737,6 +1742,7 @@ class PluginSyncService extends ChangeNotifier {
           _prefs.get(UserPreferences.recommendationSystemSource).name,
       'detailScreenStyle': _prefs.get(UserPreferences.detailScreenStyle).name,
       'detailExpandedTabs': _prefs.get(UserPreferences.detailExpandedTabs),
+      'detailShowTechnicalDetails': _prefs.get(UserPreferences.detailShowTechnicalDetails),
       'homeImageTypeContinueWatching': _prefs
           .get(UserPreferences.homeRowImageType(prefs.HomeSectionType.resume))
           .name,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -212,6 +212,14 @@
   "@expandedTabsSubtitle": {
     "description": "Explanation under the expanded tabs setting"
   },
+  "showTechnicalDetails": "Show Technical Details?",
+  "@showTechnicalDetails": {
+    "description": "Label for the detail screen setting to show stream/codec technical details"
+  },
+  "showTechnicalDetailsSubtitle": "Show codec, resolution, and stream information in banner summary",
+  "@showTechnicalDetailsSubtitle": {
+    "description": "Explanation under the show technical details setting"
+  },
   "recommendationSystem": "Recommendation System",
   "@recommendationSystem": {
     "description": "Label for the Recommendation System setting"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -496,6 +496,18 @@ abstract class AppLocalizations {
   /// **'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.'**
   String get expandedTabsSubtitle;
 
+  /// Label for the detail screen setting to show stream/codec technical details
+  ///
+  /// In en, this message translates to:
+  /// **'Show Technical Details?'**
+  String get showTechnicalDetails;
+
+  /// Explanation under the show technical details setting
+  ///
+  /// In en, this message translates to:
+  /// **'Show codec, resolution, and stream information in banner summary'**
+  String get showTechnicalDetailsSubtitle;
+
   /// Label for the Recommendation System setting
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -161,6 +161,13 @@ class AppLocalizationsAf extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -161,6 +161,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -161,6 +161,13 @@ class AppLocalizationsBe extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -161,6 +161,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -161,6 +161,13 @@ class AppLocalizationsBn extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -161,6 +161,13 @@ class AppLocalizationsCa extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Sistema de recomanacions';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -162,6 +162,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -161,6 +161,13 @@ class AppLocalizationsCy extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -163,6 +163,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -161,6 +161,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -163,6 +163,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -161,6 +161,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -161,6 +161,13 @@ class AppLocalizationsEo extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -161,6 +161,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -162,6 +162,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -161,6 +161,13 @@ class AppLocalizationsFa extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -163,6 +163,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -161,6 +161,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Système de recommandation';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -161,6 +161,13 @@ class AppLocalizationsGl extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -161,6 +161,13 @@ class AppLocalizationsHe extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -161,6 +161,13 @@ class AppLocalizationsHi extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -161,6 +161,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -161,6 +161,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Lapok tartalmának automatikus megjelenítése a lapok böngészése közben. Kapcsold ki az egyes lapok kézi megnyitásához és bezárásához.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Ajánlórendszer';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -162,6 +162,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -161,6 +161,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Sistema di raccomandazione';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -160,6 +160,13 @@ class AppLocalizationsJa extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -161,6 +161,13 @@ class AppLocalizationsKk extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -161,6 +161,13 @@ class AppLocalizationsKn extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -160,6 +160,13 @@ class AppLocalizationsKo extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -161,6 +161,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -161,6 +161,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -161,6 +161,13 @@ class AppLocalizationsMk extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -161,6 +161,13 @@ class AppLocalizationsMl extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -161,6 +161,13 @@ class AppLocalizationsMn extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -161,6 +161,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -162,6 +162,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -161,6 +161,13 @@ class AppLocalizationsPa extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -162,6 +162,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -161,6 +161,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -161,6 +161,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -161,6 +161,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -161,6 +161,13 @@ class AppLocalizationsSi extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -162,6 +162,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -162,6 +162,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -162,6 +162,13 @@ class AppLocalizationsSq extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -161,6 +161,13 @@ class AppLocalizationsSr extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -161,6 +161,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -161,6 +161,13 @@ class AppLocalizationsSw extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -161,6 +161,13 @@ class AppLocalizationsTa extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -161,6 +161,13 @@ class AppLocalizationsTe extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -162,6 +162,13 @@ class AppLocalizationsTh extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -162,6 +162,13 @@ class AppLocalizationsTl extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -161,6 +161,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Sekmeler arasında gezinirken sekme içeriğini otomatik olarak göster. Her sekmeyi manuel olarak açıp kapatmak için bu seçeneği kapatın.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Öneri Sistemi';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -161,6 +161,13 @@ class AppLocalizationsUg extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -161,6 +161,13 @@ class AppLocalizationsUk extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -161,6 +161,13 @@ class AppLocalizationsVi extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -160,6 +160,13 @@ class AppLocalizationsYue extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => 'Recommendation System';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -159,6 +159,13 @@ class AppLocalizationsZh extends AppLocalizations {
       'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
+  String get showTechnicalDetails => 'Show Technical Details?';
+
+  @override
+  String get showTechnicalDetailsSubtitle =>
+      'Show codec, resolution, and stream information in banner summary';
+
+  @override
   String get recommendationSystem => '推荐系统';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -886,6 +886,13 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: true,
   );
 
+  /// When on, the modern detail screen shows codec and stream technical details.
+  /// Global like [detailScreenStyle], so it is deliberately omitted from [_scopedPreferenceKeys].
+  static final detailShowTechnicalDetails = Preference(
+    key: 'pref_detail_show_technical_details',
+    defaultValue: false,
+  );
+
   /// Algorithm source for the similar items recommendation system. Global
   /// (not scoped per server/user), so it is deliberately omitted from [_scopedPreferenceKeys].
   static final recommendationSystemSource = EnumPreference(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4140,23 +4140,29 @@ class DetailMetadataRow extends StatelessWidget {
       parts.add(_badge(theme, item.officialRating!));
     }
 
-    final sizeBytes =
-        selectedMediaSource?['Size'] as int? ??
-        (item.mediaSources.isNotEmpty
-            ? item.mediaSources.first['Size'] as int?
-            : null);
-    if (sizeBytes != null &&
-        sizeBytes > 0 &&
-        item.type != 'Series' &&
-        item.type != 'Season') {
-      final double mb = sizeBytes / (1024 * 1024);
-      final String formattedSize;
-      if (mb > 999) {
-        formattedSize = '${(mb / 1024).toStringAsFixed(2)} GB';
-      } else {
-        formattedSize = '${mb.toStringAsFixed(0)} MB';
+    final showTech = GetIt.instance<UserPreferences>().get(
+      UserPreferences.detailShowTechnicalDetails,
+    );
+
+    if (showTech) {
+      final sizeBytes =
+          selectedMediaSource?['Size'] as int? ??
+          (item.mediaSources.isNotEmpty
+              ? item.mediaSources.first['Size'] as int?
+              : null);
+      if (sizeBytes != null &&
+          sizeBytes > 0 &&
+          item.type != 'Series' &&
+          item.type != 'Season') {
+        final double mb = sizeBytes / (1024 * 1024);
+        final String formattedSize;
+        if (mb > 999) {
+          formattedSize = '${(mb / 1024).toStringAsFixed(2)} GB';
+        } else {
+          formattedSize = '${mb.toStringAsFixed(0)} MB';
+        }
+        parts.add(_text(theme, formattedSize));
       }
-      parts.add(_text(theme, formattedSize));
     }
 
     final runtime = _runtimeForItem(item, selectedMediaSource);
@@ -4211,21 +4217,23 @@ class DetailMetadataRow extends StatelessWidget {
       }
     }
 
-    final streams = _mediaStreamsForItem(item, selectedMediaSource);
+    final streams = mediaStreamsForItem(item, selectedMediaSource);
     final badges = <String>[];
-    final res = _resolutionFromStreams(streams) ?? item.videoResolution;
-    if (res != null) badges.add(res);
-    final hdr = _hdrFromStreams(streams) ?? item.hdrType;
-    if (hdr != null) badges.add(hdr);
-    final vcodec =
-        _codecFromStreams(streams, 'Video') ?? item.videoCodec?.toUpperCase();
-    if (vcodec != null) badges.add(vcodec);
-    final acodec =
-        _audioLabelFromStreams(streams) ??
-        audioLabelFromProfileCodec(item.audioProfile, item.audioCodec);
-    if (acodec != null) badges.add(acodec);
-    final layout = _channelLayoutFromStreams(streams) ?? item.channelLayout;
-    if (layout != null) badges.add(layout);
+    if (showTech) {
+      final res = resolutionFromStreams(streams) ?? item.videoResolution;
+      if (res != null) badges.add(res);
+      final hdr = hdrFromStreams(streams) ?? item.hdrType;
+      if (hdr != null) badges.add(hdr);
+      final vcodec =
+          codecFromStreams(streams, 'Video') ?? item.videoCodec?.toUpperCase();
+      if (vcodec != null) badges.add(vcodec);
+      final acodec =
+          audioLabelFromStreams(streams) ??
+          audioLabelFromProfileCodec(item.audioProfile, item.audioCodec);
+      if (acodec != null) badges.add(acodec);
+      final layout = channelLayoutFromStreams(streams) ?? item.channelLayout;
+      if (layout != null) badges.add(layout);
+    }
 
     final compact = !_useDesktopDetailLayout(context);
 
@@ -5662,7 +5670,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         resolution.mediaStreams.isNotEmpty) {
       return resolution.mediaStreams;
     }
-    return _mediaStreamsForItem(item, selectedSource);
+    return mediaStreamsForItem(item, selectedSource);
   }
 
   void _openSubtitleSelector(BuildContext context, AggregatedItem item) {
@@ -5837,7 +5845,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       item,
       widget.selectedMediaSourceId,
     );
-    final mediaStreams = _mediaStreamsForItem(item, selectedSource);
+    final mediaStreams = mediaStreamsForItem(item, selectedSource);
     final subtitleStreams = mediaStreams
         .where((s) => s['Type'] == 'Subtitle')
         .toList();
@@ -7916,7 +7924,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       item,
       widget.selectedMediaSourceId,
     );
-    return _mediaStreamsForItem(item, selectedSource);
+    return mediaStreamsForItem(item, selectedSource);
   }
 
   bool _hasTrailer(AggregatedItem item) {
@@ -8244,7 +8252,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           refreshedItem,
           widget.selectedMediaSourceId,
         );
-        latestStreams = _mediaStreamsForItem(refreshedItem, mediaSource)
+        latestStreams = mediaStreamsForItem(refreshedItem, mediaSource)
             .where((stream) => stream['Type'] == 'Subtitle')
             .toList(growable: false);
         final hasNewStream = latestStreams.any((stream) {
@@ -8559,7 +8567,7 @@ Map<String, dynamic>? selectedMediaSourceForItem(
   return item.mediaSources.first;
 }
 
-List<Map<String, dynamic>> _mediaStreamsForItem(
+List<Map<String, dynamic>> mediaStreamsForItem(
   AggregatedItem item,
   Map<String, dynamic>? mediaSource,
 ) {
@@ -8666,7 +8674,7 @@ Future<bool> _runWithDolbyVisionStartupFallbackPrompt(
 
   for (final item in queue) {
     final selectedSource = selectedMediaSourceForItem(item, mediaSourceId);
-    final streams = _mediaStreamsForItem(item, selectedSource);
+    final streams = mediaStreamsForItem(item, selectedSource);
     for (final stream in streams) {
       if (!hasDolbyVision &&
           HdrStreamCapability.isDolbyVisionVideoStream(stream)) {
@@ -8856,7 +8864,7 @@ String? _endsAt(
   return '$h12:$minute $amPm';
 }
 
-String? _resolutionFromStreams(List<Map<String, dynamic>> streams) {
+String? resolutionFromStreams(List<Map<String, dynamic>> streams) {
   final video = streams.where((s) => s['Type'] == 'Video').firstOrNull;
   if (video == null) {
     return null;
@@ -8879,7 +8887,7 @@ String? _resolutionFromStreams(List<Map<String, dynamic>> streams) {
   return 'SD';
 }
 
-String? _hdrFromStreams(List<Map<String, dynamic>> streams) {
+String? hdrFromStreams(List<Map<String, dynamic>> streams) {
   final video = streams.where((s) => s['Type'] == 'Video').firstOrNull;
   if (video == null) {
     return null;
@@ -8891,7 +8899,7 @@ String? _hdrFromStreams(List<Map<String, dynamic>> streams) {
   return hdr.toUpperCase();
 }
 
-String? _audioLabelFromStreams(List<Map<String, dynamic>> streams) {
+String? audioLabelFromStreams(List<Map<String, dynamic>> streams) {
   final audio = streams.where((s) => s['Type'] == 'Audio').firstOrNull;
   if (audio == null) return null;
   return audioLabelFromProfileCodec(
@@ -8900,7 +8908,7 @@ String? _audioLabelFromStreams(List<Map<String, dynamic>> streams) {
   );
 }
 
-String? _codecFromStreams(
+String? codecFromStreams(
   List<Map<String, dynamic>> streams,
   String streamType,
 ) {
@@ -8912,7 +8920,7 @@ String? _codecFromStreams(
   return codec.toUpperCase();
 }
 
-String? _channelLayoutFromStreams(List<Map<String, dynamic>> streams) {
+String? channelLayoutFromStreams(List<Map<String, dynamic>> streams) {
   final audio = streams.where((s) => s['Type'] == 'Audio').firstOrNull;
   if (audio == null) {
     return null;

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4143,26 +4143,12 @@ class DetailMetadataRow extends StatelessWidget {
     final showTech = GetIt.instance<UserPreferences>().get(
       UserPreferences.detailShowTechnicalDetails,
     );
+    final tech = showTech
+        ? technicalDetailsFor(item, selectedMediaSource)
+        : null;
 
-    if (showTech) {
-      final sizeBytes =
-          selectedMediaSource?['Size'] as int? ??
-          (item.mediaSources.isNotEmpty
-              ? item.mediaSources.first['Size'] as int?
-              : null);
-      if (sizeBytes != null &&
-          sizeBytes > 0 &&
-          item.type != 'Series' &&
-          item.type != 'Season') {
-        final double mb = sizeBytes / (1024 * 1024);
-        final String formattedSize;
-        if (mb > 999) {
-          formattedSize = '${(mb / 1024).toStringAsFixed(2)} GB';
-        } else {
-          formattedSize = '${mb.toStringAsFixed(0)} MB';
-        }
-        parts.add(_text(theme, formattedSize));
-      }
+    if (tech?.formattedSize != null) {
+      parts.add(_text(theme, tech!.formattedSize!));
     }
 
     final runtime = _runtimeForItem(item, selectedMediaSource);
@@ -4217,23 +4203,7 @@ class DetailMetadataRow extends StatelessWidget {
       }
     }
 
-    final streams = mediaStreamsForItem(item, selectedMediaSource);
-    final badges = <String>[];
-    if (showTech) {
-      final res = resolutionFromStreams(streams) ?? item.videoResolution;
-      if (res != null) badges.add(res);
-      final hdr = hdrFromStreams(streams) ?? item.hdrType;
-      if (hdr != null) badges.add(hdr);
-      final vcodec =
-          codecFromStreams(streams, 'Video') ?? item.videoCodec?.toUpperCase();
-      if (vcodec != null) badges.add(vcodec);
-      final acodec =
-          audioLabelFromStreams(streams) ??
-          audioLabelFromProfileCodec(item.audioProfile, item.audioCodec);
-      if (acodec != null) badges.add(acodec);
-      final layout = channelLayoutFromStreams(streams) ?? item.channelLayout;
-      if (layout != null) badges.add(layout);
-    }
+    final badges = tech?.badges ?? const <String>[];
 
     final compact = !_useDesktopDetailLayout(context);
 
@@ -8918,6 +8888,48 @@ String? codecFromStreams(
     return null;
   }
   return codec.toUpperCase();
+}
+
+/// Formatted file size and technical stream badges (resolution, HDR, video and
+/// audio codec, channel layout) for an item, shared by the classic and modern
+/// detail layouts.
+({String? formattedSize, List<String> badges}) technicalDetailsFor(
+  AggregatedItem item,
+  Map<String, dynamic>? selectedMediaSource,
+) {
+  final streams = mediaStreamsForItem(item, selectedMediaSource);
+  final badges = <String>[];
+  final res = resolutionFromStreams(streams) ?? item.videoResolution;
+  if (res != null) badges.add(res);
+  final hdr = hdrFromStreams(streams) ?? item.hdrType;
+  if (hdr != null) badges.add(hdr);
+  final vcodec =
+      codecFromStreams(streams, 'Video') ?? item.videoCodec?.toUpperCase();
+  if (vcodec != null) badges.add(vcodec);
+  final acodec =
+      audioLabelFromStreams(streams) ??
+      audioLabelFromProfileCodec(item.audioProfile, item.audioCodec);
+  if (acodec != null) badges.add(acodec);
+  final layout = channelLayoutFromStreams(streams) ?? item.channelLayout;
+  if (layout != null) badges.add(layout);
+
+  final sizeBytes =
+      selectedMediaSource?['Size'] as int? ??
+      (item.mediaSources.isNotEmpty
+          ? item.mediaSources.first['Size'] as int?
+          : null);
+  String? formattedSize;
+  if (sizeBytes != null &&
+      sizeBytes > 0 &&
+      item.type != 'Series' &&
+      item.type != 'Season') {
+    final double mb = sizeBytes / (1024 * 1024);
+    formattedSize = mb > 999
+        ? '${(mb / 1024).toStringAsFixed(2)} GB'
+        : '${mb.toStringAsFixed(0)} MB';
+  }
+
+  return (formattedSize: formattedSize, badges: badges);
 }
 
 String? channelLayoutFromStreams(List<Map<String, dynamic>> streams) {

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -21,7 +21,6 @@ import '../../../../preference/preference_constants.dart';
 import '../../../../util/overview_text.dart';
 import '../../../../util/platform_detection.dart';
 import '../../../../util/focus/dpad_keys.dart';
-import '../../../../util/audio_labels.dart';
 import '../../../navigation/destinations.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/media_card.dart';
@@ -49,12 +48,7 @@ import '../item_detail_screen.dart'
         FilmographyRow,
         SeerrAppearancesRow,
         SeerrCrewCreditsRow,
-        mediaStreamsForItem,
-        resolutionFromStreams,
-        hdrFromStreams,
-        codecFromStreams,
-        audioLabelFromStreams,
-        channelLayoutFromStreams;
+        technicalDetailsFor;
 import 'modern_landscape_layout.dart';
 import 'modern_portrait_layout.dart';
 import 'widgets/details_tab_bar.dart';
@@ -3859,44 +3853,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final muted = AppColorScheme.onSurface.withValues(alpha: 0.75);
     final style = theme.textTheme.bodyMedium?.copyWith(color: muted);
 
-    final streams = mediaStreamsForItem(item, selectedMediaSource);
-    final badges = <String>[];
-    final res = resolutionFromStreams(streams) ?? item.videoResolution;
-    if (res != null) badges.add(res);
-    final hdr = hdrFromStreams(streams) ?? item.hdrType;
-    if (hdr != null) badges.add(hdr);
-    final vcodec =
-        codecFromStreams(streams, 'Video') ?? item.videoCodec?.toUpperCase();
-    if (vcodec != null) badges.add(vcodec);
-    final acodec =
-        audioLabelFromStreams(streams) ??
-        audioLabelFromProfileCodec(item.audioProfile, item.audioCodec);
-    if (acodec != null) badges.add(acodec);
-    final layout = channelLayoutFromStreams(streams) ?? item.channelLayout;
-    if (layout != null) badges.add(layout);
-
-    final sizeBytes =
-        selectedMediaSource?['Size'] as int? ??
-        (item.mediaSources.isNotEmpty
-            ? item.mediaSources.first['Size'] as int?
-            : null);
+    final tech = technicalDetailsFor(item, selectedMediaSource);
+    final badges = tech.badges;
 
     final pieces = <Widget>[];
 
-    if (sizeBytes != null &&
-        sizeBytes > 0 &&
-        item.type != 'Series' &&
-        item.type != 'Season') {
-      final double mb = sizeBytes / (1024 * 1024);
-      final String formattedSize;
-      if (mb > 999) {
-        formattedSize = '${(mb / 1024).toStringAsFixed(2)} GB';
-      } else {
-        formattedSize = '${mb.toStringAsFixed(0)} MB';
-      }
+    if (tech.formattedSize != null) {
       pieces.add(
         Text(
-          formattedSize,
+          tech.formattedSize!,
           style: style?.copyWith(
             fontWeight: FontWeight.w700,
             shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -21,6 +21,7 @@ import '../../../../preference/preference_constants.dart';
 import '../../../../util/overview_text.dart';
 import '../../../../util/platform_detection.dart';
 import '../../../../util/focus/dpad_keys.dart';
+import '../../../../util/audio_labels.dart';
 import '../../../navigation/destinations.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/media_card.dart';
@@ -47,7 +48,13 @@ import '../item_detail_screen.dart'
         PersonDates,
         FilmographyRow,
         SeerrAppearancesRow,
-        SeerrCrewCreditsRow;
+        SeerrCrewCreditsRow,
+        mediaStreamsForItem,
+        resolutionFromStreams,
+        hdrFromStreams,
+        codecFromStreams,
+        audioLabelFromStreams,
+        channelLayoutFromStreams;
 import 'modern_landscape_layout.dart';
 import 'modern_portrait_layout.dart';
 import 'widgets/details_tab_bar.dart';
@@ -3439,6 +3446,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
 
     final selectedSource = selectedMediaSourceForItem(item, widget.selectedMediaSourceId);
+    final showTech = widget.prefs.get(UserPreferences.detailShowTechnicalDetails);
+    final techRow = showTech ? _buildTechnicalDetailsRow(context, item, selectedSource) : null;
 
     final Column childrenCol = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -3576,6 +3585,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ],
           const SizedBox(height: 6),
           _metadataRow(context, item, selectedSource),
+          if (techRow != null) ...[
+            const SizedBox(height: 6),
+            techRow,
+          ],
           if (showRatings) ...[
             const SizedBox(height: 6),
             RatingsRow(
@@ -3638,7 +3651,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             ),
           ),
         ],
-        const SizedBox(height: 24),
+        SizedBox(height: techRow != null ? 12 : 24),
         Focus(
           canRequestFocus: false,
           skipTraversal: true,
@@ -3807,6 +3820,117 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               fontWeight: FontWeight.w600,
             ),
       ),
+    );
+  }
+
+  Widget _techChip(ThemeData theme, String label) {
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        border: Border.fromBorderSide(
+          ThemeRegistry.active.borders.chipBorder.copyWith(
+            color: isNeon
+                ? AppColorScheme.accent.withValues(alpha: 0.7)
+                : Colors.white.withValues(alpha: 0.3),
+          ),
+        ),
+        borderRadius: AppRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: isNeon
+              ? AppColorScheme.onSurface
+              : Colors.white.withValues(alpha: 0.8),
+          shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
+        ),
+      ),
+    );
+  }
+
+  Widget? _buildTechnicalDetailsRow(
+    BuildContext context,
+    AggregatedItem item,
+    Map<String, dynamic>? selectedMediaSource,
+  ) {
+    final theme = Theme.of(context);
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final muted = AppColorScheme.onSurface.withValues(alpha: 0.75);
+    final style = theme.textTheme.bodyMedium?.copyWith(color: muted);
+
+    final streams = mediaStreamsForItem(item, selectedMediaSource);
+    final badges = <String>[];
+    final res = resolutionFromStreams(streams) ?? item.videoResolution;
+    if (res != null) badges.add(res);
+    final hdr = hdrFromStreams(streams) ?? item.hdrType;
+    if (hdr != null) badges.add(hdr);
+    final vcodec =
+        codecFromStreams(streams, 'Video') ?? item.videoCodec?.toUpperCase();
+    if (vcodec != null) badges.add(vcodec);
+    final acodec =
+        audioLabelFromStreams(streams) ??
+        audioLabelFromProfileCodec(item.audioProfile, item.audioCodec);
+    if (acodec != null) badges.add(acodec);
+    final layout = channelLayoutFromStreams(streams) ?? item.channelLayout;
+    if (layout != null) badges.add(layout);
+
+    final sizeBytes =
+        selectedMediaSource?['Size'] as int? ??
+        (item.mediaSources.isNotEmpty
+            ? item.mediaSources.first['Size'] as int?
+            : null);
+
+    final pieces = <Widget>[];
+
+    if (sizeBytes != null &&
+        sizeBytes > 0 &&
+        item.type != 'Series' &&
+        item.type != 'Season') {
+      final double mb = sizeBytes / (1024 * 1024);
+      final String formattedSize;
+      if (mb > 999) {
+        formattedSize = '${(mb / 1024).toStringAsFixed(2)} GB';
+      } else {
+        formattedSize = '${mb.toStringAsFixed(0)} MB';
+      }
+      pieces.add(
+        Text(
+          formattedSize,
+          style: style?.copyWith(
+            fontWeight: FontWeight.w700,
+            shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
+          ),
+        ),
+      );
+    }
+
+    if (badges.isNotEmpty) {
+      if (pieces.isNotEmpty) {
+        pieces.add(
+          Text(
+            ' · ',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: isNeon
+                  ? AppColorScheme.onSurface.withValues(alpha: 0.6)
+                  : Colors.white.withValues(alpha: 0.5),
+              shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
+            ),
+          ),
+        );
+      }
+      pieces.addAll(
+        badges.map((b) => _techChip(theme, b)),
+      );
+    }
+
+    if (pieces.isEmpty) return null;
+
+    return Wrap(
+      crossAxisAlignment: WrapCrossAlignment.center,
+      spacing: 8,
+      runSpacing: 6,
+      children: pieces,
     );
   }
 

--- a/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
+++ b/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
@@ -68,6 +68,13 @@ class _DetailsScreenSettingsScreenState
                       icon: Icons.tab,
                       onChanged: _pushPersonalizationSync,
                     ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.detailShowTechnicalDetails,
+                      title: l10n.showTechnicalDetails,
+                      subtitle: l10n.showTechnicalDetailsSubtitle,
+                      icon: Icons.info_outline,
+                      onChanged: _pushPersonalizationSync,
+                    ),
                 ],
               ),
             ],


### PR DESCRIPTION
# Pull Request

## Summary
This pull request introduces a new user preference setting "Show Technical Details?" (default: OFF) that displays file size and stream technical details (resolution, HDR type, video codec, audio profile/codec, and channel layout) in the banner metadata summary. This toggle is visible unconditionally on the details settings page and applies to both the Classic (original) and Modern detail screen layouts.

## Related Issues
Link related issues or tickets separated by commas.

Discord feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **User Preferences**: Added `detailShowTechnicalDetails` preference defaulting to `false` in `UserPreferences`.
- **Sync Support**: Added serialization and deserialization mapping for the setting in `PluginSyncService`.
- **Localization**: Added `showTechnicalDetails` and `showTechnicalDetailsSubtitle` labels to `app_en.arb`.
- **Settings Screen**: Added a setting tile for the preference in the details settings panel, visible unconditionally.
- **Classic Details Layout**: Modified `DetailMetadataRow` to hide/show size and technical stream badges based on the toggle.
- **Modern Details Layout**: Integrated a responsive technical details row and adjusted vertical margins/spacing when enabled.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV
- [ ] Not tested (explain why):

### Test Steps
1. Go to Settings -> Details Screen.
2. Toggle "Show Technical Details?" to ON.
3. Open any Media Detail screen (Classic or Modern).
4. Verify the file size and technical media chips (1080p, SDR, H264, etc.) are visible.
5. Turn the toggle OFF and verify the layout hides them cleanly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Modern Details
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_11-41-04" src="https://github.com/user-attachments/assets/5915ec0b-a530-4878-b5dc-c71c2616d1d1" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_11-41-11" src="https://github.com/user-attachments/assets/7b11ce1b-bfb1-45f7-b43a-8d059719ec58" />

### Classic Details
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_11-41-27" src="https://github.com/user-attachments/assets/7b92bbf2-5473-4c2e-9e70-ac25b5e2a9d9" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_11-41-38" src="https://github.com/user-attachments/assets/ed5f7ec6-af0a-48ee-a107-efa663c45674" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
