### PR TITLE
bugfix-games - Place focus on Play button when loading a game details page

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -983,7 +983,7 @@ class _DetailContentState extends State<_DetailContent> {
           return;
         }
       }
-      if (attempt + 1 >= 8) return;
+      if (attempt + 1 >= 60) return;
       Future<void>.delayed(const Duration(milliseconds: 50), () {
         if (!mounted) return;
         _tryRequestTvAlbumPlayFocus(itemId, attempt + 1);
@@ -5491,7 +5491,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           return;
         }
       }
-      if (attempt + 1 >= 8) return;
+      if (attempt + 1 >= 60) return;
       Future<void>.delayed(const Duration(milliseconds: 50), () {
         if (!mounted) return;
         _tryRequestPlayFocus(itemId, attempt + 1);


### PR DESCRIPTION
# Pull Request

## Summary
This PR extends the play button initial focus retry loops on media details screens. By providing a wider 3-second window (60 attempts at 50ms intervals), it ensures that slow-loading media items (such as Games or custom integrated libraries) reliably receive initial focus on the Play/Resume button when it mounts, instead of leaving focus stuck on the navigation Back button.

## Related Issues
Link related issues or tickets separated by commas.

Discord feedback

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **[item_detail_screen.dart](file:///C:/Moonfin-Core/lib/ui/screens/detail/item_detail_screen.dart)**:
  - In `_tryRequestPlayFocus()`, increased the maximum retry count from `8` to `60` (allowing focus checks to continue for up to 3 seconds).
  - In `_tryRequestTvAlbumPlayFocus()`, increased the maximum retry count from `8` to `60` as well.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):  Verified that `flutter analyze lib/` runs and resolves with zero compile errors, but going to request testers with game library to confirm behaviour.

### Test Steps
1. Open a Game library
2. Open the media details for a game
3. Make sure when the Play button loads in that it gains focus

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
