### PR TITLE
bug/ui-settings - Move recommendation preferences and fix TMDb recommendations

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -10475,8 +10475,7 @@ class DetailSimilarRow extends StatelessWidget {
                 final mediaType = item.seerrMediaType ??
                     (item.type == 'Series' ? 'tv' : 'movie');
                 context.push(
-                  Destinations.seerrMedia(item.id),
-                  extra: {'mediaType': mediaType},
+                  Destinations.seerrMedia(item.id, mediaType: mediaType),
                 );
               } else {
                 context.push(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -10447,7 +10447,10 @@ class DetailSimilarRow extends StatelessWidget {
                     maxHeight: isMobile ? 300 : (400 * desktopScale).round(),
                     tag: item.primaryImageTag,
                   )
-                : null,
+                : (item.rawData['PosterPath'] != null &&
+                        (item.rawData['PosterPath'] as String).isNotEmpty
+                    ? 'https://image.tmdb.org/t/p/w342${item.rawData['PosterPath']}'
+                    : null),
             width: cardWidth,
             aspectRatio: ar,
             focusColor: isNeon
@@ -10467,9 +10470,20 @@ class DetailSimilarRow extends StatelessWidget {
             onLongPress: onItemLongPress == null
                 ? null
                 : () => onItemLongPress!(item),
-            onTap: () => context.push(
-              Destinations.item(item.id, serverId: item.serverId),
-            ),
+            onTap: () {
+              if (item.serverId == 'seerr') {
+                final mediaType = item.seerrMediaType ??
+                    (item.type == 'Series' ? 'tv' : 'movie');
+                context.push(
+                  Destinations.seerrMedia(item.id),
+                  extra: {'mediaType': mediaType},
+                );
+              } else {
+                context.push(
+                  Destinations.item(item.id, serverId: item.serverId),
+                );
+              }
+            },
           );
         },
       ),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -2852,8 +2852,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                     final mediaType = entry.seerrMediaType ??
                         (entry.type == 'Series' ? 'tv' : 'movie');
                     context.push(
-                      Destinations.seerrMedia(entry.id),
-                      extra: {'mediaType': mediaType},
+                      Destinations.seerrMedia(entry.id, mediaType: mediaType),
                     );
                   } else {
                     context.push(
@@ -2935,8 +2934,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                         final mediaType = entry.seerrMediaType ??
                             (entry.type == 'Series' ? 'tv' : 'movie');
                         context.push(
-                          Destinations.seerrMedia(entry.id),
-                          extra: {'mediaType': mediaType},
+                          Destinations.seerrMedia(entry.id, mediaType: mediaType),
                         );
                       } else {
                         context.push(

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -2847,9 +2847,20 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 itemType: entry.type,
                 watchedBehavior:
                     widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
-                onTap: () => context.push(
-                  Destinations.item(entry.id, serverId: entry.serverId),
-                ),
+                onTap: () {
+                  if (entry.serverId == 'seerr') {
+                    final mediaType = entry.seerrMediaType ??
+                        (entry.type == 'Series' ? 'tv' : 'movie');
+                    context.push(
+                      Destinations.seerrMedia(entry.id),
+                      extra: {'mediaType': mediaType},
+                    );
+                  } else {
+                    context.push(
+                      Destinations.item(entry.id, serverId: entry.serverId),
+                    );
+                  }
+                },
               );
             },
           ),
@@ -2919,9 +2930,20 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                         : null,
                     watchedBehavior: widget.prefs
                         .get(UserPreferences.watchedIndicatorBehavior),
-                    onTap: () => context.push(
-                      Destinations.item(entry.id, serverId: entry.serverId),
-                    ),
+                    onTap: () {
+                      if (entry.serverId == 'seerr') {
+                        final mediaType = entry.seerrMediaType ??
+                            (entry.type == 'Series' ? 'tv' : 'movie');
+                        context.push(
+                          Destinations.seerrMedia(entry.id),
+                          extra: {'mediaType': mediaType},
+                        );
+                      } else {
+                        context.push(
+                          Destinations.item(entry.id, serverId: entry.serverId),
+                        );
+                      }
+                    },
                   );
                 },
               ),
@@ -4159,6 +4181,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final tag = item.primaryImageTag;
     if (tag != null && !item.id.startsWith('tmdb:')) {
       return _vm.imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
+    }
+    final posterPath = item.rawData['PosterPath'] as String?;
+    if (posterPath != null && posterPath.isNotEmpty) {
+      return 'https://image.tmdb.org/t/p/w342$posterPath';
     }
     final profilePath = item.rawData['ProfilePath'] as String?;
     if (profilePath != null && profilePath.isNotEmpty) {

--- a/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
+++ b/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
@@ -75,6 +75,26 @@ class _DetailsScreenSettingsScreenState
                       icon: Icons.info_outline,
                       onChanged: _pushPersonalizationSync,
                     ),
+                    EnumPreferenceTile<RecommendationSystemSource>(
+                      preference: UserPreferences.recommendationSystemSource,
+                      title: l10n.recommendationSystem,
+                      description: l10n.recommendationSystemSubtitle,
+                      icon: Icons.auto_awesome,
+                      labelOf: (v) => switch (v) {
+                        RecommendationSystemSource.local =>
+                          l10n.recommendationSystemMoonfin,
+                        RecommendationSystemSource.online =>
+                          l10n.recommendationSystemTmdb,
+                      },
+                      onChanged: _pushPersonalizationSync,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.recommendationsApplyParentalRatingCap,
+                      title: l10n.recommendationsApplyParentalRatingCap,
+                      subtitle: l10n.recommendationsApplyParentalRatingCapSubtitle,
+                      icon: Icons.family_restroom,
+                      onChanged: _pushPersonalizationSync,
+                    ),
                 ],
               ),
             ],

--- a/lib/ui/screens/settings/panel/libraries_category_screen.dart
+++ b/lib/ui/screens/settings/panel/libraries_category_screen.dart
@@ -1,29 +1,7 @@
 part of '../settings_side_panel.dart';
 
-class _LibrariesCategoryScreen extends StatefulWidget {
+class _LibrariesCategoryScreen extends StatelessWidget {
   const _LibrariesCategoryScreen();
-
-  @override
-  State<_LibrariesCategoryScreen> createState() => _LibrariesCategoryScreenState();
-}
-
-class _LibrariesCategoryScreenState extends State<_LibrariesCategoryScreen> {
-  late final PreferenceBinding<RecommendationSystemSource> _recSysBinding;
-
-  @override
-  void initState() {
-    super.initState();
-    _recSysBinding = PreferenceBinding(
-      GetIt.instance<PreferenceStore>(),
-      UserPreferences.recommendationSystemSource,
-    );
-  }
-
-  @override
-  void dispose() {
-    _recSysBinding.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -41,34 +19,6 @@ class _LibrariesCategoryScreenState extends State<_LibrariesCategoryScreen> {
                 subtitle: Text(l10n.settingsLibraryVisibilitySubtitle),
                 onTap: () =>
                     context.pushSettingsScreen(const LibraryVisibilityScreen()),
-              ),
-              EnumPreferenceTile<RecommendationSystemSource>(
-                preference: UserPreferences.recommendationSystemSource,
-                title: l10n.recommendationSystem,
-                description: l10n.recommendationSystemSubtitle,
-                icon: Icons.auto_awesome,
-                labelOf: (v) => switch (v) {
-                  RecommendationSystemSource.local =>
-                    l10n.recommendationSystemMoonfin,
-                  RecommendationSystemSource.online =>
-                    l10n.recommendationSystemTmdb,
-                },
-                onChanged: _pushPersonalizationSync,
-              ),
-              ValueListenableBuilder<RecommendationSystemSource>(
-                valueListenable: _recSysBinding,
-                builder: (context, source, _) {
-                  if (source != RecommendationSystemSource.local) {
-                    return const SizedBox.shrink();
-                  }
-                  return SwitchPreferenceTile(
-                    preference: UserPreferences.recommendationsApplyParentalRatingCap,
-                    title: l10n.recommendationsApplyParentalRatingCap,
-                    subtitle: l10n.recommendationsApplyParentalRatingCapSubtitle,
-                    icon: Icons.family_restroom,
-                    onChanged: _pushPersonalizationSync,
-                  );
-                },
               ),
               SwitchPreferenceTile(
                 preference: UserPreferences.enableFolderView,


### PR DESCRIPTION
# Pull Request

## Summary
Move the "Recommendation System" and "Apply Parental Rating Cap?" preferences from the Libraries category to the Details Screen category, since it makes more sense there. Also, fix poster loading and click navigation for online (TMDB/Seerr) recommendations.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **details_screen_settings_screen.dart**: Added the `EnumPreferenceTile` for `recommendationSystemSource` and the `SwitchPreferenceTile` for `recommendationsApplyParentalRatingCap` (always visible, not conditional).
- **libraries_category_screen.dart**: Removed the corresponding preference tiles and refactored the class to a `StatelessWidget` since it no longer requires state initialization or lifecycle disposal.
- **item_detail_screen.dart & modern_detail_content.dart**:
  - **Poster Rendering**: Resolved missing recommendation posters under the online (TMDB) setting. Added a TMDB poster path fallback in `DetailSimilarRow`'s `imageUrl` construction (classic layout) and the `_imageUrl` helper method (modern layout) to fetch the poster from TMDB's image server (`https://image.tmdb.org/t/p/w342/...`) when Jellyfin's `primaryImageTag` is null.
  - **Detail Navigation (400 bad request error)**: Fixed item click navigation. When the user taps a recommended item from the online system (which has a server ID of `'seerr'`), the app now correctly pushes the Seerr detail screen (`Destinations.seerrMedia(id)`) instead of routing to the standard Jellyfin detail view (`Destinations.item(id)`) which causes a 400 bad request error due to unrecognized TMDB IDs.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Personalization -> Libraries and verify the "Recommendation System" and "Apply Parental Rating Cap?" tiles are no longer present.
2. Navigate to Personalization -> Details Screen and verify both setting tiles are present and visible.
3. Verify that changing the recommendation system setting does not hide the parental rating cap setting.
4. Navigate to any item detail page under classic/modern views and check the "Similar" recommendation row when recommendation source is set to TMDB. Verify that all poster images load successfully.
5. Tap on any similar item in the recommendations list and verify it opens the Seerr details screen without throwing a 400 Bad Request error.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### New preference home:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-13_22-03-12" src="https://github.com/user-attachments/assets/fb014622-d50f-468e-817e-ef53316fbd8b" />

### Broken TMDb recommendations:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-13_21-55-26" src="https://github.com/user-attachments/assets/6e58d0c9-5837-4e97-a6b6-1f58b87383e0" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-13_22-04-03" src="https://github.com/user-attachments/assets/4d278d74-3f3d-42a5-b8d8-a6c93e40b7d6" />

### Fixed TMDb recommendations:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-13_22-11-04" src="https://github.com/user-attachments/assets/4127ffb4-03b5-43ba-890e-5688faabbf45" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
