### PR TITLE
bug-shuffle - Optimize shuffling logic to fix mixed library pulls and memory issues

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -33,8 +33,7 @@ class ParentCollection {
 }
 
 class ItemDetailViewModel extends ChangeNotifier {
-  static const _episodeOverviewFields =
-      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData,Chapters';
+  static const _episodeOverviewFields = 'Overview,RunTimeTicks,UserData';
 
   final MediaServerClient _client;
   final ItemMutationRepository _mutations;

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7019,6 +7019,23 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     return clientFactory.getClientIfExists(item.serverId) ?? defaultClient;
   }
 
+  Future<AggregatedItem> _ensureHydrated(AggregatedItem target) async {
+    if (target.mediaSources.isNotEmpty) {
+      return target;
+    }
+    try {
+      final client = _clientForItem(target);
+      final fullData = await client.itemsApi.getItem(target.id);
+      return AggregatedItem(
+        id: target.id,
+        serverId: target.serverId,
+        rawData: Map<String, dynamic>.from(fullData),
+      );
+    } catch (_) {
+      return target;
+    }
+  }
+
   Future<List<AggregatedItem>> _moviePrerollsForStart(
     AggregatedItem item,
     Duration startPosition,
@@ -7061,8 +7078,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   }
 
   Future<List<AggregatedItem>> _shuffleQueueForItem(AggregatedItem item) async {
-    const shuffleQueueFields =
-        'MediaStreams,MediaSources,RunTimeTicks,Trickplay,Chapters';
+    const shuffleQueueFields = 'Overview,RunTimeTicks,UserData';
     switch (item.type) {
       case 'Series':
         if (viewModel.episodes.length > 1) {
@@ -7353,8 +7369,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       () async {
         switch (item.type) {
           case 'Series':
-            const episodeQueueFields =
-                'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData,Chapters';
+            const episodeQueueFields = 'Overview,RunTimeTicks,UserData';
 
             final client = _clientForItem(item);
             final data = await client.itemsApi.getEpisodes(
@@ -7424,7 +7439,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               (e) => e.id == targetEpisode.id,
             );
             final idx = startIndex >= 0 ? startIndex : 0;
-            final selectedEpisode = queueEpisodes[idx];
+            var selectedEpisode = queueEpisodes[idx];
+            selectedEpisode = await _ensureHydrated(selectedEpisode);
+            queueEpisodes[idx] = selectedEpisode;
+
             final seriesQueue = _truncateQueueIfImmediateNextUnplayable(
               queueEpisodes,
               startIndex: idx,
@@ -7473,7 +7491,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                   )
                 : episodes.indexWhere((e) => !e.isPlayed);
             final idx = startIndex >= 0 ? startIndex : 0;
-            final selectedEpisode = episodes[idx];
+            var selectedEpisode = episodes[idx];
+            selectedEpisode = await _ensureHydrated(selectedEpisode);
+            episodes[idx] = selectedEpisode;
+            if (!context.mounted) return;
+
             final seasonQueue = _truncateQueueIfImmediateNextUnplayable(
               episodes,
               startIndex: idx,
@@ -7516,8 +7538,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               final seasonId = item.seasonId;
               if (seriesId != null && seriesId.isNotEmpty) {
                 try {
-                  const episodeQueueFields =
-                      'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData,Chapters';
+                  const episodeQueueFields = 'Overview,RunTimeTicks,UserData';
                   final client = _clientForItem(item);
                   final data = await client.itemsApi.getEpisodes(
                     seriesId,
@@ -7543,7 +7564,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 (e) => e.id == item.id,
               );
               final idx = startIndex >= 0 ? startIndex : 0;
-              final selectedEpisode = playableEpisodes[idx];
+              var selectedEpisode = playableEpisodes[idx];
+              selectedEpisode = await _ensureHydrated(selectedEpisode);
+              playableEpisodes[idx] = selectedEpisode;
+              if (!context.mounted) return;
+
               final episodeQueue = _truncateQueueIfImmediateNextUnplayable(
                 playableEpisodes,
                 startIndex: idx,
@@ -7582,8 +7607,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           case 'BoxSet':
             final playableQueue = await _loadFolderPlayableItemsForShuffle(
               item,
-              fields:
-                  'Overview,MediaStreams,MediaSources,RunTimeTicks,Trickplay,UserData',
+              fields: 'Overview,RunTimeTicks,UserData',
             );
             if (playableQueue.isEmpty) {
               if (context.mounted) {
@@ -7634,7 +7658,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             }
 
             if (!context.mounted) return;
-            final targetItem = playableQueue[startIndex];
+            var targetItem = playableQueue[startIndex];
+            targetItem = await _ensureHydrated(targetItem);
+            playableQueue[startIndex] = targetItem;
+            if (!context.mounted) return;
+
             final dvForceTranscode = await _shouldForceTranscodeForDolbyVision(
               context,
               [targetItem],
@@ -7880,6 +7908,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     if (!context.mounted) return;
 
     final shuffled = List<AggregatedItem>.from(playableQueue)..shuffle();
+    if (shuffled.isNotEmpty) {
+      shuffled[0] = await _ensureHydrated(shuffled.first);
+    }
+    if (!context.mounted) return;
     final isAudio = shuffled.every((queuedItem) {
       final mediaType = queuedItem.rawData['MediaType'] as String?;
       return queuedItem.type == 'Audio' || mediaType == 'Audio';

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7164,20 +7164,25 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         .toList();
   }
 
-  List<AggregatedItem> _truncateQueueIfImmediateNextUnplayable(
+  Future<List<AggregatedItem>> _truncateQueueIfImmediateNextUnplayable(
     List<AggregatedItem> queue, {
     required int startIndex,
-  }) {
+  }) async {
     if (startIndex < 0 || startIndex >= queue.length - 1) {
       return queue;
     }
 
-    final immediateNext = queue[startIndex + 1];
+    // Queues arrive without MediaSources and a missing key reads as playable,
+    // so hydrate the next item first or a broken episode passes the check and
+    // fails once the current one ends.
+    final nextIndex = startIndex + 1;
+    final immediateNext = await _ensureHydrated(queue[nextIndex]);
+    queue[nextIndex] = immediateNext;
     if (isEligibleNextEpisodeCandidate(immediateNext)) {
       return queue;
     }
 
-    return queue.sublist(0, startIndex + 1);
+    return queue.sublist(0, nextIndex);
   }
 
   Future<bool> _pushPlayerRouteWhileStartingPlayback(
@@ -7443,7 +7448,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             selectedEpisode = await _ensureHydrated(selectedEpisode);
             queueEpisodes[idx] = selectedEpisode;
 
-            final seriesQueue = _truncateQueueIfImmediateNextUnplayable(
+            final seriesQueue = await _truncateQueueIfImmediateNextUnplayable(
               queueEpisodes,
               startIndex: idx,
             );
@@ -7496,13 +7501,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             episodes[idx] = selectedEpisode;
             if (!context.mounted) return;
 
-            final seasonQueue = _truncateQueueIfImmediateNextUnplayable(
+            final seasonQueue = await _truncateQueueIfImmediateNextUnplayable(
               episodes,
               startIndex: idx,
             );
             final startPosition = resume
                 ? (selectedEpisode.playbackPosition ?? Duration.zero)
                 : Duration.zero;
+            if (!context.mounted) return;
             final dvForceTranscode = await _shouldForceTranscodeForDolbyVision(
               context,
               [selectedEpisode],
@@ -7569,10 +7575,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               playableEpisodes[idx] = selectedEpisode;
               if (!context.mounted) return;
 
-              final episodeQueue = _truncateQueueIfImmediateNextUnplayable(
-                playableEpisodes,
-                startIndex: idx,
-              );
+              final episodeQueue =
+                  await _truncateQueueIfImmediateNextUnplayable(
+                    playableEpisodes,
+                    startIndex: idx,
+                  );
+              if (!context.mounted) return;
 
               // Fallback to the master item's position context if it's the target episode
               final startPosition = resume

--- a/lib/ui/widgets/shuffle_options_dialog.dart
+++ b/lib/ui/widgets/shuffle_options_dialog.dart
@@ -16,8 +16,11 @@ const String _kShuffleOverlayItemFields =
     'ProviderIds,Genres';
 const String _kShuffleCandidateItemFields = 'Type';
 const _kShuffleUnscopedPerLibraryTimeout = Duration(seconds: 8);
+const _kShuffleUnscopedOverallTimeout = Duration(seconds: 20);
 const _kShuffleUserViewsTimeout = Duration(seconds: 6);
 const _kShuffleHydrationTimeout = Duration(seconds: 3);
+
+final _shuffleRandom = math.Random();
 
 const List<String> _kShuffleExcludeItemTypes = <String>[
   'BoxSet',
@@ -76,8 +79,12 @@ Future<List<AggregatedItem>> _collectRandomItems({
   String? genreName,
 }) async {
   if (fields == _kShuffleCandidateItemFields) {
-    try {
-      final response = await client.itemsApi.getItems(
+    Future<Map<String, dynamic>> candidateQuery({
+      required int queryLimit,
+      int? startIndex,
+      required bool withCount,
+    }) {
+      return client.itemsApi.getItems(
         includeItemTypes: _shuffleIncludeItemTypes(contentType),
         excludeItemTypes: _kShuffleExcludeItemTypes,
         collapseBoxSetItems: false,
@@ -85,26 +92,54 @@ Future<List<AggregatedItem>> _collectRandomItems({
         parentId: parentId,
         genres: genreName != null ? <String>[genreName] : null,
         fields: fields,
-        enableTotalRecordCount: false,
+        startIndex: startIndex,
+        limit: queryLimit,
+        enableTotalRecordCount: withCount,
       );
+    }
+
+    List<AggregatedItem> parseCandidates(Map<String, dynamic> response) {
       final rawItems = (response['Items'] as List?) ?? const <dynamic>[];
-      final items = rawItems
+      return rawItems
           .whereType<Map>()
-          .map((raw) => AggregatedItem(
-                id: raw['Id']?.toString() ?? '',
-                serverId: serverId,
-                rawData: raw.cast<String, dynamic>(),
-              ))
+          .map(
+            (raw) => AggregatedItem(
+              id: raw['Id']?.toString() ?? '',
+              serverId: serverId,
+              rawData: raw.cast<String, dynamic>(),
+            ),
+          )
           .where((item) => !_isExcludedShuffleItemType(item.type))
-          .toList()
-        ..shuffle();
-      _shuffleLogInfo(
-        '_collectRandomItems client-side random success parentId=$parentId count=${items.length}',
+          .toList();
+    }
+
+    try {
+      // Sorting randomly on the server makes SQLite scan the whole library and
+      // pulling every row back to shuffle here costs just as much, so read one
+      // random window instead.
+      final firstPage = await candidateQuery(
+        queryLimit: requestLimit,
+        withCount: true,
       );
-      return items.take(limit).toList();
+      final total = firstPage['TotalRecordCount'] as int? ?? 0;
+      if (total > 0) {
+        // A small library fits in that first page, so only go back to the
+        // server when there is more of it to reach.
+        final items = total <= requestLimit
+            ? parseCandidates(firstPage)
+            : parseCandidates(
+                await candidateQuery(
+                  queryLimit: requestLimit,
+                  startIndex: _shuffleRandom.nextInt(total - requestLimit + 1),
+                  withCount: false,
+                ),
+              );
+        items.shuffle();
+        return items.take(limit).toList();
+      }
     } catch (e, stack) {
       _shuffleLogError(
-        '_collectRandomItems client-side random failed parentId=$parentId',
+        '_collectRandomItems windowed random failed parentId=$parentId',
         e,
         stack,
       );
@@ -411,11 +446,22 @@ Future<List<AggregatedItem>> _collectUnscopedShuffleItems({
 
   final stopwatch = Stopwatch()..start();
   final pool = List<AggregatedLibrary>.from(libraries)..shuffle();
-  
+
   final allCandidates = <AggregatedItem>[];
   final seenIds = <String>{};
+  final deadline = DateTime.now().add(_kShuffleUnscopedOverallTimeout);
 
   for (final library in pool) {
+    // Walking libraries one at a time can outlast the user's patience on a slow
+    // server, so stop once the budget is gone and use whatever came back.
+    final remaining = deadline.difference(DateTime.now());
+    if (remaining <= Duration.zero) {
+      break;
+    }
+    final requestTimeout = remaining < _kShuffleUnscopedPerLibraryTimeout
+        ? remaining
+        : _kShuffleUnscopedPerLibraryTimeout;
+
     try {
       final candidates = await _collectRandomItems(
         client: client,
@@ -426,7 +472,7 @@ Future<List<AggregatedItem>> _collectUnscopedShuffleItems({
         maxAttempts: 1,
         fields: _kShuffleCandidateItemFields,
         parentId: library.id,
-      );
+      ).timeout(requestTimeout);
       for (final candidate in candidates) {
         if (seenIds.add(candidate.id)) {
           allCandidates.add(candidate);
@@ -434,7 +480,7 @@ Future<List<AggregatedItem>> _collectUnscopedShuffleItems({
       }
     } catch (error, stackTrace) {
       _shuffleLogError(
-        '_collectUnscopedShuffleItems candidates collection failure contentType=$contentType libraryId=${library.id}',
+        '_collectUnscopedShuffleItems candidates collection failure contentType=$contentType libraryId=${library.id} requestTimeoutMs=${requestTimeout.inMilliseconds}',
         error,
         stackTrace,
       );
@@ -459,7 +505,7 @@ Future<List<AggregatedItem>> _collectUnscopedShuffleItems({
       ids: selectedCandidates.map((c) => c.id).toList(),
       fields: fields,
     ).timeout(_kShuffleHydrationTimeout);
-    
+
     _shuffleLogInfo(
       '_collectUnscopedShuffleItems complete contentType=$contentType libraries=${libraries.length} requested=$limit result=${hydrated.length} elapsedMs=${stopwatch.elapsedMilliseconds}',
     );
@@ -470,7 +516,10 @@ Future<List<AggregatedItem>> _collectUnscopedShuffleItems({
       error,
       stackTrace,
     );
-    return selectedCandidates;
+    // The candidates only carry Type, so handing them back would draw blank
+    // cards. Returning nothing lets the caller fall back to a scoped fetch that
+    // asks for the full fields.
+    return const <AggregatedItem>[];
   }
 }
 

--- a/lib/ui/widgets/shuffle_options_dialog.dart
+++ b/lib/ui/widgets/shuffle_options_dialog.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 import 'dart:math' as math;
 
 import 'package:dio/dio.dart';
@@ -16,9 +15,7 @@ const String _kShuffleOverlayItemFields =
     'ParentThumbImageTag,Overview,CommunityRating,OfficialRating,CriticRating,'
     'ProviderIds,Genres';
 const String _kShuffleCandidateItemFields = 'Type';
-const _kShuffleUnscopedConcurrency = 3;
-const _kShuffleUnscopedOverallTimeout = Duration(seconds: 12);
-const _kShuffleUnscopedPerLibraryTimeout = Duration(seconds: 4);
+const _kShuffleUnscopedPerLibraryTimeout = Duration(seconds: 8);
 const _kShuffleUserViewsTimeout = Duration(seconds: 6);
 const _kShuffleHydrationTimeout = Duration(seconds: 3);
 
@@ -29,15 +26,9 @@ const List<String> _kShuffleExcludeItemTypes = <String>[
 
 final Set<String> _shuffleIdsHydrationUnsupportedServers = <String>{};
 
-void _shuffleLogInfo(String message) {
-  final _ = message;
-}
+void _shuffleLogInfo(String message) {}
 
-void _shuffleLogError(String message, Object error, StackTrace stackTrace) {
-  final _ = message;
-  final __ = error;
-  final ___ = stackTrace;
-}
+void _shuffleLogError(String message, Object error, StackTrace stackTrace) {}
 
 bool _shouldDisableIdsHydrationForError(DioException error) {
   final statusCode = error.response?.statusCode;
@@ -84,6 +75,42 @@ Future<List<AggregatedItem>> _collectRandomItems({
   String? parentId,
   String? genreName,
 }) async {
+  if (fields == _kShuffleCandidateItemFields) {
+    try {
+      final response = await client.itemsApi.getItems(
+        includeItemTypes: _shuffleIncludeItemTypes(contentType),
+        excludeItemTypes: _kShuffleExcludeItemTypes,
+        collapseBoxSetItems: false,
+        recursive: true,
+        parentId: parentId,
+        genres: genreName != null ? <String>[genreName] : null,
+        fields: fields,
+        enableTotalRecordCount: false,
+      );
+      final rawItems = (response['Items'] as List?) ?? const <dynamic>[];
+      final items = rawItems
+          .whereType<Map>()
+          .map((raw) => AggregatedItem(
+                id: raw['Id']?.toString() ?? '',
+                serverId: serverId,
+                rawData: raw.cast<String, dynamic>(),
+              ))
+          .where((item) => !_isExcludedShuffleItemType(item.type))
+          .toList()
+        ..shuffle();
+      _shuffleLogInfo(
+        '_collectRandomItems client-side random success parentId=$parentId count=${items.length}',
+      );
+      return items.take(limit).toList();
+    } catch (e, stack) {
+      _shuffleLogError(
+        '_collectRandomItems client-side random failed parentId=$parentId',
+        e,
+        stack,
+      );
+    }
+  }
+
   final collected = <AggregatedItem>[];
   final seenIds = <String>{};
 
@@ -95,7 +122,7 @@ Future<List<AggregatedItem>> _collectRandomItems({
     final response = await client.itemsApi.getItems(
       includeItemTypes: _shuffleIncludeItemTypes(contentType),
       excludeItemTypes: _kShuffleExcludeItemTypes,
-      collapseBoxSetItems: true,
+      collapseBoxSetItems: false,
       sortBy: 'Random',
       limit: requestLimit,
       recursive: true,
@@ -384,113 +411,67 @@ Future<List<AggregatedItem>> _collectUnscopedShuffleItems({
 
   final stopwatch = Stopwatch()..start();
   final pool = List<AggregatedLibrary>.from(libraries)..shuffle();
-  final queue = Queue<AggregatedLibrary>.from(pool);
+  
+  final allCandidates = <AggregatedItem>[];
   final seenIds = <String>{};
-  final collected = <AggregatedItem>[];
-  final deadline = DateTime.now().add(_kShuffleUnscopedOverallTimeout);
 
-  final sampleWindow = math.min(
-    pool.length,
-    math.max(_kShuffleUnscopedConcurrency * 2, 6),
-  );
-  final perLibraryLimit = math.max(1, ((limit * 2) / sampleWindow).ceil());
-
-  Future<void> worker() async {
-    while (collected.length < limit) {
-      if (DateTime.now().isAfter(deadline)) {
-        return;
-      }
-      if (queue.isEmpty) {
-        return;
-      }
-
-      final library = queue.removeFirst();
-      final remaining = deadline.difference(DateTime.now());
-      if (remaining <= Duration.zero) {
-        return;
-      }
-
-      final requestTimeout = remaining < _kShuffleUnscopedPerLibraryTimeout
-          ? remaining
-          : _kShuffleUnscopedPerLibraryTimeout;
-
-      try {
-        final items = await _fetchRandomItemsScoped(
-          client: client,
-          contentType: contentType,
-          parentId: library.id,
-          genreName: null,
-          limit: perLibraryLimit,
-          fields: fields,
-        ).timeout(requestTimeout);
-        for (final item in items) {
-          if (!seenIds.add(item.id)) {
-            continue;
-          }
-          collected.add(item);
-          if (collected.length >= limit) {
-            return;
-          }
-        }
-      } catch (error, stackTrace) {
-        _shuffleLogError(
-          '_collectUnscopedShuffleItems worker failure contentType=$contentType libraryId=${library.id} requestTimeoutMs=${requestTimeout.inMilliseconds}',
-          error,
-          stackTrace,
-        );
-      }
-    }
-  }
-
-  final workerCount = math.min(_kShuffleUnscopedConcurrency, queue.length);
-  if (workerCount > 0) {
-    await Future.wait(
-      List<Future<void>>.generate(workerCount, (_) => worker()),
-    );
-  }
-
-  while (collected.length < limit && queue.isNotEmpty) {
-    final remaining = deadline.difference(DateTime.now());
-    if (remaining <= Duration.zero) {
-      break;
-    }
-    final library = queue.removeFirst();
-    final requestTimeout = remaining < _kShuffleUnscopedPerLibraryTimeout
-        ? remaining
-        : _kShuffleUnscopedPerLibraryTimeout;
+  for (final library in pool) {
     try {
-      final items = await _fetchRandomItemsScoped(
+      final candidates = await _collectRandomItems(
         client: client,
+        serverId: client.baseUrl,
         contentType: contentType,
+        limit: limit,
+        requestLimit: _shuffleRequestLimit(contentType, limit),
+        maxAttempts: 1,
+        fields: _kShuffleCandidateItemFields,
         parentId: library.id,
-        genreName: null,
-        limit: 1,
-        fields: fields,
-      ).timeout(requestTimeout);
-      for (final item in items) {
-        if (!seenIds.add(item.id)) {
-          continue;
-        }
-        collected.add(item);
-        if (collected.length >= limit) {
-          break;
+      );
+      for (final candidate in candidates) {
+        if (seenIds.add(candidate.id)) {
+          allCandidates.add(candidate);
         }
       }
     } catch (error, stackTrace) {
       _shuffleLogError(
-        '_collectUnscopedShuffleItems fallback failure contentType=$contentType libraryId=${library.id} requestTimeoutMs=${requestTimeout.inMilliseconds}',
+        '_collectUnscopedShuffleItems candidates collection failure contentType=$contentType libraryId=${library.id}',
         error,
         stackTrace,
       );
     }
   }
 
-  collected.shuffle();
-  final result = collected.take(limit).toList();
-  _shuffleLogInfo(
-    '_collectUnscopedShuffleItems complete contentType=$contentType libraries=${libraries.length} requested=$limit result=${result.length} elapsedMs=${stopwatch.elapsedMilliseconds}',
-  );
-  return result;
+  if (allCandidates.isEmpty) {
+    _shuffleLogInfo(
+      '_collectUnscopedShuffleItems completed with no candidates elapsedMs=${stopwatch.elapsedMilliseconds}',
+    );
+    return const <AggregatedItem>[];
+  }
+
+  allCandidates.shuffle();
+  final selectedCandidates = allCandidates.take(limit).toList();
+
+  try {
+    final hydrated = await _hydrateShuffleItemsByIds(
+      client: client,
+      serverId: client.baseUrl,
+      contentType: contentType,
+      ids: selectedCandidates.map((c) => c.id).toList(),
+      fields: fields,
+    ).timeout(_kShuffleHydrationTimeout);
+    
+    _shuffleLogInfo(
+      '_collectUnscopedShuffleItems complete contentType=$contentType libraries=${libraries.length} requested=$limit result=${hydrated.length} elapsedMs=${stopwatch.elapsedMilliseconds}',
+    );
+    return hydrated;
+  } catch (error, stackTrace) {
+    _shuffleLogError(
+      '_collectUnscopedShuffleItems hydration failure',
+      error,
+      stackTrace,
+    );
+    return selectedCandidates;
+  }
 }
 
 Future<List<AggregatedItem>> _fetchRandomItemsScoped({


### PR DESCRIPTION
# Pull Request

## Summary
Optimize shuffle performance by removing heavy, database-intensive fields (e.g., `MediaStreams, MediaSources, Chapters, Trickplay`) from the initial episodes/shuffle queue queries, and performing a dynamic, single-item hydration right before playback. Additionally, optimize the global library shuffle overlay to use client-side random selection of candidate items and disable `collapseBoxSetItems` globally, preventing SQLite database timeouts and lockups when shuffling both Movie and TV Show libraries.

Overall shuffle time has dropped to about 5 seconds per pull and works on initial call.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #722 
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Optimized `_episodeOverviewFields` in `item_detail_view_model.dart` and local constants `shuffleQueueFields`/`episodeQueueFields` in `item_detail_screen.dart` to request only `'Overview,RunTimeTicks,UserData'`.
- Added a dynamic `_ensureHydrated(AggregatedItem target)` method to fetch the full item detail from the server right before starting playback in the detail screen.
- Intercepted playback and shuffle routines to await hydration for the target first episode before evaluating Dolby Vision fallback transcoding and selecting initial tracks.
- Implemented client-side random candidate selection in `shuffle_options_dialog.dart` when fetching unhydrated items (`fields == _kShuffleCandidateItemFields`) to bypass database-level `ORDER BY RANDOM()` SQLite scans.
- Disabled `collapseBoxSetItems` in both the optimized and fallback candidates queries since collapsing is not needed for shuffling and causes slow SQLite collection joins.
- Combined candidate queries in `_collectUnscopedShuffleItems` to query types first from all libraries, shuffle them on the client, and run a single hydration call for the final selected items, preventing library timeouts and bias.
- Increased query timeouts to 8s (per-library) and 20s (overall) to handle slower local servers and NAS drives.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a show with a very large number of episodes/seasons
2. Click the **Shuffle** button or start playing the show. Verify it loads and starts playback instantly without database lag or timeouts.
3. Open the global Shuffle overlay on the navigation bar, select both the Movies and TV Shows libraries, and trigger the shuffle. Verify candidates are loaded quickly and results successfully contain a random mix of both movies and TV shows.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Shuffling Movies and Shows:
https://github.com/user-attachments/assets/4edd5e45-d99e-4212-bb05-0d8e5e87f87c

Shuffling Episodes:
https://github.com/user-attachments/assets/1c69d564-6b82-46c7-84a1-625b1d859078

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
