### PR TITLE
bugfix-playback - Fix transcoding track switching playback error

### DIFF
--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -548,11 +548,30 @@ void registerPlaybackModule() {
     );
     final activeAudioLanguage = activeAudioStream.isNotEmpty ? activeAudioStream['Language'] as String? : null;
 
-    final subtitleMode = manager.lastExplicitSubtitleEnabled == false
+    final currentItem = manager.queueService.currentItem;
+    String? seriesId;
+    if (currentItem is AggregatedItem) {
+      seriesId = currentItem.seriesId;
+    }
+
+    var subtitleMode = manager.lastExplicitSubtitleEnabled == false
         ? SubtitleMode.none
         : prefs.get(UserPreferences.subtitleMode);
 
-    final preferredLanguage = manager.lastExplicitSubtitleLanguage ??
+    var preferredLanguage = manager.lastExplicitSubtitleLanguage;
+    if (preferredLanguage == null && seriesId != null && seriesId.isNotEmpty) {
+      final seriesLanguage = prefs.getSeriesSubtitleLanguage(seriesId);
+      if (seriesLanguage == 'none') {
+        return -1;
+      } else if (seriesLanguage.isNotEmpty) {
+        preferredLanguage = seriesLanguage;
+        if (subtitleMode == SubtitleMode.none) {
+          subtitleMode = SubtitleMode.always;
+        }
+      }
+    }
+
+    preferredLanguage ??=
         (prefs.get(UserPreferences.defaultSubtitleLanguage) as String? ?? '');
 
     return computeEffectiveSubtitleIndex(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6746,8 +6746,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
   int? _effectiveSubtitleStreamIndex(
     List<Map<String, dynamic>> subtitleStreams,
-    List<Map<String, dynamic>> audioStreams,
-  ) {
+    List<Map<String, dynamic>> audioStreams, {
+    AggregatedItem? item,
+  }) {
     final prefs = GetIt.instance<UserPreferences>();
     final audioStreamIndex = _effectiveAudioStreamIndex(audioStreams);
     String? activeAudioLanguage;
@@ -6759,18 +6760,21 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       activeAudioLanguage = activeAudioStream['Language'] as String?;
     }
 
-    final item = widget.viewModel.item;
+    final targetItem = item ?? widget.viewModel.item;
     var preferredLanguage = prefs.get(UserPreferences.defaultSubtitleLanguage);
     var subtitleMode = prefs.get(UserPreferences.subtitleMode);
 
-    if (item != null && item.type == 'Episode' && item.seriesId != null) {
-      final seriesLanguage = prefs.getSeriesSubtitleLanguage(item.seriesId!);
-      if (seriesLanguage == 'none') {
-        return -1;
-      } else if (seriesLanguage.isNotEmpty) {
-        preferredLanguage = seriesLanguage;
-        if (subtitleMode == SubtitleMode.none) {
-          subtitleMode = SubtitleMode.always;
+    if (targetItem != null) {
+      final seriesId = targetItem.seriesId;
+      if (seriesId != null && seriesId.isNotEmpty) {
+        final seriesLanguage = prefs.getSeriesSubtitleLanguage(seriesId);
+        if (seriesLanguage == 'none') {
+          return -1;
+        } else if (seriesLanguage.isNotEmpty) {
+          preferredLanguage = seriesLanguage;
+          if (subtitleMode == SubtitleMode.none) {
+            subtitleMode = SubtitleMode.always;
+          }
         }
       }
     }
@@ -7296,6 +7300,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final subtitleStreamIndex = _effectiveSubtitleStreamIndex(
       subtitleStreams,
       audioStreams,
+      item: item,
     );
 
     if (item.type == 'Photo') {
@@ -7442,6 +7447,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
               epSubtitleStreams,
               epAudioStreams,
+              item: selectedEpisode,
             );
 
             await manager.playItems(
@@ -7488,6 +7494,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
               epSubtitleStreams,
               epAudioStreams,
+              item: selectedEpisode,
             );
 
             await manager.playItems(
@@ -7641,6 +7648,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
               epSubtitleStreams,
               epAudioStreams,
+              item: targetItem,
             );
 
             await manager.playItems(
@@ -7914,6 +7922,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final subtitleStreamIndex = _effectiveSubtitleStreamIndex(
       subtitleStreams,
       audioStreams,
+      item: item,
     );
     final positionTicks = item.playbackPosition == null
         ? null

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -2086,12 +2086,15 @@ class PlaybackManager implements AudioOwnable {
       _transcodeSwitchRecoveryConsumed = false;
     }
 
-    _teardownForReResolve = false;
-    await _playCurrentItem(
-      startPosition: currentPos,
-      enableDirectPlay: !forceTranscode,
-      enableDirectStream: !forceTranscode,
-    );
+    try {
+      await _playCurrentItem(
+        startPosition: currentPos,
+        enableDirectPlay: !forceTranscode,
+        enableDirectStream: !forceTranscode,
+      );
+    } finally {
+      _teardownForReResolve = false;
+    }
   }
 
   Future<void> _applyStoredTrackSelections(


### PR DESCRIPTION
# Pull Request

## Summary
This pull request fixes a playback error when switching audio/subtitle tracks during transcoding, and ensures series-specific language overrides are correctly applied and respected when starting playback from container contexts (Series/Season/BoxSet details).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #812 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **UI Details Screen (`item_detail_screen.dart`)**:
  - Updated `_effectiveSubtitleStreamIndex` to accept an optional `item` parameter representing the target episode.
  - Used `targetItem.seriesId` to fetch series-specific language overrides instead of relying on the page-level `widget.viewModel.item` (which represents the Series/Season container during container playback).
  - Updated all callers of `_effectiveSubtitleStreamIndex` (in Series, Season, BoxSet playback cases, as well as `_playInternal` and `_castToDevice`) to supply the target item.
- **Playback Infrastructure (`playback_module.dart`)**:
  - Updated the background `manager.subtitleTrackSelector` callback to fetch the target episode's `seriesId` via `manager.queueService.currentItem`.
  - Configured it to resolve to the series-specific language override if one exists and the user has not made a manual track selection. This aligns background selection logic with UI details logic on startup.
- **Playback Manager (`playback_manager.dart`)**:
  - Wrapped `await _playCurrentItem(...)` inside `_reResolveNow` in a `try-finally` block to keep the `_teardownForReResolve = true` flag active until player bringup is fully initiated. This safely suppresses any asynchronous cleanup/stop error events emitted by the player backend from the old aborted stream, preventing them from surfacing as playback failures in the new stream.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Apply a series-specific subtitle override (e.g. French subtitles) on a Series details page.
2. Play the episode from the Show Details (Series) page, and from the Episode Details page.
3. Verify that the player successfully starts transcoding/playing with the overridden subtitle track without throwing any playback errors on startup.
4. Manually switch subtitle/audio tracks during playback and verify that transcoding re-resolves successfully without error.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/8e87b3ba-2ae5-48e9-80c5-ebdd5ab6ce1c

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
