### PR TITLE
bugfix - Fix subtitle and audio selection when starting play from container

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7434,15 +7434,24 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               [selectedEpisode],
             );
             final directAllowed = !dvForceTranscode && !forceTranscode;
+
+            final epMediaStreams = _mediaStreamsForCurrentSelection(selectedEpisode);
+            final epAudioStreams = epMediaStreams.where((s) => s['Type'] == 'Audio').toList();
+            final epSubtitleStreams = epMediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+            final epAudioStreamIndex = _effectiveAudioStreamIndex(epAudioStreams);
+            final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
+              epSubtitleStreams,
+              epAudioStreams,
+            );
+
             await manager.playItems(
               seriesQueue,
               startIndex: idx,
               startPosition: startPosition,
-              audioStreamIndex: audioStreamIndex,
-              subtitleStreamIndex: subtitleStreamIndex,
-              audioSelectionExplicit: viewModel.selectedAudioIndex != null,
-              subtitleSelectionExplicit:
-                  viewModel.selectedSubtitleIndex != null,
+              audioStreamIndex: epAudioStreamIndex,
+              subtitleStreamIndex: epSubtitleStreamIndex,
+              audioSelectionExplicit: false,
+              subtitleSelectionExplicit: false,
               enableDirectPlay: directAllowed,
               enableDirectStream: directAllowed,
             );
@@ -7471,15 +7480,24 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               [selectedEpisode],
             );
             final directAllowed = !dvForceTranscode && !forceTranscode;
+
+            final epMediaStreams = _mediaStreamsForCurrentSelection(selectedEpisode);
+            final epAudioStreams = epMediaStreams.where((s) => s['Type'] == 'Audio').toList();
+            final epSubtitleStreams = epMediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+            final epAudioStreamIndex = _effectiveAudioStreamIndex(epAudioStreams);
+            final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
+              epSubtitleStreams,
+              epAudioStreams,
+            );
+
             await manager.playItems(
               seasonQueue,
               startIndex: idx,
               startPosition: startPosition,
-              audioStreamIndex: audioStreamIndex,
-              subtitleStreamIndex: subtitleStreamIndex,
-              audioSelectionExplicit: viewModel.selectedAudioIndex != null,
-              subtitleSelectionExplicit:
-                  viewModel.selectedSubtitleIndex != null,
+              audioStreamIndex: epAudioStreamIndex,
+              subtitleStreamIndex: epSubtitleStreamIndex,
+              audioSelectionExplicit: false,
+              subtitleSelectionExplicit: false,
               enableDirectPlay: directAllowed,
               enableDirectStream: directAllowed,
             );
@@ -7615,15 +7633,24 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               [targetItem],
             );
             final directAllowed = !dvForceTranscode && !forceTranscode;
+
+            final epMediaStreams = _mediaStreamsForCurrentSelection(targetItem);
+            final epAudioStreams = epMediaStreams.where((s) => s['Type'] == 'Audio').toList();
+            final epSubtitleStreams = epMediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+            final epAudioStreamIndex = _effectiveAudioStreamIndex(epAudioStreams);
+            final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
+              epSubtitleStreams,
+              epAudioStreams,
+            );
+
             await manager.playItems(
               playableQueue,
               startIndex: startIndex,
               startPosition: startPosition,
-              audioStreamIndex: audioStreamIndex,
-              subtitleStreamIndex: subtitleStreamIndex,
-              audioSelectionExplicit: viewModel.selectedAudioIndex != null,
-              subtitleSelectionExplicit:
-                  viewModel.selectedSubtitleIndex != null,
+              audioStreamIndex: epAudioStreamIndex,
+              subtitleStreamIndex: epSubtitleStreamIndex,
+              audioSelectionExplicit: false,
+              subtitleSelectionExplicit: false,
               enableDirectPlay: directAllowed,
               enableDirectStream: directAllowed,
             );

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1250,6 +1250,23 @@ class PlaybackManager implements AudioOwnable {
       }
     }
 
+    if (_subtitleStreamIndex == null) {
+      // Keep the server-selected subtitle index for later re-resolves.
+      // If it is missing, fall back to the file's default subtitle track.
+      _subtitleStreamIndex = resolution.selectedSubtitleStreamIndex;
+      if (_subtitleStreamIndex == null) {
+        final subtitleStreams =
+            resolution.mediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
+        if (subtitleStreams.isNotEmpty) {
+          final defaultSubtitle = subtitleStreams.firstWhere(
+            (s) => s['IsDefault'] == true,
+            orElse: () => subtitleStreams.first,
+          );
+          _subtitleStreamIndex = defaultSubtitle['Index'] as int?;
+        }
+      }
+    }
+
     final playbackDecisionLogger = _playbackDecisionLogger;
     if (playbackDecisionLogger != null && _backend != null) {
       try {

--- a/packages/playback_core/lib/src/stream_resolution_result.dart
+++ b/packages/playback_core/lib/src/stream_resolution_result.dart
@@ -34,6 +34,7 @@ class StreamResolutionResult {
   final List<ExternalSubtitle> externalSubtitles;
   final List<Map<String, dynamic>> mediaStreams;
   final int? selectedAudioStreamIndex;
+  final int? selectedSubtitleStreamIndex;
   final List<String> transcodingReasons;
   final String? hybridAudioUrl;
 
@@ -55,6 +56,7 @@ class StreamResolutionResult {
     this.externalSubtitles = const [],
     this.mediaStreams = const [],
     this.selectedAudioStreamIndex,
+    this.selectedSubtitleStreamIndex,
     this.transcodingReasons = const [],
     this.hybridAudioUrl,
     this.isLocalMedia = false,

--- a/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
+++ b/packages/playback_emby/lib/src/emby_media_stream_resolver.dart
@@ -108,6 +108,7 @@ class EmbyMediaStreamResolver implements MediaStreamResolver {
       externalSubtitles: authedSubs,
       mediaStreams: source.mediaStreams,
       selectedAudioStreamIndex: source.defaultAudioStreamIndex,
+      selectedSubtitleStreamIndex: source.defaultSubtitleStreamIndex,
       transcodingReasons: source.transcodingReasons,
     );
   }

--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -188,6 +188,7 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       externalSubtitles: authedSubs,
       mediaStreams: source.mediaStreams,
       selectedAudioStreamIndex: source.defaultAudioStreamIndex,
+      selectedSubtitleStreamIndex: source.defaultSubtitleStreamIndex,
       transcodingReasons: reasons,
       hybridAudioUrl: hybridAudioUrl,
     );

--- a/packages/server_core/lib/src/models/playback_models.dart
+++ b/packages/server_core/lib/src/models/playback_models.dart
@@ -109,6 +109,7 @@ class PlaybackMediaSource {
   final PlayMethod? defaultPlayMethod;
   final List<Map<String, dynamic>> mediaStreams;
   final int? defaultAudioStreamIndex;
+  final int? defaultSubtitleStreamIndex;
   final List<String> transcodingReasons;
 
   const PlaybackMediaSource({
@@ -129,6 +130,7 @@ class PlaybackMediaSource {
     this.defaultPlayMethod,
     this.mediaStreams = const [],
     this.defaultAudioStreamIndex,
+    this.defaultSubtitleStreamIndex,
     this.transcodingReasons = const [],
   });
 
@@ -152,6 +154,7 @@ class PlaybackMediaSource {
                 ?.cast<Map<String, dynamic>>() ??
             const [],
         defaultAudioStreamIndex: json['DefaultAudioStreamIndex'] as int?,
+        defaultSubtitleStreamIndex: json['DefaultSubtitleStreamIndex'] as int?,
         defaultPlayMethod: json['PlayMethod'] != null
             ? PlayMethod.fromServerString(json['PlayMethod'] as String?)
             : null,


### PR DESCRIPTION
# Pull Request

## Summary
Fixed an issue where audio and subtitle track switching failed or default track selection differed when starting playback from a container page (Show, Season, or BoxSet details) vs. starting it directly from an episode details page.

## Related Issues
Link related issues or tickets separated by commas.

Linked to Discord tester feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

1. **Container Playback Optimization**: Updated the `Series`, `Season`, and `BoxSet` play actions in `item_detail_screen.dart` to compute client-preferred audio/subtitle track indices (`_effectiveAudioStreamIndex`, `_effectiveSubtitleStreamIndex`) using the target episode's media streams before calling `manager.playItems`.
2. **Server-selected Subtitle Parsing**: Added parsing of `DefaultSubtitleStreamIndex` to `PlaybackMediaSource` (server_core models), `StreamResolutionResult` (playback_core), and both Jellyfin and Emby media stream resolvers.
3. **Playback Manager Tracking**: Back-populated `_subtitleStreamIndex` in `PlaybackManager` using the parsed server-selected index if no explicit index was specified at launch. This prevents the active subtitle tracker from remaining null when using server defaults, allowing subsequent track-switching during transcoding to behave correctly.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed 
- [ ] Not tested (explain why):

### Test Steps
1. Launched the client app and triggered video playback from a Show Details page.
2. Verified that initial track selections align with the client preferences (matching direct episode details launching).
3. Verified that switching audio/subtitle tracks during transcoding correctly updates the stream.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
