### PR TITLE
bugfix-ui - Fix text label selection/focused color for Classic Details page

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -9967,7 +9967,8 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         : (widget.isActive
               ? (widget.activeColor ?? (isNeon ? neonAccent : Colors.white))
               : (isNeon ? neonAccent : Colors.white));
-    final labelColor = showHighlight
+    final showLabelInside = modern && (widget.isPrimary || !isMobile);
+    final labelColor = (showHighlight && showLabelInside)
         ? AppColorScheme.onButtonFocused
         : (isNeon ? neonAccent : Colors.white);
 

--- a/lib/ui/theme/app_theme.dart
+++ b/lib/ui/theme/app_theme.dart
@@ -96,6 +96,11 @@ class AppTheme {
         scrim: c.scrim,
       ),
       scaffoldBackgroundColor: c.background,
+      textSelectionTheme: TextSelectionThemeData(
+        selectionColor: c.accent.withValues(alpha: 0.40),
+        selectionHandleColor: c.accent,
+        cursorColor: c.accent,
+      ),
       cardTheme: CardThemeData(
         color: JellyfinTokens.colors.card,
         shape: buttonShape,


### PR DESCRIPTION
# Pull Request

## Summary
This PR resolves text selection and focused button label legibility issues on dark backgrounds by:
1. Adding a global `textSelectionTheme` config using the active theme's accent color (with 40% alpha) for selection highlights.
2. Fixing the focused button text label color to only switch to `onButtonFocused` (black) when it is rendered inside the focused container pill, leaving external/underneath labels white.

## Related Issues
Link related issues or tickets separated by commas.

Discord feedback.
- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **`app_theme.dart`:
  - Added a global `textSelectionTheme` config to the `ThemeData` build method.
  - Set `selectionColor` to the active theme's accent color with `40%` opacity (`c.accent.withValues(alpha: 0.40)`).
  - Set `selectionHandleColor` and `cursorColor` to `c.accent`.

- **`item_detail_screen.dart`**:
  - Fixed `labelColor` styling logic in `_DetailActionButtonState` to only switch button labels to `onButtonFocused` (black) when the label is rendered inside the focused container (pill shape).
  - Left labels white or neon accent when they are rendered outside the container (like in the Classic details layout or on Mobile UI).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin and browse details pages

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### ORIGINAL
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_22-16-03" src="https://github.com/user-attachments/assets/141e64f4-adfc-4d1d-8071-55a87c4ba708" />

### NEW
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_22-30-40" src="https://github.com/user-attachments/assets/9aeff00e-4055-4181-a807-51d92874097b" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-12_22-31-40" src="https://github.com/user-attachments/assets/29d6beb8-4199-4682-a047-0f2aaec8d943" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
