### PR TITLE
feat-windows - Add In-App Updater for Windows Desktop

### DIFF
--- a/lib/ui/widgets/app_update_dialog.dart
+++ b/lib/ui/widgets/app_update_dialog.dart
@@ -66,7 +66,9 @@ Future<void> showAppUpdateDialog(
 
   if (choice == null || !context.mounted) return;
 
-  if (choice == 'download' && Platform.isWindows) {
+  if (choice == 'download' &&
+      Platform.isWindows &&
+      update.downloadUri.isScheme('https')) {
     await _downloadAndInstallWindowsUpdate(context, update);
     return;
   }
@@ -86,7 +88,7 @@ Future<void> _downloadAndInstallWindowsUpdate(
 
   showStyledPlayerDialog<void>(
     context,
-    title: 'Updating Moonfin',
+    title: l10n.updating,
     barrierDismissible: false,
     builder: (dialogContext) => PopScope(
       canPop: false,
@@ -184,7 +186,8 @@ Future<void> _downloadAndInstallWindowsUpdate(
     );
     exit(0);
   } catch (e) {
-    errorNotifier.value = 'Error downloading/launching update: $e';
+    debugPrint('Windows in-app update failed: $e');
+    errorNotifier.value = l10n.updateDownloadFailed;
   }
 }
 

--- a/lib/ui/widgets/app_update_dialog.dart
+++ b/lib/ui/widgets/app_update_dialog.dart
@@ -1,5 +1,7 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../data/services/app_update_service.dart';
@@ -64,9 +66,126 @@ Future<void> showAppUpdateDialog(
 
   if (choice == null || !context.mounted) return;
 
+  if (choice == 'download' && Platform.isWindows) {
+    await _downloadAndInstallWindowsUpdate(context, update);
+    return;
+  }
+
   final uri =
       choice == 'notes' ? Uri.parse(update.releaseNotesUrl) : update.downloadUri;
   await launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+Future<void> _downloadAndInstallWindowsUpdate(
+  BuildContext context,
+  DesktopUpdateInfo update,
+) async {
+  final l10n = AppLocalizations.of(context);
+  final valueNotifier = ValueNotifier<double>(0.0);
+  final errorNotifier = ValueNotifier<String?>(null);
+
+  showStyledPlayerDialog<void>(
+    context,
+    title: 'Updating Moonfin',
+    barrierDismissible: false,
+    builder: (dialogContext) => PopScope(
+      canPop: false,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        child: AnimatedBuilder(
+          animation: Listenable.merge([valueNotifier, errorNotifier]),
+          builder: (context, child) {
+            final error = errorNotifier.value;
+            if (error != null) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    error,
+                    style: const TextStyle(color: Colors.redAccent, fontSize: 14),
+                  ),
+                  const SizedBox(height: 16),
+                  Align(
+                    alignment: Alignment.bottomRight,
+                    child: TextButton(
+                      onPressed: () => Navigator.of(dialogContext).pop(),
+                      child: Text(
+                        l10n.close,
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            }
+
+            final progress = valueNotifier.value;
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                LinearProgressIndicator(
+                  value: progress,
+                  backgroundColor: Colors.white24,
+                  valueColor: const AlwaysStoppedAnimation<Color>(Colors.blueAccent),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  '${(progress * 100).toStringAsFixed(0)}%',
+                  style: const TextStyle(color: Colors.white70, fontSize: 14),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    ),
+  );
+
+  try {
+    final tempDir = await getTemporaryDirectory();
+    final file = File('${tempDir.path}${Platform.pathSeparator}moonfin_updater.exe');
+    if (await file.exists()) {
+      await file.delete();
+    }
+
+    final client = HttpClient()
+      ..connectionTimeout = const Duration(seconds: 15);
+
+    try {
+      final request = await client.getUrl(update.downloadUri);
+      final response = await request.close();
+
+      if (response.statusCode != 200) {
+        throw Exception('Server returned status code ${response.statusCode}');
+      }
+
+      final contentLength = response.contentLength;
+      var downloaded = 0;
+      final sink = file.openWrite();
+
+      await for (final chunk in response) {
+        sink.add(chunk);
+        downloaded += chunk.length;
+        if (contentLength > 0) {
+          valueNotifier.value = downloaded / contentLength;
+        }
+      }
+      await sink.flush();
+      await sink.close();
+    } finally {
+      client.close();
+    }
+
+    await Process.start(
+      file.path,
+      [],
+      mode: ProcessStartMode.detached,
+    );
+    exit(0);
+  } catch (e) {
+    errorNotifier.value = 'Error downloading/launching update: $e';
+  }
 }
 
 class _UpdateOption extends StatelessWidget {

--- a/lib/ui/widgets/track_selector_dialog.dart
+++ b/lib/ui/widgets/track_selector_dialog.dart
@@ -17,10 +17,12 @@ Future<T?> showStyledPlayerDialog<T>(
   bool showCancel = false,
   double maxWidth = 440,
   bool useRootNavigator = true,
+  bool barrierDismissible = true,
 }) {
   return showFocusRestoringDialog<T>(
     context: context,
     useRootNavigator: useRootNavigator,
+    barrierDismissible: barrierDismissible,
     builder: (dialogContext) {
       final mediaQuery = MediaQuery.of(dialogContext);
       final maxDialogHeight = mediaQuery.size.height -

--- a/lib/util/app_distribution.dart
+++ b/lib/util/app_distribution.dart
@@ -12,6 +12,7 @@
 ///   linux          : Linux direct download (opens browser)
 ///   linux_aur      : Linux AUR package (no in-app updater)
 ///   ios_signed     : Signed IPA (App Store)
+///   ios_unsigned   : Unsigned IPA (sideload)
 library;
 
 import 'dart:io';

--- a/lib/util/app_distribution.dart
+++ b/lib/util/app_distribution.dart
@@ -12,7 +12,11 @@
 ///   linux          : Linux direct download (opens browser)
 ///   linux_aur      : Linux AUR package (no in-app updater)
 ///   ios_signed     : Signed IPA (App Store)
-///   ios_unsigned   : Unsigned IPA (sideload)
+library;
+
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+
 enum DistributionChannel {
   apk,
   aab,
@@ -59,6 +63,9 @@ class AppDistribution {
       case 'ios_unsigned':
         return DistributionChannel.iosUnsigned;
       default:
+        if (!kIsWeb && Platform.isWindows) {
+          return DistributionChannel.windows;
+        }
         return DistributionChannel.unknown;
     }
   }


### PR DESCRIPTION
# Pull Request

## Summary
This PR implements a direct in-app update downloader and installer for Windows client apps. It downloads the `.exe` installer directly to a temp folder, displays progress in a non-dismissible styled dialog, and launches the installer while cleanly terminating Moonfin to prevent file conflicts.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Added Default Windows Channel**: Updated `AppDistribution.channel` (`app_distribution.dart`) to default to `windows` when running on a Windows platform (and not on Web) if no explicit environment variable flag is supplied. This resolves updater check disabling in development builds.
- **Added Styled Dialog Dismissibility Control**: Added `barrierDismissible` parameter to `showStyledPlayerDialog()` (`track_selector_dialog.dart`) and forwarded it down to `showFocusRestoringDialog()`.
- **Implemented Direct In-App Downloader & Executer**:
  - Modified the download choice handler in `showAppUpdateDialog()` (`app_update_dialog.dart`) to intercept download events on Windows.
  - Implemented `_downloadAndInstallWindowsUpdate()` which displays a non-dismissible styled progress bar dialog, downloads the update payload chunk-by-chunk using `HttpClient`, writes it to the local system temp folder, triggers the installer in `ProcessStartMode.detached` mode, and terminates the application cleanly via `exit(0)`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code - but only applies to Windows Desktop

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Testing completed on Windows Desktop (see screenshots)
- [ ] Not tested (explain why):

### Test Steps
1. Verified with `flutter analyze lib/` (completed with 0 errors/warnings).
2. Manually tested by temporarily setting `version: 1.0.0+1` in `pubspec.yaml`, compiling the Windows app, triggering the update manually, and confirming it completes the in-app progress update, quits Moonfin, and executes the UAC installer package launch.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Faked Old Version:
<img width="2314" height="1403" alt="2026-07-12_14-46-48_moonfin" src="https://github.com/user-attachments/assets/2191eeda-1891-4edb-9cc6-6b70b2342786" />
<img width="2314" height="1403" alt="2026-07-12_14-46-55_moonfin" src="https://github.com/user-attachments/assets/b729bd58-9bb9-476a-ac1e-0520323f6801" />
<img width="2314" height="1403" alt="2026-07-12_14-47-01_%pn" src="https://github.com/user-attachments/assets/29074396-a6aa-472c-b794-b9e48d703d37" />
<img width="1602" height="1165" alt="2026-07-12_14-47-16_explorer" src="https://github.com/user-attachments/assets/e2c32fde-88fd-43b8-82be-104305453863" />

### Proper Stable Release Installed:
<img width="2314" height="1403" alt="2026-07-12_14-47-31_moonfin" src="https://github.com/user-attachments/assets/8320af52-6de1-4a4a-9fc7-7b137b7f401e" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
