### PR TITLE
feat-library - Add option to hide backdrops when browsing libraries

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -421,6 +421,10 @@
   "@gameSaveState": {
     "description": "In-game menu action to save the game state"
   },
+  "games": "Games",
+  "@games": {
+    "description": "Label for the games category tab in search results"
+  },
   "gameLoadState": "Load state",
   "@gameLoadState": {
     "description": "In-game menu action to load the saved game state"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8093,6 +8093,10 @@
   "@showMediaDetailsOnLibraryPageDescription": {
     "description": "Setting description to show/hide focused media details at the top of the library page"
   },
+  "hideBackdropsInLibraries": "Hide Backdrops while Browsing?",
+  "@hideBackdropsInLibraries": {
+    "description": "Setting title to show/hide backdrops when browsing library pages"
+  },
   "useDetailedSubHeadings": "Use Detailed Sub-Headings",
   "@useDetailedSubHeadings": {
     "description": "Label for setting to toggle detailed or minimal subrow on library pages"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -802,6 +802,12 @@ abstract class AppLocalizations {
   /// **'Save state'**
   String get gameSaveState;
 
+  /// Label for the games category tab in search results
+  ///
+  /// In en, this message translates to:
+  /// **'Games'**
+  String get games;
+
   /// In-game menu action to load the saved game state
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15340,6 +15340,12 @@ abstract class AppLocalizations {
   /// **'Show details of the selected item at the top of Library pages.'**
   String get showMediaDetailsOnLibraryPageDescription;
 
+  /// Setting title to show/hide backdrops when browsing library pages
+  ///
+  /// In en, this message translates to:
+  /// **'Hide Backdrops while Browsing?'**
+  String get hideBackdropsInLibraries;
+
   /// Label for setting to toggle detailed or minimal subrow on library pages
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -336,6 +336,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -8605,6 +8605,9 @@ class AppLocalizationsAf extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Gebruik gedetailleerde subopskrifte';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -334,6 +334,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -8557,6 +8557,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'استخدم العناوين الفرعية التفصيلية';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -336,6 +336,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8627,6 +8627,9 @@ class AppLocalizationsBe extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings =>
       'Выкарыстоўвайце падрабязныя падзагалоўкі';
 

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -335,6 +335,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8671,6 +8671,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Използвайте подробни подзаглавия';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -335,6 +335,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -8594,6 +8594,9 @@ class AppLocalizationsBn extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'বিস্তারিত উপ-শিরোনাম ব্যবহার করুন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -337,6 +337,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get gameSaveState => 'Desa l’estat actual';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Carregar estat';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8711,6 +8711,9 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra els detalls de l\'item seleccionat a dalt la pàgina de Biblioteca.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Utilitzeu subtítols detallats';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -337,6 +337,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8609,6 +8609,9 @@ class AppLocalizationsCs extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Použijte podrobné podnadpisy';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -336,6 +336,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8622,6 +8622,9 @@ class AppLocalizationsCy extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Defnyddiwch Is-benawdau Manwl';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -337,6 +337,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8598,6 +8598,9 @@ class AppLocalizationsDa extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Brug detaljerede underoverskrifter';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -154,14 +154,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Erweiterte Tabs';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Tab-Inhalte beim Wechseln zwischen den Tabs automatisch anzeigen. Deaktivieren, um jeden Tab manuell zu öffnen und zu schließen.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
-  String get showTechnicalDetails => 'Technische Details anzeigen?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
@@ -178,11 +178,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb-Ähnlichkeit';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Begrenzung nach Altersfreigabe anwenden?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
@@ -225,7 +225,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wechsel zwischen \"Moonfin\" und \"Neon Pulse\", ohne die App neu zu starten';
 
   @override
-  String get customThemeTitle => 'Benutzerdefiniertes Theme';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
@@ -334,6 +334,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get gameSaveState => 'Save state';
+
+  @override
+  String get games => 'Games';
 
   @override
   String get gameLoadState => 'Load state';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -154,14 +154,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Expanded Tabs';
+  String get expandedTabs => 'Erweiterte Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
+      'Tab-Inhalte beim Wechseln zwischen den Tabs automatisch anzeigen. Deaktivieren, um jeden Tab manuell zu öffnen und zu schließen.';
 
   @override
-  String get showTechnicalDetails => 'Show Technical Details?';
+  String get showTechnicalDetails => 'Technische Details anzeigen?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
@@ -178,11 +178,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb Similarity';
+  String get recommendationSystemTmdb => 'TMDb-Ähnlichkeit';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Apply Parental Rating Cap?';
+      'Begrenzung nach Altersfreigabe anwenden?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
@@ -225,7 +225,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wechsel zwischen \"Moonfin\" und \"Neon Pulse\", ohne die App neu zu starten';
 
   @override
-  String get customThemeTitle => 'Custom Theme';
+  String get customThemeTitle => 'Benutzerdefiniertes Theme';
 
   @override
   String get customThemeSubtitle =>
@@ -8731,6 +8731,9 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
       'Show details of the selected item at the top of Library pages.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings =>

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -338,6 +338,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8712,6 +8712,9 @@ class AppLocalizationsEl extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings =>
       'Χρησιμοποιήστε λεπτομερείς υποεπικεφαλίδες';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -335,6 +335,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override
@@ -17146,6 +17149,9 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
       'Show details of the selected item at the top of Library pages.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8543,6 +8543,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -335,6 +335,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -8588,6 +8588,9 @@ class AppLocalizationsEo extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Uzu Detalaj Sub-Titoloj';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -336,6 +336,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override
@@ -17413,6 +17416,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
       'Aplique sugerencias de tamaño de fuente incrustadas en la pista de subtítulos. Desactive el uso del tamaño de los subtítulos en sus preferencias de estilo.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Utilice subtítulos detallados';
 
   @override
@@ -25377,6 +25383,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
       'Aplique sugerencias de tamaño de fuente incrustadas en la pista de subtítulos. Desactive el uso del tamaño de los subtítulos en sus preferencias de estilo.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Utilice subtítulos detallados';
@@ -33345,6 +33354,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
       'Aplique sugerencias de tamaño de fuente incrustadas en la pista de subtítulos. Desactive el uso del tamaño de los subtítulos en sus preferencias de estilo.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Utilice subtítulos detallados';
 
   @override
@@ -41309,6 +41321,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
       'Aplique sugerencias de tamaño de fuente incrustadas en la pista de subtítulos. Desactive el uso del tamaño de los subtítulos en sus preferencias de estilo.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Utilice subtítulos detallados';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8674,6 +8674,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Utilice subtítulos detallados';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -337,6 +337,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8613,6 +8613,9 @@ class AppLocalizationsEt extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Kasutage üksikasjalikke alapealkirju';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -334,6 +334,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -8561,6 +8561,9 @@ class AppLocalizationsFa extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'از عناوین فرعی تفصیلی استفاده کنید';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -338,6 +338,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8625,6 +8625,9 @@ class AppLocalizationsFi extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Käytä yksityiskohtaisia ​​alaotsikoita';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -335,6 +335,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get gameSaveState => 'Sauvegarder';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Charger une sauvegarde';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8699,6 +8699,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les détails de l\'élément sélectionné en haut des pages de la bibliothèque.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Informations détaillées sous le titre';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -337,6 +337,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8699,6 +8699,9 @@ class AppLocalizationsGl extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -333,6 +333,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -8498,6 +8498,9 @@ class AppLocalizationsHe extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -336,6 +336,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -8580,6 +8580,9 @@ class AppLocalizationsHi extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -336,6 +336,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -8624,6 +8624,9 @@ class AppLocalizationsHr extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -337,6 +337,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get gameSaveState => 'Állás mentése';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Állás betöltése';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8703,6 +8703,9 @@ class AppLocalizationsHu extends AppLocalizations {
       'A kijelölt elem részleteinek megjelenítése a könyvtároldalak tetején.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Részletes alcímek használata';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -336,6 +336,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -8603,6 +8603,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Tampilkan detail item yang dipilih di bagian atas halaman Pustaka.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Gunakan Subjudul Terperinci';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -336,6 +336,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get gameSaveState => 'Salva stato';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Carica stato';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8648,6 +8648,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -329,6 +329,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -8407,6 +8407,9 @@ class AppLocalizationsJa extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -335,6 +335,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8635,6 +8635,9 @@ class AppLocalizationsKk extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -336,6 +336,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8650,6 +8650,9 @@ class AppLocalizationsKn extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -329,6 +329,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -8402,6 +8402,9 @@ class AppLocalizationsKo extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -336,6 +336,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8629,6 +8629,9 @@ class AppLocalizationsLt extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Naudokite išsamias antraštes';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -337,6 +337,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8636,6 +8636,9 @@ class AppLocalizationsLv extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings =>
       'Izmantojiet detalizētus apakšvirsrakstus';
 

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -336,6 +336,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8653,6 +8653,9 @@ class AppLocalizationsMk extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -337,6 +337,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8693,6 +8693,9 @@ class AppLocalizationsMl extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'വിശദമായ ഉപതലക്കെട്ടുകൾ ഉപയോഗിക്കുക';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -336,6 +336,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8628,6 +8628,9 @@ class AppLocalizationsMn extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Нарийвчилсан дэд гарчгийг ашиглана уу';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -336,6 +336,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8603,6 +8603,9 @@ class AppLocalizationsNb extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -337,6 +337,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8633,6 +8633,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -336,6 +336,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -8583,6 +8583,9 @@ class AppLocalizationsPa extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -9,26 +9,26 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
-  String get appTitle => 'Moonfin';
+  String get appTitle => 'Księżycowa Płetwa';
 
   @override
-  String get accountPreferences => 'Ustawienia konta';
+  String get accountPreferences => 'ACCOUNT PREFERENCES';
 
   @override
-  String get interfaceLanguage => 'Język interfejsu';
+  String get interfaceLanguage => 'Interface Language';
 
   @override
-  String get systemLanguageDefault => 'Zgodnie z systemem';
+  String get systemLanguageDefault => 'System Default';
 
   @override
-  String get signIn => 'Logowanie';
+  String get signIn => 'Zalogować się';
 
   @override
-  String get empty => 'Brak';
+  String get empty => 'Empty';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Połącz z $serverName';
+    return 'Connecting to $serverName';
   }
 
   @override
@@ -45,13 +45,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get quickConnectInstruction =>
-      'Wpisz ten kod w panelu internetowym swojego serwera:';
+      'Wpisz ten kod na panelu internetowym swojego serwera:';
 
   @override
-  String get waitingForAuthorization => 'Autoryzacja...';
+  String get waitingForAuthorization => 'Oczekiwanie na autoryzację...';
 
   @override
-  String get back => 'Powrót';
+  String get back => 'Z powrotem';
 
   @override
   String get serverUnavailable => 'Serwer jest niedostępny';
@@ -61,12 +61,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'Szybkie połączenie nieudane: $detail';
+    return 'QuickConnect unavailable: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'Szybkie połączenie nieudane ($status): $detail';
+    return 'QuickConnect unavailable ($status): $detail';
   }
 
   @override
@@ -80,17 +80,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin wersja $version';
+    return 'Moonfin version $version';
   }
 
   @override
   String get savedServers => 'Zapisane serwery';
 
   @override
-  String get discoveredServers => 'Wykryte serwery';
+  String get discoveredServers => 'Odkryte serwery';
 
   @override
-  String get noneFound => 'Nie znaleziono';
+  String get noneFound => 'Nie znaleziono żadnych';
 
   @override
   String get unableToConnectToServer => 'Nie można połączyć się z serwerem';
@@ -99,21 +99,21 @@ class AppLocalizationsPl extends AppLocalizations {
   String get addServer => 'Dodaj serwer';
 
   @override
-  String get embyConnect => 'Połącz z Emby';
+  String get embyConnect => 'Emby Połącz';
 
   @override
   String get removeServer => 'Usuń serwer';
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Usunąć \"$serverName\" ?';
+    return 'Remove \"$serverName\" from your servers?';
   }
 
   @override
-  String get cancel => 'Anuluj';
+  String get cancel => 'Anulować';
 
   @override
-  String get remove => 'Usuń';
+  String get remove => 'Usunąć';
 
   @override
   String get connectToServer => 'Połącz się z serwerem';
@@ -125,10 +125,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get serverAddressHint => 'https://twój-serwer.example.com';
 
   @override
-  String get connect => 'Połącz';
+  String get connect => 'Łączyć';
 
   @override
-  String get secureStorageUnavailable => 'Bezpieczny magazyn niedostępny';
+  String get secureStorageUnavailable =>
+      'Bezpieczne przechowywanie jest niedostępne';
 
   @override
   String get secureStorageUnavailableMessage =>
@@ -141,24 +142,24 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAppearanceTheme => 'Motyw aplikacji';
 
   @override
-  String get detailScreenStyle => 'Widok szczegółów';
+  String get detailScreenStyle => 'Detail screen style';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Klasyczny to oryginalny układ Moonfin. Nowoczesny to responsywny układ w stylu kinowym.';
+      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Klasyczny';
+  String get detailScreenStyleMoonfin => 'Classic';
 
   @override
-  String get detailScreenStyleModern => 'Nowoczesny';
+  String get detailScreenStyleModern => 'Modern';
 
   @override
-  String get expandedTabs => 'Rozwinięcie zakładki';
+  String get expandedTabs => 'Expanded Tabs';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automatycznie pokazuj zawartość zakładki podczas przeglądania. Wyłącz aby otwierać i zamykać zakładki ręcznie.';
+      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
 
   @override
   String get showTechnicalDetails => 'Show Technical Details?';
@@ -168,35 +169,35 @@ class AppLocalizationsPl extends AppLocalizations {
       'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'System rekomendacji';
+  String get recommendationSystem => 'Recommendation System';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Użyj lokalnego algorytmu Moonfin lub metryk online z TMDb. Uwaga! Rekomendacje online wymagają integracji z Seerr.';
+      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'Dopasowanie TMDb';
+  String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Zastosować limit oceny rodzicielskiej?';
+      'Apply Parental Rating Cap?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Ogranicz sugestie Moonfin do poziomu oceny rodzicielskiej filmu';
+      'Limit Moonfin Recommends suggestions by parental rating of target media';
 
   @override
-  String get interfaceStyle => 'Styl interfejsu';
+  String get interfaceStyle => 'Interface Style';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatyczne dopasowanie do urządzenia. Wybierz Apple lub Material aby wymusić wygląd.';
+      'Automatic matches your device. Choose Apple or Material to force a look.';
 
   @override
-  String get interfaceStyleAutomatic => 'Tryb auto';
+  String get interfaceStyleAutomatic => 'Automatic';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -205,65 +206,66 @@ class AppLocalizationsPl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Jakość efektu szkła/rozmycia';
+  String get glassQuality => 'Glass Quality';
 
   @override
   String get glassQualitySubtitle =>
-      'Automatycznie dobiera najlepszy efekt dla tego urządzenia. Pełny wymusza prawdziwe rozmycie. Zmniejszony korzysta z uproszczonego efektu, oszczędzając GPU.';
+      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
 
   @override
   String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Pełny';
+  String get glassQualityFull => 'Full';
 
   @override
-  String get glassQualityReduced => 'Zmniejszony';
+  String get glassQualityReduced => 'Reduced';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
-      'Zastosuj niestandardowy motyw i przełączaj się między interfejsami.';
+      'Przełączaj się między Moonfin i Neon Pulse bez ponownego uruchamiania aplikacji';
 
   @override
-  String get customThemeTitle => 'Niestandardowy motyw';
+  String get customThemeTitle => 'Custom Theme';
 
   @override
   String get customThemeSubtitle =>
-      'Niestandardowe motywy zmieniają elementy wizualne całej aplikacji Moonfin. Wybierz jedną z opcji, aby dopasować wygląd do swojego upodobania.';
+      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
 
   @override
-  String get keyboardPreferSystemIme => 'Preferuj klawiaturę systemową';
+  String get keyboardPreferSystemIme => 'Prefer system keyboard';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Używaj systemowej metody wprowadzania tekstu';
+      'Use your device input method by default for text entry';
 
   @override
-  String get themeMoonfin => 'Moonfin';
+  String get themeMoonfin => 'Księżycowa Płetwa';
 
   @override
-  String get themeMoonfinSubtitle => 'Oryginalny czysty motyw Moonfin.';
+  String get themeMoonfinSubtitle =>
+      'Obecny wygląd Moonfin, który wszyscy pokochaliście';
 
   @override
-  String get themeNeonPulse => 'Neon Pulse';
+  String get themeNeonPulse => 'Neonowy puls';
 
   @override
   String get themeNeonPulseSubtitle =>
-      'Synthwave z magentową poświatą, cyjanowym tekstem i silniejszym kontrastem chromu';
+      'Styl Synthwave z magentową poświatą, cyjanowym tekstem i silniejszym kontrastem chromu';
 
   @override
-  String get themeGlass => 'Rozmycie';
+  String get themeGlass => 'Glass';
 
   @override
   String get themeGlassSubtitle =>
-      'Liquid-glass z gradientowym tłem, matowymi powierzchniami i akcentem w kolorze Apple-blue';
+      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pikselowy styl z grubą paletą kolorów, kanciastymi ramkami, twardymi cieniami i pikselową czcionką';
+      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -313,7 +315,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Nie można połączyć się z  $target';
+    return 'Unable to connect to $target';
   }
 
   @override
@@ -329,40 +331,42 @@ class AppLocalizationsPl extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Wstrzymano';
+  String get gamePaused => 'Paused';
 
   @override
-  String get gameSaveState => 'Zapisz stan';
+  String get gameSaveState => 'Save state';
 
   @override
-  String get gameLoadState => 'Wczytaj stan';
+  String get games => 'Games';
 
   @override
-  String get gameFastForward => 'Przewijanie do przodu';
+  String get gameLoadState => 'Load state';
 
   @override
-  String get gameEmulatorSettings => 'Opcje emulatora';
+  String get gameFastForward => 'Fast-forward';
 
   @override
-  String get gameNoCoreOptions =>
-      'Ten rdzeń nie udostępnia żadnych opcji do zastosowania.';
+  String get gameEmulatorSettings => 'Emulator settings';
 
   @override
-  String get gameHoldToOpenMenu => 'Przytrzymaj aby otworzyć menu';
+  String get gameNoCoreOptions => 'This core has no adjustable options.';
+
+  @override
+  String get gameHoldToOpenMenu => 'Hold to open menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Odtwarzanie gier nie jest jeszcze obsługiwane na tym urządzeniu.';
+      'Game playback is not supported on this device yet.';
 
   @override
   String get noHomeRowsLoaded => 'Nie można wczytać żadnych wierszy głównych';
 
   @override
   String get noHomeRowsHint =>
-      'Spróbuj odświeżyć stronę lub zmniejszyć liczbę aktywnych sekcji na ekranie głównym.';
+      'Spróbuj odświeżyć lub zmniejszyć aktywne sekcje strony głównej.';
 
   @override
-  String get retryHomeRows => 'Odśwież wiersze Home';
+  String get retryHomeRows => 'Ponów próbę wierszy głównych';
 
   @override
   String get guide => 'Przewodnik';
@@ -374,7 +378,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get schedule => 'Harmonogram';
 
   @override
-  String get series => 'Seriale';
+  String get series => 'Szereg';
 
   @override
   String get noItemsFound => 'Nie znaleziono żadnych elementów';
@@ -392,7 +396,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get collectionPlaceholder => 'Tutaj pojawią się elementy kolekcji';
 
   @override
-  String get browseByLetter => 'Alfabetycznie';
+  String get browseByLetter => 'Przeglądaj według listu';
 
   @override
   String get alphabeticalBrowsePlaceholder =>
@@ -424,7 +428,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Nie udało się wczytać folderu: $error';
+    return 'Failed to load folder: $error';
   }
 
   @override
@@ -432,14 +436,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count elementów';
+    return '$count items';
   }
 
   @override
   String get failedToLoadFavorites => 'Nie udało się załadować ulubionych';
 
   @override
-  String get retry => 'Ponów';
+  String get retry => 'Spróbować ponownie';
 
   @override
   String get noFavoritesYet => 'Nie ma jeszcze ulubionych';
@@ -449,11 +453,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count elementów';
+    return '$count Items';
   }
 
   @override
-  String get continuing => 'W trakcie';
+  String get continuing => 'Kontynuacja';
 
   @override
   String get ended => 'Zakończone';
@@ -468,7 +472,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get sortBy => 'Sortuj według';
 
   @override
-  String get display => 'Wyświetlanie';
+  String get display => 'Wyświetlacz';
 
   @override
   String get imageType => 'Typ obrazu';
@@ -490,7 +494,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Gatunki';
+    return '$name — Genres';
   }
 
   @override
@@ -500,7 +504,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get albums => 'Albumy';
 
   @override
-  String get albumArtists => 'Wykonawcy albumu';
+  String get albumArtists => 'Artyści albumowi';
 
   @override
   String get artists => 'Artyści';
@@ -525,32 +529,32 @@ class AppLocalizationsPl extends AppLocalizations {
   String get bookmark => 'Zakładka w książce';
 
   @override
-  String get justNow => 'Przed chwilą';
+  String get justNow => 'Właśnie';
 
   @override
   String minutesAgo(int count) {
-    return '${count}m temu';
+    return '${count}m ago';
   }
 
   @override
   String hoursAgo(int count) {
-    return '${count}h temu';
+    return '${count}h ago';
   }
 
   @override
   String daysAgo(int count) {
-    return '${count}d temu';
+    return '${count}d ago';
   }
 
   @override
-  String get discoverySubjects => 'Tematy';
+  String get discoverySubjects => 'Przedmioty odkrycia';
 
   @override
   String get pickDiscoverySubjects =>
       'Wybierz kanały tematyczne, które mają być wyświetlane w Discover.';
 
   @override
-  String get apply => 'Zastosuj';
+  String get apply => 'Stosować';
 
   @override
   String get openLink => 'Otwórz łącze';
@@ -569,11 +573,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get discoverAudiobooks => 'Odkryj audiobooki';
 
   @override
-  String get librivoxDescription => 'Popularne tytuły od LibriVox.';
+  String get librivoxDescription =>
+      'Popularne tytuły domeny publicznej od LibriVox.';
 
   @override
   String titlesCount(int count) {
-    return '$count tytułów';
+    return '$count titles';
   }
 
   @override
@@ -595,10 +600,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get continueListening => 'Kontynuuj słuchanie';
 
   @override
-  String get listen => 'Słuchaj';
+  String get listen => 'Słuchać';
 
   @override
-  String get resume => 'Wznów';
+  String get resume => 'Wznawiać';
 
   @override
   String get failedToLoadLibrary => 'Nie udało się załadować biblioteki';
@@ -613,10 +618,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get topListens => 'Najczęściej słuchane';
 
   @override
-  String get unreadDiscoveries => 'Nieprzeczytane propozycje';
+  String get unreadDiscoveries => 'Nieprzeczytane odkrycia';
 
   @override
-  String get pickUpAgain => 'Wróć do czytania';
+  String get pickUpAgain => 'Odbierz ponownie';
 
   @override
   String get bookHighlightsDescription =>
@@ -635,11 +640,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get jumpBackNarration =>
-      'Wróć dosłuchania bez szukania miejsca, w którym skończyłeś.';
+      'Wróć do narracji bez szukania swojego miejsca.';
 
   @override
   String get unreadBooksReady =>
-      'Nieprzeczytane książki gotowe na Twoją najbliższą wolną chwilę.';
+      'Nieprzeczytane książki gotowe na następną cichą godzinę.';
 
   @override
   String get quickAccessFavorites =>
@@ -661,24 +666,24 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count autorzy';
+    return '$count authors';
   }
 
   @override
   String genresCount(int count) {
-    return '$count gatunki';
+    return '$count genres';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% ukończone';
+    return '$percent% completed';
   }
 
   @override
-  String get readyWhenYouAre => 'Czekamy, aż zaczniesz';
+  String get readyWhenYouAre => 'Gotowy, kiedy będziesz';
 
   @override
-  String get details => 'Detale';
+  String get details => 'Bliższe dane';
 
   @override
   String get listeningRoom => 'Pokój Słuchania';
@@ -688,7 +693,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count tytułów dostępnych do przeglądania.';
+    return '$count titles arranged for reading-first browsing.';
   }
 
   @override
@@ -698,7 +703,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get allTitles => 'Wszystkie tytuły';
 
   @override
-  String get authors => 'Autorzy';
+  String get authors => 'Autorski';
 
   @override
   String get browseByAuthor => 'Przeglądaj według autora';
@@ -707,7 +712,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get browseByGenre => 'Przeglądaj według gatunku';
 
   @override
-  String get discover => 'Odkrywaj';
+  String get discover => 'Odkryć';
 
   @override
   String get trendingTitlesOpenLibrary =>
@@ -726,11 +731,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'Nie znaleziono $label';
+    return 'No $label found';
   }
 
   @override
-  String get folder => 'Folder';
+  String get folder => 'Falcówka';
 
   @override
   String get filters => 'Filtry';
@@ -739,22 +744,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get readingStatus => 'Stan czytania';
 
   @override
-  String get playedStatus => 'Status odtworzenia';
+  String get playedStatus => 'Stan gry';
 
   @override
-  String get readStatus => 'Czytaj';
+  String get readStatus => 'Czytać';
 
   @override
-  String get watched => 'Obejrzane';
+  String get watched => 'Obejrzałem';
 
   @override
-  String get unread => 'Nieprzeczytane';
+  String get unread => 'Niewykształcony';
 
   @override
-  String get unwatched => 'Zaznacz jako obejrzane';
+  String get unwatched => 'Nieobserwowane';
 
   @override
-  String get seriesStatus => 'Status serialu';
+  String get seriesStatus => 'Stan serii';
 
   @override
   String get allLibraries => 'Wszystkie biblioteki';
@@ -763,43 +768,43 @@ class AppLocalizationsPl extends AppLocalizations {
   String get books => 'Książki';
 
   @override
-  String get latestBooks => 'Ostatnio dodane książki';
+  String get latestBooks => 'Latest Books';
 
   @override
-  String get latestAudiobooks => 'Ostatnio dodane Audiobooki';
+  String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count książki',
-      one: '1 książka',
+      other: '$count books',
+      one: '1 book',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Książka';
+  String get bookFormatBook => 'Book';
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% przeczytane';
+    return '$percent% read';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time zostało';
+    return '$time left';
   }
 
   @override
-  String get bookHeroRead => 'Przeczytane';
+  String get bookHeroRead => 'Read';
 
   @override
-  String get bookHeroListen => 'Słuchaj';
+  String get bookHeroListen => 'Listen';
 
   @override
   String get author => 'Autor';
@@ -818,7 +823,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'LibriVox nie dostarczył jeszcze opisu dla tego tytułu.';
 
   @override
-  String get readers => 'Lektorzy';
+  String get readers => 'Czytelnicy';
 
   @override
   String get openLinks => 'Otwórz linki';
@@ -837,12 +842,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count sekcji';
+    return '$count sections';
   }
 
   @override
   String firstPublished(int year) {
-    return 'Data pierwszego wydania $year';
+    return 'First published $year';
   }
 
   @override
@@ -850,14 +855,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'W Open Library nie ma jeszcze przeglądu tego tytułu.';
 
   @override
-  String get subjects => 'Tematy';
+  String get subjects => 'Przedmioty';
 
   @override
   String get all => 'Wszystko';
 
   @override
   String booksCount(int count) {
-    return '$count książek';
+    return '$count books';
   }
 
   @override
@@ -868,7 +873,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count Autorów';
+    return '$count Authors';
   }
 
   @override
@@ -876,7 +881,7 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiobooki',
+      other: '$count audiobooks',
       one: '1 audiobook',
     );
     return '$_temp0';
@@ -886,22 +891,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trackList => 'Lista utworów';
 
   @override
-  String get itemListPlaceholder => 'Tutaj pojawi się lista pozycji';
+  String get itemListPlaceholder => 'Tutaj pojawi się lista przedmiotów';
 
   @override
   String get favoriteTracksPlaceholder => 'Tutaj pojawią się ulubione utwory';
 
   @override
-  String get failedToLoad => 'Nie udało się wczytać';
+  String get failedToLoad => 'Nie udało się załadować';
 
   @override
-  String get delete => 'Usuń';
+  String get delete => 'Usuwać';
 
   @override
-  String get save => 'Zapisz';
+  String get save => 'Ratować';
 
   @override
-  String get moreLikeThis => 'Więcej podobnych';
+  String get moreLikeThis => 'Więcej takich';
 
   @override
   String get castAndCrew => 'Obsada i ekipa';
@@ -916,22 +921,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get nextUp => 'Następny w kolejce';
 
   @override
-  String get seasons => 'Sezony';
+  String get seasons => 'Pory roku';
 
   @override
   String get chapters => 'Rozdziały';
 
   @override
-  String get features => 'Dodatki specjalne';
+  String get features => 'Cechy';
 
   @override
-  String get movies => 'Filmy';
+  String get movies => 'Kino';
 
   @override
-  String get musicVideos => 'Teledyski';
+  String get musicVideos => 'Music Videos';
 
   @override
-  String get other => 'Inne';
+  String get other => 'Inny';
 
   @override
   String get discography => 'Dyskografia';
@@ -947,14 +952,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Płyta $number';
+    return 'Disc $number';
   }
 
   @override
   String get biography => 'Biografia';
 
   @override
-  String get authorDetails => 'O autorze';
+  String get authorDetails => 'Szczegóły autora';
 
   @override
   String get noOverviewAvailable => 'Nie ma jeszcze przeglądu tego tytułu.';
@@ -971,7 +976,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Wydane w $year';
+    return 'Published $year';
   }
 
   @override
@@ -982,52 +987,52 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Sezony',
-      one: '1 Sezon',
+      other: '$count Seasons',
+      one: '1 Season',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Koniec o  $time';
+    return 'Ends at $time';
   }
 
   @override
-  String get items => 'Elementy';
+  String get items => 'Items';
 
   @override
-  String get extras => 'Dodatki';
+  String get extras => 'Extras';
 
   @override
-  String get behindTheScenes => 'Kulisy produkcji';
+  String get behindTheScenes => 'Behind the Scenes';
 
   @override
-  String get deletedScenes => 'Usunięte sceny';
+  String get deletedScenes => 'Deleted Scenes';
 
   @override
-  String get featurettes => 'Materiały dodatkowe';
+  String get featurettes => 'Featurettes';
 
   @override
-  String get interviews => 'Wywiady';
+  String get interviews => 'Interviews';
 
   @override
-  String get scenes => 'Sceny';
+  String get scenes => 'Scenes';
 
   @override
-  String get shorts => 'Krótkie filmy';
+  String get shorts => 'Shorts';
 
   @override
-  String get trailers => 'Zwiastuny';
+  String get trailers => 'Trailers';
 
   @override
   String timeRemaining(String time) {
-    return '$time pozostało';
+    return '$time remaining';
   }
 
   @override
   String endsIn(String time) {
-    return 'Koniec za $time';
+    return 'Ends in $time';
   }
 
   @override
@@ -1037,15 +1042,15 @@ class AppLocalizationsPl extends AppLocalizations {
   String get resumeReading => 'Wznów czytanie';
 
   @override
-  String get read => 'Czytaj';
+  String get read => 'Czytać';
 
   @override
   String resumeFrom(String position) {
-    return 'Wznów od $position';
+    return 'Resume from $position';
   }
 
   @override
-  String get play => 'Włącz';
+  String get play => 'Grać';
 
   @override
   String get startOver => 'Zacznij od nowa';
@@ -1060,22 +1065,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get playOffline => 'Graj w trybie offline';
 
   @override
-  String get audio => 'Wybierz ścieżkę audio';
+  String get audio => 'Audio';
 
   @override
-  String get subtitles => 'Napisy';
+  String get subtitles => 'Napisy na filmie obcojęzycznym';
 
   @override
   String get version => 'Wersja';
 
   @override
-  String get cast => 'Przesyłaj';
+  String get cast => 'Rzucać';
 
   @override
-  String get trailer => 'Zwiastun';
+  String get trailer => 'Przyczepa';
 
   @override
-  String get finished => 'Ukończono';
+  String get finished => 'Gotowy';
 
   @override
   String get favorited => 'Ulubione';
@@ -1093,7 +1098,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get downloadAll => 'Pobierz wszystko';
 
   @override
-  String get download => 'Pobierz';
+  String get download => 'Pobierać';
 
   @override
   String get deleteDownloaded => 'Usuń pobrane';
@@ -1139,7 +1144,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Usuń pobrany utwór \"$title\"?';
+    return 'Delete downloaded tracks for \"$title\"?';
   }
 
   @override
@@ -1154,28 +1159,28 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'Nie udało się wczytać $itemLabel';
+    return 'No $itemLabel loaded';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Pobieranie $title ($count elementów)...';
+    return 'Downloading $title ($count items)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Napewno chcesz usunąć \"$name\" z serwera? Tego nie można cofnąć.';
+    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
   }
 
   @override
   String get itemDeleted => 'Element usunięty';
 
   @override
-  String get noPlayableTrailerFound => 'Nie znaleziono zwiastuna.';
+  String get noPlayableTrailerFound => 'Nie znaleziono grywalnego zwiastuna.';
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'NIewspierany format: .$extension';
+    return 'Unsupported book format: .$extension';
   }
 
   @override
@@ -1185,13 +1190,14 @@ class AppLocalizationsPl extends AppLocalizations {
   String get subtitleTrack => 'Ścieżka napisów';
 
   @override
-  String get none => 'Brak';
+  String get none => 'Nic';
 
   @override
   String get downloadSubtitlesLabel => 'Pobierz napisy...';
 
   @override
-  String get searchOpenSubtitlesPlugin => 'Szukaj z wtyczką OpenSubtitles';
+  String get searchOpenSubtitlesPlugin =>
+      'Szukaj za pomocą wtyczki OpenSubtitles';
 
   @override
   String get downloadSubtitles => 'Pobierz napisy';
@@ -1201,7 +1207,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Napisy pobrane i wybrane: $name';
+    return 'Subtitle downloaded and selected: $name';
   }
 
   @override
@@ -1210,15 +1216,15 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'Nie znaleziono napisów po $language.';
+    return 'No remote subtitles found for $language.';
   }
 
   @override
-  String get selectVersion => 'Wybierz wersję';
+  String get selectVersion => 'Wybierz opcję Wersja';
 
   @override
   String versionNumber(int number) {
-    return 'Wersja $number';
+    return 'Version $number';
   }
 
   @override
@@ -1228,17 +1234,19 @@ class AppLocalizationsPl extends AppLocalizations {
   String get downloadQuality => 'Jakość pobierania';
 
   @override
-  String get originalFileNoReencoding => 'Oryginalny plik';
+  String get originalFileNoReencoding =>
+      'Oryginalny plik, bez ponownego kodowania';
 
   @override
-  String get originalFilesNoReencoding => 'Oryginalne pliki';
+  String get originalFilesNoReencoding =>
+      'Oryginalne pliki, bez ponownego kodowania';
 
   @override
   String get noEpisodesLoaded => 'Nie wczytano żadnych odcinków';
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Pobieranie $name ($quality)...';
+    return 'Downloading $name ($quality)...';
   }
 
   @override
@@ -1246,7 +1254,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Usuń lokalne pliki $typeLabel?\n\nZwolni to miejsce. Pliki można pobrać ponownie później.';
+    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
   }
 
   @override
@@ -1259,28 +1267,28 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteFiles => 'Usuń pliki';
 
   @override
-  String get director => 'REŻYSER';
+  String get director => 'DYREKTOR';
 
   @override
-  String get directors => 'REŻYSERIA';
+  String get directors => 'DIRECTORS';
 
   @override
-  String get writer => 'SCENARIUSZ';
+  String get writer => 'WRITER';
 
   @override
-  String get writers => 'SCENARIUSZ';
+  String get writers => 'PISARZE';
 
   @override
   String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count więcej';
+    return '+$count more';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count odcinków';
+    return '$count Episodes';
   }
 
   @override
@@ -1290,12 +1298,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Odcinek $number';
+    return 'Episode $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Rozdział $number';
+    return 'Chapter $number';
   }
 
   @override
@@ -1303,8 +1311,8 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count utworów',
-      one: '1 utwór',
+      other: '$count tracks',
+      one: '1 track',
     );
     return '$_temp0';
   }
@@ -1314,48 +1322,48 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count rozdziałów',
-      one: '1 rozdział',
+      other: '$count chapters',
+      one: '1 chapter',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Urodziny $date';
+    return 'Born $date';
   }
 
   @override
   String died(String date) {
-    return 'Śmierć $date';
+    return 'Died $date';
   }
 
   @override
   String age(int age) {
-    return 'Wiek $age';
+    return 'Age $age';
   }
 
   @override
   String get showLess => 'Pokaż mniej';
 
   @override
-  String get readMore => 'Czytaj więcej';
+  String get readMore => 'Przeczytaj więcej';
 
   @override
-  String get shuffle => 'Losowo';
+  String get shuffle => 'Człapać';
 
   @override
-  String get shuffleAllMusic => 'Odtwarzaj muzykę losowo';
+  String get shuffleAllMusic => 'Shuffle all music';
 
   @override
-  String get carSignInPrompt => 'Zaloguj się do Moonfin na telefonie';
+  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
 
   @override
-  String get carServerUnreachable => 'Nie można połączyć się z serwerem';
+  String get carServerUnreachable => 'Can\'t reach your server';
 
   @override
   String downloadsCount(int count) {
-    return '$count pobrań';
+    return '$count downloads';
   }
 
   @override
@@ -1363,43 +1371,43 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '${count}kanałów';
+    return '${count}ch';
   }
 
   @override
-  String get mono => 'Mono';
+  String get mono => 'Mononukleoza';
 
   @override
-  String get stereo => 'Stereo';
+  String get stereo => 'Stereofoniczny';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Wykonanie $action wymaga uprawnienia do zarządzania napisami w Jellyfin dla tego użytkownika.';
+    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'Nie znaleziono na serwerze $action.';
+    return 'This item could not be found on the server for remote subtitle $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Napisy zdalne $action nieudane: $detail';
+    return 'Remote subtitle $action failed: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Napisy $action nieudane (HTTP $status).';
+    return 'Remote subtitle $action failed (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Nieudane $action napisów.';
+    return 'Failed to $action remote subtitles.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'wszystkie pobrane odcinki \"$name\"';
+    return 'all downloaded episodes for \"$name\"';
   }
 
   @override
@@ -1409,10 +1417,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get stillWatching => 'Nadal oglądasz?';
 
   @override
-  String get unableToLoadTrailerStream => 'Nie można wczytać zwiastuna.';
+  String get unableToLoadTrailerStream =>
+      'Nie można załadować strumienia zwiastuna.';
 
   @override
-  String get trailerTimedOut => 'Przekroczono limit czasu ładowania zwiastuna.';
+  String get trailerTimedOut =>
+      'Przekroczono limit czasu przyczepy podczas ładowania.';
 
   @override
   String get playbackFailedForTrailer =>
@@ -1429,24 +1439,24 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label nieudane: $error';
+    return '$label action failed: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Nieudane przesyłanie głośności: $error';
+    return 'Failed to set cast volume: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label Sterowanie';
+    return '$label Controls';
   }
 
   @override
   String get deviceVolume => 'Głośność urządzenia';
 
   @override
-  String get unavailable => 'Niedostępne';
+  String get unavailable => 'Nie płynny';
 
   @override
   String get pause => 'Pauza';
@@ -1464,11 +1474,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Utwór $number';
+    return 'Track $number';
   }
 
   @override
-  String get remotePlayback => 'Odtwarzanie zdalne';
+  String get remotePlayback => 'Zdalne odtwarzanie';
 
   @override
   String get castingToGoogleCast => 'Przesyłanie do Google Cast';
@@ -1481,14 +1491,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds s';
+    return '$seconds seconds';
   }
 
   @override
-  String get longPressToUnlock => 'Przytrzymaj, aby odblokować';
+  String get longPressToUnlock => 'Naciśnij długo, aby odblokować';
 
   @override
-  String get off => 'Wyłączone';
+  String get off => 'Wyłączony';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1496,7 +1506,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Auto';
+  String get auto => 'Automatyczny';
 
   @override
   String bitrateValueMbps(int mbps) {
@@ -1504,7 +1514,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get bitrateOverride => 'Wymuszony bitrate';
+  String get bitrateOverride => 'Zastąpienie szybkości transmisji';
 
   @override
   String get audioDelay => 'Opóźnienie dźwięku';
@@ -1523,22 +1533,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get subtitleDelay => 'Opóźnienie napisów';
 
   @override
-  String get reset => 'Resetuj';
+  String get reset => 'Nastawić';
 
   @override
-  String get unknown => 'Nieznane';
+  String get unknown => 'Nieznany';
 
   @override
   String get playbackInformation => 'Informacje o odtwarzaniu';
 
   @override
-  String get playback => 'Odtwarzanie';
+  String get playback => 'Odtwarzanie nagranego dźwięku';
 
   @override
   String get playMethod => 'Metoda odtwarzania';
 
   @override
-  String get directPlay => 'Odtwarzanie bezpośrednie';
+  String get directPlay => 'Gra bezpośrednia';
 
   @override
   String get directStream => 'Bezpośredni strumień';
@@ -1553,7 +1563,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get player => 'Odtwarzacz';
 
   @override
-  String get container => 'Kontener';
+  String get container => 'Pojemnik';
 
   @override
   String get bitrate => 'Szybkość transmisji';
@@ -1562,7 +1572,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get video => 'Wideo';
 
   @override
-  String get resolution => 'Rozdzielczość';
+  String get resolution => 'Rezolucja';
 
   @override
   String get hdr => 'HDR';
@@ -1571,7 +1581,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get codec => 'Kodek';
 
   @override
-  String get videoBitrate => 'Bitrate wideo';
+  String get videoBitrate => 'Szybkość transmisji wideo';
 
   @override
   String get track => 'Ścieżka';
@@ -1580,10 +1590,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get channels => 'Kanały';
 
   @override
-  String get audioBitrate => 'Bitrate dźwięku';
+  String get audioBitrate => 'Szybkość transmisji dźwięku';
 
   @override
-  String get sampleRate => 'Częstotliwość audio';
+  String get sampleRate => 'Częstotliwość próbkowania';
 
   @override
   String get format => 'Format';
@@ -1596,12 +1606,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol błąd sesji';
+    return '$protocol session error';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Nie udało się wczytać informacji o książce: $error';
+    return 'Failed to load book details: $error';
   }
 
   @override
@@ -1610,7 +1620,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'Ten format (.$extension) nie jest jeszcze obsługiwany.';
+    return 'This format (.$extension) cannot be rendered in-app yet.';
   }
 
   @override
@@ -1623,17 +1633,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Nie udało się otworzyć czytnika w aplikacji: $error';
+    return 'Failed to open in-app reader: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Zakładka już zapisana w $label.';
+    return 'Bookmark already saved at $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Zakładka dodana: $label';
+    return 'Bookmark added: $label';
   }
 
   @override
@@ -1645,14 +1655,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Strona $number';
+    return 'Page $number';
   }
 
   @override
   String get position => 'Pozycja';
 
   @override
-  String get bookReader => 'Czytnik książek';
+  String get bookReader => 'Czytelnik książek';
 
   @override
   String formatExtension(String extension) {
@@ -1661,7 +1671,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String percentRead(String percent) {
-    return '$percent% przeczytane';
+    return '$percent% read';
   }
 
   @override
@@ -1685,14 +1695,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Reset powiększenia (${zoom}x)';
+    return 'Reset Zoom (${zoom}x)';
   }
 
   @override
   String get singlePage => 'Pojedyncza strona';
 
   @override
-  String get twoPageSpread => 'Widok dwustronnicowy';
+  String get twoPageSpread => 'Rozkładówka dwustronicowa';
 
   @override
   String get addBookmark => 'Dodaj zakładkę';
@@ -1708,20 +1718,20 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Nie udało się zaktualizować stanu czytania: $error';
+    return 'Failed to update read state: $error';
   }
 
   @override
-  String get themeSystem => 'Styl: Systemowy';
+  String get themeSystem => 'Temat: System';
 
   @override
-  String get themeLight => 'Styl: Jasny';
+  String get themeLight => 'Temat: Światło';
 
   @override
-  String get themeDark => 'Styl: Ciemny';
+  String get themeDark => 'Temat: Ciemność';
 
   @override
-  String get themeSepia => 'Styl: Sepia';
+  String get themeSepia => 'Temat: Sepia';
 
   @override
   String get invertColorsFixedLayout => 'Odwróć kolory (stały układ)';
@@ -1740,7 +1750,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'Ta platforma nie obsługuje wbudowanego silnika $extension plików.';
+    return 'This platform cannot host the embedded document engine for $extension files.';
   }
 
   @override
@@ -1763,10 +1773,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get now => 'Teraz';
 
   @override
-  String get sports => 'Sport';
+  String get sports => 'Lekkoatletyka';
 
   @override
-  String get news => 'Wiadomości';
+  String get news => 'Aktualności';
 
   @override
   String get kids => 'Dzieci';
@@ -1779,7 +1789,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Nie udało sie załadować przewodnika: $error';
+    return 'Failed to load guide: $error';
   }
 
   @override
@@ -1790,22 +1800,22 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Następny: $time  $title';
+    return 'Next: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}m zostało';
+    return '${minutes}m left';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}h zostało';
+    return '${hours}h left';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}m zostało';
+    return '${hours}h ${minutes}m left';
   }
 
   @override
@@ -1828,29 +1838,29 @@ class AppLocalizationsPl extends AppLocalizations {
   String get favoriteChannel => 'Ulubiony kanał';
 
   @override
-  String get record => 'Nagrywaj';
+  String get record => 'Record';
 
   @override
-  String get cancelRecordingAction => 'Anuluj nagrywanie';
+  String get cancelRecordingAction => 'Cancel Recording';
 
   @override
-  String get programSetToRecord => 'Nagrywanie zaplanowane';
+  String get programSetToRecord => 'Program set to record';
 
   @override
-  String get recordingCancelled => 'Nagrywanie anulowane';
+  String get recordingCancelled => 'Recording cancelled';
 
   @override
-  String get unableToCreateRecording => 'Nie udało się włączyć nagrywania';
+  String get unableToCreateRecording => 'Unable to create recording';
 
   @override
-  String get watch => 'Oglądaj';
+  String get watch => 'Oglądać';
 
   @override
-  String get close => 'Zamknij';
+  String get close => 'Zamknąć';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Nie można włączyć $name';
+    return 'Failed to play $name';
   }
 
   @override
@@ -1877,7 +1887,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Anulować zaplanowane nagrywanie \"$name\"?';
+    return 'Cancel scheduled recording of \"$name\"?';
   }
 
   @override
@@ -1904,7 +1914,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Zakończ nagrywanie \"$name\"?';
+    return 'Stop recording \"$name\"?';
   }
 
   @override
@@ -1919,12 +1929,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'Brak wyników dla \"$query\"';
+    return 'No results for \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Wyszukiwanie nieudane: $error';
+    return 'Search failed: $error';
   }
 
   @override
@@ -1961,16 +1971,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get browseLibrary => 'Przeglądaj bibliotekę';
 
   @override
-  String get deleteDownload => 'Usuń pobrany plik';
+  String get deleteDownload => 'Usuń pobieranie';
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Usuń \"$name\" wraz z plikami?';
+    return 'Remove \"$name\" and its files?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count utworów';
+    return '$count tracks';
   }
 
   @override
@@ -1981,12 +1991,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Nie udało sie załadować albumu: $error';
+    return 'Failed to load album: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'Nie znaleziono pobranych utworów dla $name.';
+    return 'No downloaded tracks found for $name.';
   }
 
   @override
@@ -2003,7 +2013,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Usunąć \"$name\"?';
+    return 'Remove \"$name\"?';
   }
 
   @override
@@ -2013,12 +2023,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'S$season O$episode';
+    return 'S$season E$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Odcinek $number';
+    return 'Episode $number';
   }
 
   @override
@@ -2032,7 +2042,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Sezon $number';
+    return 'Season $number';
   }
 
   @override
@@ -2041,14 +2051,14 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get specials => 'Odcinki specjalne';
+  String get specials => 'Promocje';
 
   @override
   String get deleteSeason => 'Usuń sezon';
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Usunąć wszystkie pobrane odcinki w $season?';
+    return 'Delete all downloaded episodes in $season?';
   }
 
   @override
@@ -2056,23 +2066,23 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count odcinki',
-      one: '1 odcinek',
+      other: '$count episodes',
+      one: '1 episode',
     );
     return '$_temp0';
   }
 
   @override
-  String get storageManagement => 'Zarządzanie pamięcią';
+  String get storageManagement => 'Zarządzanie pamięcią masową';
 
   @override
-  String get storageBreakdown => 'Podział pamięci';
+  String get storageBreakdown => 'Podział magazynu';
 
   @override
   String get downloadedItems => 'Pobrane elementy';
 
   @override
-  String get storageLimit => 'Limit pamięci';
+  String get storageLimit => 'Limit przechowywania';
 
   @override
   String get noLimit => 'Bez limitu';
@@ -2092,7 +2102,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Usunąć $count pobranych elementów?';
+    return 'Delete $count downloaded items?';
   }
 
   @override
@@ -2106,7 +2116,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'z $limit limitu';
+    return 'of $limit limit';
   }
 
   @override
@@ -2132,20 +2142,21 @@ class AppLocalizationsPl extends AppLocalizations {
   String get contentRatingRestrictions => 'Ograniczenia dotyczące oceny treści';
 
   @override
-  String get bitRateResolutionBehavior => 'Bitrate, rozdzielczość, zachowanie';
+  String get bitRateResolutionBehavior =>
+      'Szybkość transmisji, rozdzielczość, zachowanie';
 
   @override
   String get languageSizeAppearance => 'Język, rozmiar, wygląd';
 
   @override
-  String get qualityStorage => 'Jakość, pamięć';
+  String get qualityStorage => 'Jakość, magazyn';
 
   @override
   String get serverSyncAndPluginStatus =>
-      'Synchronizacja z serwerem i status wtyczek';
+      'Synchronizacja serwera i stan wtyczki';
 
   @override
-  String get mediaRequestIntegration => 'Integracja żądań multimediów';
+  String get mediaRequestIntegration => 'Integracja żądań mediów';
 
   @override
   String get switchServer => 'Przełącz serwer';
@@ -2182,7 +2193,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get integrations => 'Integracje';
 
   @override
-  String get pluginAndRequests => 'Wtyczki i żądania';
+  String get pluginAndRequests => 'Wtyczka i żądania';
 
   @override
   String get customizeAccountPlaybackInterface =>
@@ -2190,23 +2201,23 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count opcji';
+    return '$count options';
   }
 
   @override
   String get themeAndAppearance => 'Motyw i wygląd';
 
   @override
-  String get focusBorderColor => 'Kolor obramowania fokusu';
+  String get focusBorderColor => 'Kolor obramowania ostrości';
 
   @override
-  String get watchedIndicators => 'Wskaźniki obejrzanych';
+  String get watchedIndicators => 'Obserwowane wskaźniki';
 
   @override
   String get always => 'Zawsze';
 
   @override
-  String get hideUnwatched => 'Ukryj nieobejrzane';
+  String get hideUnwatched => 'Ukryj nieobserwowane';
 
   @override
   String get episodesOnly => 'Tylko odcinki';
@@ -2215,38 +2226,37 @@ class AppLocalizationsPl extends AppLocalizations {
   String get never => 'Nigdy';
 
   @override
-  String get focusExpansionAnimation => 'Animacja powiększenia przy fokusie';
+  String get focusExpansionAnimation => 'Animacja rozwijania ostrości';
 
   @override
-  String get desktopUiScale => 'Skalowanie interfejsu';
+  String get desktopUiScale => 'Skala interfejsu użytkownika pulpitu';
 
   @override
   String get scaleFocusedCards =>
-      'Skaluj karty i kafelki po najechaniu lub zaznaczeniu';
+      'Skaluj skupione lub najechane karty i kafelki';
 
   @override
-  String get backgroundBackdrops => 'Tła w tle';
+  String get backgroundBackdrops => 'Tła Tła';
 
   @override
   String get showBackdropImages => 'Pokaż obrazy tła za treścią';
 
   @override
-  String get seriesThumbnails => 'Wyświetlaj miniatury seriali';
+  String get seriesThumbnails => 'Miniatury serii';
 
   @override
   String get seriesThumbnailsDescription =>
-      'Dla seriali używaj głównej grafiki serialu zamiast miniatury odcinka.';
+      'Tylko odcinki: użyj grafiki serialu odpowiadającej typowi obrazu w każdym wierszu';
 
   @override
-  String get homeRowInfoOverlay =>
-      'Nakładka informacyjna w wierszu ekranu głównego';
+  String get homeRowInfoOverlay => 'Nakładka informacyjna wiersza głównego';
 
   @override
   String get showTitleMetadataOnHomeRows =>
-      'Pokazuj tytuł i metadane podczas przeglądania wierszy ekranu głównego';
+      'Pokaż tytuł i metadane podczas przeglądania wierszy głównych';
 
   @override
-  String get clockDisplay => 'Wyświetlaj zegar';
+  String get clockDisplay => 'Wyświetlacz zegara';
 
   @override
   String get inMenus => 'W Menu';
@@ -2285,7 +2295,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Strony szczegółów, wiersze ekranu głównego i głośność';
+      'Detail pages, home rows, and volume';
 
   @override
   String percentValue(int value) {
@@ -2293,22 +2303,21 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get themeMusicOnHomeRows =>
-      'Muzyka motywu w wierszach ekranu głównego';
+  String get themeMusicOnHomeRows => 'Motyw muzyczny w rzędach domowych';
 
   @override
   String get playWhenBrowsingHomeScreen =>
-      'Odtwarzaj podczas przeglądania ekranu głównego';
+      'Odtwórz podczas przeglądania ekranu głównego';
 
   @override
-  String get loopThemeMusic => 'Odtwarzaj muzykę motywu w pętli';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Powtarzaj utwór zamiast odtworzyć go raz';
+      'Repeat the track instead of playing it once';
 
   @override
-  String get detailsBackgroundBlur => 'Rozmycie tła na stronie szczegółów';
+  String get detailsBackgroundBlur => 'Szczegóły Rozmycie tła';
 
   @override
   String pixelValue(int value) {
@@ -2316,119 +2325,120 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get browsingBackgroundBlur => 'Rozmycie tła podczas przeglądania';
+  String get browsingBackgroundBlur => 'Przeglądanie rozmycia tła';
 
   @override
-  String get maxStreamingBitrate => 'Maksymalny bitrate strumieniowania';
+  String get maxStreamingBitrate =>
+      'Maksymalna szybkość transmisji strumieniowej';
 
   @override
   String get maxResolution => 'Maksymalna rozdzielczość';
 
   @override
-  String get playerZoomMode => 'Tryb powiększenia odtwarzacza';
+  String get playerZoomMode => 'Tryb powiększenia gracza';
 
   @override
-  String get settingsScrollWheelAction => 'Kółko przewijania myszy';
+  String get settingsScrollWheelAction => 'Mouse scroll wheel';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Wybierz, co robi przewijanie kółkiem myszy nad wideo podczas odtwarzania.';
+      'Choose what scrolling the mouse wheel over the video does during playback.';
 
   @override
-  String get scrollWheelActionOff => 'Wyłączone';
+  String get scrollWheelActionOff => 'Off';
 
   @override
-  String get scrollWheelActionSeek => 'Przewijanie (do przodu / do tyłu)';
+  String get scrollWheelActionSeek => 'Seek (forward / back)';
 
   @override
-  String get scrollWheelActionVolume => 'Głośność';
+  String get scrollWheelActionVolume => 'Volume';
 
   @override
-  String get playerTooltipVolume => 'Głośność';
+  String get playerTooltipVolume => 'Volume';
 
   @override
-  String get fit => 'Dopasuj';
+  String get fit => 'Pasować';
 
   @override
-  String get autoCrop => 'Automatyczne dopasowanie';
+  String get autoCrop => 'Automatyczne przycinanie';
 
   @override
-  String get stretch => 'Rozciągnij';
+  String get stretch => 'Rozciągać się';
 
   @override
-  String get refreshRateSwitching => 'Zmiana częstotliwości odświeżania';
+  String get refreshRateSwitching => 'Przełączanie częstotliwości odświeżania';
 
   @override
   String get disabled => 'Wyłączony';
 
   @override
-  String get scaleOnTv => 'Skaluj na TV';
+  String get scaleOnTv => 'Skala w telewizji';
 
   @override
   String get scaleOnDevice => 'Skaluj na urządzeniu';
 
   @override
-  String get trickPlay => 'Podgląd klatek (Trick Play)';
+  String get trickPlay => 'Zabawa w sztuczki';
 
   @override
   String get showPreviewThumbnailsWhenSeeking =>
-      'Pokazuj podgląd klatek podczas przewijania';
+      'Pokaż miniatury podglądu podczas wyszukiwania';
 
   @override
-  String get showDescriptionOnPause => 'Pokazuj opis podczas pauzy';
+  String get showDescriptionOnPause => 'Pokaż opis w trybie pauzy';
 
   @override
   String get dimVideoShowOverview =>
-      'Przyciemnij wideo i pokazuj opis podczas pauzy';
+      'Przyciemnij wideo i pokaż tekst przeglądu podczas pauzy';
 
   @override
   String get osdLockButton => 'Przycisk blokady OSD';
 
   @override
   String get osdLockButtonDescription =>
-      'Pokazuj przycisk blokady, który blokuje dotyk do czasu długiego naciśnięcia';
+      'Pokaż przycisk blokady, który blokuje wprowadzanie dotykowe do momentu długiego naciśnięcia';
 
   @override
-  String get audioBehavior => 'Zachowanie dźwięku';
+  String get audioBehavior => 'Zachowanie dźwiękowe';
 
   @override
   String get downmixToStereo => 'Zmiksuj do stereo';
 
   @override
-  String get defaultAudioLanguage => 'Domyślny język audio';
+  String get defaultAudioLanguage => 'Domyślny język dźwięku';
 
   @override
-  String get fallbackAudioLanguage => 'Zapasowy język audio';
+  String get fallbackAudioLanguage => 'Fallback Audio Language';
 
   @override
-  String get preferDefaultAudioTrack => 'Preferuj domyślną ścieżkę audio';
+  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Preferuj oryginalną ścieżkę audio zamiast dubbingu.';
+      'Prefer original audio track over localized dub.';
 
   @override
-  String get preferAudioDescription => 'Preferuj ścieżki audiodeskrypcji';
+  String get preferAudioDescription => 'Prefer Audio Description Tracks';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Preferuj ścieżki audiodeskrypcji zamiast zwykłych ścieżek.';
+      'Prefer audio description tracks over normal tracks.';
 
   @override
-  String get transcodingAudio => 'Transkodowanie (audio)';
+  String get transcodingAudio => 'Transcoding (Audio)';
 
   @override
-  String get directStreamRemux => 'Strumieniowanie bezpośrednie (remux)';
+  String get directStreamRemux => 'Direct Stream (Remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transkodowanie (bitrate lub rozdzielczość)';
+      'Transcoding (Bitrate or Resolution)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transkodowanie (wideo i audio)';
+  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
 
   @override
-  String get transcodingVideo => 'Transkodowanie (wideo)';
+  String get transcodingVideo => 'Transcoding (Video)';
 
   @override
   String get autoServerDefault => 'Automatycznie (domyślne ustawienie serwera)';
@@ -2473,7 +2483,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dutch => 'Holenderski';
 
   @override
-  String get swedish => 'Szwedzki';
+  String get swedish => 'szwedzki';
 
   @override
   String get norwegian => 'norweski';
@@ -2498,35 +2508,34 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get enableDtsPassthrough =>
-      'Przesyłaj strumień DTS bezpośrednio (bitstream) do amplitunera; wymaga obsługi przez amplituner oraz źródłowej ścieżki DTS';
+      'Tylko dźwięk Bitstream DTS do AVR; wymaga obsługi odbiornika i ścieżki źródłowej DTS';
 
   @override
   String get enableTrueHdAudio =>
       'Włącz dźwięk TrueHD (może nie działać na wszystkich platformach)';
 
   @override
-  String get settingsAudioOutputMode => 'Tryb wyjścia audio';
+  String get settingsAudioOutputMode => 'Audio Output Mode';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Wybierz sposób dekodowania audio. Passthrough do amplitunera przesyła surowy strumień Dolby/DTS; tryb Automatyczny lub Downmix dekoduje lokalnie.';
+      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Zapasowy kodek audio';
+  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Wybierz format docelowy do transkodowania dźwięku wielokanałowego, gdy strumień źródłowy nie może zostać odtworzony bezpośrednio ani przesłany przez passthrough.';
+      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
 
   @override
-  String get settingsAudioFallbackCodecAuto =>
-      'Wykrywanie automatyczne\n(zalecane)';
+  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Domyślnie)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2538,24 +2547,23 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Wydajny)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Bezstratny)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
 
   @override
-  String get settingsMaxAudioChannels => 'Maksymalna liczba kanałów audio';
+  String get settingsMaxAudioChannels => 'Max Audio Channels';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Skonfiguruj maksymalną liczbę kanałów obsługiwaną przez Twój zestaw audio. Strumienie wielokanałowe przekraczające ten limit zostaną zmiksowane w dół lub transkodowane.';
+      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
 
   @override
-  String get settingsMaxAudioChannelsAuto =>
-      'Wykrywanie automatyczne\n(domyślne sprzętowe)';
+  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2582,36 +2590,36 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (zaawansowane)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Passthrough kodeka';
+  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Włączaj tylko formaty obsługiwane przez Twój amplituner lub odbiornik HDMI.';
+      'Enable only formats your AVR or HDMI sink supports.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 przejście';
+  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) przejście';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core przejście';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA przejście';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD przejście';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos przejście';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Przesyłaj strumień Dolby Digital Plus (EAC3) bezpośrednio do zewnętrznego dekodera.';
+      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
@@ -2660,7 +2668,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Słuchawki';
+  String get settingsAudioRouteHeadphones => 'Headphones';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2839,31 +2847,31 @@ class AppLocalizationsPl extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Dostosuj wygląd napisów';
 
   @override
-  String get subtitleMode => 'Tryb napisów';
+  String get subtitleMode => 'Subtitle Mode';
 
   @override
-  String get subtitleModeFlagged => 'Oznaczone';
+  String get subtitleModeFlagged => 'Flagged';
 
   @override
-  String get subtitleModeAlways => 'Zawsze';
+  String get subtitleModeAlways => 'Always';
 
   @override
-  String get subtitleModeForeign => 'W innym języku';
+  String get subtitleModeForeign => 'Foreign';
 
   @override
-  String get subtitleModeForced => 'Wymuszone';
+  String get subtitleModeForced => 'Forced';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Odtwarza ścieżki oznaczone w metadanych pliku jako „domyślne” lub „wymuszone”.';
+      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Automatycznie wczytuj i wyświetlaj napisy przy każdym uruchomieniu wideo.';
+      'Automatically loads and displays subtitles every time a video starts.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Automatycznie włącza napisy, jeśli domyślna ścieżka audio jest w innym języku niż wybrany.';
+      'Automatically turns on subtitles if the default audio track is in a foreign language.';
 
   @override
   String get subtitleModeForcedDescription =>

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -9,26 +9,26 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
-  String get appTitle => 'Księżycowa Płetwa';
+  String get appTitle => 'Moonfin';
 
   @override
-  String get accountPreferences => 'ACCOUNT PREFERENCES';
+  String get accountPreferences => 'Ustawienia konta';
 
   @override
-  String get interfaceLanguage => 'Interface Language';
+  String get interfaceLanguage => 'Język interfejsu';
 
   @override
-  String get systemLanguageDefault => 'System Default';
+  String get systemLanguageDefault => 'Zgodnie z systemem';
 
   @override
-  String get signIn => 'Zalogować się';
+  String get signIn => 'Logowanie';
 
   @override
-  String get empty => 'Empty';
+  String get empty => 'Brak';
 
   @override
   String connectingToServer(String serverName) {
-    return 'Connecting to $serverName';
+    return 'Połącz z $serverName';
   }
 
   @override
@@ -45,13 +45,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get quickConnectInstruction =>
-      'Wpisz ten kod na panelu internetowym swojego serwera:';
+      'Wpisz ten kod w panelu internetowym swojego serwera:';
 
   @override
-  String get waitingForAuthorization => 'Oczekiwanie na autoryzację...';
+  String get waitingForAuthorization => 'Autoryzacja...';
 
   @override
-  String get back => 'Z powrotem';
+  String get back => 'Powrót';
 
   @override
   String get serverUnavailable => 'Serwer jest niedostępny';
@@ -61,12 +61,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String quickConnectUnavailable(String detail) {
-    return 'QuickConnect unavailable: $detail';
+    return 'Szybkie połączenie nieudane: $detail';
   }
 
   @override
   String quickConnectUnavailableWithStatus(String status, String detail) {
-    return 'QuickConnect unavailable ($status): $detail';
+    return 'Szybkie połączenie nieudane ($status): $detail';
   }
 
   @override
@@ -80,17 +80,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String appVersionFooter(String version) {
-    return 'Moonfin version $version';
+    return 'Moonfin wersja $version';
   }
 
   @override
   String get savedServers => 'Zapisane serwery';
 
   @override
-  String get discoveredServers => 'Odkryte serwery';
+  String get discoveredServers => 'Wykryte serwery';
 
   @override
-  String get noneFound => 'Nie znaleziono żadnych';
+  String get noneFound => 'Nie znaleziono';
 
   @override
   String get unableToConnectToServer => 'Nie można połączyć się z serwerem';
@@ -99,21 +99,21 @@ class AppLocalizationsPl extends AppLocalizations {
   String get addServer => 'Dodaj serwer';
 
   @override
-  String get embyConnect => 'Emby Połącz';
+  String get embyConnect => 'Połącz z Emby';
 
   @override
   String get removeServer => 'Usuń serwer';
 
   @override
   String removeServerConfirmation(String serverName) {
-    return 'Remove \"$serverName\" from your servers?';
+    return 'Usunąć \"$serverName\" ?';
   }
 
   @override
-  String get cancel => 'Anulować';
+  String get cancel => 'Anuluj';
 
   @override
-  String get remove => 'Usunąć';
+  String get remove => 'Usuń';
 
   @override
   String get connectToServer => 'Połącz się z serwerem';
@@ -125,11 +125,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get serverAddressHint => 'https://twój-serwer.example.com';
 
   @override
-  String get connect => 'Łączyć';
+  String get connect => 'Połącz';
 
   @override
-  String get secureStorageUnavailable =>
-      'Bezpieczne przechowywanie jest niedostępne';
+  String get secureStorageUnavailable => 'Bezpieczny magazyn niedostępny';
 
   @override
   String get secureStorageUnavailableMessage =>
@@ -142,24 +141,24 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAppearanceTheme => 'Motyw aplikacji';
 
   @override
-  String get detailScreenStyle => 'Detail screen style';
+  String get detailScreenStyle => 'Widok szczegółów';
 
   @override
   String get detailScreenStyleSubtitle =>
-      'Classic is the original centered moonfin layout. Modern is a responsive cinematic layout.';
+      'Klasyczny to oryginalny układ Moonfin. Nowoczesny to responsywny układ w stylu kinowym.';
 
   @override
-  String get detailScreenStyleMoonfin => 'Classic';
+  String get detailScreenStyleMoonfin => 'Klasyczny';
 
   @override
-  String get detailScreenStyleModern => 'Modern';
+  String get detailScreenStyleModern => 'Nowoczesny';
 
   @override
-  String get expandedTabs => 'Expanded Tabs';
+  String get expandedTabs => 'Rozwinięcie zakładki';
 
   @override
   String get expandedTabsSubtitle =>
-      'Automatically show tab content while browsing tabs. Turn off to open and close each tab manually.';
+      'Automatycznie pokazuj zawartość zakładki podczas przeglądania. Wyłącz aby otwierać i zamykać zakładki ręcznie.';
 
   @override
   String get showTechnicalDetails => 'Show Technical Details?';
@@ -169,35 +168,35 @@ class AppLocalizationsPl extends AppLocalizations {
       'Show codec, resolution, and stream information in banner summary';
 
   @override
-  String get recommendationSystem => 'Recommendation System';
+  String get recommendationSystem => 'System rekomendacji';
 
   @override
   String get recommendationSystemSubtitle =>
-      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
+      'Użyj lokalnego algorytmu Moonfin lub metryk online z TMDb. Uwaga! Rekomendacje online wymagają integracji z Seerr.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
-  String get recommendationSystemTmdb => 'TMDb Similarity';
+  String get recommendationSystemTmdb => 'Dopasowanie TMDb';
 
   @override
   String get recommendationsApplyParentalRatingCap =>
-      'Apply Parental Rating Cap?';
+      'Zastosować limit oceny rodzicielskiej?';
 
   @override
   String get recommendationsApplyParentalRatingCapSubtitle =>
-      'Limit Moonfin Recommends suggestions by parental rating of target media';
+      'Ogranicz sugestie Moonfin do poziomu oceny rodzicielskiej filmu';
 
   @override
-  String get interfaceStyle => 'Interface Style';
+  String get interfaceStyle => 'Styl interfejsu';
 
   @override
   String get interfaceStyleSubtitle =>
-      'Automatic matches your device. Choose Apple or Material to force a look.';
+      'Automatyczne dopasowanie do urządzenia. Wybierz Apple lub Material aby wymusić wygląd.';
 
   @override
-  String get interfaceStyleAutomatic => 'Automatic';
+  String get interfaceStyleAutomatic => 'Tryb auto';
 
   @override
   String get interfaceStyleApple => 'Apple';
@@ -206,66 +205,65 @@ class AppLocalizationsPl extends AppLocalizations {
   String get interfaceStyleMaterial => 'Material';
 
   @override
-  String get glassQuality => 'Glass Quality';
+  String get glassQuality => 'Jakość efektu szkła/rozmycia';
 
   @override
   String get glassQualitySubtitle =>
-      'Auto picks the best glass effect for this device. Full forces real blur; Reduced uses a lightweight glass that saves GPU power.';
+      'Automatycznie dobiera najlepszy efekt dla tego urządzenia. Pełny wymusza prawdziwe rozmycie. Zmniejszony korzysta z uproszczonego efektu, oszczędzając GPU.';
 
   @override
   String get glassQualityAuto => 'Auto';
 
   @override
-  String get glassQualityFull => 'Full';
+  String get glassQualityFull => 'Pełny';
 
   @override
-  String get glassQualityReduced => 'Reduced';
+  String get glassQualityReduced => 'Zmniejszony';
 
   @override
   String get settingsAppearanceThemeSubtitle =>
-      'Przełączaj się między Moonfin i Neon Pulse bez ponownego uruchamiania aplikacji';
+      'Zastosuj niestandardowy motyw i przełączaj się między interfejsami.';
 
   @override
-  String get customThemeTitle => 'Custom Theme';
+  String get customThemeTitle => 'Niestandardowy motyw';
 
   @override
   String get customThemeSubtitle =>
-      'Custom themes alter visual elements across Moonfin. Choose one of these options to suit your style.';
+      'Niestandardowe motywy zmieniają elementy wizualne całej aplikacji Moonfin. Wybierz jedną z opcji, aby dopasować wygląd do swojego upodobania.';
 
   @override
-  String get keyboardPreferSystemIme => 'Prefer system keyboard';
+  String get keyboardPreferSystemIme => 'Preferuj klawiaturę systemową';
 
   @override
   String get keyboardPreferSystemImeDescription =>
-      'Use your device input method by default for text entry';
+      'Używaj systemowej metody wprowadzania tekstu';
 
   @override
-  String get themeMoonfin => 'Księżycowa Płetwa';
+  String get themeMoonfin => 'Moonfin';
 
   @override
-  String get themeMoonfinSubtitle =>
-      'Obecny wygląd Moonfin, który wszyscy pokochaliście';
+  String get themeMoonfinSubtitle => 'Oryginalny czysty motyw Moonfin.';
 
   @override
-  String get themeNeonPulse => 'Neonowy puls';
+  String get themeNeonPulse => 'Neon Pulse';
 
   @override
   String get themeNeonPulseSubtitle =>
-      'Styl Synthwave z magentową poświatą, cyjanowym tekstem i silniejszym kontrastem chromu';
+      'Synthwave z magentową poświatą, cyjanowym tekstem i silniejszym kontrastem chromu';
 
   @override
-  String get themeGlass => 'Glass';
+  String get themeGlass => 'Rozmycie';
 
   @override
   String get themeGlassSubtitle =>
-      'Liquid-glass styling with a drifting gradient backdrop, frosted surfaces, and Apple-blue accent';
+      'Liquid-glass z gradientowym tłem, matowymi powierzchniami i akcentem w kolorze Apple-blue';
 
   @override
   String get theme8BitHero => '8-bit Hero';
 
   @override
   String get theme8BitHeroSubtitle =>
-      'Retro pixel-art styling with a chunky palette, blocky borders, hard drop-shadows, and a pixel font';
+      'Retro pikselowy styl z grubą paletą kolorów, kanciastymi ramkami, twardymi cieniami i pikselową czcionką';
 
   @override
   String get embyConnectSignInSubtitle =>
@@ -315,7 +313,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String unableToConnectTo(String target) {
-    return 'Unable to connect to $target';
+    return 'Nie można połączyć się z  $target';
   }
 
   @override
@@ -331,39 +329,40 @@ class AppLocalizationsPl extends AppLocalizations {
   String get gameMenu => 'Menu';
 
   @override
-  String get gamePaused => 'Paused';
+  String get gamePaused => 'Wstrzymano';
 
   @override
-  String get gameSaveState => 'Save state';
+  String get gameSaveState => 'Zapisz stan';
 
   @override
-  String get gameLoadState => 'Load state';
+  String get gameLoadState => 'Wczytaj stan';
 
   @override
-  String get gameFastForward => 'Fast-forward';
+  String get gameFastForward => 'Przewijanie do przodu';
 
   @override
-  String get gameEmulatorSettings => 'Emulator settings';
+  String get gameEmulatorSettings => 'Opcje emulatora';
 
   @override
-  String get gameNoCoreOptions => 'This core has no adjustable options.';
+  String get gameNoCoreOptions =>
+      'Ten rdzeń nie udostępnia żadnych opcji do zastosowania.';
 
   @override
-  String get gameHoldToOpenMenu => 'Hold to open menu';
+  String get gameHoldToOpenMenu => 'Przytrzymaj aby otworzyć menu';
 
   @override
   String get gamePlaybackUnsupported =>
-      'Game playback is not supported on this device yet.';
+      'Odtwarzanie gier nie jest jeszcze obsługiwane na tym urządzeniu.';
 
   @override
   String get noHomeRowsLoaded => 'Nie można wczytać żadnych wierszy głównych';
 
   @override
   String get noHomeRowsHint =>
-      'Spróbuj odświeżyć lub zmniejszyć aktywne sekcje strony głównej.';
+      'Spróbuj odświeżyć stronę lub zmniejszyć liczbę aktywnych sekcji na ekranie głównym.';
 
   @override
-  String get retryHomeRows => 'Ponów próbę wierszy głównych';
+  String get retryHomeRows => 'Odśwież wiersze Home';
 
   @override
   String get guide => 'Przewodnik';
@@ -375,7 +374,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get schedule => 'Harmonogram';
 
   @override
-  String get series => 'Szereg';
+  String get series => 'Seriale';
 
   @override
   String get noItemsFound => 'Nie znaleziono żadnych elementów';
@@ -393,7 +392,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get collectionPlaceholder => 'Tutaj pojawią się elementy kolekcji';
 
   @override
-  String get browseByLetter => 'Przeglądaj według listu';
+  String get browseByLetter => 'Alfabetycznie';
 
   @override
   String get alphabeticalBrowsePlaceholder =>
@@ -425,7 +424,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToLoadFolderError(String error) {
-    return 'Failed to load folder: $error';
+    return 'Nie udało się wczytać folderu: $error';
   }
 
   @override
@@ -433,14 +432,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String itemCountLabel(int count) {
-    return '$count items';
+    return '$count elementów';
   }
 
   @override
   String get failedToLoadFavorites => 'Nie udało się załadować ulubionych';
 
   @override
-  String get retry => 'Spróbować ponownie';
+  String get retry => 'Ponów';
 
   @override
   String get noFavoritesYet => 'Nie ma jeszcze ulubionych';
@@ -450,11 +449,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String totalCountItems(int count) {
-    return '$count Items';
+    return '$count elementów';
   }
 
   @override
-  String get continuing => 'Kontynuacja';
+  String get continuing => 'W trakcie';
 
   @override
   String get ended => 'Zakończone';
@@ -469,7 +468,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get sortBy => 'Sortuj według';
 
   @override
-  String get display => 'Wyświetlacz';
+  String get display => 'Wyświetlanie';
 
   @override
   String get imageType => 'Typ obrazu';
@@ -491,7 +490,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String libraryGenresTitle(String name) {
-    return '$name — Genres';
+    return '$name — Gatunki';
   }
 
   @override
@@ -501,7 +500,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get albums => 'Albumy';
 
   @override
-  String get albumArtists => 'Artyści albumowi';
+  String get albumArtists => 'Wykonawcy albumu';
 
   @override
   String get artists => 'Artyści';
@@ -526,32 +525,32 @@ class AppLocalizationsPl extends AppLocalizations {
   String get bookmark => 'Zakładka w książce';
 
   @override
-  String get justNow => 'Właśnie';
+  String get justNow => 'Przed chwilą';
 
   @override
   String minutesAgo(int count) {
-    return '${count}m ago';
+    return '${count}m temu';
   }
 
   @override
   String hoursAgo(int count) {
-    return '${count}h ago';
+    return '${count}h temu';
   }
 
   @override
   String daysAgo(int count) {
-    return '${count}d ago';
+    return '${count}d temu';
   }
 
   @override
-  String get discoverySubjects => 'Przedmioty odkrycia';
+  String get discoverySubjects => 'Tematy';
 
   @override
   String get pickDiscoverySubjects =>
       'Wybierz kanały tematyczne, które mają być wyświetlane w Discover.';
 
   @override
-  String get apply => 'Stosować';
+  String get apply => 'Zastosuj';
 
   @override
   String get openLink => 'Otwórz łącze';
@@ -570,12 +569,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get discoverAudiobooks => 'Odkryj audiobooki';
 
   @override
-  String get librivoxDescription =>
-      'Popularne tytuły domeny publicznej od LibriVox.';
+  String get librivoxDescription => 'Popularne tytuły od LibriVox.';
 
   @override
   String titlesCount(int count) {
-    return '$count titles';
+    return '$count tytułów';
   }
 
   @override
@@ -597,10 +595,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get continueListening => 'Kontynuuj słuchanie';
 
   @override
-  String get listen => 'Słuchać';
+  String get listen => 'Słuchaj';
 
   @override
-  String get resume => 'Wznawiać';
+  String get resume => 'Wznów';
 
   @override
   String get failedToLoadLibrary => 'Nie udało się załadować biblioteki';
@@ -615,10 +613,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get topListens => 'Najczęściej słuchane';
 
   @override
-  String get unreadDiscoveries => 'Nieprzeczytane odkrycia';
+  String get unreadDiscoveries => 'Nieprzeczytane propozycje';
 
   @override
-  String get pickUpAgain => 'Odbierz ponownie';
+  String get pickUpAgain => 'Wróć do czytania';
 
   @override
   String get bookHighlightsDescription =>
@@ -637,11 +635,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get jumpBackNarration =>
-      'Wróć do narracji bez szukania swojego miejsca.';
+      'Wróć dosłuchania bez szukania miejsca, w którym skończyłeś.';
 
   @override
   String get unreadBooksReady =>
-      'Nieprzeczytane książki gotowe na następną cichą godzinę.';
+      'Nieprzeczytane książki gotowe na Twoją najbliższą wolną chwilę.';
 
   @override
   String get quickAccessFavorites =>
@@ -663,24 +661,24 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String authorsCount(int count) {
-    return '$count authors';
+    return '$count autorzy';
   }
 
   @override
   String genresCount(int count) {
-    return '$count genres';
+    return '$count gatunki';
   }
 
   @override
   String percentCompleted(int percent) {
-    return '$percent% completed';
+    return '$percent% ukończone';
   }
 
   @override
-  String get readyWhenYouAre => 'Gotowy, kiedy będziesz';
+  String get readyWhenYouAre => 'Czekamy, aż zaczniesz';
 
   @override
-  String get details => 'Bliższe dane';
+  String get details => 'Detale';
 
   @override
   String get listeningRoom => 'Pokój Słuchania';
@@ -690,7 +688,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String titlesArrangedForBrowsing(int count) {
-    return '$count titles arranged for reading-first browsing.';
+    return '$count tytułów dostępnych do przeglądania.';
   }
 
   @override
@@ -700,7 +698,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get allTitles => 'Wszystkie tytuły';
 
   @override
-  String get authors => 'Autorski';
+  String get authors => 'Autorzy';
 
   @override
   String get browseByAuthor => 'Przeglądaj według autora';
@@ -709,7 +707,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get browseByGenre => 'Przeglądaj według gatunku';
 
   @override
-  String get discover => 'Odkryć';
+  String get discover => 'Odkrywaj';
 
   @override
   String get trendingTitlesOpenLibrary =>
@@ -728,11 +726,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noLabelFound(String label) {
-    return 'No $label found';
+    return 'Nie znaleziono $label';
   }
 
   @override
-  String get folder => 'Falcówka';
+  String get folder => 'Folder';
 
   @override
   String get filters => 'Filtry';
@@ -741,22 +739,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get readingStatus => 'Stan czytania';
 
   @override
-  String get playedStatus => 'Stan gry';
+  String get playedStatus => 'Status odtworzenia';
 
   @override
-  String get readStatus => 'Czytać';
+  String get readStatus => 'Czytaj';
 
   @override
-  String get watched => 'Obejrzałem';
+  String get watched => 'Obejrzane';
 
   @override
-  String get unread => 'Niewykształcony';
+  String get unread => 'Nieprzeczytane';
 
   @override
-  String get unwatched => 'Nieobserwowane';
+  String get unwatched => 'Zaznacz jako obejrzane';
 
   @override
-  String get seriesStatus => 'Stan serii';
+  String get seriesStatus => 'Status serialu';
 
   @override
   String get allLibraries => 'Wszystkie biblioteki';
@@ -765,43 +763,43 @@ class AppLocalizationsPl extends AppLocalizations {
   String get books => 'Książki';
 
   @override
-  String get latestBooks => 'Latest Books';
+  String get latestBooks => 'Ostatnio dodane książki';
 
   @override
-  String get latestAudiobooks => 'Latest Audiobooks';
+  String get latestAudiobooks => 'Ostatnio dodane Audiobooki';
 
   @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count books',
-      one: '1 book',
+      other: '$count książki',
+      one: '1 książka',
     );
     return '$_temp0';
   }
 
   @override
-  String get bookFormatBook => 'Book';
+  String get bookFormatBook => 'Książka';
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
 
   @override
   String bookPercentRead(int percent) {
-    return '$percent% read';
+    return '$percent% przeczytane';
   }
 
   @override
   String bookTimeLeft(String time) {
-    return '$time left';
+    return '$time zostało';
   }
 
   @override
-  String get bookHeroRead => 'Read';
+  String get bookHeroRead => 'Przeczytane';
 
   @override
-  String get bookHeroListen => 'Listen';
+  String get bookHeroListen => 'Słuchaj';
 
   @override
   String get author => 'Autor';
@@ -820,7 +818,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'LibriVox nie dostarczył jeszcze opisu dla tego tytułu.';
 
   @override
-  String get readers => 'Czytelnicy';
+  String get readers => 'Lektorzy';
 
   @override
   String get openLinks => 'Otwórz linki';
@@ -839,12 +837,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String sectionCountLabel(int count) {
-    return '$count sections';
+    return '$count sekcji';
   }
 
   @override
   String firstPublished(int year) {
-    return 'First published $year';
+    return 'Data pierwszego wydania $year';
   }
 
   @override
@@ -852,14 +850,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'W Open Library nie ma jeszcze przeglądu tego tytułu.';
 
   @override
-  String get subjects => 'Przedmioty';
+  String get subjects => 'Tematy';
 
   @override
   String get all => 'Wszystko';
 
   @override
   String booksCount(int count) {
-    return '$count books';
+    return '$count książek';
   }
 
   @override
@@ -870,7 +868,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String authorsCountTitle(int count) {
-    return '$count Authors';
+    return '$count Autorów';
   }
 
   @override
@@ -878,7 +876,7 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count audiobooks',
+      other: '$count audiobooki',
       one: '1 audiobook',
     );
     return '$_temp0';
@@ -888,22 +886,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trackList => 'Lista utworów';
 
   @override
-  String get itemListPlaceholder => 'Tutaj pojawi się lista przedmiotów';
+  String get itemListPlaceholder => 'Tutaj pojawi się lista pozycji';
 
   @override
   String get favoriteTracksPlaceholder => 'Tutaj pojawią się ulubione utwory';
 
   @override
-  String get failedToLoad => 'Nie udało się załadować';
+  String get failedToLoad => 'Nie udało się wczytać';
 
   @override
-  String get delete => 'Usuwać';
+  String get delete => 'Usuń';
 
   @override
-  String get save => 'Ratować';
+  String get save => 'Zapisz';
 
   @override
-  String get moreLikeThis => 'Więcej takich';
+  String get moreLikeThis => 'Więcej podobnych';
 
   @override
   String get castAndCrew => 'Obsada i ekipa';
@@ -918,22 +916,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get nextUp => 'Następny w kolejce';
 
   @override
-  String get seasons => 'Pory roku';
+  String get seasons => 'Sezony';
 
   @override
   String get chapters => 'Rozdziały';
 
   @override
-  String get features => 'Cechy';
+  String get features => 'Dodatki specjalne';
 
   @override
-  String get movies => 'Kino';
+  String get movies => 'Filmy';
 
   @override
-  String get musicVideos => 'Music Videos';
+  String get musicVideos => 'Teledyski';
 
   @override
-  String get other => 'Inny';
+  String get other => 'Inne';
 
   @override
   String get discography => 'Dyskografia';
@@ -949,14 +947,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String discNumber(int number) {
-    return 'Disc $number';
+    return 'Płyta $number';
   }
 
   @override
   String get biography => 'Biografia';
 
   @override
-  String get authorDetails => 'Szczegóły autora';
+  String get authorDetails => 'O autorze';
 
   @override
   String get noOverviewAvailable => 'Nie ma jeszcze przeglądu tego tytułu.';
@@ -973,7 +971,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String published(int year) {
-    return 'Published $year';
+    return 'Wydane w $year';
   }
 
   @override
@@ -984,52 +982,52 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count Seasons',
-      one: '1 Season',
+      other: '$count Sezony',
+      one: '1 Sezon',
     );
     return '$_temp0';
   }
 
   @override
   String endsAt(String time) {
-    return 'Ends at $time';
+    return 'Koniec o  $time';
   }
 
   @override
-  String get items => 'Items';
+  String get items => 'Elementy';
 
   @override
-  String get extras => 'Extras';
+  String get extras => 'Dodatki';
 
   @override
-  String get behindTheScenes => 'Behind the Scenes';
+  String get behindTheScenes => 'Kulisy produkcji';
 
   @override
-  String get deletedScenes => 'Deleted Scenes';
+  String get deletedScenes => 'Usunięte sceny';
 
   @override
-  String get featurettes => 'Featurettes';
+  String get featurettes => 'Materiały dodatkowe';
 
   @override
-  String get interviews => 'Interviews';
+  String get interviews => 'Wywiady';
 
   @override
-  String get scenes => 'Scenes';
+  String get scenes => 'Sceny';
 
   @override
-  String get shorts => 'Shorts';
+  String get shorts => 'Krótkie filmy';
 
   @override
-  String get trailers => 'Trailers';
+  String get trailers => 'Zwiastuny';
 
   @override
   String timeRemaining(String time) {
-    return '$time remaining';
+    return '$time pozostało';
   }
 
   @override
   String endsIn(String time) {
-    return 'Ends in $time';
+    return 'Koniec za $time';
   }
 
   @override
@@ -1039,15 +1037,15 @@ class AppLocalizationsPl extends AppLocalizations {
   String get resumeReading => 'Wznów czytanie';
 
   @override
-  String get read => 'Czytać';
+  String get read => 'Czytaj';
 
   @override
   String resumeFrom(String position) {
-    return 'Resume from $position';
+    return 'Wznów od $position';
   }
 
   @override
-  String get play => 'Grać';
+  String get play => 'Włącz';
 
   @override
   String get startOver => 'Zacznij od nowa';
@@ -1062,22 +1060,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get playOffline => 'Graj w trybie offline';
 
   @override
-  String get audio => 'Audio';
+  String get audio => 'Wybierz ścieżkę audio';
 
   @override
-  String get subtitles => 'Napisy na filmie obcojęzycznym';
+  String get subtitles => 'Napisy';
 
   @override
   String get version => 'Wersja';
 
   @override
-  String get cast => 'Rzucać';
+  String get cast => 'Przesyłaj';
 
   @override
-  String get trailer => 'Przyczepa';
+  String get trailer => 'Zwiastun';
 
   @override
-  String get finished => 'Gotowy';
+  String get finished => 'Ukończono';
 
   @override
   String get favorited => 'Ulubione';
@@ -1095,7 +1093,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get downloadAll => 'Pobierz wszystko';
 
   @override
-  String get download => 'Pobierać';
+  String get download => 'Pobierz';
 
   @override
   String get deleteDownloaded => 'Usuń pobrane';
@@ -1141,7 +1139,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String deleteDownloadedTracksMessage(String title) {
-    return 'Delete downloaded tracks for \"$title\"?';
+    return 'Usuń pobrany utwór \"$title\"?';
   }
 
   @override
@@ -1156,28 +1154,28 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noItemsLoaded(String itemLabel) {
-    return 'No $itemLabel loaded';
+    return 'Nie udało się wczytać $itemLabel';
   }
 
   @override
   String downloadingTitle(String title, int count) {
-    return 'Downloading $title ($count items)...';
+    return 'Pobieranie $title ($count elementów)...';
   }
 
   @override
   String deleteConfirmMessage(String name) {
-    return 'Are you sure you want to delete \"$name\" from the server? This action cannot be undone.';
+    return 'Napewno chcesz usunąć \"$name\" z serwera? Tego nie można cofnąć.';
   }
 
   @override
   String get itemDeleted => 'Element usunięty';
 
   @override
-  String get noPlayableTrailerFound => 'Nie znaleziono grywalnego zwiastuna.';
+  String get noPlayableTrailerFound => 'Nie znaleziono zwiastuna.';
 
   @override
   String unsupportedBookFormat(String extension) {
-    return 'Unsupported book format: .$extension';
+    return 'NIewspierany format: .$extension';
   }
 
   @override
@@ -1187,14 +1185,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get subtitleTrack => 'Ścieżka napisów';
 
   @override
-  String get none => 'Nic';
+  String get none => 'Brak';
 
   @override
   String get downloadSubtitlesLabel => 'Pobierz napisy...';
 
   @override
-  String get searchOpenSubtitlesPlugin =>
-      'Szukaj za pomocą wtyczki OpenSubtitles';
+  String get searchOpenSubtitlesPlugin => 'Szukaj z wtyczką OpenSubtitles';
 
   @override
   String get downloadSubtitles => 'Pobierz napisy';
@@ -1204,7 +1201,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String subtitleDownloadedSelected(String name) {
-    return 'Subtitle downloaded and selected: $name';
+    return 'Napisy pobrane i wybrane: $name';
   }
 
   @override
@@ -1213,15 +1210,15 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noRemoteSubtitlesFound(String language) {
-    return 'No remote subtitles found for $language.';
+    return 'Nie znaleziono napisów po $language.';
   }
 
   @override
-  String get selectVersion => 'Wybierz opcję Wersja';
+  String get selectVersion => 'Wybierz wersję';
 
   @override
   String versionNumber(int number) {
-    return 'Version $number';
+    return 'Wersja $number';
   }
 
   @override
@@ -1231,19 +1228,17 @@ class AppLocalizationsPl extends AppLocalizations {
   String get downloadQuality => 'Jakość pobierania';
 
   @override
-  String get originalFileNoReencoding =>
-      'Oryginalny plik, bez ponownego kodowania';
+  String get originalFileNoReencoding => 'Oryginalny plik';
 
   @override
-  String get originalFilesNoReencoding =>
-      'Oryginalne pliki, bez ponownego kodowania';
+  String get originalFilesNoReencoding => 'Oryginalne pliki';
 
   @override
   String get noEpisodesLoaded => 'Nie wczytano żadnych odcinków';
 
   @override
   String downloadingItem(String name, String quality) {
-    return 'Downloading $name ($quality)...';
+    return 'Pobieranie $name ($quality)...';
   }
 
   @override
@@ -1251,7 +1246,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String deleteLocalFilesMessage(String typeLabel) {
-    return 'Delete local files for $typeLabel?\n\nThis will free up storage space. You can re-download later.';
+    return 'Usuń lokalne pliki $typeLabel?\n\nZwolni to miejsce. Pliki można pobrać ponownie później.';
   }
 
   @override
@@ -1264,28 +1259,28 @@ class AppLocalizationsPl extends AppLocalizations {
   String get deleteFiles => 'Usuń pliki';
 
   @override
-  String get director => 'DYREKTOR';
+  String get director => 'REŻYSER';
 
   @override
-  String get directors => 'DIRECTORS';
+  String get directors => 'REŻYSERIA';
 
   @override
-  String get writer => 'WRITER';
+  String get writer => 'SCENARIUSZ';
 
   @override
-  String get writers => 'PISARZE';
+  String get writers => 'SCENARIUSZ';
 
   @override
   String get studio => 'STUDIO';
 
   @override
   String studioMoreCount(int count) {
-    return '+$count more';
+    return '+$count więcej';
   }
 
   @override
   String totalEpisodes(int count) {
-    return '$count Episodes';
+    return '$count odcinków';
   }
 
   @override
@@ -1295,12 +1290,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String episodeLabel(int number) {
-    return 'Episode $number';
+    return 'Odcinek $number';
   }
 
   @override
   String chapterNumber(int number) {
-    return 'Chapter $number';
+    return 'Rozdział $number';
   }
 
   @override
@@ -1308,8 +1303,8 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count tracks',
-      one: '1 track',
+      other: '$count utworów',
+      one: '1 utwór',
     );
     return '$_temp0';
   }
@@ -1319,48 +1314,48 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count chapters',
-      one: '1 chapter',
+      other: '$count rozdziałów',
+      one: '1 rozdział',
     );
     return '$_temp0';
   }
 
   @override
   String born(String date) {
-    return 'Born $date';
+    return 'Urodziny $date';
   }
 
   @override
   String died(String date) {
-    return 'Died $date';
+    return 'Śmierć $date';
   }
 
   @override
   String age(int age) {
-    return 'Age $age';
+    return 'Wiek $age';
   }
 
   @override
   String get showLess => 'Pokaż mniej';
 
   @override
-  String get readMore => 'Przeczytaj więcej';
+  String get readMore => 'Czytaj więcej';
 
   @override
-  String get shuffle => 'Człapać';
+  String get shuffle => 'Losowo';
 
   @override
-  String get shuffleAllMusic => 'Shuffle all music';
+  String get shuffleAllMusic => 'Odtwarzaj muzykę losowo';
 
   @override
-  String get carSignInPrompt => 'Sign in to Moonfin on your phone';
+  String get carSignInPrompt => 'Zaloguj się do Moonfin na telefonie';
 
   @override
-  String get carServerUnreachable => 'Can\'t reach your server';
+  String get carServerUnreachable => 'Nie można połączyć się z serwerem';
 
   @override
   String downloadsCount(int count) {
-    return '$count downloads';
+    return '$count pobrań';
   }
 
   @override
@@ -1368,43 +1363,43 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String channelsCount(int count) {
-    return '${count}ch';
+    return '${count}kanałów';
   }
 
   @override
-  String get mono => 'Mononukleoza';
+  String get mono => 'Mono';
 
   @override
-  String get stereo => 'Stereofoniczny';
+  String get stereo => 'Stereo';
 
   @override
   String remoteSubtitlePermissionError(String action) {
-    return 'Remote subtitle $action requires the Jellyfin subtitle management permission for this user.';
+    return 'Wykonanie $action wymaga uprawnienia do zarządzania napisami w Jellyfin dla tego użytkownika.';
   }
 
   @override
   String remoteSubtitleNotFoundError(String action) {
-    return 'This item could not be found on the server for remote subtitle $action.';
+    return 'Nie znaleziono na serwerze $action.';
   }
 
   @override
   String remoteSubtitleDetailError(String action, String detail) {
-    return 'Remote subtitle $action failed: $detail';
+    return 'Napisy zdalne $action nieudane: $detail';
   }
 
   @override
   String remoteSubtitleHttpError(String action, int status) {
-    return 'Remote subtitle $action failed (HTTP $status).';
+    return 'Napisy $action nieudane (HTTP $status).';
   }
 
   @override
   String remoteSubtitleGenericError(String action) {
-    return 'Failed to $action remote subtitles.';
+    return 'Nieudane $action napisów.';
   }
 
   @override
   String deleteSeriesFiles(String name) {
-    return 'all downloaded episodes for \"$name\"';
+    return 'wszystkie pobrane odcinki \"$name\"';
   }
 
   @override
@@ -1414,12 +1409,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get stillWatching => 'Nadal oglądasz?';
 
   @override
-  String get unableToLoadTrailerStream =>
-      'Nie można załadować strumienia zwiastuna.';
+  String get unableToLoadTrailerStream => 'Nie można wczytać zwiastuna.';
 
   @override
-  String get trailerTimedOut =>
-      'Przekroczono limit czasu przyczepy podczas ładowania.';
+  String get trailerTimedOut => 'Przekroczono limit czasu ładowania zwiastuna.';
 
   @override
   String get playbackFailedForTrailer =>
@@ -1436,24 +1429,24 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String castActionFailed(String label, String error) {
-    return '$label action failed: $error';
+    return '$label nieudane: $error';
   }
 
   @override
   String failedToSetCastVolume(String error) {
-    return 'Failed to set cast volume: $error';
+    return 'Nieudane przesyłanie głośności: $error';
   }
 
   @override
   String castControlsTitle(String label) {
-    return '$label Controls';
+    return '$label Sterowanie';
   }
 
   @override
   String get deviceVolume => 'Głośność urządzenia';
 
   @override
-  String get unavailable => 'Nie płynny';
+  String get unavailable => 'Niedostępne';
 
   @override
   String get pause => 'Pauza';
@@ -1471,11 +1464,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String trackNumber(int number) {
-    return 'Track $number';
+    return 'Utwór $number';
   }
 
   @override
-  String get remotePlayback => 'Zdalne odtwarzanie';
+  String get remotePlayback => 'Odtwarzanie zdalne';
 
   @override
   String get castingToGoogleCast => 'Przesyłanie do Google Cast';
@@ -1488,14 +1481,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String secondsCount(int seconds) {
-    return '$seconds seconds';
+    return '$seconds s';
   }
 
   @override
-  String get longPressToUnlock => 'Naciśnij długo, aby odblokować';
+  String get longPressToUnlock => 'Przytrzymaj, aby odblokować';
 
   @override
-  String get off => 'Wyłączony';
+  String get off => 'Wyłączone';
 
   @override
   String streamTypeFallback(String streamType, int number) {
@@ -1503,7 +1496,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get auto => 'Automatyczny';
+  String get auto => 'Auto';
 
   @override
   String bitrateValueMbps(int mbps) {
@@ -1511,7 +1504,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get bitrateOverride => 'Zastąpienie szybkości transmisji';
+  String get bitrateOverride => 'Wymuszony bitrate';
 
   @override
   String get audioDelay => 'Opóźnienie dźwięku';
@@ -1530,22 +1523,22 @@ class AppLocalizationsPl extends AppLocalizations {
   String get subtitleDelay => 'Opóźnienie napisów';
 
   @override
-  String get reset => 'Nastawić';
+  String get reset => 'Resetuj';
 
   @override
-  String get unknown => 'Nieznany';
+  String get unknown => 'Nieznane';
 
   @override
   String get playbackInformation => 'Informacje o odtwarzaniu';
 
   @override
-  String get playback => 'Odtwarzanie nagranego dźwięku';
+  String get playback => 'Odtwarzanie';
 
   @override
   String get playMethod => 'Metoda odtwarzania';
 
   @override
-  String get directPlay => 'Gra bezpośrednia';
+  String get directPlay => 'Odtwarzanie bezpośrednie';
 
   @override
   String get directStream => 'Bezpośredni strumień';
@@ -1560,7 +1553,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get player => 'Odtwarzacz';
 
   @override
-  String get container => 'Pojemnik';
+  String get container => 'Kontener';
 
   @override
   String get bitrate => 'Szybkość transmisji';
@@ -1569,7 +1562,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get video => 'Wideo';
 
   @override
-  String get resolution => 'Rezolucja';
+  String get resolution => 'Rozdzielczość';
 
   @override
   String get hdr => 'HDR';
@@ -1578,7 +1571,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get codec => 'Kodek';
 
   @override
-  String get videoBitrate => 'Szybkość transmisji wideo';
+  String get videoBitrate => 'Bitrate wideo';
 
   @override
   String get track => 'Ścieżka';
@@ -1587,10 +1580,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get channels => 'Kanały';
 
   @override
-  String get audioBitrate => 'Szybkość transmisji dźwięku';
+  String get audioBitrate => 'Bitrate dźwięku';
 
   @override
-  String get sampleRate => 'Częstotliwość próbkowania';
+  String get sampleRate => 'Częstotliwość audio';
 
   @override
   String get format => 'Format';
@@ -1603,12 +1596,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String castSessionError(String protocol) {
-    return '$protocol session error';
+    return '$protocol błąd sesji';
   }
 
   @override
   String failedToLoadBookDetails(String error) {
-    return 'Failed to load book details: $error';
+    return 'Nie udało się wczytać informacji o książce: $error';
   }
 
   @override
@@ -1617,7 +1610,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String formatCannotRenderInApp(String extension) {
-    return 'This format (.$extension) cannot be rendered in-app yet.';
+    return 'Ten format (.$extension) nie jest jeszcze obsługiwany.';
   }
 
   @override
@@ -1630,17 +1623,17 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToOpenInAppReader(String error) {
-    return 'Failed to open in-app reader: $error';
+    return 'Nie udało się otworzyć czytnika w aplikacji: $error';
   }
 
   @override
   String bookmarkAlreadySaved(String label) {
-    return 'Bookmark already saved at $label.';
+    return 'Zakładka już zapisana w $label.';
   }
 
   @override
   String bookmarkAdded(String label) {
-    return 'Bookmark added: $label';
+    return 'Zakładka dodana: $label';
   }
 
   @override
@@ -1652,14 +1645,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String pageLabel(int number) {
-    return 'Page $number';
+    return 'Strona $number';
   }
 
   @override
   String get position => 'Pozycja';
 
   @override
-  String get bookReader => 'Czytelnik książek';
+  String get bookReader => 'Czytnik książek';
 
   @override
   String formatExtension(String extension) {
@@ -1668,7 +1661,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String percentRead(String percent) {
-    return '$percent% read';
+    return '$percent% przeczytane';
   }
 
   @override
@@ -1692,14 +1685,14 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String resetZoom(String zoom) {
-    return 'Reset Zoom (${zoom}x)';
+    return 'Reset powiększenia (${zoom}x)';
   }
 
   @override
   String get singlePage => 'Pojedyncza strona';
 
   @override
-  String get twoPageSpread => 'Rozkładówka dwustronicowa';
+  String get twoPageSpread => 'Widok dwustronnicowy';
 
   @override
   String get addBookmark => 'Dodaj zakładkę';
@@ -1715,20 +1708,20 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToUpdateReadState(String error) {
-    return 'Failed to update read state: $error';
+    return 'Nie udało się zaktualizować stanu czytania: $error';
   }
 
   @override
-  String get themeSystem => 'Temat: System';
+  String get themeSystem => 'Styl: Systemowy';
 
   @override
-  String get themeLight => 'Temat: Światło';
+  String get themeLight => 'Styl: Jasny';
 
   @override
-  String get themeDark => 'Temat: Ciemność';
+  String get themeDark => 'Styl: Ciemny';
 
   @override
-  String get themeSepia => 'Temat: Sepia';
+  String get themeSepia => 'Styl: Sepia';
 
   @override
   String get invertColorsFixedLayout => 'Odwróć kolory (stały układ)';
@@ -1747,7 +1740,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String platformCannotHostDocumentEngine(String extension) {
-    return 'This platform cannot host the embedded document engine for $extension files.';
+    return 'Ta platforma nie obsługuje wbudowanego silnika $extension plików.';
   }
 
   @override
@@ -1770,10 +1763,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get now => 'Teraz';
 
   @override
-  String get sports => 'Lekkoatletyka';
+  String get sports => 'Sport';
 
   @override
-  String get news => 'Aktualności';
+  String get news => 'Wiadomości';
 
   @override
   String get kids => 'Dzieci';
@@ -1786,7 +1779,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToLoadGuide(String error) {
-    return 'Failed to load guide: $error';
+    return 'Nie udało sie załadować przewodnika: $error';
   }
 
   @override
@@ -1797,22 +1790,22 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String guideNextProgram(String time, String title) {
-    return 'Next: $time  $title';
+    return 'Następny: $time  $title';
   }
 
   @override
   String guideMinutesLeft(int minutes) {
-    return '${minutes}m left';
+    return '${minutes}m zostało';
   }
 
   @override
   String guideHoursLeft(int hours) {
-    return '${hours}h left';
+    return '${hours}h zostało';
   }
 
   @override
   String guideHoursMinutesLeft(int hours, int minutes) {
-    return '${hours}h ${minutes}m left';
+    return '${hours}h ${minutes}m zostało';
   }
 
   @override
@@ -1835,29 +1828,29 @@ class AppLocalizationsPl extends AppLocalizations {
   String get favoriteChannel => 'Ulubiony kanał';
 
   @override
-  String get record => 'Record';
+  String get record => 'Nagrywaj';
 
   @override
-  String get cancelRecordingAction => 'Cancel Recording';
+  String get cancelRecordingAction => 'Anuluj nagrywanie';
 
   @override
-  String get programSetToRecord => 'Program set to record';
+  String get programSetToRecord => 'Nagrywanie zaplanowane';
 
   @override
-  String get recordingCancelled => 'Recording cancelled';
+  String get recordingCancelled => 'Nagrywanie anulowane';
 
   @override
-  String get unableToCreateRecording => 'Unable to create recording';
+  String get unableToCreateRecording => 'Nie udało się włączyć nagrywania';
 
   @override
-  String get watch => 'Oglądać';
+  String get watch => 'Oglądaj';
 
   @override
-  String get close => 'Zamknąć';
+  String get close => 'Zamknij';
 
   @override
   String failedToPlayChannel(String name) {
-    return 'Failed to play $name';
+    return 'Nie można włączyć $name';
   }
 
   @override
@@ -1884,7 +1877,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String cancelScheduledRecordingOf(String name) {
-    return 'Cancel scheduled recording of \"$name\"?';
+    return 'Anulować zaplanowane nagrywanie \"$name\"?';
   }
 
   @override
@@ -1911,7 +1904,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String stopRecordingName(String name) {
-    return 'Stop recording \"$name\"?';
+    return 'Zakończ nagrywanie \"$name\"?';
   }
 
   @override
@@ -1926,12 +1919,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String noResultsForQuery(String query) {
-    return 'No results for \"$query\"';
+    return 'Brak wyników dla \"$query\"';
   }
 
   @override
   String searchFailedError(String error) {
-    return 'Search failed: $error';
+    return 'Wyszukiwanie nieudane: $error';
   }
 
   @override
@@ -1968,16 +1961,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get browseLibrary => 'Przeglądaj bibliotekę';
 
   @override
-  String get deleteDownload => 'Usuń pobieranie';
+  String get deleteDownload => 'Usuń pobrany plik';
 
   @override
   String removeItemAndFiles(String name) {
-    return 'Remove \"$name\" and its files?';
+    return 'Usuń \"$name\" wraz z plikami?';
   }
 
   @override
   String tracksCount(int count) {
-    return '$count tracks';
+    return '$count utworów';
   }
 
   @override
@@ -1988,12 +1981,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String failedToLoadAlbum(String error) {
-    return 'Failed to load album: $error';
+    return 'Nie udało sie załadować albumu: $error';
   }
 
   @override
   String noDownloadedTracksForAlbum(String name) {
-    return 'No downloaded tracks found for $name.';
+    return 'Nie znaleziono pobranych utworów dla $name.';
   }
 
   @override
@@ -2010,7 +2003,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String removeName(String name) {
-    return 'Remove \"$name\"?';
+    return 'Usunąć \"$name\"?';
   }
 
   @override
@@ -2020,12 +2013,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String seasonEpisodeLabel(int season, int episode) {
-    return 'S$season E$episode';
+    return 'S$season O$episode';
   }
 
   @override
   String episodeNumber(int number) {
-    return 'Episode $number';
+    return 'Odcinek $number';
   }
 
   @override
@@ -2039,7 +2032,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String seasonNumber(int number) {
-    return 'Season $number';
+    return 'Sezon $number';
   }
 
   @override
@@ -2048,14 +2041,14 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get specials => 'Promocje';
+  String get specials => 'Odcinki specjalne';
 
   @override
   String get deleteSeason => 'Usuń sezon';
 
   @override
   String deleteAllEpisodesInSeason(String season) {
-    return 'Delete all downloaded episodes in $season?';
+    return 'Usunąć wszystkie pobrane odcinki w $season?';
   }
 
   @override
@@ -2063,23 +2056,23 @@ class AppLocalizationsPl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count episodes',
-      one: '1 episode',
+      other: '$count odcinki',
+      one: '1 odcinek',
     );
     return '$_temp0';
   }
 
   @override
-  String get storageManagement => 'Zarządzanie pamięcią masową';
+  String get storageManagement => 'Zarządzanie pamięcią';
 
   @override
-  String get storageBreakdown => 'Podział magazynu';
+  String get storageBreakdown => 'Podział pamięci';
 
   @override
   String get downloadedItems => 'Pobrane elementy';
 
   @override
-  String get storageLimit => 'Limit przechowywania';
+  String get storageLimit => 'Limit pamięci';
 
   @override
   String get noLimit => 'Bez limitu';
@@ -2099,7 +2092,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String deleteSelectedCount(int count) {
-    return 'Delete $count downloaded items?';
+    return 'Usunąć $count pobranych elementów?';
   }
 
   @override
@@ -2113,7 +2106,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String ofStorageLimit(String limit) {
-    return 'of $limit limit';
+    return 'z $limit limitu';
   }
 
   @override
@@ -2139,21 +2132,20 @@ class AppLocalizationsPl extends AppLocalizations {
   String get contentRatingRestrictions => 'Ograniczenia dotyczące oceny treści';
 
   @override
-  String get bitRateResolutionBehavior =>
-      'Szybkość transmisji, rozdzielczość, zachowanie';
+  String get bitRateResolutionBehavior => 'Bitrate, rozdzielczość, zachowanie';
 
   @override
   String get languageSizeAppearance => 'Język, rozmiar, wygląd';
 
   @override
-  String get qualityStorage => 'Jakość, magazyn';
+  String get qualityStorage => 'Jakość, pamięć';
 
   @override
   String get serverSyncAndPluginStatus =>
-      'Synchronizacja serwera i stan wtyczki';
+      'Synchronizacja z serwerem i status wtyczek';
 
   @override
-  String get mediaRequestIntegration => 'Integracja żądań mediów';
+  String get mediaRequestIntegration => 'Integracja żądań multimediów';
 
   @override
   String get switchServer => 'Przełącz serwer';
@@ -2190,7 +2182,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get integrations => 'Integracje';
 
   @override
-  String get pluginAndRequests => 'Wtyczka i żądania';
+  String get pluginAndRequests => 'Wtyczki i żądania';
 
   @override
   String get customizeAccountPlaybackInterface =>
@@ -2198,23 +2190,23 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String optionsCount(int count) {
-    return '$count options';
+    return '$count opcji';
   }
 
   @override
   String get themeAndAppearance => 'Motyw i wygląd';
 
   @override
-  String get focusBorderColor => 'Kolor obramowania ostrości';
+  String get focusBorderColor => 'Kolor obramowania fokusu';
 
   @override
-  String get watchedIndicators => 'Obserwowane wskaźniki';
+  String get watchedIndicators => 'Wskaźniki obejrzanych';
 
   @override
   String get always => 'Zawsze';
 
   @override
-  String get hideUnwatched => 'Ukryj nieobserwowane';
+  String get hideUnwatched => 'Ukryj nieobejrzane';
 
   @override
   String get episodesOnly => 'Tylko odcinki';
@@ -2223,37 +2215,38 @@ class AppLocalizationsPl extends AppLocalizations {
   String get never => 'Nigdy';
 
   @override
-  String get focusExpansionAnimation => 'Animacja rozwijania ostrości';
+  String get focusExpansionAnimation => 'Animacja powiększenia przy fokusie';
 
   @override
-  String get desktopUiScale => 'Skala interfejsu użytkownika pulpitu';
+  String get desktopUiScale => 'Skalowanie interfejsu';
 
   @override
   String get scaleFocusedCards =>
-      'Skaluj skupione lub najechane karty i kafelki';
+      'Skaluj karty i kafelki po najechaniu lub zaznaczeniu';
 
   @override
-  String get backgroundBackdrops => 'Tła Tła';
+  String get backgroundBackdrops => 'Tła w tle';
 
   @override
   String get showBackdropImages => 'Pokaż obrazy tła za treścią';
 
   @override
-  String get seriesThumbnails => 'Miniatury serii';
+  String get seriesThumbnails => 'Wyświetlaj miniatury seriali';
 
   @override
   String get seriesThumbnailsDescription =>
-      'Tylko odcinki: użyj grafiki serialu odpowiadającej typowi obrazu w każdym wierszu';
+      'Dla seriali używaj głównej grafiki serialu zamiast miniatury odcinka.';
 
   @override
-  String get homeRowInfoOverlay => 'Nakładka informacyjna wiersza głównego';
+  String get homeRowInfoOverlay =>
+      'Nakładka informacyjna w wierszu ekranu głównego';
 
   @override
   String get showTitleMetadataOnHomeRows =>
-      'Pokaż tytuł i metadane podczas przeglądania wierszy głównych';
+      'Pokazuj tytuł i metadane podczas przeglądania wierszy ekranu głównego';
 
   @override
-  String get clockDisplay => 'Wyświetlacz zegara';
+  String get clockDisplay => 'Wyświetlaj zegar';
 
   @override
   String get inMenus => 'W Menu';
@@ -2292,7 +2285,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get themeMusicSettingsSubtitle =>
-      'Detail pages, home rows, and volume';
+      'Strony szczegółów, wiersze ekranu głównego i głośność';
 
   @override
   String percentValue(int value) {
@@ -2300,21 +2293,22 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get themeMusicOnHomeRows => 'Motyw muzyczny w rzędach domowych';
+  String get themeMusicOnHomeRows =>
+      'Muzyka motywu w wierszach ekranu głównego';
 
   @override
   String get playWhenBrowsingHomeScreen =>
-      'Odtwórz podczas przeglądania ekranu głównego';
+      'Odtwarzaj podczas przeglądania ekranu głównego';
 
   @override
-  String get loopThemeMusic => 'Loop Theme Music';
+  String get loopThemeMusic => 'Odtwarzaj muzykę motywu w pętli';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Repeat the track instead of playing it once';
+      'Powtarzaj utwór zamiast odtworzyć go raz';
 
   @override
-  String get detailsBackgroundBlur => 'Szczegóły Rozmycie tła';
+  String get detailsBackgroundBlur => 'Rozmycie tła na stronie szczegółów';
 
   @override
   String pixelValue(int value) {
@@ -2322,120 +2316,119 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get browsingBackgroundBlur => 'Przeglądanie rozmycia tła';
+  String get browsingBackgroundBlur => 'Rozmycie tła podczas przeglądania';
 
   @override
-  String get maxStreamingBitrate =>
-      'Maksymalna szybkość transmisji strumieniowej';
+  String get maxStreamingBitrate => 'Maksymalny bitrate strumieniowania';
 
   @override
   String get maxResolution => 'Maksymalna rozdzielczość';
 
   @override
-  String get playerZoomMode => 'Tryb powiększenia gracza';
+  String get playerZoomMode => 'Tryb powiększenia odtwarzacza';
 
   @override
-  String get settingsScrollWheelAction => 'Mouse scroll wheel';
+  String get settingsScrollWheelAction => 'Kółko przewijania myszy';
 
   @override
   String get settingsScrollWheelActionDescription =>
-      'Choose what scrolling the mouse wheel over the video does during playback.';
+      'Wybierz, co robi przewijanie kółkiem myszy nad wideo podczas odtwarzania.';
 
   @override
-  String get scrollWheelActionOff => 'Off';
+  String get scrollWheelActionOff => 'Wyłączone';
 
   @override
-  String get scrollWheelActionSeek => 'Seek (forward / back)';
+  String get scrollWheelActionSeek => 'Przewijanie (do przodu / do tyłu)';
 
   @override
-  String get scrollWheelActionVolume => 'Volume';
+  String get scrollWheelActionVolume => 'Głośność';
 
   @override
-  String get playerTooltipVolume => 'Volume';
+  String get playerTooltipVolume => 'Głośność';
 
   @override
-  String get fit => 'Pasować';
+  String get fit => 'Dopasuj';
 
   @override
-  String get autoCrop => 'Automatyczne przycinanie';
+  String get autoCrop => 'Automatyczne dopasowanie';
 
   @override
-  String get stretch => 'Rozciągać się';
+  String get stretch => 'Rozciągnij';
 
   @override
-  String get refreshRateSwitching => 'Przełączanie częstotliwości odświeżania';
+  String get refreshRateSwitching => 'Zmiana częstotliwości odświeżania';
 
   @override
   String get disabled => 'Wyłączony';
 
   @override
-  String get scaleOnTv => 'Skala w telewizji';
+  String get scaleOnTv => 'Skaluj na TV';
 
   @override
   String get scaleOnDevice => 'Skaluj na urządzeniu';
 
   @override
-  String get trickPlay => 'Zabawa w sztuczki';
+  String get trickPlay => 'Podgląd klatek (Trick Play)';
 
   @override
   String get showPreviewThumbnailsWhenSeeking =>
-      'Pokaż miniatury podglądu podczas wyszukiwania';
+      'Pokazuj podgląd klatek podczas przewijania';
 
   @override
-  String get showDescriptionOnPause => 'Pokaż opis w trybie pauzy';
+  String get showDescriptionOnPause => 'Pokazuj opis podczas pauzy';
 
   @override
   String get dimVideoShowOverview =>
-      'Przyciemnij wideo i pokaż tekst przeglądu podczas pauzy';
+      'Przyciemnij wideo i pokazuj opis podczas pauzy';
 
   @override
   String get osdLockButton => 'Przycisk blokady OSD';
 
   @override
   String get osdLockButtonDescription =>
-      'Pokaż przycisk blokady, który blokuje wprowadzanie dotykowe do momentu długiego naciśnięcia';
+      'Pokazuj przycisk blokady, który blokuje dotyk do czasu długiego naciśnięcia';
 
   @override
-  String get audioBehavior => 'Zachowanie dźwiękowe';
+  String get audioBehavior => 'Zachowanie dźwięku';
 
   @override
   String get downmixToStereo => 'Zmiksuj do stereo';
 
   @override
-  String get defaultAudioLanguage => 'Domyślny język dźwięku';
+  String get defaultAudioLanguage => 'Domyślny język audio';
 
   @override
-  String get fallbackAudioLanguage => 'Fallback Audio Language';
+  String get fallbackAudioLanguage => 'Zapasowy język audio';
 
   @override
-  String get preferDefaultAudioTrack => 'Prefer Default Audio Track';
+  String get preferDefaultAudioTrack => 'Preferuj domyślną ścieżkę audio';
 
   @override
   String get preferDefaultAudioTrackDescription =>
-      'Prefer original audio track over localized dub.';
+      'Preferuj oryginalną ścieżkę audio zamiast dubbingu.';
 
   @override
-  String get preferAudioDescription => 'Prefer Audio Description Tracks';
+  String get preferAudioDescription => 'Preferuj ścieżki audiodeskrypcji';
 
   @override
   String get preferAudioDescriptionDescription =>
-      'Prefer audio description tracks over normal tracks.';
+      'Preferuj ścieżki audiodeskrypcji zamiast zwykłych ścieżek.';
 
   @override
-  String get transcodingAudio => 'Transcoding (Audio)';
+  String get transcodingAudio => 'Transkodowanie (audio)';
 
   @override
-  String get directStreamRemux => 'Direct Stream (Remux)';
+  String get directStreamRemux => 'Strumieniowanie bezpośrednie (remux)';
 
   @override
   String get transcodingBitrateOrResolution =>
-      'Transcoding (Bitrate or Resolution)';
+      'Transkodowanie (bitrate lub rozdzielczość)';
 
   @override
-  String get transcodingVideoAndAudio => 'Transcoding (Video & Audio)';
+  String get transcodingVideoAndAudio => 'Transkodowanie (wideo i audio)';
 
   @override
-  String get transcodingVideo => 'Transcoding (Video)';
+  String get transcodingVideo => 'Transkodowanie (wideo)';
 
   @override
   String get autoServerDefault => 'Automatycznie (domyślne ustawienie serwera)';
@@ -2480,7 +2473,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dutch => 'Holenderski';
 
   @override
-  String get swedish => 'szwedzki';
+  String get swedish => 'Szwedzki';
 
   @override
   String get norwegian => 'norweski';
@@ -2505,34 +2498,35 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get enableDtsPassthrough =>
-      'Tylko dźwięk Bitstream DTS do AVR; wymaga obsługi odbiornika i ścieżki źródłowej DTS';
+      'Przesyłaj strumień DTS bezpośrednio (bitstream) do amplitunera; wymaga obsługi przez amplituner oraz źródłowej ścieżki DTS';
 
   @override
   String get enableTrueHdAudio =>
       'Włącz dźwięk TrueHD (może nie działać na wszystkich platformach)';
 
   @override
-  String get settingsAudioOutputMode => 'Audio Output Mode';
+  String get settingsAudioOutputMode => 'Tryb wyjścia audio';
 
   @override
   String get settingsAudioOutputModeDescription =>
-      'Choose how audio is decoded. AVR Passthrough sends raw Dolby/DTS streams to your receiver; Auto or Downmix decodes locally.';
+      'Wybierz sposób dekodowania audio. Passthrough do amplitunera przesyła surowy strumień Dolby/DTS; tryb Automatyczny lub Downmix dekoduje lokalnie.';
 
   @override
   String get settingsAudioOutputModeAvrPassthrough => 'AVR Passthrough';
 
   @override
-  String get settingsAudioFallbackCodec => 'Audio Fallback Codec';
+  String get settingsAudioFallbackCodec => 'Zapasowy kodek audio';
 
   @override
   String get settingsAudioFallbackCodecDescription =>
-      'Select the target format to transcode multi-channel audio when the source stream cannot be direct-played or passed through.';
+      'Wybierz format docelowy do transkodowania dźwięku wielokanałowego, gdy strumień źródłowy nie może zostać odtworzony bezpośrednio ani przesłany przez passthrough.';
 
   @override
-  String get settingsAudioFallbackCodecAuto => 'Auto Detect\n(Recommended)';
+  String get settingsAudioFallbackCodecAuto =>
+      'Wykrywanie automatyczne\n(zalecane)';
 
   @override
-  String get settingsAudioFallbackCodecAac => 'AAC\n(Default)';
+  String get settingsAudioFallbackCodecAac => 'AAC\n(Domyślnie)';
 
   @override
   String get settingsAudioFallbackCodecAc3 => 'AC3\n(Dolby Digital)';
@@ -2544,23 +2538,24 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAudioFallbackCodecTrueHd => 'TrueHD\n(Lossless)';
 
   @override
-  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo Only)';
+  String get settingsAudioFallbackCodecMp3 => 'MP3\n(Stereo)';
 
   @override
-  String get settingsAudioFallbackCodecOpus => 'Opus\n(Efficient)';
+  String get settingsAudioFallbackCodecOpus => 'Opus\n(Wydajny)';
 
   @override
-  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Lossless)';
+  String get settingsAudioFallbackCodecFlac => 'FLAC\n(Bezstratny)';
 
   @override
-  String get settingsMaxAudioChannels => 'Max Audio Channels';
+  String get settingsMaxAudioChannels => 'Maksymalna liczba kanałów audio';
 
   @override
   String get settingsMaxAudioChannelsDescription =>
-      'Configure the maximum channels of your audio setup. Multichannel streams exceeding this limit will downmix or transcode.';
+      'Skonfiguruj maksymalną liczbę kanałów obsługiwaną przez Twój zestaw audio. Strumienie wielokanałowe przekraczające ten limit zostaną zmiksowane w dół lub transkodowane.';
 
   @override
-  String get settingsMaxAudioChannelsAuto => 'Auto Detect\n(Hardware Default)';
+  String get settingsMaxAudioChannelsAuto =>
+      'Wykrywanie automatyczne\n(domyślne sprzętowe)';
 
   @override
   String get settingsMaxAudioChannelsMono => '1.0 Mono';
@@ -2587,36 +2582,36 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsMaxAudioChannels7_1 => '7.1 Surround';
 
   @override
-  String get settingsAudioPassthroughAdvanced => 'Passthrough (Advanced)';
+  String get settingsAudioPassthroughAdvanced => 'Passthrough (zaawansowane)';
 
   @override
-  String get settingsAudioCodecPassthrough => 'Codec Passthrough';
+  String get settingsAudioCodecPassthrough => 'Passthrough kodeka';
 
   @override
   String get settingsAudioCodecPassthroughDescription =>
-      'Enable only formats your AVR or HDMI sink supports.';
+      'Włączaj tylko formaty obsługiwane przez Twój amplituner lub odbiornik HDMI.';
 
   @override
-  String get settingsAudioEac3Passthrough => 'EAC3 Passthrough';
+  String get settingsAudioEac3Passthrough => 'EAC3 przejście';
 
   @override
-  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) Passthrough';
+  String get settingsAudioEac3JocPassthrough => 'EAC3 JOC (Atmos) przejście';
 
   @override
-  String get settingsAudioDtsCorePassthrough => 'DTS Core Passthrough';
+  String get settingsAudioDtsCorePassthrough => 'DTS Core przejście';
 
   @override
-  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA Passthrough';
+  String get settingsAudioDtsHdPassthrough => 'DTS-HD MA przejście';
 
   @override
-  String get settingsAudioTrueHdPassthrough => 'TrueHD Passthrough';
+  String get settingsAudioTrueHdPassthrough => 'TrueHD przejście';
 
   @override
-  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos Passthrough';
+  String get settingsAudioTrueHdAtmosPassthrough => 'TrueHD Atmos przejście';
 
   @override
   String get settingsAudioBitstreamEac3ToExternalDecoder =>
-      'Bitstream Dolby Digital Plus (EAC3) to external decoder.';
+      'Przesyłaj strumień Dolby Digital Plus (EAC3) bezpośrednio do zewnętrznego dekodera.';
 
   @override
   String get settingsAudioBitstreamEac3JocToExternalDecoder =>
@@ -2665,7 +2660,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsAudioRouteSpeaker => 'Speaker';
 
   @override
-  String get settingsAudioRouteHeadphones => 'Headphones';
+  String get settingsAudioRouteHeadphones => 'Słuchawki';
 
   @override
   String settingsAudioPcmChannels(int count) {
@@ -2844,31 +2839,31 @@ class AppLocalizationsPl extends AppLocalizations {
   String get subtitleCustomizationDescription => 'Dostosuj wygląd napisów';
 
   @override
-  String get subtitleMode => 'Subtitle Mode';
+  String get subtitleMode => 'Tryb napisów';
 
   @override
-  String get subtitleModeFlagged => 'Flagged';
+  String get subtitleModeFlagged => 'Oznaczone';
 
   @override
-  String get subtitleModeAlways => 'Always';
+  String get subtitleModeAlways => 'Zawsze';
 
   @override
-  String get subtitleModeForeign => 'Foreign';
+  String get subtitleModeForeign => 'W innym języku';
 
   @override
-  String get subtitleModeForced => 'Forced';
+  String get subtitleModeForced => 'Wymuszone';
 
   @override
   String get subtitleModeFlaggedDescription =>
-      'Plays tracks internally flagged in the media file\'s metadata as \"default\" or \"forced\".';
+      'Odtwarza ścieżki oznaczone w metadanych pliku jako „domyślne” lub „wymuszone”.';
 
   @override
   String get subtitleModeAlwaysDescription =>
-      'Automatically loads and displays subtitles every time a video starts.';
+      'Automatycznie wczytuj i wyświetlaj napisy przy każdym uruchomieniu wideo.';
 
   @override
   String get subtitleModeForeignDescription =>
-      'Automatically turns on subtitles if the default audio track is in a foreign language.';
+      'Automatycznie włącza napisy, jeśli domyślna ścieżka audio jest w innym języku niż wybrany.';
 
   @override
   String get subtitleModeForcedDescription =>
@@ -8643,6 +8638,9 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
       'Show details of the selected item at the top of Library pages.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -335,6 +335,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override
@@ -17209,6 +17212,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
@@ -25199,6 +25205,9 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
       'Aplica dicas de tamanho de fonte incorporadas na faixa de legenda. Desativa o uso do tamanho da legenda nas tuas preferências de estilo.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Usa subtítulos detalhados';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8655,6 +8655,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use subtítulos detalhados';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -336,6 +336,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8647,6 +8647,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Utilizați subtitluri detaliate';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -336,6 +336,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8654,6 +8654,9 @@ class AppLocalizationsRu extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -335,6 +335,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -8590,6 +8590,9 @@ class AppLocalizationsSi extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -336,6 +336,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8635,6 +8635,9 @@ class AppLocalizationsSk extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -337,6 +337,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8632,6 +8632,9 @@ class AppLocalizationsSl extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -336,6 +336,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8663,6 +8663,9 @@ class AppLocalizationsSq extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -336,6 +336,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -8629,6 +8629,9 @@ class AppLocalizationsSr extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -335,6 +335,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8614,6 +8614,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -337,6 +337,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8655,6 +8655,9 @@ class AppLocalizationsSw extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -335,6 +335,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8657,6 +8657,9 @@ class AppLocalizationsTa extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -336,6 +336,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8648,6 +8648,9 @@ class AppLocalizationsTe extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'వివరణాత్మక ఉపశీర్షికలను ఉపయోగించండి';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -337,6 +337,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -8550,6 +8550,9 @@ class AppLocalizationsTh extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'ใช้หัวข้อย่อยโดยละเอียด';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -337,6 +337,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8682,6 +8682,9 @@ class AppLocalizationsTl extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -161,11 +161,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Sekmeler arasında gezinirken sekme içeriğini otomatik olarak göster. Her sekmeyi manuel olarak açıp kapatmak için bu seçeneği kapatın.';
 
   @override
-  String get showTechnicalDetails => 'Teknik Detaylar Gösterilsin Mi?';
+  String get showTechnicalDetails => 'Show Technical Details?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Başlık özetinde kodek, çözünürlük ve akış bilgilerini göster';
+      'Show codec, resolution, and stream information in banner summary';
 
   @override
   String get recommendationSystem => 'Öneri Sistemi';
@@ -332,6 +332,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get gameSaveState => 'Durumu Kaydet';
+
+  @override
+  String get games => 'Games';
 
   @override
   String get gameLoadState => 'Durumu Yükle';
@@ -2294,11 +2297,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Ana ekrana göz atarken oynat';
 
   @override
-  String get loopThemeMusic => 'Tema Müziğini Sürekli Çal';
+  String get loopThemeMusic => 'Loop Theme Music';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Parçayı bir kez oynatmak yerine döngüye al';
+      'Repeat the track instead of playing it once';
 
   @override
   String get detailsBackgroundBlur => 'Detay Arka Plan Bulanıklığı';
@@ -3284,11 +3287,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Fragmanları medya çubuğunda 3 saniye sonra otomatik oynat';
 
   @override
-  String get trailerAudio => 'Fragman Sesi';
+  String get trailerAudio => 'Trailer Audio';
 
   @override
-  String get enableTrailerAudio =>
-      'Medya çubuğundaki fragmanlar için sesi etkinleştir';
+  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
 
   @override
   String get episodePreview => 'Bölüm Önizlemesi';
@@ -3308,7 +3310,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get previewAudio => 'Sesi Önizle';
 
   @override
-  String get enablePreviewAudio => 'Medya önizlemeleri için sesi aç';
+  String get enablePreviewAudio =>
+      'Fragman ve bölüm önizlemeleri için sesi etkinleştirin';
 
   @override
   String get latestMedia => 'En Son Eklenen Medya';
@@ -3680,10 +3683,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Onaylandı, reddedildi ve kütüphanenize eklendi';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Sorun Güncellemeleri';
+  String get seerrNotifyIssuesTitle => 'Issue updates';
 
   @override
-  String get seerrNotifyIssuesSubtitle => 'Yeni sorunlar, yanıtlar ve çözümler';
+  String get seerrNotifyIssuesSubtitle =>
+      'New issues, replies, and resolutions';
 
   @override
   String loggedInAs(String username) {
@@ -3841,11 +3845,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'İndiriliyor · %$percent';
+    return 'Downloading · $percent%';
   }
 
   @override
-  String get seerrImportingStatus => 'İçe Aktarılıyor';
+  String get seerrImportingStatus => 'Importing';
 
   @override
   String itemsCount(int count) {
@@ -3987,147 +3991,148 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deletedStatus => 'Silindi';
 
   @override
-  String get failedStatus => 'Başarısız Oldu';
+  String get failedStatus => 'Failed';
 
   @override
-  String get processingStatus => 'İşleniyor';
+  String get processingStatus => 'Processing';
 
   @override
   String modifiedByName(String name) {
-    return '$name tarafından değiştirildi';
+    return 'Modified by $name';
   }
 
   @override
-  String get completedStatus => 'Tamamlandı';
+  String get completedStatus => 'Completed';
 
   @override
-  String get requestErrorDuplicate => 'Bu içerik zaten talep edilmiş';
+  String get requestErrorDuplicate => 'This title was already requested';
 
   @override
-  String get requestErrorQuota => 'İstek sınırına ulaşıldı';
+  String get requestErrorQuota => 'Request limit reached';
 
   @override
-  String get requestErrorBlocklisted => 'Bu içerik kara listede';
+  String get requestErrorBlocklisted => 'This title is blocklisted';
 
   @override
-  String get requestErrorNoSeasons => 'Talep edilecek sezon kalmadı';
+  String get requestErrorNoSeasons => 'No seasons left to request';
 
   @override
   String get requestErrorPermission =>
-      'Bu talebi gerçekleştirmek için izniniz yok';
+      'You don\'t have permission to make this request';
 
   @override
-  String get seerrRequestsTitle => 'İstekler';
+  String get seerrRequestsTitle => 'Requests';
 
   @override
-  String get seerrIssuesTitle => 'Sorunlar';
+  String get seerrIssuesTitle => 'Issues';
 
   @override
-  String get sortNewest => 'En Yeni';
+  String get sortNewest => 'Newest';
 
   @override
-  String get sortLastModified => 'Son Düzenlenen';
+  String get sortLastModified => 'Last Modified';
 
   @override
-  String get noIssues => 'Sorun Yok';
+  String get noIssues => 'No issues';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return 'Kalan film talebi: $remaining / $limit';
+    return '$remaining of $limit movie requests remaining';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return 'Kalan sezon talebi: $remaining / $limit';
+    return '$remaining of $limit season requests remaining';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return '$name koleksiyonunun parçası';
+    return 'Part of $name';
   }
 
   @override
-  String get viewCollection => 'Koleksiyonu Görüntüle';
+  String get viewCollection => 'View Collection';
 
   @override
-  String get requestCollection => 'Koleksiyonu İste';
+  String get requestCollection => 'Request Collection';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total film · $available mevcut';
+    return '$total movies · $available available';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return '$count film iste';
+    return 'Request $count movies';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'İsteniyor: $current / $total...';
+    return 'Requesting $current of $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return '$count film istendi';
+    return 'Requested $count movies';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'İstenen film: $ok / $total';
+    return 'Requested $ok of $total movies';
   }
 
   @override
-  String get collectionAllRequested => 'Tüm filmler zaten mevcut veya istenmiş';
+  String get collectionAllRequested =>
+      'All movies are already available or requested';
 
   @override
-  String get reportIssue => 'Sorun Bildir';
+  String get reportIssue => 'Report Issue';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Ses';
+  String get issueTypeAudio => 'Audio';
 
   @override
-  String get whatsWrong => 'Sorun ne?';
+  String get whatsWrong => 'What\'s wrong?';
 
   @override
-  String get allEpisodes => 'Tüm Bölümler';
+  String get allEpisodes => 'All Episodes';
 
   @override
-  String get episode => 'Bölüm';
+  String get episode => 'Episode';
 
   @override
-  String get openStatus => 'Açık';
+  String get openStatus => 'Open';
 
   @override
-  String get resolvedStatus => 'Çözüldü';
+  String get resolvedStatus => 'Resolved';
 
   @override
-  String get resolveAction => 'Çöz';
+  String get resolveAction => 'Resolve';
 
   @override
-  String get reopenAction => 'Tekrar aç';
+  String get reopenAction => 'Reopen';
 
   @override
   String reportedByName(String name) {
-    return '$name tarafından bildirildi';
+    return 'Reported by $name';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count yorum';
+    return '$count comments';
   }
 
   @override
-  String get addComment => 'Yorum ekle';
+  String get addComment => 'Add a comment';
 
   @override
-  String get deleteIssueConfirm => 'Sorun silinsin mi?';
+  String get deleteIssueConfirm => 'Delete this issue?';
 
   @override
-  String get submitReport => 'Raporu Gönder';
+  String get submitReport => 'Submit Report';
 
   @override
   String get tmdbScore => 'TMDB Puanı';
@@ -7671,20 +7676,20 @@ class AppLocalizationsTr extends AppLocalizations {
   String get offlineSavedMedia => 'Kayıtlı Medya';
 
   @override
-  String get offlineBannerTitle => 'Çevrimdışısın';
+  String get offlineBannerTitle => 'You\'re offline';
 
   @override
-  String get offlineBannerSubtitle => 'İndirdikleriniz gösteriliyor';
+  String get offlineBannerSubtitle => 'Showing your downloads';
 
   @override
-  String get offlineBannerAction => 'İndirilenler';
+  String get offlineBannerAction => 'Downloads';
 
   @override
-  String get serverUnreachableBannerTitle => 'Sunucuya erişilemiyor';
+  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Bağlantı geri gelene kadar indirilenlerden oynatılıyor';
+      'Playing from downloads until it\'s back';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -9743,7 +9748,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Jellyfin görselleri güncelleyemedi. Kütüphaneniz, görselleri doğrudan medya klasörlerine kaydedecek şekilde yapılandırılmış (\'Görselleri medya klasörlerine kaydet\' seçeneği etkin). Bu hata genellikle Jellyfin sunucu işleminin, medya dizinlerinize dosya yazma izni olmadığında meydana gelir.';
 
   @override
-  String get externalLists => 'Harici Listeler';
+  String get externalLists => 'Harici Ana Sayfa Satır Listeleri';
 
   @override
   String get replay => 'Tekrar';
@@ -9914,20 +9919,20 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminLibChapterImageResolutionMatchSource => 'Kaynağa göre eşle';
 
   @override
-  String get imdbTop250Movies => 'IMDB En İyi 250 Film';
+  String get imdbTop250Movies => 'IMDb Top 250 Movies';
 
   @override
-  String get imdbTop250TvShows => 'IMDB En İyi 250 Dizi';
+  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
 
   @override
-  String get imdbMostPopularMovies => 'IMDB En Popüler Filmler';
+  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDB En Popüler Diziler';
+  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDB En Düşük Puanlı Filmler';
+  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDB En Yüksek Puanlı İngilizce Filmler';
+  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -161,11 +161,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Sekmeler arasında gezinirken sekme içeriğini otomatik olarak göster. Her sekmeyi manuel olarak açıp kapatmak için bu seçeneği kapatın.';
 
   @override
-  String get showTechnicalDetails => 'Show Technical Details?';
+  String get showTechnicalDetails => 'Teknik Detaylar Gösterilsin Mi?';
 
   @override
   String get showTechnicalDetailsSubtitle =>
-      'Show codec, resolution, and stream information in banner summary';
+      'Başlık özetinde kodek, çözünürlük ve akış bilgilerini göster';
 
   @override
   String get recommendationSystem => 'Öneri Sistemi';
@@ -2294,11 +2294,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get playWhenBrowsingHomeScreen => 'Ana ekrana göz atarken oynat';
 
   @override
-  String get loopThemeMusic => 'Loop Theme Music';
+  String get loopThemeMusic => 'Tema Müziğini Sürekli Çal';
 
   @override
   String get loopThemeMusicSubtitle =>
-      'Repeat the track instead of playing it once';
+      'Parçayı bir kez oynatmak yerine döngüye al';
 
   @override
   String get detailsBackgroundBlur => 'Detay Arka Plan Bulanıklığı';
@@ -3284,10 +3284,11 @@ class AppLocalizationsTr extends AppLocalizations {
       'Fragmanları medya çubuğunda 3 saniye sonra otomatik oynat';
 
   @override
-  String get trailerAudio => 'Trailer Audio';
+  String get trailerAudio => 'Fragman Sesi';
 
   @override
-  String get enableTrailerAudio => 'Enable audio for trailers in media bar';
+  String get enableTrailerAudio =>
+      'Medya çubuğundaki fragmanlar için sesi etkinleştir';
 
   @override
   String get episodePreview => 'Bölüm Önizlemesi';
@@ -3307,8 +3308,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get previewAudio => 'Sesi Önizle';
 
   @override
-  String get enablePreviewAudio =>
-      'Fragman ve bölüm önizlemeleri için sesi etkinleştirin';
+  String get enablePreviewAudio => 'Medya önizlemeleri için sesi aç';
 
   @override
   String get latestMedia => 'En Son Eklenen Medya';
@@ -3680,11 +3680,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Onaylandı, reddedildi ve kütüphanenize eklendi';
 
   @override
-  String get seerrNotifyIssuesTitle => 'Issue updates';
+  String get seerrNotifyIssuesTitle => 'Sorun Güncellemeleri';
 
   @override
-  String get seerrNotifyIssuesSubtitle =>
-      'New issues, replies, and resolutions';
+  String get seerrNotifyIssuesSubtitle => 'Yeni sorunlar, yanıtlar ve çözümler';
 
   @override
   String loggedInAs(String username) {
@@ -3842,11 +3841,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String seerrDownloadingPercent(int percent) {
-    return 'Downloading · $percent%';
+    return 'İndiriliyor · %$percent';
   }
 
   @override
-  String get seerrImportingStatus => 'Importing';
+  String get seerrImportingStatus => 'İçe Aktarılıyor';
 
   @override
   String itemsCount(int count) {
@@ -3988,148 +3987,147 @@ class AppLocalizationsTr extends AppLocalizations {
   String get deletedStatus => 'Silindi';
 
   @override
-  String get failedStatus => 'Failed';
+  String get failedStatus => 'Başarısız Oldu';
 
   @override
-  String get processingStatus => 'Processing';
+  String get processingStatus => 'İşleniyor';
 
   @override
   String modifiedByName(String name) {
-    return 'Modified by $name';
+    return '$name tarafından değiştirildi';
   }
 
   @override
-  String get completedStatus => 'Completed';
+  String get completedStatus => 'Tamamlandı';
 
   @override
-  String get requestErrorDuplicate => 'This title was already requested';
+  String get requestErrorDuplicate => 'Bu içerik zaten talep edilmiş';
 
   @override
-  String get requestErrorQuota => 'Request limit reached';
+  String get requestErrorQuota => 'İstek sınırına ulaşıldı';
 
   @override
-  String get requestErrorBlocklisted => 'This title is blocklisted';
+  String get requestErrorBlocklisted => 'Bu içerik kara listede';
 
   @override
-  String get requestErrorNoSeasons => 'No seasons left to request';
+  String get requestErrorNoSeasons => 'Talep edilecek sezon kalmadı';
 
   @override
   String get requestErrorPermission =>
-      'You don\'t have permission to make this request';
+      'Bu talebi gerçekleştirmek için izniniz yok';
 
   @override
-  String get seerrRequestsTitle => 'Requests';
+  String get seerrRequestsTitle => 'İstekler';
 
   @override
-  String get seerrIssuesTitle => 'Issues';
+  String get seerrIssuesTitle => 'Sorunlar';
 
   @override
-  String get sortNewest => 'Newest';
+  String get sortNewest => 'En Yeni';
 
   @override
-  String get sortLastModified => 'Last Modified';
+  String get sortLastModified => 'Son Düzenlenen';
 
   @override
-  String get noIssues => 'No issues';
+  String get noIssues => 'Sorun Yok';
 
   @override
   String movieQuotaRemaining(int remaining, int limit) {
-    return '$remaining of $limit movie requests remaining';
+    return 'Kalan film talebi: $remaining / $limit';
   }
 
   @override
   String seasonQuotaRemaining(int remaining, int limit) {
-    return '$remaining of $limit season requests remaining';
+    return 'Kalan sezon talebi: $remaining / $limit';
   }
 
   @override
   String partOfCollectionName(String name) {
-    return 'Part of $name';
+    return '$name koleksiyonunun parçası';
   }
 
   @override
-  String get viewCollection => 'View Collection';
+  String get viewCollection => 'Koleksiyonu Görüntüle';
 
   @override
-  String get requestCollection => 'Request Collection';
+  String get requestCollection => 'Koleksiyonu İste';
 
   @override
   String collectionMoviesSummary(int total, int available) {
-    return '$total movies · $available available';
+    return '$total film · $available mevcut';
   }
 
   @override
   String requestMoviesCount(int count) {
-    return 'Request $count movies';
+    return '$count film iste';
   }
 
   @override
   String requestingProgress(int current, int total) {
-    return 'Requesting $current of $total...';
+    return 'İsteniyor: $current / $total...';
   }
 
   @override
   String requestedMoviesCount(int count) {
-    return 'Requested $count movies';
+    return '$count film istendi';
   }
 
   @override
   String requestedMoviesPartial(int ok, int total) {
-    return 'Requested $ok of $total movies';
+    return 'İstenen film: $ok / $total';
   }
 
   @override
-  String get collectionAllRequested =>
-      'All movies are already available or requested';
+  String get collectionAllRequested => 'Tüm filmler zaten mevcut veya istenmiş';
 
   @override
-  String get reportIssue => 'Report Issue';
+  String get reportIssue => 'Sorun Bildir';
 
   @override
   String get issueTypeVideo => 'Video';
 
   @override
-  String get issueTypeAudio => 'Audio';
+  String get issueTypeAudio => 'Ses';
 
   @override
-  String get whatsWrong => 'What\'s wrong?';
+  String get whatsWrong => 'Sorun ne?';
 
   @override
-  String get allEpisodes => 'All Episodes';
+  String get allEpisodes => 'Tüm Bölümler';
 
   @override
-  String get episode => 'Episode';
+  String get episode => 'Bölüm';
 
   @override
-  String get openStatus => 'Open';
+  String get openStatus => 'Açık';
 
   @override
-  String get resolvedStatus => 'Resolved';
+  String get resolvedStatus => 'Çözüldü';
 
   @override
-  String get resolveAction => 'Resolve';
+  String get resolveAction => 'Çöz';
 
   @override
-  String get reopenAction => 'Reopen';
+  String get reopenAction => 'Tekrar aç';
 
   @override
   String reportedByName(String name) {
-    return 'Reported by $name';
+    return '$name tarafından bildirildi';
   }
 
   @override
   String commentsCount(int count) {
-    return '$count comments';
+    return '$count yorum';
   }
 
   @override
-  String get addComment => 'Add a comment';
+  String get addComment => 'Yorum ekle';
 
   @override
-  String get deleteIssueConfirm => 'Delete this issue?';
+  String get deleteIssueConfirm => 'Sorun silinsin mi?';
 
   @override
-  String get submitReport => 'Submit Report';
+  String get submitReport => 'Raporu Gönder';
 
   @override
   String get tmdbScore => 'TMDB Puanı';
@@ -7673,20 +7671,20 @@ class AppLocalizationsTr extends AppLocalizations {
   String get offlineSavedMedia => 'Kayıtlı Medya';
 
   @override
-  String get offlineBannerTitle => 'You\'re offline';
+  String get offlineBannerTitle => 'Çevrimdışısın';
 
   @override
-  String get offlineBannerSubtitle => 'Showing your downloads';
+  String get offlineBannerSubtitle => 'İndirdikleriniz gösteriliyor';
 
   @override
-  String get offlineBannerAction => 'Downloads';
+  String get offlineBannerAction => 'İndirilenler';
 
   @override
-  String get serverUnreachableBannerTitle => 'Can\'t reach your server';
+  String get serverUnreachableBannerTitle => 'Sunucuya erişilemiyor';
 
   @override
   String get serverUnreachableBannerSubtitle =>
-      'Playing from downloads until it\'s back';
+      'Bağlantı geri gelene kadar indirilenlerden oynatılıyor';
 
   @override
   String get castGoogleCast => 'Google Cast';
@@ -8633,6 +8631,9 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get showMediaDetailsOnLibraryPageDescription =>
       'Kütüphane sayfalarında, seçilen ögenin detaylarını üst kısımda göster.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Detaylı alt başlıklar kullan';
@@ -9742,7 +9743,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Jellyfin görselleri güncelleyemedi. Kütüphaneniz, görselleri doğrudan medya klasörlerine kaydedecek şekilde yapılandırılmış (\'Görselleri medya klasörlerine kaydet\' seçeneği etkin). Bu hata genellikle Jellyfin sunucu işleminin, medya dizinlerinize dosya yazma izni olmadığında meydana gelir.';
 
   @override
-  String get externalLists => 'Harici Ana Sayfa Satır Listeleri';
+  String get externalLists => 'Harici Listeler';
 
   @override
   String get replay => 'Tekrar';
@@ -9913,20 +9914,20 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminLibChapterImageResolutionMatchSource => 'Kaynağa göre eşle';
 
   @override
-  String get imdbTop250Movies => 'IMDb Top 250 Movies';
+  String get imdbTop250Movies => 'IMDB En İyi 250 Film';
 
   @override
-  String get imdbTop250TvShows => 'IMDb Top 250 TV Shows';
+  String get imdbTop250TvShows => 'IMDB En İyi 250 Dizi';
 
   @override
-  String get imdbMostPopularMovies => 'IMDb Most Popular Movies';
+  String get imdbMostPopularMovies => 'IMDB En Popüler Filmler';
 
   @override
-  String get imdbMostPopularTvShows => 'IMDb Most Popular TV Shows';
+  String get imdbMostPopularTvShows => 'IMDB En Popüler Diziler';
 
   @override
-  String get imdbLowestRatedMovies => 'IMDb Lowest Rated Movies';
+  String get imdbLowestRatedMovies => 'IMDB En Düşük Puanlı Filmler';
 
   @override
-  String get imdbTopEnglishMovies => 'IMDb Top Rated English Movies';
+  String get imdbTopEnglishMovies => 'IMDB En Yüksek Puanlı İngilizce Filmler';
 }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -336,6 +336,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -8610,6 +8610,9 @@ class AppLocalizationsUg extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -336,6 +336,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8646,6 +8646,9 @@ class AppLocalizationsUk extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Використовуйте детальні підзаголовки';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -337,6 +337,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -8608,6 +8608,9 @@ class AppLocalizationsVi extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Sử dụng các tiêu đề phụ chi tiết';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -326,6 +326,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get gameSaveState => 'Save state';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => 'Load state';
 
   @override
@@ -16608,6 +16611,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
       'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override
@@ -24220,6 +24226,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
       'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -8359,6 +8359,9 @@ class AppLocalizationsYue extends AppLocalizations {
       'Show details of the selected item at the top of Library pages.';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -320,6 +320,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get gameSaveState => '保存存档';
 
   @override
+  String get games => 'Games';
+
+  @override
   String get gameLoadState => '读取存档';
 
   @override
@@ -16486,6 +16489,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String get subtitlesUseEmbeddedFontSizesSubtitle =>
       'Apply font-size hints embedded in the subtitle track. Disable to use the subtitle size from your style preferences.';
+
+  @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
 
   @override
   String get useDetailedSubHeadings => 'Use Detailed Sub-Headings';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8298,6 +8298,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showMediaDetailsOnLibraryPageDescription => '在媒体库页面顶部显示所选媒体项的详情。';
 
   @override
+  String get hideBackdropsInLibraries => 'Hide Backdrops while Browsing?';
+
+  @override
   String get useDetailedSubHeadings => '使用详细的副标题';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -180,6 +180,7 @@ class UserPreferences extends ChangeNotifier {
     'pref_show_seerr_button',
     'pref_show_media_details_on_library_page',
     'pref_use_detailed_sub_headings',
+    'pref_hide_backdrops_in_libraries',
     'pref_show_clock',
     'pref_use_24_hour_clock',
     'pref_clock_behavior',
@@ -1022,6 +1023,11 @@ class UserPreferences extends ChangeNotifier {
   static final useDetailedSubHeadings = Preference(
     key: 'pref_use_detailed_sub_headings',
     defaultValue: true,
+  );
+
+  static final hideBackdropsInLibraries = Preference(
+    key: 'pref_hide_backdrops_in_libraries',
+    defaultValue: false,
   );
   static final maxBitrate = Preference(
     key: 'pref_max_bitrate',

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -56,6 +56,10 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   List<GenreCardData> _genres = [];
   bool _isLoading = true;
 
+  void _onChanged() {
+    if (mounted) setState(() {});
+  }
+
   @override
   void initState() {
     super.initState();
@@ -63,6 +67,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
       if (mounted) setState(() => _backdropUrl = url);
     });
     _backdropUrl = _backgroundService.currentUrl;
+    _prefs.addListener(_onChanged);
     _load();
   }
 
@@ -70,6 +75,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   void dispose() {
     _disposed = true;
     _backgroundSub?.cancel();
+    _prefs.removeListener(_onChanged);
     super.dispose();
   }
 
@@ -307,7 +313,8 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   Widget _buildContent(BuildContext context) {
     final isMobile = _isCompact(context);
     final desktopScale = _desktopUiScaleFactor();
-    final hasBackdrop = !isMobile && _backdropUrl != null;
+    final hideBackdrops = _prefs.get(UserPreferences.hideBackdropsInLibraries);
+    final hasBackdrop = !isMobile && !hideBackdrops && _backdropUrl != null;
     return Scaffold(
       backgroundColor: _navyBackground,
       body: Stack(

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -238,7 +238,8 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
 
   Widget _buildContent(BuildContext context) {
     final isMobile = _isCompact(context);
-    final hasBackdrop = !isMobile && _backdropUrl != null;
+    final hideBackdrops = _prefs.get(UserPreferences.hideBackdropsInLibraries);
+    final hasBackdrop = !isMobile && !hideBackdrops && _backdropUrl != null;
     return Scaffold(
       backgroundColor: _navyBackground,
       body: Stack(

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -495,7 +495,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
   Widget _buildContent(BuildContext context) {
     final isMobile = _isCompact(context);
-    final hasBackdrop = !isMobile && _backdropUrl != null;
+    final hideBackdrops = _prefs.get(UserPreferences.hideBackdropsInLibraries);
+    final hasBackdrop = !isMobile && !hideBackdrops && _backdropUrl != null;
     final blurAmount = _prefs
       .get(UserPreferences.browsingBackgroundBlurAmount)
       .toDouble();

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -59,6 +59,10 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
   PosterSize get _posterSize => _prefs.resolveLibraryPosterSize();
 
+  void _onChanged() {
+    if (mounted) setState(() {});
+  }
+
   @override
   void initState() {
     super.initState();
@@ -66,6 +70,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
       if (mounted) setState(() => _backdropUrl = url);
     });
     _backdropUrl = _backgroundService.currentUrl;
+    _prefs.addListener(_onChanged);
     _load();
   }
 
@@ -73,6 +78,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
   void dispose() {
     _disposed = true;
     _backgroundSub?.cancel();
+    _prefs.removeListener(_onChanged);
     super.dispose();
   }
 
@@ -332,7 +338,8 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
   Widget _buildContent(BuildContext context) {
     final isMobile = _isCompact(context);
-    final hasBackdrop = !isMobile && _backdropUrl != null;
+    final hideBackdrops = _prefs.get(UserPreferences.hideBackdropsInLibraries);
+    final hasBackdrop = !isMobile && !hideBackdrops && _backdropUrl != null;
     return Scaffold(
       backgroundColor: _navyBackground,
       body: Stack(

--- a/lib/ui/screens/browse/music_browse_screen.dart
+++ b/lib/ui/screens/browse/music_browse_screen.dart
@@ -85,6 +85,7 @@ class MusicBrowseScreen extends StatefulWidget {
 class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
   late final MusicBrowseViewModel _vm;
   final _backgroundService = GetIt.instance<BackgroundService>();
+  final _prefs = GetIt.instance<UserPreferences>();
   StreamSubscription<String?>? _backgroundSub;
   String? _backdropUrl;
 
@@ -102,12 +103,14 @@ class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
       if (mounted) setState(() => _backdropUrl = url);
     });
     _backdropUrl = _backgroundService.currentUrl;
+    _prefs.addListener(_onChanged);
   }
 
   @override
   void dispose() {
     _backgroundSub?.cancel();
     _vm.removeListener(_onChanged);
+    _prefs.removeListener(_onChanged);
     _vm.dispose();
     super.dispose();
   }
@@ -177,7 +180,8 @@ class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
     final l10n = AppLocalizations.of(context);
     final isMobile = PlatformDetection.useMobileUi;
     final isDesktop = PlatformDetection.useDesktopUi;
-    final hasBackdrop = !isMobile && _backdropUrl != null;
+    final hideBackdrops = _prefs.get(UserPreferences.hideBackdropsInLibraries);
+    final hasBackdrop = !isMobile && !hideBackdrops && _backdropUrl != null;
     return Scaffold(
       backgroundColor: _navyBackground,
       body: Stack(

--- a/lib/ui/screens/settings/panel/libraries_category_screen.dart
+++ b/lib/ui/screens/settings/panel/libraries_category_screen.dart
@@ -143,6 +143,12 @@ class _LibrariesCategoryScreenState extends State<_LibrariesCategoryScreen> {
                 icon: Icons.subtitles,
                 onChanged: _pushPersonalizationSync,
               ),
+              SwitchPreferenceTile(
+                preference: UserPreferences.hideBackdropsInLibraries,
+                title: l10n.hideBackdropsInLibraries,
+                icon: Icons.hide_image_outlined,
+                onChanged: _pushPersonalizationSync,
+              ),
             ],
           ),
         ],


### PR DESCRIPTION
# Pull Request

## Summary
Add a new personalization preference "Hide Backdrops while Browsing?" to Libraries configuration.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #803 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added `pref_hide_backdrops_in_libraries` boolean preference to `UserPreferences` (scoped, defaults to false).
- Added `SwitchPreferenceTile` settings toggle for this setting under Personalization -> Libraries.
- Created l10n English translation strings for the toggle.
- Integrated the setting check on all library browsing screens (Library Browse, Music Browse, Library Genres, Favorites, and All Genres) so that when the setting is enabled, the background backdrops are hidden.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Personalization -> Libraries.
2. Verify the new toggle "Hide Backdrops while Browsing?" is present and OFF.
3. Verify that backdrops are shown when browsing library pages.
4. Toggle "Hide Backdrops while Browsing?" to ON.
5. Verify that backdrops are now hidden when browsing library pages.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-13_21-29-50" src="https://github.com/user-attachments/assets/ec1e1e36-b2c9-4ed9-a91d-445e64634dd6" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-13_21-30-25" src="https://github.com/user-attachments/assets/74504f4a-a7b9-4143-a702-5e8af9e518a0" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-13_21-31-05" src="https://github.com/user-attachments/assets/0be66a1f-5bb3-49a4-ba20-c048615df488" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
