### PR TITLE
bugfix-ui - Fix Toggle Screen Movement

### DIFF
--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1350,23 +1350,23 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
 
   void _focusSectionAndEnsureVisible(int index) {
     if (!mounted || index < 0 || index >= _focusNodes.length) return;
-    final node = _focusNodes[index];
-    if (!node.hasFocus) {
-      node.requestFocus();
-    }
 
-    // Defer the scroll until the reorder rebuild commits, so the target row's
-    // context exists.
+    // Defer the focus request and scroll until the reorder rebuild commits,
+    // so the target row's context and widget are fully attached.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || index < 0 || index >= _focusNodes.length) return;
-      final targetContext = _focusNodes[index].context;
+      final node = _focusNodes[index];
+      if (!node.hasFocus) {
+        node.requestFocus();
+      }
+      final targetContext = node.context;
       if (targetContext == null) return;
       Scrollable.ensureVisible(
         targetContext,
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOut,
         alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
       );
     });
   }
@@ -1836,7 +1836,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
           // its sorted slot, so it animates instead of jumping.
           isSameItem: (a, b) =>
               a.stableId == b.stableId && a.enabled == b.enabled,
-          enableSwap: false,
+          enableSwap: true,
           enterTransition: [FadeIn(), SizeAnimation()],
           exitTransition: [FadeIn(), SizeAnimation()],
           onReorder: (oldIndex, newIndex) {
@@ -2321,7 +2321,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
           // its sorted slot, so it animates instead of jumping.
           isSameItem: (a, b) =>
               a.stableId == b.stableId && a.enabled == b.enabled,
-          enableSwap: false,
+          enableSwap: true,
           enterTransition: [FadeIn(), SizeAnimation()],
           exitTransition: [FadeIn(), SizeAnimation()],
           itemBuilder: (context, index) {

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -2865,97 +2865,100 @@ class _HomeSectionTileState extends State<_HomeSectionTile> {
                 UserPreferences.mergeContinueWatchingNextUp,
               ),
             ),
-            child: ListTile(
-              focusColor: Colors.transparent,
-              hoverColor: Colors.transparent,
-              contentPadding: _kHomeSectionTileContentPadding,
-              minLeadingWidth: 44,
-              horizontalTitleGap: 14,
-              leading: buildSettingsLeadingIconShell(
-                context,
-                icon: Icon(
-                  (widget.enabled && !widget.isEmpty)
-                      ? Icons.check_box
-                      : Icons.check_box_outline_blank,
-                ),
-                focused: _focused,
-                iconColor: _focused
-                    ? AppColors.black.withValues(alpha: 0.54)
-                    : AppColorScheme.onSurface.withValues(alpha: 0.78),
-              ),
-              title: Row(
-                children: [
-                  Text(
-                    widget.label,
-                    style: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      fontFamily: kCleanSettingsFontFamily,
-                      color: _focused
-                          ? AppColors.black.withValues(alpha: 0.87)
-                          : AppColorScheme.onSurface,
-                    ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: ListTile(
+                focusColor: Colors.transparent,
+                hoverColor: Colors.transparent,
+                contentPadding: _kHomeSectionTileContentPadding,
+                minLeadingWidth: 44,
+                horizontalTitleGap: 14,
+                leading: buildSettingsLeadingIconShell(
+                  context,
+                  icon: Icon(
+                    (widget.enabled && !widget.isEmpty)
+                        ? Icons.check_box
+                        : Icons.check_box_outline_blank,
                   ),
-                  if (widget.isEmpty) ...[
-                    const SizedBox(width: 8),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 6,
-                        vertical: 2,
-                      ),
-                      decoration: BoxDecoration(
-                        color: Colors.red.withValues(alpha: 0.15),
-                        borderRadius: AppRadius.circular(4),
-                        border: Border.all(
-                          color: Colors.red.withValues(alpha: 0.5),
-                          width: 0.8,
-                        ),
-                      ),
-                      child: Text(
-                        l10n.empty,
-                        style: TextStyle(
-                          fontSize: 10,
-                          color: Colors.red,
-                          fontWeight: FontWeight.bold,
-                          fontFamily: kCleanSettingsFontFamily,
-                        ),
+                  focused: _focused,
+                  iconColor: _focused
+                      ? AppColors.black.withValues(alpha: 0.54)
+                      : AppColorScheme.onSurface.withValues(alpha: 0.78),
+                ),
+                title: Row(
+                  children: [
+                    Text(
+                      widget.label,
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                        fontFamily: kCleanSettingsFontFamily,
+                        color: _focused
+                            ? AppColors.black.withValues(alpha: 0.87)
+                            : AppColorScheme.onSurface,
                       ),
                     ),
+                    if (widget.isEmpty) ...[
+                      const SizedBox(width: 8),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.red.withValues(alpha: 0.15),
+                          borderRadius: AppRadius.circular(4),
+                          border: Border.all(
+                            color: Colors.red.withValues(alpha: 0.5),
+                            width: 0.8,
+                          ),
+                        ),
+                        child: Text(
+                          l10n.empty,
+                          style: TextStyle(
+                            fontSize: 10,
+                            color: Colors.red,
+                            fontWeight: FontWeight.bold,
+                            fontFamily: kCleanSettingsFontFamily,
+                          ),
+                        ),
+                      ),
+                    ],
                   ],
-                ],
-              ),
-              subtitle: widget.subtitle != null
-                  ? Text(
-                      widget.subtitle!,
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontFamily: kCleanSettingsFontFamily,
+                ),
+                subtitle: widget.subtitle != null
+                    ? Text(
+                        widget.subtitle!,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontFamily: kCleanSettingsFontFamily,
+                          color: _focused
+                              ? AppColors.black.withValues(alpha: 0.54)
+                              : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      )
+                    : null,
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (!widget.isFirst)
+                      Icon(
+                        Icons.arrow_left,
+                        size: 18,
                         color: _focused
                             ? AppColors.black.withValues(alpha: 0.54)
                             : AppColorScheme.onSurface.withValues(alpha: 0.7),
                       ),
-                    )
-                  : null,
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (!widget.isFirst)
-                    Icon(
-                      Icons.arrow_left,
-                      size: 18,
-                      color: _focused
-                          ? AppColors.black.withValues(alpha: 0.54)
-                          : AppColorScheme.onSurface.withValues(alpha: 0.7),
-                    ),
-                  if (!widget.isLast)
-                    Icon(
-                      Icons.arrow_right,
-                      size: 18,
-                      color: _focused
-                          ? AppColors.black.withValues(alpha: 0.54)
-                          : AppColorScheme.onSurface.withValues(alpha: 0.7),
-                    ),
-                ],
+                    if (!widget.isLast)
+                      Icon(
+                        Icons.arrow_right,
+                        size: 18,
+                        color: _focused
+                            ? AppColors.black.withValues(alpha: 0.54)
+                            : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -18,6 +18,7 @@ import '../../../preference/user_preferences.dart';
 import '../../../preference/seerr_preferences.dart';
 import '../../../preference/seerr_row_config.dart';
 import '../../../util/extensions.dart';
+import '../../../util/focus/scroll_utils.dart';
 import '../../../util/platform_detection.dart';
 import '../../navigation/route_lifecycle_observer.dart';
 import '../../widgets/overlay_sheet.dart';
@@ -1349,26 +1350,11 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
   }
 
   void _focusSectionAndEnsureVisible(int index) {
-    if (!mounted || index < 0 || index >= _focusNodes.length) return;
-
-    // Defer the focus request and scroll until the reorder rebuild commits,
-    // so the target row's context and widget are fully attached.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || index < 0 || index >= _focusNodes.length) return;
-      final node = _focusNodes[index];
-      if (!node.hasFocus) {
-        node.requestFocus();
-      }
-      final targetContext = node.context;
-      if (targetContext == null) return;
-      Scrollable.ensureVisible(
-        targetContext,
-        duration: const Duration(milliseconds: 140),
-        curve: Curves.easeOut,
-        alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
-      );
-    });
+    focusItemAndEnsureVisible(
+      isMounted: () => mounted,
+      focusNodes: _focusNodes,
+      index: index,
+    );
   }
 
   void _sortSectionsEnabledAboveDisabled() {

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -1,4 +1,6 @@
+import 'package:animated_reorderable_list/animated_reorderable_list.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
@@ -228,34 +230,44 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
   }
 
   Widget _buildTvList(AppLocalizations l10n) {
-    return ListView.builder(
-      itemCount: _items.length + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return _buildHeader(l10n);
-        }
-        final itemIndex = index - 1;
-        final item = _items[itemIndex];
-        return _ReorderableTile(
-          key: ValueKey(item.key),
-          focusNode: _focusNodes[itemIndex],
-          label: _sourceLabel(item.key, l10n),
-          enabled: item.enabled,
-          isFirst: itemIndex == 0,
-          isLast: itemIndex == _items.length - 1,
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (itemIndex != 0) const Icon(Icons.arrow_left, size: 18),
-              if (itemIndex != _items.length - 1)
-                const Icon(Icons.arrow_right, size: 18),
-            ],
-          ),
-          onToggle: (enabled) => _toggleRatingItem(itemIndex, enabled),
-          onMoveUp: () => _moveItemTo(itemIndex, itemIndex - 1),
-          onMoveDown: () => _moveItemTo(itemIndex, itemIndex + 1),
-        );
-      },
+    return CustomScrollView(
+      scrollCacheExtent: const ScrollCacheExtent.pixels(3000.0),
+      slivers: [
+        SliverToBoxAdapter(child: _buildHeader(l10n)),
+        ReorderableAnimatedListImpl<_RatingItem>(
+          items: _items,
+          scrollDirection: Axis.vertical,
+          // Comparing the enabled state and turning off swap detection makes a
+          // toggled row read as a removal from its old slot and an insert at
+          // its sorted slot, so it animates instead of jumping.
+          isSameItem: (a, b) => a.key == b.key && a.enabled == b.enabled,
+          enableSwap: false,
+          enterTransition: [FadeIn(), SizeAnimation()],
+          exitTransition: [FadeIn(), SizeAnimation()],
+          itemBuilder: (context, itemIndex) {
+            final item = _items[itemIndex];
+            return _ReorderableTile(
+              key: ValueKey('${item.key}:${item.enabled}'),
+              focusNode: _focusNodes[itemIndex],
+              label: _sourceLabel(item.key, l10n),
+              enabled: item.enabled,
+              isFirst: itemIndex == 0,
+              isLast: itemIndex == _items.length - 1,
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (itemIndex != 0) const Icon(Icons.arrow_left, size: 18),
+                  if (itemIndex != _items.length - 1)
+                    const Icon(Icons.arrow_right, size: 18),
+                ],
+              ),
+              onToggle: (enabled) => _toggleRatingItem(itemIndex, enabled),
+              onMoveUp: () => _moveItemTo(itemIndex, itemIndex - 1),
+              onMoveDown: () => _moveItemTo(itemIndex, itemIndex + 1),
+            );
+          },
+        ),
+      ],
     );
   }
 
@@ -325,11 +337,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
       _focusNodes.insert(newIndex, node);
     });
     _save();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        _focusNodes[newIndex].requestFocus();
-      }
-    });
+    _focusItemAndEnsureVisible(newIndex);
   }
 }
 

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -14,6 +14,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import 'settings_app_bar.dart';
 import '../../widgets/focus/request_initial_focus.dart';
+import '../../../util/focus/scroll_utils.dart';
 
 const _allSources = [
   'tomatoes',
@@ -306,26 +307,11 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
   }
 
   void _focusItemAndEnsureVisible(int index) {
-    if (!mounted || index < 0 || index >= _focusNodes.length) return;
-
-    // Defer the focus request and scroll until the reorder rebuild commits,
-    // so the target row's context and widget are fully attached.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || index < 0 || index >= _focusNodes.length) return;
-      final node = _focusNodes[index];
-      if (!node.hasFocus) {
-        node.requestFocus();
-      }
-      final targetContext = node.context;
-      if (targetContext == null) return;
-      Scrollable.ensureVisible(
-        targetContext,
-        duration: const Duration(milliseconds: 140),
-        curve: Curves.easeOut,
-        alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
-      );
-    });
+    focusItemAndEnsureVisible(
+      isMounted: () => mounted,
+      focusNodes: _focusNodes,
+      index: index,
+    );
   }
 
   void _moveItemTo(int index, int newIndex) {

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -425,14 +425,17 @@ class _ReorderableTileState extends State<_ReorderableTile> {
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 90),
         color: bg,
-        child: ListTile(
-          onTap: () => widget.onToggle(!widget.enabled),
-          leading: Icon(
-            widget.enabled ? Icons.check_box : Icons.check_box_outline_blank,
-            color: widget.enabled ? colorScheme.primary : null,
+        child: Material(
+          type: MaterialType.transparency,
+          child: ListTile(
+            onTap: () => widget.onToggle(!widget.enabled),
+            leading: Icon(
+              widget.enabled ? Icons.check_box : Icons.check_box_outline_blank,
+              color: widget.enabled ? colorScheme.primary : null,
+            ),
+            title: Text(widget.label),
+            trailing: widget.trailing,
           ),
-          title: Text(widget.label),
-          trailing: widget.trailing,
         ),
       ),
     );

--- a/lib/ui/screens/settings/ratings_config_screen.dart
+++ b/lib/ui/screens/settings/ratings_config_screen.dart
@@ -241,7 +241,7 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
           // toggled row read as a removal from its old slot and an insert at
           // its sorted slot, so it animates instead of jumping.
           isSameItem: (a, b) => a.key == b.key && a.enabled == b.enabled,
-          enableSwap: false,
+          enableSwap: true,
           enterTransition: [FadeIn(), SizeAnimation()],
           exitTransition: [FadeIn(), SizeAnimation()],
           itemBuilder: (context, itemIndex) {
@@ -307,23 +307,23 @@ class _RatingsConfigScreenState extends State<RatingsConfigScreen> {
 
   void _focusItemAndEnsureVisible(int index) {
     if (!mounted || index < 0 || index >= _focusNodes.length) return;
-    final node = _focusNodes[index];
-    if (!node.hasFocus) {
-      node.requestFocus();
-    }
 
-    // Defer the scroll until the reorder rebuild commits, so the target row's
-    // context exists.
+    // Defer the focus request and scroll until the reorder rebuild commits,
+    // so the target row's context and widget are fully attached.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || index < 0 || index >= _focusNodes.length) return;
-      final targetContext = _focusNodes[index].context;
+      final node = _focusNodes[index];
+      if (!node.hasFocus) {
+        node.requestFocus();
+      }
+      final targetContext = node.context;
       if (targetContext == null) return;
       Scrollable.ensureVisible(
         targetContext,
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOut,
         alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
       );
     });
   }

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -349,23 +349,23 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
 
   void _focusRowAndEnsureVisible(int index) {
     if (!mounted || index < 0 || index >= _focusNodes.length) return;
-    final node = _focusNodes[index];
-    if (!node.hasFocus) {
-      node.requestFocus();
-    }
 
-    // Defer the scroll until the reorder rebuild commits, so the target row's
-    // context exists.
+    // Defer the focus request and scroll until the reorder rebuild commits,
+    // so the target row's context and widget are fully attached.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || index < 0 || index >= _focusNodes.length) return;
-      final targetContext = _focusNodes[index].context;
+      final node = _focusNodes[index];
+      if (!node.hasFocus) {
+        node.requestFocus();
+      }
+      final targetContext = node.context;
       if (targetContext == null) return;
       Scrollable.ensureVisible(
         targetContext,
         duration: const Duration(milliseconds: 140),
         curve: Curves.easeOut,
         alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
       );
     });
   }
@@ -669,7 +669,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
             // a toggled row read as a removal from its old slot and an insert
             // at its sorted slot, so it animates instead of jumping.
             isSameItem: (a, b) => a.type == b.type && a.enabled == b.enabled,
-            enableSwap: false,
+            enableSwap: true,
             enterTransition: [FadeIn(), SizeAnimation()],
             exitTransition: [FadeIn(), SizeAnimation()],
             itemBuilder: (context, rowIndex) {

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -18,6 +18,7 @@ import '../../../preference/preference_constants.dart';
 import '../../../preference/seerr_preferences.dart';
 import '../../../preference/seerr_row_config.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../util/focus/scroll_utils.dart';
 import '../../../util/extensions.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
@@ -348,26 +349,11 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
   }
 
   void _focusRowAndEnsureVisible(int index) {
-    if (!mounted || index < 0 || index >= _focusNodes.length) return;
-
-    // Defer the focus request and scroll until the reorder rebuild commits,
-    // so the target row's context and widget are fully attached.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || index < 0 || index >= _focusNodes.length) return;
-      final node = _focusNodes[index];
-      if (!node.hasFocus) {
-        node.requestFocus();
-      }
-      final targetContext = node.context;
-      if (targetContext == null) return;
-      Scrollable.ensureVisible(
-        targetContext,
-        duration: const Duration(milliseconds: 140),
-        curve: Curves.easeOut,
-        alignment: 0.2,
-        alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
-      );
-    });
+    focusItemAndEnsureVisible(
+      isMounted: () => mounted,
+      focusNodes: _focusNodes,
+      index: index,
+    );
   }
 
   Future<void> _resetRows() async {

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -1819,27 +1819,30 @@ class _SeerrReorderableTileState extends State<_SeerrReorderableTile> {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 90),
           decoration: _tileDecoration(context, focused: _focused),
-          child: ListTile(
-            onTap: () => widget.onToggle(!widget.enabled),
-            leading: Icon(
-              widget.enabled ? Icons.check_box : Icons.check_box_outline_blank,
-              color: widget.enabled
-                  ? (_focused ? AppColors.black : colorScheme.primary)
-                  : iconColor,
-            ),
-            title: Text(
-              widget.label,
-              style: TextStyle(color: textColor, fontWeight: FontWeight.w600),
-            ),
-            subtitle: Text(
-              widget.enabled ? widget.enabledLabel : widget.hiddenLabel,
-              style: TextStyle(
-                color: _focused
-                    ? AppColors.black.withValues(alpha: 0.6)
-                    : colorScheme.onSurfaceVariant,
+          child: Material(
+            type: MaterialType.transparency,
+            child: ListTile(
+              onTap: () => widget.onToggle(!widget.enabled),
+              leading: Icon(
+                widget.enabled ? Icons.check_box : Icons.check_box_outline_blank,
+                color: widget.enabled
+                    ? (_focused ? AppColors.black : colorScheme.primary)
+                    : iconColor,
               ),
+              title: Text(
+                widget.label,
+                style: TextStyle(color: textColor, fontWeight: FontWeight.w600),
+              ),
+              subtitle: Text(
+                widget.enabled ? widget.enabledLabel : widget.hiddenLabel,
+                style: TextStyle(
+                  color: _focused
+                      ? AppColors.black.withValues(alpha: 0.6)
+                      : colorScheme.onSurfaceVariant,
+                ),
+              ),
+              trailing: widget.trailing,
             ),
-            trailing: widget.trailing,
           ),
         ),
       ),

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -1,6 +1,8 @@
+import 'package:animated_reorderable_list/animated_reorderable_list.dart';
 import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get_it/get_it.dart';
@@ -399,11 +401,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
       _focusNodes.insert(newIndex, node);
     });
     _saveRows();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        _focusNodes[newIndex].requestFocus();
-      }
-    });
+    _focusRowAndEnsureVisible(newIndex);
   }
 
   String _rowLabel(SeerrRowType type, AppLocalizations l10n) => switch (type) {
@@ -652,41 +650,54 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     bool seerrAvailable,
     bool showSeerrSettings,
   ) {
-    return ListView.builder(
-      itemCount: (showSeerrSettings ? _rows.length : 0) + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return _buildRowsHeader(
+    return CustomScrollView(
+      scrollCacheExtent: const ScrollCacheExtent.pixels(3000.0),
+      slivers: [
+        SliverToBoxAdapter(
+          child: _buildRowsHeader(
             context,
             l10n,
             seerrAvailable,
             showSeerrSettings,
-          );
-        }
-        final rowIndex = index - 1;
-        final row = _rows[rowIndex];
-        return _SeerrReorderableTile(
-          key: ValueKey(row.type),
-          focusNode: _focusNodes[rowIndex],
-          label: _rowLabel(row.type, l10n),
-          enabled: row.enabled,
-          enabledLabel: l10n.enabled,
-          hiddenLabel: l10n.hidden,
-          isFirst: rowIndex == 0,
-          isLast: rowIndex == _rows.length - 1,
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (rowIndex != 0) const Icon(Icons.arrow_left, size: 18),
-              if (rowIndex != _rows.length - 1)
-                const Icon(Icons.arrow_right, size: 18),
-            ],
           ),
-          onToggle: (enabled) => _toggleSeerrRow(rowIndex, enabled),
-          onMoveUp: () => _moveSeerrRowTo(rowIndex, rowIndex - 1),
-          onMoveDown: () => _moveSeerrRowTo(rowIndex, rowIndex + 1),
-        );
-      },
+        ),
+        if (showSeerrSettings)
+          ReorderableAnimatedListImpl<SeerrRowConfig>(
+            items: _rows,
+            scrollDirection: Axis.vertical,
+            // Comparing the enabled state and turning off swap detection makes
+            // a toggled row read as a removal from its old slot and an insert
+            // at its sorted slot, so it animates instead of jumping.
+            isSameItem: (a, b) => a.type == b.type && a.enabled == b.enabled,
+            enableSwap: false,
+            enterTransition: [FadeIn(), SizeAnimation()],
+            exitTransition: [FadeIn(), SizeAnimation()],
+            itemBuilder: (context, rowIndex) {
+              final row = _rows[rowIndex];
+              return _SeerrReorderableTile(
+                key: ValueKey('${row.type}:${row.enabled}'),
+                focusNode: _focusNodes[rowIndex],
+                label: _rowLabel(row.type, l10n),
+                enabled: row.enabled,
+                enabledLabel: l10n.enabled,
+                hiddenLabel: l10n.hidden,
+                isFirst: rowIndex == 0,
+                isLast: rowIndex == _rows.length - 1,
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (rowIndex != 0) const Icon(Icons.arrow_left, size: 18),
+                    if (rowIndex != _rows.length - 1)
+                      const Icon(Icons.arrow_right, size: 18),
+                  ],
+                ),
+                onToggle: (enabled) => _toggleSeerrRow(rowIndex, enabled),
+                onMoveUp: () => _moveSeerrRowTo(rowIndex, rowIndex - 1),
+                onMoveDown: () => _moveSeerrRowTo(rowIndex, rowIndex + 1),
+              );
+            },
+          ),
+      ],
     );
   }
 

--- a/lib/ui/widgets/focus/request_initial_focus.dart
+++ b/lib/ui/widgets/focus/request_initial_focus.dart
@@ -39,9 +39,11 @@ class _RequestInitialFocusState extends State<RequestInitialFocus> {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.targetNode, widget.targetNode) &&
         widget.targetNode != null) {
-      _retryTimer?.cancel();
-      _settled = false;
-      _scheduleFrameFocusCheck(0);
+      if (!FocusScope.of(context).hasFocus) {
+        _retryTimer?.cancel();
+        _settled = false;
+        _scheduleFrameFocusCheck(0);
+      }
     }
   }
 

--- a/lib/util/focus/scroll_utils.dart
+++ b/lib/util/focus/scroll_utils.dart
@@ -41,10 +41,10 @@ void focusItemAndEnsureVisible({
   Curve curve = Curves.easeOut,
 }) {
   if (!isMounted() || index < 0 || index >= focusNodes.length) return;
+  final node = focusNodes[index];
 
   WidgetsBinding.instance.addPostFrameCallback((_) {
-    if (!isMounted() || index < 0 || index >= focusNodes.length) return;
-    final node = focusNodes[index];
+    if (!isMounted()) return;
     if (!node.hasFocus) {
       node.requestFocus();
     }

--- a/lib/util/focus/scroll_utils.dart
+++ b/lib/util/focus/scroll_utils.dart
@@ -31,3 +31,31 @@ double computeAlignmentForBand({
   if (denom <= 0) return 0.0;
   return (desiredItemTop / denom).clamp(0.0, 1.0);
 }
+
+void focusItemAndEnsureVisible({
+  required bool Function() isMounted,
+  required List<FocusNode> focusNodes,
+  required int index,
+  double alignment = 0.2,
+  Duration duration = const Duration(milliseconds: 140),
+  Curve curve = Curves.easeOut,
+}) {
+  if (!isMounted() || index < 0 || index >= focusNodes.length) return;
+
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (!isMounted() || index < 0 || index >= focusNodes.length) return;
+    final node = focusNodes[index];
+    if (!node.hasFocus) {
+      node.requestFocus();
+    }
+    final targetContext = node.context;
+    if (targetContext == null) return;
+    Scrollable.ensureVisible(
+      targetContext,
+      duration: duration,
+      curve: curve,
+      alignment: alignment,
+      alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+    );
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes the scroll view focus loss and focus hijacking bugs when programmatically reordering item rows (e.g. ratings, Seerr rows, and Home Sections rows) using D-pad Left and Right. As the logic is the same for the three screens, this PR also introduces a shared helper to use for each of them (welcome to the family, `focusAndEnsureVisible`, what a beautiful name) to keep things DRY.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Created `focusItemAndEnsureVisible` shared helper method in `scroll_utils.dart` to handle deferring the focus request and executing `Scrollable.ensureVisible` with an `explicit` alignment policy after the reorder frame builds.
- Resolved the `FocusNode` **outside** the `addPostFrameCallback` in `focusItemAndEnsureVisible` to capture the exact node object before any rapid key repeat changes can shift the list index, preventing focus from jumping to other items (like the reset button in the AppBar) under heavy navigation load.
- Refactored `ratings_config_screen.dart`, `seerr_config_screen.dart`, and `home_sections_screen.dart` to import and call this shared helper instead of duplicate post-frame focus-scrolling code blocks.
- Set `enableSwap: true` on `ReorderableAnimatedListImpl` widgets in the Settings screens so D-pad reordering triggers smooth, native swaps rather than a full remove/insert sequence that detaches widgets and breaks size/offset math.
- Added a `!FocusScope.of(context).hasFocus` check in `RequestInitialFocus.didUpdateWidget` in `request_initial_focus.dart` to prevent initial focus handlers from hijacking focus back to the top item during D-pad moves.
- Wrapped reorderable `ListTile` items in a transparent `Material` widget in all three screens to resolve the diagnostic error: `"ListTile background color or ink splashes may be invisible. ListTile requires a Material ancestor to paint its background and ink splashes."`

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Ratings.
2. Select any checked source (e.g., Metacritic) and press D-pad Left or Right to reorder it.
3. Verify the focus stays on the item being moved and the list scrolls properly to keep it visible, even when moving downward from the top of the list.
4. Verify the same behavior on the Seerr and Home Sections screens.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
