### PR TITLE
ui-mediacards - Adjust media card text scroll to stop the Eminem effect

### DIFF
--- a/lib/ui/widgets/marquee_text.dart
+++ b/lib/ui/widgets/marquee_text.dart
@@ -6,6 +6,8 @@ class MarqueeText extends StatefulWidget {
   final int minDurationMs;
   final int maxDurationMs;
   final double millisPerPixel;
+  final double gap;
+  final int pauseDurationMs;
 
   const MarqueeText({
     super.key,
@@ -14,6 +16,8 @@ class MarqueeText extends StatefulWidget {
     this.minDurationMs = 2200,
     this.maxDurationMs = 12000,
     this.millisPerPixel = 50,
+    this.gap = 30.0,
+    this.pauseDurationMs = 1500,
   });
 
   @override
@@ -24,35 +28,15 @@ class _MarqueeTextState extends State<MarqueeText>
     with SingleTickerProviderStateMixin {
   late final ScrollController _controller;
   late final AnimationController _anim;
+  double _lastTextWidth = 0.0;
+  double _lastParentWidth = 0.0;
 
   @override
   void initState() {
     super.initState();
     _controller = ScrollController();
     _anim = AnimationController(vsync: this);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
-  }
-
-  void _checkOverflow() {
-    if (!mounted || !_controller.hasClients) return;
-    final max = _controller.position.maxScrollExtent;
-    if (max > 0) {
-      final duration = Duration(
-        milliseconds: (max * widget.millisPerPixel).toInt().clamp(
-          widget.minDurationMs,
-          widget.maxDurationMs,
-        ),
-      );
-      _anim.duration = duration;
-      _anim.addListener(_onTick);
-      _anim.repeat(reverse: true);
-    }
-  }
-
-  void _onTick() {
-    if (_controller.hasClients) {
-      _controller.jumpTo(_anim.value * _controller.position.maxScrollExtent);
-    }
+    _anim.addListener(_onTick);
   }
 
   @override
@@ -64,12 +48,110 @@ class _MarqueeTextState extends State<MarqueeText>
   }
 
   @override
+  void didUpdateWidget(covariant MarqueeText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text || oldWidget.style != widget.style) {
+      if (_controller.hasClients) {
+        _controller.jumpTo(0);
+      }
+      _anim.stop();
+      _anim.value = 0.0;
+    }
+  }
+
+  void _onTick() {
+    if (_controller.hasClients && _anim.duration != null) {
+      final scrollDistance = _lastTextWidth + widget.gap;
+      final totalMs = _anim.duration!.inMilliseconds.toDouble();
+      if (totalMs > 0) {
+        final pauseFraction = widget.pauseDurationMs / totalMs;
+        final v = _anim.value;
+        if (v < pauseFraction) {
+          _controller.jumpTo(0.0);
+        } else {
+          final t = (v - pauseFraction) / (1.0 - pauseFraction);
+          _controller.jumpTo(t * scrollDistance);
+        }
+      }
+    }
+  }
+
+  void _updateAnimation(double textWidth, double parentWidth) {
+    if (!mounted) return;
+
+    _lastTextWidth = textWidth;
+    _lastParentWidth = parentWidth;
+
+    final overflows = textWidth > parentWidth;
+    if (!overflows) {
+      if (_anim.isAnimating) {
+        _anim.stop();
+      }
+      if (_controller.hasClients && _controller.offset != 0) {
+        _controller.jumpTo(0);
+      }
+      return;
+    }
+
+    final scrollDistance = textWidth + widget.gap;
+    final scrollDurationMs = (scrollDistance * widget.millisPerPixel).toInt();
+    final totalDurationMs = scrollDurationMs + widget.pauseDurationMs;
+    final newDuration = Duration(milliseconds: totalDurationMs);
+
+    if (_anim.duration != newDuration) {
+      _anim.duration = newDuration;
+      if (_anim.isAnimating) {
+        _anim.repeat();
+      }
+    }
+
+    if (!_anim.isAnimating) {
+      _anim.repeat();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      controller: _controller,
-      scrollDirection: Axis.horizontal,
-      physics: const NeverScrollableScrollPhysics(),
-      child: Text(widget.text, maxLines: 1, style: widget.style),
+    final textPainter = TextPainter(
+      text: TextSpan(text: widget.text, style: widget.style),
+      textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+      maxLines: 1,
+    )..layout();
+    final textWidth = textPainter.width;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final parentWidth = constraints.maxWidth;
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _updateAnimation(textWidth, parentWidth);
+        });
+
+        final overflows = textWidth > parentWidth;
+
+        if (!overflows) {
+          return Text(
+            widget.text,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: widget.style,
+          );
+        }
+
+        return SingleChildScrollView(
+          controller: _controller,
+          scrollDirection: Axis.horizontal,
+          physics: const NeverScrollableScrollPhysics(),
+          child: Row(
+            children: [
+              Text(widget.text, maxLines: 1, style: widget.style),
+              SizedBox(width: widget.gap),
+              Text(widget.text, maxLines: 1, style: widget.style),
+            ],
+          ),
+        );
+      },
     );
   }
 }
+


### PR DESCRIPTION
# Pull Request

## Summary
This pull request changes the marquee text scroll behavior across the main UI. It makes the scroll speed constant regardless of text length and implements a continuous forward looping scroll behavior instead of a bouncing animation. It also introduces a brief 1.5-second initial pause before scrolling starts.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Calculated text width using `TextPainter` and compared it against the parent width via `LayoutBuilder`.
- Removed duration clamping in `MarqueeText` to ensure a constant scroll speed.
- Replaced the bounce animation with a continuous loop by rendering two instances of the text in a `Row` separated by a gap (30px).
- Added a 1.5-second initial pause before the marquee starts scrolling on each loop.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Focused on media cards with short, medium, and long titles.
2. Confirmed text does not scroll unless it overflows.
3. Verified scrolling speed is constant across different title lengths.
4. Confirmed text loops continuously and pauses at the start of each loop.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/aa51811f-f92d-495e-88e4-a39479471e8f

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
