### PR TITLE
bugfix-seer - Adjust Seerr Discovery page focus logic

### DIFF
--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -65,6 +65,10 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     return _rowScrollControllers.putIfAbsent(index, () => ScrollController());
   }
 
+  // Touch UIs should not force focus onto items, so the initial-focus
+  // machinery only runs where dpad or keyboard navigation is used.
+  bool get _wantsInitialFocus => !PlatformDetection.useMobileUi;
+
   void _onRowLeftEdge() {
     final prefs = GetIt.instance<UserPreferences>();
     final navbarIsLeft = prefs.get(UserPreferences.navbarPosition) == NavbarPosition.left;
@@ -110,11 +114,13 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     _prefs.addListener(_onPrefsChanged);
     _initialFocusNode.addListener(_onInitialFocusNodeChanged);
     _initViewModel();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || _initialFocusResolved) return;
-      if (_loadingHoldFocusNode.context == null) return;
-      _loadingHoldFocusNode.requestFocus();
-    });
+    if (_wantsInitialFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || _initialFocusResolved) return;
+        if (_loadingHoldFocusNode.context == null) return;
+        _loadingHoldFocusNode.requestFocus();
+      });
+    }
   }
 
   Future<void> _initViewModel() async {
@@ -192,7 +198,9 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     _initialFocusNode.removeListener(_onInitialFocusNodeChanged);
     final targetContext = _initialFocusNode.context;
     if (!mounted || targetContext == null) return;
-    if (_firstFocusableVisibleIndex == 0) {
+    // The first focusable row is always the visual top (earlier empty rows
+    // collapse), so keep the list at offset 0 rather than shifting the nav off.
+    if (_firstFocusableVisibleIndex >= 0) {
       if (_scrollController.hasClients) {
         _scrollController.animateTo(
           0.0,
@@ -243,7 +251,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
   void _onChanged() {
     if (!mounted) return;
     setState(() {});
-    if (_initialFocusResolved) return;
+    if (_initialFocusResolved || !_wantsInitialFocus) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || _initialFocusResolved || _initialFocusNode.hasFocus) {
         return;
@@ -289,6 +297,8 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
   @override
   Widget build(BuildContext context) =>
       RequestInitialFocus(
+        // On mobile the target is never attached (no row autofocuses it), so
+        // RequestInitialFocus simply finds nothing to focus and gives up.
         targetNode: _initialFocusNode,
         child: _buildScreenContent(context),
       );
@@ -416,14 +426,15 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
           return const SizedBox.shrink();
         }
         final isFirstFocusableRow = index == _firstFocusableVisibleIndex;
-        final firstNode = isFirstFocusableRow ? _initialFocusNode : null;
+        final autofocusRow = isFirstFocusableRow && _wantsInitialFocus;
+        final firstNode = autofocusRow ? _initialFocusNode : null;
         Widget rowWidget;
         if (row.isGenreRow) {
           rowWidget = _buildGenreRow(
             row,
             index,
             isFirstVisibleRow: isFirstFocusableRow,
-            autofocusFirst: isFirstFocusableRow,
+            autofocusFirst: autofocusRow,
             firstFocusNode: firstNode,
           );
         } else if (row.isNetworkRow) {
@@ -431,7 +442,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
             row,
             index,
             isFirstVisibleRow: isFirstFocusableRow,
-            autofocusFirst: isFirstFocusableRow,
+            autofocusFirst: autofocusRow,
             firstFocusNode: firstNode,
           );
         } else if (row.isStudioRow) {
@@ -439,7 +450,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
             row,
             index,
             isFirstVisibleRow: isFirstFocusableRow,
-            autofocusFirst: isFirstFocusableRow,
+            autofocusFirst: autofocusRow,
             firstFocusNode: firstNode,
           );
         } else {
@@ -447,7 +458,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
             row,
             index,
             isFirstVisibleRow: isFirstFocusableRow,
-            autofocusFirst: isFirstFocusableRow,
+            autofocusFirst: autofocusRow,
             firstFocusNode: firstNode,
           );
         }
@@ -456,7 +467,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
             skipTraversal: true,
             onFocusChange: (hasFocus) {
               if (hasFocus) {
-                if (index == 0) {
+                if (index == _firstFocusableVisibleIndex) {
                   if (_scrollController.hasClients) {
                     _scrollController.animateTo(
                       0.0,

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -53,6 +53,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
   int _badgeCount = 0;
   bool _initialFocusResolved = false;
   bool _isFirstRowFocused = false;
+  int _firstFocusableVisibleIndex = -1;
   final Map<int, GlobalKey<LockedFocusRowState>> _rowKeys = {};
   final Map<int, ScrollController> _rowScrollControllers = {};
 
@@ -191,12 +192,22 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     _initialFocusNode.removeListener(_onInitialFocusNodeChanged);
     final targetContext = _initialFocusNode.context;
     if (!mounted || targetContext == null) return;
-    Scrollable.ensureVisible(
-      targetContext,
-      alignment: 0.0,
-      duration: const Duration(milliseconds: 200),
-      curve: Curves.easeOut,
-    );
+    if (_firstFocusableVisibleIndex == 0) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          0.0,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    } else {
+      Scrollable.ensureVisible(
+        targetContext,
+        alignment: 0.0,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    }
   }
 
   KeyEventResult _onContentKeyEvent(FocusNode node, KeyEvent event) {
@@ -382,11 +393,14 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       return const Center(child: CircularProgressIndicator());
     }
 
-    var firstFocusableVisibleIndex = -1;
+    _firstFocusableVisibleIndex = -1;
     for (var i = 0; i < rows.length; i++) {
       final row = rows[i];
+      if (row.isLoading) {
+        break;
+      }
       if (_rowHasFocusableContent(row)) {
-        firstFocusableVisibleIndex = i;
+        _firstFocusableVisibleIndex = i;
         break;
       }
     }
@@ -401,7 +415,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
         if (!row.isLoading && !_rowHasFocusableContent(row)) {
           return const SizedBox.shrink();
         }
-        final isFirstFocusableRow = index == firstFocusableVisibleIndex;
+        final isFirstFocusableRow = index == _firstFocusableVisibleIndex;
         final firstNode = isFirstFocusableRow ? _initialFocusNode : null;
         Widget rowWidget;
         if (row.isGenreRow) {
@@ -442,12 +456,22 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
             skipTraversal: true,
             onFocusChange: (hasFocus) {
               if (hasFocus) {
-                Scrollable.ensureVisible(
-                  rowContext,
-                  alignment: 0.0,
-                  duration: const Duration(milliseconds: 240),
-                  curve: Curves.easeInOut,
-                );
+                if (index == 0) {
+                  if (_scrollController.hasClients) {
+                    _scrollController.animateTo(
+                      0.0,
+                      duration: const Duration(milliseconds: 240),
+                      curve: Curves.easeInOut,
+                    );
+                  }
+                } else {
+                  Scrollable.ensureVisible(
+                    rowContext,
+                    alignment: 0.0,
+                    duration: const Duration(milliseconds: 240),
+                    curve: Curves.easeInOut,
+                  );
+                }
               }
             },
             child: rowWidget,


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves focus resolution and scrolling issues on the Seerr Discovery page on Android TV by ensuring initial focus respects loading rows, and preventing viewport shifting on top row focus.

## Related Issues
Link related issues or tickets separated by commas.

Issue mentioned on Discord.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Ordered Initial Focus**: Adjusted the calculation of `firstFocusableVisibleIndex` in `_buildContent()` (`seerr_discover_screen.dart`) to abort the scanning loop if any preceding row is still loading. This ensures initial page-load focus waits for preceding rows (like "Recent Requests" or "Recently Added") rather than focusing lower-order rows that loaded faster.
- **Bypassed Viewport Shifting for Row 0**:
  - Saved `_firstFocusableVisibleIndex` as a class state variable.
  - Updated `_onInitialFocusNodeChanged()` and the row-level focus builder within `_buildContent()` to animate the scroll controller directly to `0.0` offset instead of calling `Scrollable.ensureVisible()` when Row 0 is focused.
  - This prevents the page viewport from shifting down and cutting off the top navigation bar during initial focus resolution and Row 0 focus changes.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on AndroidTV
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Integrations -> Seerr and enable Seerr Discovery rows including "Recent Requests" as (a slow loading) first row.
2. Enter the Seerr Discovery Page.
3. Verify that focus stays on the loading placeholder until Row 0 loads, then cleanly focuses the first item of Row 0.
4. Verify that the top navigation bar is fully visible and not cut off on initial load and when navigating back to Row 0.
## Screenshots (if applicable)

Include screenshots or recordings for UI changes.

Focus now waits for Recent Requests to be loaded before selecting the first item. This ensures row 1, column 1 is always focused.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_14-19-26" src="https://github.com/user-attachments/assets/e07ce253-e142-4c7d-960e-a7b8011320db" />

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_14-16-24" src="https://github.com/user-attachments/assets/d162267d-0cf6-41bb-b824-5a976df3c3da" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
