### PR TITLE
more settings sync

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1132,10 +1132,11 @@ class PluginSyncService extends ChangeNotifier {
         UserPreferences.sinceYouWatchedSource,
         enumValues: prefs.SinceYouWatchedSource.values,
       );
-      _applyInt(
+      _applyString(
         resolved,
         'sinceYouWatchedNumRows',
         UserPreferences.sinceYouWatchedNumRows,
+        enumValues: prefs.SinceYouWatchedNumRows.values,
       );
       _applyString(
         resolved,
@@ -1819,8 +1820,17 @@ class PluginSyncService extends ChangeNotifier {
       'displayGenresRows': _prefs.get(UserPreferences.displayGenresRows),
       'displayAudioRows': _prefs.get(UserPreferences.displayAudioRows),
       'displaySinceYouWatchedRows': _prefs.get(UserPreferences.displaySinceYouWatchedRows),
+      'sinceYouWatchedSource': _prefs.get(UserPreferences.sinceYouWatchedSource).name,
+      'sinceYouWatchedNumRows': _prefs.get(UserPreferences.sinceYouWatchedNumRows).name,
+      'sinceYouWatchedSourceType': _prefs.get(UserPreferences.sinceYouWatchedSourceType).name,
+      'sinceYouWatchedSourceItem': _prefs.get(UserPreferences.sinceYouWatchedSourceItem).name,
+      'sinceYouWatchedIncludeWatched': _prefs.get(UserPreferences.sinceYouWatchedIncludeWatched),
       'displayPlaylistsRows': _prefs.get(UserPreferences.displayPlaylistsRows),
       'displayRewatchRow': _prefs.get(UserPreferences.displayRewatchRow),
+      'rewatchSortBy': _prefs.get(UserPreferences.rewatchSortBy).name,
+      'rewatchIncludeMovies': _prefs.get(UserPreferences.rewatchIncludeMovies),
+      'rewatchIncludeShows': _prefs.get(UserPreferences.rewatchIncludeShows),
+      'rewatchIncludeCollections': _prefs.get(UserPreferences.rewatchIncludeCollections),
       'fullScreenRows': _prefs.get(UserPreferences.fullScreenRows),
       'useDetailedSubHeadings': _prefs.get(
         UserPreferences.useDetailedSubHeadings,

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1126,6 +1126,34 @@ class PluginSyncService extends ChangeNotifier {
         'displaySinceYouWatchedRows',
         UserPreferences.displaySinceYouWatchedRows,
       );
+      _applyString(
+        resolved,
+        'sinceYouWatchedSource',
+        UserPreferences.sinceYouWatchedSource,
+        enumValues: prefs.SinceYouWatchedSource.values,
+      );
+      _applyInt(
+        resolved,
+        'sinceYouWatchedNumRows',
+        UserPreferences.sinceYouWatchedNumRows,
+      );
+      _applyString(
+        resolved,
+        'sinceYouWatchedSourceType',
+        UserPreferences.sinceYouWatchedSourceType,
+        enumValues: prefs.SinceYouWatchedSourceType.values,
+      );
+      _applyString(
+        resolved,
+        'sinceYouWatchedSourceItem',
+        UserPreferences.sinceYouWatchedSourceItem,
+        enumValues: prefs.SinceYouWatchedSourceItem.values,
+      );
+      _applyBool(
+        resolved,
+        'sinceYouWatchedIncludeWatched',
+        UserPreferences.sinceYouWatchedIncludeWatched,
+      );
       _applyBool(
         resolved,
         'displayPlaylistsRows',
@@ -1135,6 +1163,27 @@ class PluginSyncService extends ChangeNotifier {
         resolved,
         'displayRewatchRow',
         UserPreferences.displayRewatchRow,
+      );
+      _applyString(
+        resolved,
+        'rewatchSortBy',
+        UserPreferences.rewatchSortBy,
+        enumValues: prefs.RewatchSortBy.values,
+      );
+      _applyBool(
+        resolved,
+        'rewatchIncludeMovies',
+        UserPreferences.rewatchIncludeMovies,
+      );
+      _applyBool(
+        resolved,
+        'rewatchIncludeShows',
+        UserPreferences.rewatchIncludeShows,
+      );
+      _applyBool(
+        resolved,
+        'rewatchIncludeCollections',
+        UserPreferences.rewatchIncludeCollections,
       );
       _applyBool(
         resolved,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -707,7 +707,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final displaySinceYouWatchedRows = Preference(
     key: 'pref_display_since_you_watched_rows',
-    defaultValue: false,
+    defaultValue: true,
   );
 
   static final sinceYouWatched1Enabled = Preference(
@@ -766,7 +766,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final displayRewatchRow = Preference(
     key: 'pref_display_rewatch_row',
-    defaultValue: false,
+    defaultValue: true,
   );
 
   static final rewatchSortBy = EnumPreference(


### PR DESCRIPTION
# Pull Request

## Summary
Update settings sync now that other repos are more up to date

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- change displaySinceYouWatched and displayRewatch toggles to default TRUE. Smarttv/roku don't have the toggles, they are basically "true" always, so this makes core match the default behavior without adding/removing toggles anywhere
- add sinceyouwatched and rewatched configuration settings to syncable settings
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="1416" height="979" alt="image" src="https://github.com/user-attachments/assets/c719a55f-648c-4e8a-93a5-582d7897d966" />
anything green that says "missing" is what I am adding in this PR

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
