### PR TITLE
ui-similaritems - Adjust view for labels in modern details grid

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -2844,12 +2844,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final grid = LayoutBuilder(
       builder: (context, constraints) {
         const spacing = 12.0;
-        final columns = (constraints.maxWidth / (_landscape ? 150.0 : 130.0))
+        final columns = (constraints.maxWidth / (_landscape ? 160.0 : 130.0))
             .floor()
-            .clamp(3, _landscape ? 8 : 6);
+            .clamp(3, _landscape ? 10 : 6);
         final cardWidth =
-            ((constraints.maxWidth - spacing * (columns - 1)) / columns)
-                .floorToDouble();
+            (((constraints.maxWidth - spacing * (columns - 1)) / columns)
+                .floorToDouble())
+            .clamp(0.0, 260.0 * _desktopUiScale(prefs: widget.prefs));
         return Wrap(
           spacing: spacing,
           runSpacing: 16,


### PR DESCRIPTION
# Pull Request

## Summary
Small adjustment for the responsive poster size constraints inside the Modern detail content grids to ensure movie titles are not cut off at the bottom of the viewport in landscape/TV layouts. Note: positioning is somewhat based on user interactions/settings. If you enter Similar, you now see the full cards, their titles, and a small amount of peek at the next row. If you move up to the playback controls and back down again, the view settles on a really nice 1 row w/text layout. Photos of both states below.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- `modern_detail_content.dart`:
  - Changed the landscape columns divisor from `150.0` to `160.0`.
  - Increased landscape columns clamp from `8` to `10`.
  - Clamped `cardWidth` to a maximum of `260.0 * desktopScale`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - tested on AndroidTV
- [ ] Not tested (explain why):

### Test Steps
1. Open media details page
2. Navigate to the Similar tab
3. Move focus indicator around

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Entering Similar (either via click or auto-open):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_17-08-13" src="https://github.com/user-attachments/assets/8c3701f3-2c61-4868-97f5-d55de8b398fb" />

### Having navigated up and back down to Similar:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_17-07-26" src="https://github.com/user-attachments/assets/60ec31b1-6b12-4c77-9416-de300ae07776" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
