### PR TITLE
ui-media details - Enhance Studio Image Legibility

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1984,6 +1984,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                       color: Colors.white.withValues(alpha: 0.15),
                       width: 1,
                     ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.2),
+                        blurRadius: 6,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
                   ),
                   child: ClipRRect(
                     borderRadius: AppRadius.circular(12),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1991,6 +1991,19 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                         ? OfflineAwareImage(
                             imageUrl: imageUrl,
                             fit: BoxFit.contain,
+                            imageBuilder: (context, imageProvider) {
+                              return Container(
+                                color: Colors.white,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 8,
+                                ),
+                                child: Image(
+                                  image: imageProvider,
+                                  fit: BoxFit.contain,
+                                ),
+                              );
+                            },
                             placeholder: (context, url) => _buildStudioFallback(context, name),
                             errorWidget: (context, url, error) => _buildStudioFallback(context, name),
                           )


### PR DESCRIPTION
# Pull Request

## Summary
Improves the legibility and layout of TMDB Studio logos displayed on the Media Details page (Modern layout) by adding a solid white card background and inner padding when the logo successfully loads.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Added White Card Background & Padding**: Configured the `imageBuilder` property of `OfflineAwareImage` in `_studiosTab` (`modern_detail_content.dart`) to wrap loaded studio logos in a solid white container (`color: Colors.white`) with symmetric padding (`horizontal: 12, vertical: 8`). This scales/shrinks the logo inside the card bounds and ensures legibility for transparent dark or black logos.
- **Loading & Error Fallbacks**: Preserved the original gradient background text block fallback for both `placeholder` and `errorWidget` states to prevent rendering empty white placeholder boxes when a logo is missing.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on AndroidTV
- [ ] Not tested (explain why):

### Test Steps
1. Open media item
2. Verify that both dark logos (e.g., Paramount, XYZ) and colored logos (e.g., HG Entertainment) render legibly on the white cards.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### PREVIOUS VISUAL
<img width="1024" height="576" alt="media__1783887486287" src="https://github.com/user-attachments/assets/5c0f088d-2d5c-4acc-b42a-0b3aea0a8801" />

### UPDATED, STUDIOS PRESENT:
<img width="2172" height="812" alt="Shield_Screenshot_2026-07-12_13-41-49" src="https://github.com/user-attachments/assets/dc819af0-c6c6-4581-969e-225a5ff9463a" />
<img width="2272" height="807" alt="Shield_Screenshot_2026-07-12_13-42-14" src="https://github.com/user-attachments/assets/64d83136-9a08-4e65-9d44-4bdbdee893ba" />

### STUDIOS ABSENT (PLACEHOLDER):
<img width="1838" height="826" alt="Shield_Screenshot_2026-07-12_13-44-52" src="https://github.com/user-attachments/assets/3fc98d55-3a3d-46d3-b331-a99d9c18c594" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
