### PR TITLE
feature-ui - Refactor OSD center controls to center the play button

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -5578,26 +5578,35 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         final isPlaying = _displayPlaying;
 
         return Row(
-          mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            if (_queue.hasPrevious)
-              _controlButton(
-                Icons.skip_previous_rounded,
-                onPressed: _manager.previous,
-                size: 40,
-                extent: 72,
-                tooltip: l10n.playerTooltipPrevious,
-              ),
-            _controlButton(
-              seekBackIcon(_prefs.get(UserPreferences.skipBackLength)),
-              onPressed: () =>
-                  _seekRelative(-_prefs.get(UserPreferences.skipBackLength)),
-              size: 46,
-              extent: 78,
-              tooltip: _tooltipMessage(
-                l10n.playerTooltipSeekBack,
-                shortcut: 'Left',
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (_queue.hasPrevious)
+                      _controlButton(
+                        Icons.skip_previous_rounded,
+                        onPressed: _manager.previous,
+                        size: 40,
+                        extent: 72,
+                        tooltip: l10n.playerTooltipPrevious,
+                      ),
+                    _controlButton(
+                      seekBackIcon(_prefs.get(UserPreferences.skipBackLength)),
+                      onPressed: () =>
+                          _seekRelative(-_prefs.get(UserPreferences.skipBackLength)),
+                      size: 46,
+                      extent: 78,
+                      tooltip: _tooltipMessage(
+                        l10n.playerTooltipSeekBack,
+                        shortcut: 'Left',
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
             _controlButton(
@@ -5611,25 +5620,35 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 shortcut: 'Space',
               ),
             ),
-            _controlButton(
-              seekForwardIcon(_prefs.get(UserPreferences.skipForwardLength)),
-              onPressed: () =>
-                  _seekRelative(_prefs.get(UserPreferences.skipForwardLength)),
-              size: 46,
-              extent: 78,
-              tooltip: _tooltipMessage(
-                l10n.playerTooltipSeekForward,
-                shortcut: 'Right',
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _controlButton(
+                      seekForwardIcon(_prefs.get(UserPreferences.skipForwardLength)),
+                      onPressed: () =>
+                          _seekRelative(_prefs.get(UserPreferences.skipForwardLength)),
+                      size: 46,
+                      extent: 78,
+                      tooltip: _tooltipMessage(
+                        l10n.playerTooltipSeekForward,
+                        shortcut: 'Right',
+                      ),
+                    ),
+                    if (_queue.hasNext)
+                      _controlButton(
+                        Icons.skip_next_rounded,
+                        onPressed: _manager.next,
+                        size: 40,
+                        extent: 72,
+                        tooltip: l10n.next,
+                      ),
+                  ],
+                ),
               ),
             ),
-            if (_queue.hasNext)
-              _controlButton(
-                Icons.skip_next_rounded,
-                onPressed: _manager.next,
-                size: 40,
-                extent: 72,
-                tooltip: l10n.next,
-              ),
           ],
         );
       },


### PR DESCRIPTION
# Pull Request

## Summary
Addresses an OSD issue where the play/pause button was not anchored in the center of the video player screen on mobile and desktop, resulting in layout shifting when the number of navigation/seek buttons is asymmetric. By wrapping the left and right sections in `Expanded` and `Align` widgets, the play/pause button is kept in the absolute horizontal center.

## Related Issues
Link related issues or tickets separated by commas.

Discord feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `_buildCenterTransportControls()` in `lib/ui/screens/playback/video_player_screen.dart` to use two `Expanded` children with `Align` containing the navigation/seek buttons on either side of the Play/Pause button.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video.
2. Observe the center transport controls (Play/Pause, seek backward/forward, skip next/prev) with various button states.
3. Verify that the Play/Pause button remains locked in the horizontal center of the screen, and doesn't shift when previous/next button availability changes.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Symmetric vs Asymmetric Centering:
<img width="2560" height="1600" alt="2026-07-15_23-18-50_moonfin" src="https://github.com/user-attachments/assets/a99627d8-760d-4180-b446-bfde70378646" />
<img width="2560" height="1600" alt="2026-07-15_23-19-18_moonfin" src="https://github.com/user-attachments/assets/cde76fe8-961d-4738-8d30-7f25ee3e7089" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
