### PR TITLE
ui-musicplayer - Adjust Music Player Positioning to overlay content

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4284,7 +4284,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             _buildBackdrop(_landscape, backdropUrl),
       ),
     );
-    final topInset = TopToolbar.heightFor(context);
+    final topInset = TopToolbar.baseHeightFor(context);
 
     final isEpisode = item.type == 'Episode';
     final logoTag = item.logoImageTag ?? (isEpisode ? item.seriesLogoImageTag : null);

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -236,7 +236,10 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
             child: content,
           )
         : content;
-    final insetBody = body;
+    final musicExtra = TopToolbar.musicBarExtraHeight();
+    final insetBody = (widget.pinTopToolbar && musicExtra > 0)
+        ? Padding(padding: EdgeInsets.only(top: musicExtra), child: body)
+        : body;
     return Column(
       children: [
         Expanded(

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -236,14 +236,7 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
             child: content,
           )
         : content;
-    // The top toolbar is a fixed overlay off-TV, so content must reserve the
-    // embedded music bar's extra height or it gets occluded. On TV the toolbar
-    // translates with scroll, so its reserve belongs in the scrolling list
-    // inset instead and is handled there.
-    final musicExtra = TopToolbar.musicBarExtraHeight();
-    final insetBody = (!translateWithScroll && musicExtra > 0)
-        ? Padding(padding: EdgeInsets.only(top: musicExtra), child: body)
-        : body;
+    final insetBody = body;
     return Column(
       children: [
         Expanded(

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -80,15 +80,18 @@ class TopToolbar extends StatefulWidget {
     return PlatformDetection.useLeanbackUi ? 64.0 : 54.0;
   }
 
-  /// Total laid-out height of the toolbar for the current platform.
-  static double heightFor(BuildContext context) {
-    final baseHeight = PlatformDetection.useLeanbackUi
+  /// Base height of the toolbar for the current platform (excluding music bar).
+  static double baseHeightFor(BuildContext context) {
+    return PlatformDetection.useLeanbackUi
         ? _kToolbarHeightTV
         : PlatformDetection.useMobileUi
         ? _kToolbarHeightMobile
         : _kToolbarHeightDesktop;
+  }
 
-    return baseHeight + musicBarExtraHeight();
+  /// Total laid-out height of the toolbar for the current platform.
+  static double heightFor(BuildContext context) {
+    return baseHeightFor(context) + musicBarExtraHeight();
   }
 
   @override


### PR DESCRIPTION
# Pull Request

## Summary
This PR decouples the top toolbar height extension (added by the music player) from the top padding/inset constraints used by the content views. This allows the music player to overlay/sit on top of the UI content rather than shifting layout elements lower. This resolves layout shift issue where the music player moved UI elements lower on details screens and home screens.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **`top_toolbar.dart`**:
  - Added `TopToolbar.baseHeightFor(context)` static helper to query baseline toolbar height.
- **`modern_detail_content.dart`**:
  - Changed details page inset calculation to use `baseHeightFor` instead of `heightFor`.
- **`navigation_layout.dart`**:
  - Cleaned up off-TV music extra height padding on body content to prevent layout shifts.
  
## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start music playback
2. Navigate to different areas of the interface

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Original Positioning
<img width="4000" height="3000" alt="old" src="https://github.com/user-attachments/assets/93e635a5-f3f5-47d6-bfe5-8eabf2431b37" />

### Updated Positioning
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_19-03-58" src="https://github.com/user-attachments/assets/32da63c5-265b-4067-9714-d874467bc396" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_19-04-12" src="https://github.com/user-attachments/assets/a4bc7f71-8ccd-4b7a-90d7-d92e0da51943" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_19-04-27" src="https://github.com/user-attachments/assets/4511473b-4f39-495c-9e42-c79682daa162" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_19-04-41" src="https://github.com/user-attachments/assets/846362df-8421-4462-87cb-5cff41daa12e" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
