### PR TITLE
bug-ui - Stop reported cases of focus indicator clipping

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -11580,7 +11580,7 @@ class _EpisodesRow extends StatelessWidget {
     final desktopScale = _desktopUiScale();
 
     return SizedBox(
-      height: isMobile ? 150 : 180 * desktopScale,
+      height: isMobile ? 132 : 156 * desktopScale,
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -11579,8 +11579,18 @@ class _EpisodesRow extends StatelessWidget {
     final isMobile = _isCompact(context);
     final desktopScale = _desktopUiScale();
 
+    // The card is a fixed-height poster plus a single label line. The poster
+    // tracks the desktop scale while the label tracks the text scaler, so size
+    // the row from both. Folding the text scaler in keeps a larger system font
+    // from overflowing the row and clipping the labels.
+    final imageHeight = isMobile ? 100.0 : 124 * desktopScale;
+    final labelStyle = Theme.of(context).textTheme.bodySmall;
+    final labelLine = MediaQuery.textScalerOf(
+      context,
+    ).scale((labelStyle?.fontSize ?? 12) * (labelStyle?.height ?? 1.4));
+
     return SizedBox(
-      height: isMobile ? 132 : 156 * desktopScale,
+      height: imageHeight + 10 + labelLine + 6,
       child: ListView.separated(
         controller: scrollController,
         scrollDirection: Axis.horizontal,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -11695,123 +11695,136 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
             width: widget.isMobile ? 180.0 : 220.0 * desktopScale,
             decoration: BoxDecoration(
               borderRadius: AppRadius.circular(8),
-              border: showFocusBorder
-                  ? Border.fromBorderSide(
-                      ThemeRegistry.active.borders.focusBorder.copyWith(
-                        color: isNeon ? AppColorScheme.accent : focusColor,
-                        width: 1.5,
-                      ),
-                    )
-                  : widget.isCurrent
-                  ? Border.fromBorderSide(
-                      ThemeRegistry.active.borders.focusBorder.copyWith(
-                        color: AppColorScheme.onSurface,
-                        width: 2.5,
-                      ),
-                    )
-                  : null,
             ),
             clipBehavior: Clip.antiAlias,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+            child: Stack(
+              fit: StackFit.passthrough,
               children: [
-                SizedBox(
-                  height: widget.isMobile ? 100 : 124 * desktopScale,
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      if (ep.primaryImageTag != null)
-                        OfflineAwareImage(
-                          imageUrl: widget.imageApi.getPrimaryImageUrl(
-                            ep.id,
-                            maxHeight: widget.isMobile
-                                ? 250
-                                : (250 * desktopScale).round(),
-                            tag: ep.primaryImageTag,
-                          ),
-                          fit: BoxFit.cover,
-                          errorWidget: (_, _, _) => Container(
-                            color: Colors.white.withValues(alpha: 0.05),
-                            child: const AdaptiveIcon(
-                              Icons.movie,
-                              color: Colors.white24,
-                              size: 32,
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(
+                      height: widget.isMobile ? 100 : 124 * desktopScale,
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          if (ep.primaryImageTag != null)
+                            OfflineAwareImage(
+                              imageUrl: widget.imageApi.getPrimaryImageUrl(
+                                ep.id,
+                                maxHeight: widget.isMobile
+                                    ? 250
+                                    : (250 * desktopScale).round(),
+                                tag: ep.primaryImageTag,
+                              ),
+                              fit: BoxFit.cover,
+                              errorWidget: (_, _, _) => Container(
+                                color: Colors.white.withValues(alpha: 0.05),
+                                child: const AdaptiveIcon(
+                                  Icons.movie,
+                                  color: Colors.white24,
+                                  size: 32,
+                                ),
+                              ),
+                            )
+                          else
+                            Container(
+                              color: Colors.white.withValues(alpha: 0.05),
+                              child: const AdaptiveIcon(
+                                Icons.movie,
+                                color: Colors.white24,
+                                size: 32,
+                              ),
+                            ),
+                          if ((ep.playedPercentage ?? 0) > 0)
+                            _EpisodeProgressBar(percentage: ep.playedPercentage!),
+                          if (ep.isPlayed && (ep.playedPercentage ?? 0) == 0)
+                            const Positioned(
+                              top: 6,
+                              right: 6,
+                              child: AdaptiveIcon(
+                                Icons.check_circle,
+                                color: Colors.green,
+                                size: 18,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 6, 8, 4),
+                      child: Row(
+                        children: [
+                          if (epNum != null)
+                            Text(
+                              'E$epNum',
+                              style: Theme.of(context).textTheme.labelSmall
+                                  ?.copyWith(
+                                    color: isNeon
+                                        ? AppColorScheme.onSurface.withValues(
+                                            alpha: 0.85,
+                                          )
+                                        : Colors.white.withValues(alpha: 0.5),
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                            ),
+                          if (epNum != null) const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              ep.name,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: isNeon
+                                        ? AppColorScheme.accent
+                                        : Colors.white,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
                             ),
                           ),
-                        )
-                      else
-                        Container(
-                          color: Colors.white.withValues(alpha: 0.05),
-                          child: const AdaptiveIcon(
-                            Icons.movie,
-                            color: Colors.white24,
-                            size: 32,
-                          ),
-                        ),
-                      if ((ep.playedPercentage ?? 0) > 0)
-                        _EpisodeProgressBar(percentage: ep.playedPercentage!),
-                      if (ep.isPlayed && (ep.playedPercentage ?? 0) == 0)
-                        const Positioned(
-                          top: 6,
-                          right: 6,
-                          child: AdaptiveIcon(
-                            Icons.check_circle,
-                            color: Colors.green,
-                            size: 18,
-                          ),
-                        ),
-                    ],
-                  ),
+                          if (runtimeText != null) ...[
+                            const SizedBox(width: 4),
+                            Text(
+                              runtimeText,
+                              style: Theme.of(context).textTheme.labelSmall
+                                  ?.copyWith(
+                                    color: isNeon
+                                        ? AppColorScheme.onSurface.withValues(
+                                            alpha: 0.8,
+                                          )
+                                        : Colors.white.withValues(alpha: 0.5),
+                                  ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(8, 6, 8, 4),
-                  child: Row(
-                    children: [
-                      if (epNum != null)
-                        Text(
-                          'E$epNum',
-                          style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(
-                                color: isNeon
-                                    ? AppColorScheme.onSurface.withValues(
-                                        alpha: 0.85,
-                                      )
-                                    : Colors.white.withValues(alpha: 0.5),
-                                fontWeight: FontWeight.w600,
-                              ),
-                        ),
-                      if (epNum != null) const SizedBox(width: 6),
-                      Expanded(
-                        child: Text(
-                          ep.name,
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: isNeon
-                                    ? AppColorScheme.accent
-                                    : Colors.white,
-                                fontWeight: FontWeight.w600,
-                              ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                if (showFocusBorder || widget.isCurrent)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: AppRadius.circular(8),
+                          border: showFocusBorder
+                              ? Border.fromBorderSide(
+                                  ThemeRegistry.active.borders.focusBorder.copyWith(
+                                    color: isNeon ? AppColorScheme.accent : focusColor,
+                                    width: 1.5,
+                                  ),
+                                )
+                              : Border.fromBorderSide(
+                                  ThemeRegistry.active.borders.focusBorder.copyWith(
+                                    color: AppColorScheme.onSurface,
+                                    width: 2.5,
+                                  ),
+                                ),
                         ),
                       ),
-                      if (runtimeText != null) ...[
-                        const SizedBox(width: 4),
-                        Text(
-                          runtimeText,
-                          style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(
-                                color: isNeon
-                                    ? AppColorScheme.onSurface.withValues(
-                                        alpha: 0.8,
-                                      )
-                                    : Colors.white.withValues(alpha: 0.5),
-                              ),
-                        ),
-                      ],
-                    ],
+                    ),
                   ),
-                ),
               ],
             ),
           ),
@@ -11894,84 +11907,97 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                     ? Colors.transparent
                     : Colors.white.withValues(alpha: 0.08),
                 borderRadius: AppRadius.circular(8),
-                border: showFocusBorder
-                    ? Border.fromBorderSide(
-                        ThemeRegistry.active.borders.focusBorder.copyWith(
-                          color: isNeon ? AppColorScheme.accent : focusColor,
-                          width: 1.5,
-                        ),
-                      )
-                    : null,
               ),
               clipBehavior: Clip.antiAlias,
-              child: Row(
+              child: Stack(
+                fit: StackFit.passthrough,
                 children: [
-                  SizedBox(
-                    width: isMobile ? 178.0 : 213.0 * desktopScale,
-                    child: Stack(
-                      fit: StackFit.expand,
-                      children: [
-                        if (episode.primaryImageTag != null)
-                          OfflineAwareImage(
-                            imageUrl: widget.imageApi.getPrimaryImageUrl(
-                              episode.id,
-                              maxHeight: isMobile
-                                  ? 240
-                                  : (240 * desktopScale).round(),
-                              tag: episode.primaryImageTag,
-                            ),
-                            fit: BoxFit.cover,
-                            errorWidget: (_, _, _) => const SizedBox.shrink(),
-                          ),
-                        if ((episode.playedPercentage ?? 0) > 0)
-                          _EpisodeProgressBar(
-                            percentage: episode.playedPercentage!,
-                          ),
-                      ],
-                    ),
-                  ),
-                  SizedBox(width: isMobile ? 16 : 16 * desktopScale),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          subtitle,
-                          style: Theme.of(context).textTheme.titleSmall
-                              ?.copyWith(
-                                color: isNeon
-                                    ? AppColorScheme.accent
-                                    : Colors.white,
-                                fontWeight: FontWeight.w600,
-                              ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        if (episode.overview != null) ...[
-                          const SizedBox(height: 4),
-                          Text(
-                            episode.overview!,
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(
-                                  color: isNeon
-                                      ? AppColorScheme.onSurface
-                                      : Colors.white.withValues(alpha: 0.7),
+                  Row(
+                    children: [
+                      SizedBox(
+                        width: isMobile ? 178.0 : 213.0 * desktopScale,
+                        child: Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            if (episode.primaryImageTag != null)
+                              OfflineAwareImage(
+                                imageUrl: widget.imageApi.getPrimaryImageUrl(
+                                  episode.id,
+                                  maxHeight: isMobile
+                                      ? 240
+                                      : (240 * desktopScale).round(),
+                                  tag: episode.primaryImageTag,
                                 ),
-                            maxLines: 3,
-                            overflow: TextOverflow.ellipsis,
+                                fit: BoxFit.cover,
+                                errorWidget: (_, _, _) => const SizedBox.shrink(),
+                              ),
+                            if ((episode.playedPercentage ?? 0) > 0)
+                              _EpisodeProgressBar(
+                                percentage: episode.playedPercentage!,
+                              ),
+                          ],
+                        ),
+                      ),
+                      SizedBox(width: isMobile ? 16 : 16 * desktopScale),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              subtitle,
+                              style: Theme.of(context).textTheme.titleSmall
+                                  ?.copyWith(
+                                    color: isNeon
+                                        ? AppColorScheme.accent
+                                        : Colors.white,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            if (episode.overview != null) ...[
+                              const SizedBox(height: 4),
+                              Text(
+                                episode.overview!,
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: isNeon
+                                          ? AppColorScheme.onSurface
+                                          : Colors.white.withValues(alpha: 0.7),
+                                    ),
+                                maxLines: 3,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                      SizedBox(width: isMobile ? 16 : 16 * desktopScale),
+                      AdaptiveIcon(
+                        Icons.play_circle_outline,
+                        color: Colors.white54,
+                        size: isMobile ? 40 : 40 * desktopScale,
+                      ),
+                      SizedBox(width: isMobile ? 16 : 16 * desktopScale),
+                    ],
+                  ),
+                  if (showFocusBorder)
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            borderRadius: AppRadius.circular(8),
+                            border: Border.fromBorderSide(
+                              ThemeRegistry.active.borders.focusBorder.copyWith(
+                                color: isNeon ? AppColorScheme.accent : focusColor,
+                                width: 1.5,
+                              ),
+                            ),
                           ),
-                        ],
-                      ],
+                        ),
+                      ),
                     ),
-                  ),
-                  SizedBox(width: isMobile ? 16 : 16 * desktopScale),
-                  AdaptiveIcon(
-                    Icons.play_circle_outline,
-                    color: Colors.white54,
-                    size: isMobile ? 40 : 40 * desktopScale,
-                  ),
-                  SizedBox(width: isMobile ? 16 : 16 * desktopScale),
                 ],
               ),
             ),
@@ -12081,146 +12107,151 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                     ? Colors.transparent
                     : Colors.white.withValues(alpha: 0.06),
                 borderRadius: AppRadius.circular(8),
-                border: showFocusBorder
-                    ? Border.fromBorderSide(
-                        ThemeRegistry.active.borders.focusBorder.copyWith(
-                          color: isNeon ? AppColorScheme.accent : focusColor,
-                          width: 1.5,
-                        ),
-                      )
-                    : (widget.isActive
-                          ? Border.fromBorderSide(
-                              ThemeRegistry.active.borders.focusBorder.copyWith(
-                                color: isNeon
-                                    ? const Color(0xFF00FFFF)
-                                    : Colors.cyan.withValues(alpha: 0.7),
-                                width: 1.5,
-                              ),
-                            )
-                          : null),
               ),
               clipBehavior: Clip.none,
-              child: ClipRRect(
-                borderRadius: AppRadius.circular(8),
-                child: Row(
-                  children: [
-                    SizedBox(
-                      width: isMobile ? 160.0 : 196.0 * desktopScale,
-                      child: Stack(
-                        fit: StackFit.expand,
-                        children: [
-                          if (episode.primaryImageTag != null)
-                            OfflineAwareImage(
-                              imageUrl: widget.imageApi.getPrimaryImageUrl(
-                                episode.id,
-                                maxHeight: isMobile
-                                    ? 220
-                                    : (220 * desktopScale).round(),
-                                tag: episode.primaryImageTag,
-                              ),
-                              fit: BoxFit.cover,
-                              errorWidget: (_, _, _) => Container(
-                                color: Colors.white.withValues(alpha: 0.05),
-                                child: const AdaptiveIcon(
-                                  Icons.movie,
-                                  color: Colors.white24,
-                                  size: 32,
-                                ),
-                              ),
-                            )
-                          else
-                            Container(
-                              color: Colors.white.withValues(alpha: 0.05),
-                              child: const AdaptiveIcon(
-                                Icons.movie,
-                                color: Colors.white24,
-                                size: 32,
-                              ),
-                            ),
-                          if ((episode.playedPercentage ?? 0) > 0)
-                            _EpisodeProgressBar(
-                              percentage: episode.playedPercentage!,
-                            ),
-                          if (episode.isPlayed)
-                            Positioned(
-                              top: 6,
-                              right: 6,
-                              child: DecoratedBox(
-                                decoration: BoxDecoration(
-                                  color: AppColorScheme.accent,
-                                  shape: BoxShape.circle,
-                                ),
-                                child: Padding(
-                                  padding: EdgeInsets.all(3),
-                                  child: AdaptiveIcon(
-                                    Icons.check,
-                                    color: Colors.white,
-                                    size: 14,
+              child: Stack(
+                clipBehavior: Clip.none,
+                fit: StackFit.passthrough,
+                children: [
+                  ClipRRect(
+                    borderRadius: AppRadius.circular(8),
+                    child: Row(
+                      children: [
+                        SizedBox(
+                          width: isMobile ? 160.0 : 196.0 * desktopScale,
+                          child: Stack(
+                            fit: StackFit.expand,
+                            children: [
+                              if (episode.primaryImageTag != null)
+                                OfflineAwareImage(
+                                  imageUrl: widget.imageApi.getPrimaryImageUrl(
+                                    episode.id,
+                                    maxHeight: isMobile
+                                        ? 220
+                                        : (220 * desktopScale).round(),
+                                    tag: episode.primaryImageTag,
+                                  ),
+                                  fit: BoxFit.cover,
+                                  errorWidget: (_, _, _) => Container(
+                                    color: Colors.white.withValues(alpha: 0.05),
+                                    child: const AdaptiveIcon(
+                                      Icons.movie,
+                                      color: Colors.white24,
+                                      size: 32,
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                    SizedBox(width: isMobile ? 16 : 16 * desktopScale),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            [
-                              if (epNum != null)
-                                AppLocalizations.of(
-                                  context,
-                                ).episodeLabel(epNum),
-                              episode.name,
-                            ].join(' - '),
-                            style: Theme.of(context).textTheme.titleSmall
-                                ?.copyWith(
-                                  color: isNeon
-                                      ? AppColorScheme.accent
-                                      : Colors.white,
-                                  fontWeight: FontWeight.w600,
+                              if ((episode.playedPercentage ?? 0) > 0)
+                                _EpisodeProgressBar(
+                                  percentage: episode.playedPercentage!,
                                 ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
+                              if (episode.isPlayed)
+                                Positioned(
+                                  top: 6,
+                                  right: 6,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: AppColorScheme.accent,
+                                      shape: BoxShape.circle,
+                                    ),
+                                    child: Padding(
+                                      padding: EdgeInsets.all(3),
+                                      child: AdaptiveIcon(
+                                        Icons.check,
+                                        color: Colors.white,
+                                        size: 14,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                            ],
                           ),
-                          if (runtimeText != null) ...[
-                            const SizedBox(height: 2),
-                            Text(
-                              runtimeText,
-                              style: Theme.of(context).textTheme.bodySmall
-                                  ?.copyWith(
-                                    color: isNeon
-                                        ? AppColorScheme.onSurface.withValues(
-                                            alpha: 0.8,
-                                          )
-                                        : Colors.white.withValues(alpha: 0.5),
+                        ),
+                        SizedBox(width: isMobile ? 16 : 16 * desktopScale),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                [
+                                  if (epNum != null)
+                                    AppLocalizations.of(
+                                      context,
+                                    ).episodeLabel(epNum),
+                                  episode.name,
+                                ].join(' - '),
+                                style: Theme.of(context).textTheme.titleSmall
+                                    ?.copyWith(
+                                      color: isNeon
+                                          ? AppColorScheme.accent
+                                          : Colors.white,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              if (runtimeText != null) ...[
+                                const SizedBox(height: 2),
+                                Text(
+                                  runtimeText,
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(
+                                        color: isNeon
+                                            ? AppColorScheme.onSurface.withValues(
+                                                alpha: 0.8,
+                                              )
+                                            : Colors.white.withValues(alpha: 0.5),
+                                      ),
+                                ),
+                              ],
+                              if (episode.overview != null) ...[
+                                const SizedBox(height: 4),
+                                Text(
+                                  episode.overview!,
+                                  style: Theme.of(context).textTheme.bodySmall
+                                      ?.copyWith(
+                                        color: isNeon
+                                            ? AppColorScheme.onSurface
+                                            : Colors.white.withValues(alpha: 0.7),
+                                      ),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                        SizedBox(width: isMobile ? 12 : 12 * desktopScale),
+                      ],
+                    ),
+                  ),
+                  if (showFocusBorder || widget.isActive)
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            borderRadius: AppRadius.circular(8),
+                            border: showFocusBorder
+                                ? Border.fromBorderSide(
+                                    ThemeRegistry.active.borders.focusBorder.copyWith(
+                                      color: isNeon ? AppColorScheme.accent : focusColor,
+                                      width: 1.5,
+                                    ),
+                                  )
+                                : Border.fromBorderSide(
+                                    ThemeRegistry.active.borders.focusBorder.copyWith(
+                                      color: isNeon
+                                          ? const Color(0xFF00FFFF)
+                                          : Colors.cyan.withValues(alpha: 0.7),
+                                      width: 1.5,
+                                    ),
                                   ),
-                            ),
-                          ],
-                          if (episode.overview != null) ...[
-                            const SizedBox(height: 4),
-                            Text(
-                              episode.overview!,
-                              style: Theme.of(context).textTheme.bodySmall
-                                  ?.copyWith(
-                                    color: isNeon
-                                        ? AppColorScheme.onSurface
-                                        : Colors.white.withValues(alpha: 0.7),
-                                  ),
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ],
-                        ],
+                          ),
+                        ),
                       ),
                     ),
-                    SizedBox(width: isMobile ? 12 : 12 * desktopScale),
-                  ],
-                ),
+                ],
               ),
             ),
           ),

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -70,86 +70,93 @@ class SeasonCard extends StatelessWidget {
           decoration: BoxDecoration(
             borderRadius: radius,
             color: AppColorScheme.surface.withValues(alpha: 0.35),
-            border: isNextUp
-                ? Border.fromBorderSide(
-                    ThemeRegistry.active.borders.focusBorder.copyWith(
-                      color: isNeon
-                          ? const Color(0xFF00FFFF)
-                          : Colors.cyan.withValues(alpha: 0.7),
-                      width: 1.5,
-                    ),
-                  )
-                : Border.all(
-                    color: AppColorScheme.onSurface.withValues(alpha: 0.12),
-                  ),
           ),
-          child: ClipRRect(
-            borderRadius: radius,
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                if (imageUrl != null && imageUrl!.isNotEmpty)
-                  OfflineAwareImage(
-                    imageUrl: imageUrl!,
-                    fit: BoxFit.cover,
-                    errorWidget: (context, url, error) =>
-                        const SizedBox.shrink(),
-                  ),
-                Positioned.fill(
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Colors.transparent,
-                          Colors.black.withValues(alpha: 0.2),
-                          Colors.black.withValues(alpha: 0.85),
-                        ],
-                        stops: const [0.0, 0.4, 1.0],
-                      ),
+          clipBehavior: Clip.antiAlias,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              if (imageUrl != null && imageUrl!.isNotEmpty)
+                OfflineAwareImage(
+                  imageUrl: imageUrl!,
+                  fit: BoxFit.cover,
+                  errorWidget: (context, url, error) =>
+                      const SizedBox.shrink(),
+                ),
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [
+                        Colors.transparent,
+                        Colors.black.withValues(alpha: 0.2),
+                        Colors.black.withValues(alpha: 0.85),
+                      ],
+                      stops: const [0.0, 0.4, 1.0],
                     ),
                   ),
                 ),
-                Positioned(
-                  left: 8,
-                  right: 8,
-                  bottom: 8,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (isFallbackImage) ...[
-                        Text(
-                          title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: textTheme.labelLarge?.copyWith(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 11,
-                          ),
-                        ),
-                        const SizedBox(height: 2),
-                      ],
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Text(
-                          subtitle,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: textTheme.bodySmall?.copyWith(
-                            color: Colors.white.withValues(alpha: 0.85),
-                            fontWeight: FontWeight.w500,
-                            fontSize: 9,
-                          ),
+              ),
+              Positioned(
+                left: 8,
+                right: 8,
+                bottom: 8,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (isFallbackImage) ...[
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textTheme.labelLarge?.copyWith(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 11,
                         ),
                       ),
+                      const SizedBox(height: 2),
                     ],
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: Text(
+                        subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: Colors.white.withValues(alpha: 0.85),
+                          fontWeight: FontWeight.w500,
+                          fontSize: 9,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: radius,
+                      border: isNextUp
+                          ? Border.fromBorderSide(
+                              ThemeRegistry.active.borders.focusBorder.copyWith(
+                                color: isNeon
+                                    ? const Color(0xFF00FFFF)
+                                    : Colors.cyan.withValues(alpha: 0.7),
+                                width: 1.5,
+                              ),
+                            )
+                          : Border.all(
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.12),
+                            ),
+                    ),
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/ui/widgets/focus/focusable_wrapper.dart
+++ b/lib/ui/widgets/focus/focusable_wrapper.dart
@@ -232,15 +232,11 @@ class _FocusableWrapperState extends State<FocusableWrapper>
         fit: StackFit.passthrough,
         children: [
           widget.child,
-          Positioned(
-            left: -borderWidth,
-            top: -borderWidth,
-            right: -borderWidth,
-            bottom: -borderWidth,
+          Positioned.fill(
             child: IgnorePointer(
               child: Container(
                 decoration: BoxDecoration(
-                  borderRadius: AppRadius.circular(effectiveRadius + borderWidth),
+                  borderRadius: AppRadius.circular(effectiveRadius),
                   border: Border.fromBorderSide(
                     borders.focusBorder.copyWith(
                       color: color,

--- a/lib/ui/widgets/focus/focusable_wrapper.dart
+++ b/lib/ui/widgets/focus/focusable_wrapper.dart
@@ -222,16 +222,20 @@ class _FocusableWrapperState extends State<FocusableWrapper>
             suppressFocusGlow: widget.suppressFocusGlow,
           );
 
-    Widget childWithOverlay = widget.child;
-    if (_focused && !widget.useBackgroundFocus) {
-      final borders = ThemeRegistry.active.borders;
-      final effectiveRadius = AppColorScheme.isPixel ? 0.0 : widget.borderRadius;
-      final borderWidth = FocusTheme.borderWidth;
-      childWithOverlay = Stack(
-        clipBehavior: Clip.none,
-        fit: StackFit.passthrough,
-        children: [
-          widget.child,
+    // Keep the child inside a stable Stack whether or not it is focused, and
+    // only add or remove the border overlay. Rebuilding the Stack around the
+    // child on every focus change would give the child a fresh element and
+    // restart things like image fade-ins each time it gains or loses focus.
+    final borders = ThemeRegistry.active.borders;
+    final effectiveRadius = AppColorScheme.isPixel ? 0.0 : widget.borderRadius;
+    final borderWidth = FocusTheme.borderWidth;
+    final showOverlayBorder = _focused && !widget.useBackgroundFocus;
+    final childWithOverlay = Stack(
+      clipBehavior: Clip.none,
+      fit: StackFit.passthrough,
+      children: [
+        widget.child,
+        if (showOverlayBorder)
           Positioned.fill(
             child: IgnorePointer(
               child: Container(
@@ -247,9 +251,8 @@ class _FocusableWrapperState extends State<FocusableWrapper>
               ),
             ),
           ),
-        ],
-      );
-    }
+      ],
+    );
 
     Widget content = AnimatedContainer(
       duration: FocusTheme.animationDuration,

--- a/lib/ui/widgets/focus/focusable_wrapper.dart
+++ b/lib/ui/widgets/focus/focusable_wrapper.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'package:moonfin_design/moonfin_design.dart';
+
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/focus/key_event_utils.dart';
 import 'focus_theme.dart';
@@ -216,15 +218,48 @@ class _FocusableWrapperState extends State<FocusableWrapper>
         : FocusTheme.focusDecoration(
             isFocused: _focused,
             radius: widget.borderRadius,
-            color: color,
+            color: null,
             suppressFocusGlow: widget.suppressFocusGlow,
           );
+
+    Widget childWithOverlay = widget.child;
+    if (_focused && !widget.useBackgroundFocus) {
+      final borders = ThemeRegistry.active.borders;
+      final effectiveRadius = AppColorScheme.isPixel ? 0.0 : widget.borderRadius;
+      final borderWidth = FocusTheme.borderWidth;
+      childWithOverlay = Stack(
+        clipBehavior: Clip.none,
+        fit: StackFit.passthrough,
+        children: [
+          widget.child,
+          Positioned(
+            left: -borderWidth,
+            top: -borderWidth,
+            right: -borderWidth,
+            bottom: -borderWidth,
+            child: IgnorePointer(
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: AppRadius.circular(effectiveRadius + borderWidth),
+                  border: Border.fromBorderSide(
+                    borders.focusBorder.copyWith(
+                      color: color,
+                      width: borderWidth,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
 
     Widget content = AnimatedContainer(
       duration: FocusTheme.animationDuration,
       curve: Curves.easeOut,
       decoration: decoration,
-      child: widget.child,
+      child: childWithOverlay,
     );
 
     if (!widget.disableScale) {


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves focus outline clipping, alignment, and gap issues on TV cards (including "More from this season" episode cards and "Season" cards) by rendering borders as Stack overlays instead of container decorations. This resolves focus indicator clipping/gaps that were reported on Discord.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **`focusable_wrapper.dart`**: Renders focus border overlay on top of the child using a negative-margin-free `Positioned.fill` Stack overlay.
- **`season_card.dart`**: Draws default/nextUp borders as a Stack overlay instead of a `BoxDecoration` border, and enabled `clipBehavior: Clip.antiAlias` on its Container to ensure the poster fills the card perfectly to the corners (preventing corner background peeking).
- **`item_detail_screen.dart`**: Adjusted the horizontal `_EpisodesRow` `ListView` container height to exactly fit the card content height, eliminating the empty layout space below the card labels. Updated `_EpisodeListCard`, `DetailNextUpCard`, and `DetailEpisodeCard` to use the same Stack overlay pattern for drawing focus and active borders.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on AndroidTV
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the pages
2. Look for the clipping
3. Don't find it!

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### OLD CLIPPED CORNERS:
<img width="918" height="763" alt="2026-07-12_19-33-28_Discord" src="https://github.com/user-attachments/assets/dee64e02-7c08-4179-81f3-64d37e908196" />
<img width="468" height="589" alt="image0" src="https://github.com/user-attachments/assets/1631bed1-0cb1-4504-9b06-69442647cb48" />
<img width="836" height="1387" alt="Shield_Screenshot_2026-07-12_19-37-47" src="https://github.com/user-attachments/assets/815a5335-aa29-4b24-9b45-a9e4c0282930" />

### FIXED:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_20-02-21" src="https://github.com/user-attachments/assets/ddd2f65d-2f31-4826-882a-5d5b761e4987" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_20-03-21" src="https://github.com/user-attachments/assets/7d351163-13d9-4739-b193-72862239aa6c" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
