### PR TITLE
bugfix-subs - Fix PGS and ASS Subtitle Positioning

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -470,7 +470,15 @@ class Media3VideoView(
             FrameLayout.LayoutParams.MATCH_PARENT,
         )
         container.addView(videoView, videoLayoutParams)
-        container.addView(firstFrameCover, subtitleLayoutParams)
+        // The cover keeps its own params so resizing the subtitle canvas to the
+        // active video box never shrinks the full-frame cover.
+        container.addView(
+            firstFrameCover,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            ),
+        )
         container.addView(subtitleView, subtitleLayoutParams)
     }
     private val isLowRamDevice = context.getSystemService<ActivityManager>()?.isLowRamDevice == true
@@ -2208,32 +2216,30 @@ class Media3VideoView(
     }
 
     private fun applyVideoLayout() {
-        val videoParams = videoView.layoutParams as? FrameLayout.LayoutParams
-        val subtitleParams = subtitleView.layoutParams as? FrameLayout.LayoutParams
+        val videoLayoutParams = videoView.layoutParams as? FrameLayout.LayoutParams
+            ?: FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                Gravity.CENTER,
+            )
+        val subtitleLayoutParams = subtitleView.layoutParams as? FrameLayout.LayoutParams
+            ?: FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                Gravity.CENTER,
+            )
 
-        val videoLayoutParams = videoParams ?: FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            Gravity.CENTER,
-        )
-        val subtitleLayoutParams = subtitleParams ?: FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            Gravity.CENTER,
-        )
+        // Keep the subtitle canvas aligned to the active video box so PGS cues
+        // and the ASS overlay position against the video, not the full frame.
+        fun applyBounds(width: Int, height: Int) {
+            applyLayoutBounds(videoView, videoLayoutParams, width, height)
+            applyLayoutBounds(subtitleView, subtitleLayoutParams, width, height)
+        }
 
         if (zoomMode == ZoomMode.STRETCH) {
-            updateLayoutParams(
-                view = videoView,
-                layoutParams = videoLayoutParams,
-                width = FrameLayout.LayoutParams.MATCH_PARENT,
-                height = FrameLayout.LayoutParams.MATCH_PARENT,
-            )
-            updateLayoutParams(
-                view = subtitleView,
-                layoutParams = subtitleLayoutParams,
-                width = FrameLayout.LayoutParams.MATCH_PARENT,
-                height = FrameLayout.LayoutParams.MATCH_PARENT,
+            applyBounds(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
             )
             return
         }
@@ -2243,17 +2249,9 @@ class Media3VideoView(
         val sourceWidth = videoWidthPx.toFloat() * videoPixelRatio
         val sourceHeight = videoHeightPx.toFloat()
         if (containerWidth <= 0 || containerHeight <= 0 || sourceWidth <= 0f || sourceHeight <= 0f) {
-            updateLayoutParams(
-                view = videoView,
-                layoutParams = videoLayoutParams,
-                width = FrameLayout.LayoutParams.MATCH_PARENT,
-                height = FrameLayout.LayoutParams.MATCH_PARENT,
-            )
-            updateLayoutParams(
-                view = subtitleView,
-                layoutParams = subtitleLayoutParams,
-                width = FrameLayout.LayoutParams.MATCH_PARENT,
-                height = FrameLayout.LayoutParams.MATCH_PARENT,
+            applyBounds(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
             )
             return
         }
@@ -2288,24 +2286,13 @@ class Media3VideoView(
             ZoomMode.STRETCH -> FrameLayout.LayoutParams.MATCH_PARENT to FrameLayout.LayoutParams.MATCH_PARENT
         }
 
-        val targetWidth = targetSize.first.coerceAtLeast(1)
-        val targetHeight = targetSize.second.coerceAtLeast(1)
-
-        updateLayoutParams(
-            view = videoView,
-            layoutParams = videoLayoutParams,
-            width = targetWidth,
-            height = targetHeight,
-        )
-        updateLayoutParams(
-            view = subtitleView,
-            layoutParams = subtitleLayoutParams,
-            width = targetWidth,
-            height = targetHeight,
+        applyBounds(
+            targetSize.first.coerceAtLeast(1),
+            targetSize.second.coerceAtLeast(1),
         )
     }
 
-    private fun updateLayoutParams(
+    private fun applyLayoutBounds(
         view: View,
         layoutParams: FrameLayout.LayoutParams,
         width: Int,

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -2208,16 +2208,30 @@ class Media3VideoView(
     }
 
     private fun applyVideoLayout() {
-        val currentParams = videoView.layoutParams as? FrameLayout.LayoutParams
-        val layoutParams = currentParams ?: FrameLayout.LayoutParams(
+        val videoParams = videoView.layoutParams as? FrameLayout.LayoutParams
+        val subtitleParams = subtitleView.layoutParams as? FrameLayout.LayoutParams
+
+        val videoLayoutParams = videoParams ?: FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            Gravity.CENTER,
+        )
+        val subtitleLayoutParams = subtitleParams ?: FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             FrameLayout.LayoutParams.MATCH_PARENT,
             Gravity.CENTER,
         )
 
         if (zoomMode == ZoomMode.STRETCH) {
-            updateVideoLayoutParams(
-                layoutParams = layoutParams,
+            updateLayoutParams(
+                view = videoView,
+                layoutParams = videoLayoutParams,
+                width = FrameLayout.LayoutParams.MATCH_PARENT,
+                height = FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+            updateLayoutParams(
+                view = subtitleView,
+                layoutParams = subtitleLayoutParams,
                 width = FrameLayout.LayoutParams.MATCH_PARENT,
                 height = FrameLayout.LayoutParams.MATCH_PARENT,
             )
@@ -2229,8 +2243,15 @@ class Media3VideoView(
         val sourceWidth = videoWidthPx.toFloat() * videoPixelRatio
         val sourceHeight = videoHeightPx.toFloat()
         if (containerWidth <= 0 || containerHeight <= 0 || sourceWidth <= 0f || sourceHeight <= 0f) {
-            updateVideoLayoutParams(
-                layoutParams = layoutParams,
+            updateLayoutParams(
+                view = videoView,
+                layoutParams = videoLayoutParams,
+                width = FrameLayout.LayoutParams.MATCH_PARENT,
+                height = FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+            updateLayoutParams(
+                view = subtitleView,
+                layoutParams = subtitleLayoutParams,
                 width = FrameLayout.LayoutParams.MATCH_PARENT,
                 height = FrameLayout.LayoutParams.MATCH_PARENT,
             )
@@ -2267,14 +2288,25 @@ class Media3VideoView(
             ZoomMode.STRETCH -> FrameLayout.LayoutParams.MATCH_PARENT to FrameLayout.LayoutParams.MATCH_PARENT
         }
 
-        updateVideoLayoutParams(
-            layoutParams = layoutParams,
-            width = targetSize.first.coerceAtLeast(1),
-            height = targetSize.second.coerceAtLeast(1),
+        val targetWidth = targetSize.first.coerceAtLeast(1)
+        val targetHeight = targetSize.second.coerceAtLeast(1)
+
+        updateLayoutParams(
+            view = videoView,
+            layoutParams = videoLayoutParams,
+            width = targetWidth,
+            height = targetHeight,
+        )
+        updateLayoutParams(
+            view = subtitleView,
+            layoutParams = subtitleLayoutParams,
+            width = targetWidth,
+            height = targetHeight,
         )
     }
 
-    private fun updateVideoLayoutParams(
+    private fun updateLayoutParams(
+        view: View,
         layoutParams: FrameLayout.LayoutParams,
         width: Int,
         height: Int,
@@ -2290,7 +2322,7 @@ class Media3VideoView(
         layoutParams.width = width
         layoutParams.height = height
         layoutParams.gravity = Gravity.CENTER
-        videoView.layoutParams = layoutParams
+        view.layoutParams = layoutParams
     }
 
     private fun applySubtitleRendererMode(mode: SubtitleRendererMode) {


### PR DESCRIPTION
# Pull Request

## Summary
This PR synchronizes `subtitleView` layout bounds with the calculated active `videoView` layout bounds in `Media3VideoView`. This ensures that formatted (ASS/PGS) subtitles are properly positioned and scaled relative to the active video box rather than stretching full-screen.

## Related Issues
Link related issues or tickets separated by commas.

Discord feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Synchronized Subtitle Canvas**: Updated `applyVideoLayout()` in `Media3VideoView.kt` to update the layout bounds (width, height, centering gravity) of `subtitleView` (which hosts native PGS cues and the ASS rendering overlay) alongside `videoView`.
- **Layout Helper Refactoring**: Renamed `updateVideoLayoutParams()` to a generic `updateLayoutParams()` helper that adjusts the layout configuration for both `videoView` and `subtitleView` synchronously.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on AndroidTV
- [ ] Not tested (explain why):

### Test Steps
1. Play a 16:9 video with letterboxing (black bars on top/bottom) or a cinematic 2.39:1 video containing ASS or PGS subtitles.
2. Verify that subtitles are properly aligned inside the active video bounds (not positioned too high or overlapping video bars incorrectly).
3. Toggle different zoom modes (Fit, Crop) and verify that subtitles adjust positioning dynamically to match the resized active video box.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### PGS Rendering
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_13-11-25" src="https://github.com/user-attachments/assets/28420f91-ce32-4937-8b70-8b71c0c07de8" />

### ASS Rendering
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_13-09-53" src="https://github.com/user-attachments/assets/8ebbaaea-f6c0-4482-80a8-acf98ac86b80" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
