### PR TITLE
bug-offline-playback - Make sure all playback lookups in offline mode remember they are offline

### DIFF
--- a/lib/data/offline/connectivity_aware_media_server_client.dart
+++ b/lib/data/offline/connectivity_aware_media_server_client.dart
@@ -1,11 +1,25 @@
+import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
 
+import '../../util/platform_detection.dart';
+import '../services/connectivity_service.dart';
 import '../services/storage_path_service.dart';
 import 'offline_catalog.dart';
 import 'offline_image_api.dart';
 import 'offline_items_api.dart';
 import 'offline_stub_apis.dart';
 import 'offline_user_views_api.dart';
+
+/// Whether browse and read calls should come from the downloads catalog.
+///
+/// TV can't download, so it keeps the online client and its cached home rows
+/// instead of an empty offline catalog.
+bool shouldUseOfflineCatalog() {
+  final getIt = GetIt.instance;
+  return !PlatformDetection.isTV &&
+      getIt.isRegistered<ConnectivityService>() &&
+      !getIt<ConnectivityService>().canReachServer;
+}
 
 /// Wraps the active server client and routes the browse/read APIs to the
 /// offline downloads catalog whenever the server is unreachable, so the

--- a/lib/data/services/media_server_client_factory.dart
+++ b/lib/data/services/media_server_client_factory.dart
@@ -1,8 +1,15 @@
+import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
-import 'package:server_jellyfin/server_jellyfin.dart';
 import 'package:server_emby/server_emby.dart';
+import 'package:server_jellyfin/server_jellyfin.dart';
 
+import '../../util/platform_detection.dart';
 import '../../util/server_url.dart';
+import '../offline/connectivity_aware_media_server_client.dart';
+import '../offline/offline_catalog.dart';
+import 'connectivity_service.dart';
+import 'storage_path_service.dart';
+
 
 class MediaServerClientFactory {
   final DeviceInfo deviceInfo;
@@ -49,6 +56,26 @@ class MediaServerClientFactory {
   }
 
   MediaServerClient _createClient({
+    required ServerType serverType,
+    required String baseUrl,
+  }) {
+    final raw = _createRawClient(
+      serverType: serverType,
+      baseUrl: baseUrl,
+    );
+    final getIt = GetIt.instance;
+    return ConnectivityAwareMediaServerClient(
+      raw,
+      useOffline: () =>
+          !PlatformDetection.isTV &&
+          getIt.isRegistered<ConnectivityService>() &&
+          !getIt<ConnectivityService>().canReachServer,
+      catalog: getIt<OfflineCatalog>(),
+      storagePath: getIt<StoragePathService>(),
+    );
+  }
+
+  MediaServerClient _createRawClient({
     required ServerType serverType,
     required String baseUrl,
   }) {

--- a/lib/data/services/media_server_client_factory.dart
+++ b/lib/data/services/media_server_client_factory.dart
@@ -3,13 +3,10 @@ import 'package:server_core/server_core.dart';
 import 'package:server_emby/server_emby.dart';
 import 'package:server_jellyfin/server_jellyfin.dart';
 
-import '../../util/platform_detection.dart';
 import '../../util/server_url.dart';
 import '../offline/connectivity_aware_media_server_client.dart';
 import '../offline/offline_catalog.dart';
-import 'connectivity_service.dart';
 import 'storage_path_service.dart';
-
 
 class MediaServerClientFactory {
   final DeviceInfo deviceInfo;
@@ -59,17 +56,17 @@ class MediaServerClientFactory {
     required ServerType serverType,
     required String baseUrl,
   }) {
-    final raw = _createRawClient(
-      serverType: serverType,
-      baseUrl: baseUrl,
-    );
+    final raw = _createRawClient(serverType: serverType, baseUrl: baseUrl);
     final getIt = GetIt.instance;
+    // Background isolates skip the offline stack, so there's nothing to route
+    // to and the raw client is all they need.
+    if (!getIt.isRegistered<OfflineCatalog>() ||
+        !getIt.isRegistered<StoragePathService>()) {
+      return raw;
+    }
     return ConnectivityAwareMediaServerClient(
       raw,
-      useOffline: () =>
-          !PlatformDetection.isTV &&
-          getIt.isRegistered<ConnectivityService>() &&
-          !getIt<ConnectivityService>().canReachServer,
+      useOffline: shouldUseOfflineCatalog,
       catalog: getIt<OfflineCatalog>(),
       storagePath: getIt<StoragePathService>(),
     );

--- a/lib/di/modules/server_module.dart
+++ b/lib/di/modules/server_module.dart
@@ -3,14 +3,12 @@ import 'package:server_core/server_core.dart';
 
 import '../../data/offline/connectivity_aware_media_server_client.dart';
 import '../../data/offline/offline_catalog.dart';
-import '../../data/services/connectivity_service.dart';
 import '../../data/services/download_notification_service.dart';
 import '../../data/services/download_service.dart';
 import '../../data/services/media_server_client_factory.dart';
 import '../../data/services/push_messaging_service.dart';
 import '../../data/services/seerr_notification_service.dart';
 import '../../data/services/storage_path_service.dart';
-import '../../util/platform_detection.dart';
 
 final _getIt = GetIt.instance;
 
@@ -47,14 +45,9 @@ void setActiveServerClient(MediaServerClient client) {
   final rawClient = client is ConnectivityAwareMediaServerClient
       ? client.onlineClient
       : client;
-  // TV can't download, so it keeps the online client and its cached home
-  // rows instead of an empty offline catalog.
   final wrapped = ConnectivityAwareMediaServerClient(
     rawClient,
-    useOffline: () =>
-        !PlatformDetection.isTV &&
-        _getIt.isRegistered<ConnectivityService>() &&
-        !_getIt<ConnectivityService>().canReachServer,
+    useOffline: shouldUseOfflineCatalog,
     catalog: _getIt<OfflineCatalog>(),
     storagePath: _getIt<StoragePathService>(),
   );

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -2441,7 +2441,7 @@ class Media3VideoView(
         val language = args["language"]?.toString()
         val title = args["title"]?.toString()
 
-        val subtitleBuilder = MediaItem.SubtitleConfiguration.Builder(Uri.parse(url))
+        val subtitleBuilder = MediaItem.SubtitleConfiguration.Builder(parseUri(url))
             .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
             // ass-media matches selected Media3 text tracks back to libass tracks by ID.
             .setId((EXTERNAL_SUBTITLE_ID_BASE + externalSubtitleConfigurations.size).toString())
@@ -2526,7 +2526,7 @@ class Media3VideoView(
 
         val subtitleConfigurations = externalSubtitleConfigurations.toList()
         val mediaItemBuilder = MediaItem.Builder()
-            .setUri(url)
+            .setUri(parseUri(url))
             .setSubtitleConfigurations(subtitleConfigurations)
             .setMediaMetadata(buildNowPlayingMetadata())
         val inferredMimeType = inferStreamMimeType(url, currentContainer, currentMediaType)
@@ -2575,7 +2575,7 @@ class Media3VideoView(
             }
             if (artworkUrl.isNotEmpty()) {
                 runCatching {
-                    setArtworkUri(Uri.parse(artworkUrl))
+                    setArtworkUri(parseUri(artworkUrl))
                 }
             }
         }.build()
@@ -2968,7 +2968,7 @@ class Media3VideoView(
         // the request the same way. Comparing a parsed uri to the raw string
         // misses whenever Android normalizes it, dropping us to positional
         // selection which is off for externals.
-        val target = Uri.parse(url)
+        val target = parseUri(url)
         val configIndex = externalSubtitleConfigurations.indexOfFirst {
             it.uri == target
         }
@@ -3113,6 +3113,14 @@ class Media3VideoView(
     private fun emitState() {
         if (suppressStateEmissionsForRekick) return
         Media3Bridge.emitEvent(stateMap() + ("event" to "state"))
+    }
+
+    private fun parseUri(url: String): Uri {
+        return if (url.startsWith("/") || !url.contains("://")) {
+            Uri.fromFile(java.io.File(url))
+        } else {
+            Uri.parse(url)
+        }
     }
 
     private fun startTicker() {

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -3115,12 +3115,11 @@ class Media3VideoView(
         Media3Bridge.emitEvent(stateMap() + ("event" to "state"))
     }
 
+    // Offline playback hands us bare filesystem paths. Media3 needs a scheme to
+    // pick a data source, so anything arriving without one becomes a file uri.
     private fun parseUri(url: String): Uri {
-        return if (url.startsWith("/") || !url.contains("://")) {
-            Uri.fromFile(java.io.File(url))
-        } else {
-            Uri.parse(url)
-        }
+        val parsed = Uri.parse(url)
+        return if (parsed.scheme.isNullOrEmpty()) Uri.fromFile(File(url)) else parsed
     }
 
     private fun startTicker() {

--- a/test/offline/media_server_client_factory_test.dart
+++ b/test/offline/media_server_client_factory_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/offline/connectivity_aware_media_server_client.dart';
+import 'package:moonfin/data/services/media_server_client_factory.dart';
+import 'package:server_core/server_core.dart';
+
+void main() {
+  test('skips the offline wrapper when the offline stack is missing', () {
+    // Background isolates register a minimal set of services, so resolving the
+    // catalog here used to throw and take the worker down with it.
+    final factory = MediaServerClientFactory(
+      deviceInfo: const DeviceInfo(
+        id: 'device',
+        name: 'Device',
+        appName: 'Moonfin',
+        appVersion: '1.0.0',
+      ),
+    );
+
+    final client = factory.getClient(
+      serverId: 'server',
+      serverType: ServerType.jellyfin,
+      baseUrl: 'http://example.test',
+    );
+
+    expect(client, isNot(isA<ConnectivityAwareMediaServerClient>()));
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Wraps all client instances returned by `MediaServerClientFactory` in `ConnectivityAwareMediaServerClient` to ensure they route requests to the offline database catalog when the server is offline or unreachable.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #838, #837  
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `MediaServerClientFactory` to decorate client instantiations with `ConnectivityAwareMediaServerClient`.
- This ensures detail screens and play actions use the connectivity-aware wrapper to resolve local downloads when offline, instead of attempting to communicate directly with the server and throwing a `DioException [connection error]: Failed host lookup`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android Mobile (beta apk)
- [ ] Not tested (explain why):

### Test Steps
1. Download a media file
2. Turn on airplane mode
3. Try to play it

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="1280" height="2856" alt="Screenshot_20260718-003055" src="https://github.com/user-attachments/assets/08936a10-d178-4a11-9b3c-fa7e1ffb7d49" />
<img width="1280" height="2856" alt="Screenshot_20260718-003112" src="https://github.com/user-attachments/assets/35fe152f-5f25-4576-8099-7acacf10da4e" />
<img width="2856" height="1280" alt="Screenshot_20260718-003120" src="https://github.com/user-attachments/assets/46087898-2a2b-4da0-a8b7-b34ba3f7cb27" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
