### PR TITLE
bugfix-ratings - Normalize rating sources casing during plugin sync

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1359,12 +1359,7 @@ class PluginSyncService extends ChangeNotifier {
       if (resolved['mdblistRatingSources'] is List) {
         final sources = (resolved['mdblistRatingSources'] as List)
             .cast<String>()
-            .map((s) => switch (s) {
-                  'metacriticUser' => 'metacriticuser',
-                  'myAnimeList' => 'myanimelist',
-                  'aniList' => 'anilist',
-                  _ => s,
-                })
+            .map((s) => _serverToClientRatingSource[s] ?? s)
             .join(',');
         _store.set(
           _prefs.getEffectivePreference(UserPreferences.enabledRatings),
@@ -1720,6 +1715,19 @@ class PluginSyncService extends ChangeNotifier {
     }
   }
 
+  // The Moonbase dashboard stores a few rating source keys in camelCase while
+  // the client uses lowercase. Keep one canonical map and derive its inverse so
+  // the two directions can never drift.
+  static const Map<String, String> _serverToClientRatingSource = {
+    'metacriticUser': 'metacriticuser',
+    'myAnimeList': 'myanimelist',
+    'aniList': 'anilist',
+  };
+  static final Map<String, String> _clientToServerRatingSource = {
+    for (final entry in _serverToClientRatingSource.entries)
+      entry.value: entry.key,
+  };
+
   List<String> _csvToList(Preference<String> pref) {
     return _prefs.get(pref).split(',').where((s) => s.isNotEmpty).toList();
   }
@@ -1840,12 +1848,7 @@ class PluginSyncService extends ChangeNotifier {
       'seerrEnabled': _prefs.get(UserPreferences.seerrEnabled),
       'seerrBlockNsfw': _prefs.get(UserPreferences.seerrBlockNsfw),
       'mdblistRatingSources': _csvToList(UserPreferences.enabledRatings)
-          .map((s) => switch (s) {
-                'metacriticuser' => 'metacriticUser',
-                'myanimelist' => 'myAnimeList',
-                'anilist' => 'aniList',
-                _ => s,
-              })
+          .map((s) => _clientToServerRatingSource[s] ?? s)
           .toList(),
       'homeRowOrder': _prefs.homeSectionsConfig
           .where((c) => c.enabled)

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1359,6 +1359,12 @@ class PluginSyncService extends ChangeNotifier {
       if (resolved['mdblistRatingSources'] is List) {
         final sources = (resolved['mdblistRatingSources'] as List)
             .cast<String>()
+            .map((s) => switch (s) {
+                  'metacriticUser' => 'metacriticuser',
+                  'myAnimeList' => 'myanimelist',
+                  'aniList' => 'anilist',
+                  _ => s,
+                })
             .join(',');
         _store.set(
           _prefs.getEffectivePreference(UserPreferences.enabledRatings),
@@ -1833,7 +1839,14 @@ class PluginSyncService extends ChangeNotifier {
       ),
       'seerrEnabled': _prefs.get(UserPreferences.seerrEnabled),
       'seerrBlockNsfw': _prefs.get(UserPreferences.seerrBlockNsfw),
-      'mdblistRatingSources': _csvToList(UserPreferences.enabledRatings),
+      'mdblistRatingSources': _csvToList(UserPreferences.enabledRatings)
+          .map((s) => switch (s) {
+                'metacriticuser' => 'metacriticUser',
+                'myanimelist' => 'myAnimeList',
+                'anilist' => 'aniList',
+                _ => s,
+              })
+          .toList(),
       'homeRowOrder': _prefs.homeSectionsConfig
           .where((c) => c.enabled)
           .map((c) => c.type.serializedName)

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
-import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:server_core/server_core.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
@@ -58,7 +57,6 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
     _ => key,
   };
 
-  final _store = GetIt.instance<PreferenceStore>();
   final _prefs = GetIt.instance<UserPreferences>();
   String _lastEnabledRatingsCsv = '';
   late List<_RatingItem> _items;
@@ -84,13 +82,13 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
 
   void _onPrefsChanged() {
     if (!mounted) return;
-    final currentCsv = _store.get(UserPreferences.enabledRatings);
+    final currentCsv = _prefs.get(UserPreferences.enabledRatings);
     if (currentCsv == _lastEnabledRatingsCsv) return;
     setState(_loadFromPrefs);
   }
 
   void _loadFromPrefs() {
-    final csv = _store.get(UserPreferences.enabledRatings);
+    final csv = _prefs.get(UserPreferences.enabledRatings);
     _lastEnabledRatingsCsv = csv;
     final enabled = csv.split(',').where((s) => s.isNotEmpty).toList();
 
@@ -127,7 +125,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
     // Keep local ordering/focus stable for in-screen edits; external updates
     // still refresh via _onPrefsChanged when the stored CSV differs.
     _lastEnabledRatingsCsv = csv;
-    _store.set(UserPreferences.enabledRatings, csv);
+    _prefs.set(UserPreferences.enabledRatings, csv);
 
     final syncService = GetIt.instance<PluginSyncService>();
     if (syncService.pluginAvailable) {
@@ -159,7 +157,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
                 tooltip: l10n.resetToDefaults,
                 onPressed: () {
                   setState(() {
-                    _store.set(
+                    _prefs.set(
                       UserPreferences.enabledRatings,
                       UserPreferences.enabledRatings.defaultValue,
                     );


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves rating synchronization mismatches between the server plugin (Moonbase) and client app (Moonfin-Core). 

Specifically:
- It fixes a preference scoping issue where `ratings_config_screen.dart` used raw `PreferenceStore` methods (`_store.get()` / `_store.set()`) instead of `UserPreferences` helper methods (`_prefs.get()` / `_prefs.set()`). Because rating sources selection (`enabledRatings`) is a profile-scoped preference (resolving to `enabledRatings_tv` on Android TV), raw store calls completely bypassed scoping. Synced ratings from the server were saved to the scoped key, but the UI loaded and saved to the global unscoped key, causing custom rating sources to never be selected in the client settings list.
- It resolves casing mismatches between the CamelCase rating source keys used in the Jellyfin plugin dashboard (`metacriticUser`, `myAnimeList`, `aniList`) and the lowercase keys expected by the client.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **`ratings_config_screen.dart`**:
  - Replaced raw `_store.get()` and `_store.set()` calls with `_prefs.get()` and `_prefs.set()` for proper scoped preference access.
  - Removed unused `_store` imports and class fields.
- **`plugin_sync_service.dart`**:
  - Inside `_applyServerSettings()`, mapped incoming server CamelCase keys (`metacriticUser`, `myAnimeList`, `aniList`) to client lowercase equivalents.
  - Inside `_buildProfileFromLocal()`, mapped outgoing client keys back to server CamelCase equivalents.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Needs Moonbase update synchronization

### Test Steps
1. Change review defaults and push them from Moonbase.
2. See the updates locally on core client

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
