### PR TITLE
fix system screensaver overriding internal screensaver

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -325,6 +325,9 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
     _hardwareKeyHandler = _onHardwareKeyEvent;
     HardwareKeyboard.instance.addHandler(_hardwareKeyHandler);
     _screensaverController.visible.addListener(_onScreensaverVisibleChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _screensaverController.refreshWakeLock();
+    });
     if (_trackMouseThumbHistory) {
       appRouter.routerDelegate.addListener(_onRouterStateChanged);
       _onRouterStateChanged();

--- a/lib/ui/screensaver/screensaver_controller.dart
+++ b/lib/ui/screensaver/screensaver_controller.dart
@@ -20,6 +20,7 @@ class ScreensaverController {
       _prefs.addListener(_onPrefsChanged);
       _restartIdleTimer();
     }
+    visible.addListener(refreshWakeLock);
     _refreshWakeLock();
   }
 
@@ -57,6 +58,7 @@ class ScreensaverController {
   void setMediaBarTrailerActive(bool value) {
     if (_trailerActive == value) return;
     _trailerActive = value;
+    _refreshWakeLock();
     _onStateChanged();
   }
 
@@ -108,6 +110,7 @@ class ScreensaverController {
   void _onPlayingChanged(bool playing) {
     if (_streamPlaying == playing) return;
     _streamPlaying = playing;
+    _refreshWakeLock();
     _onStateChanged();
   }
 
@@ -159,18 +162,27 @@ class ScreensaverController {
     } catch (_) {}
   }
 
-  void _refreshWakeLock() {
+  void _refreshWakeLock({bool force = false}) {
     final shouldEnable =
         !_activityPaused &&
-        (_playbackActive || (PlatformDetection.isTV && _enabledCache));
-    if (_wakeLockEnabled == shouldEnable) {
+            (_playbackActive ||
+                _streamPlaying ||
+                _trailerActive ||
+                visible.value ||
+                (PlatformDetection.isTV && _enabledCache));
+    if (_wakeLockEnabled == shouldEnable && !force) {
       return;
     }
     _wakeLockEnabled = shouldEnable;
     unawaited(_setWakeLockEnabled(shouldEnable));
   }
 
+  void refreshWakeLock() {
+    _refreshWakeLock(force: true);
+  }
+
   void dispose() {
+    visible.removeListener(refreshWakeLock);
     _playingSub?.cancel();
     _idleTimer?.cancel();
     _prefs.removeListener(_onPrefsChanged);


### PR DESCRIPTION
## Summary
Modified ScreensaverController to account for more states.  When the internal screensaver is enabled, the app holds a wake lock even when idle for TV platforms.  This prevents the system screensaver entirely.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- _refreshWakeLock is now also called in setMediaBarTrailerActive, _onPlayingChanged, and in a listener for visible
- added a public refreshWakeLock method with the force flag set to true - called in app.dart's _GlobalShortcutScopeState - initState in a postframe callback

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. enable internal screensaver, verify system screensaver never turns on
2. disable internal screensaver, verify system sreensaver turns on after the system timer

## Screenshots (if applicable)

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
