### PR TITLE
bug-seerr - Restrict Seerr request cancellation

### DIFF
--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -79,6 +79,16 @@ class SeerrHttpClient {
     );
   }
 
+  /// Turns the request mutation error codes Seerr uses, such as a 403 for a
+  /// permission or quota refusal, into a typed exception the UI can localize.
+  void _throwIfRequestError(Response response) {
+    final requestError = SeerrRequestException.fromResponse(
+      response.statusCode,
+      response.data,
+    );
+    if (requestError != null) throw requestError;
+  }
+
   void _requireSuccess(Response response, String context) {
     if (response.statusCode == null || response.statusCode! < 200 || response.statusCode! > 299) {
       throw DioException(
@@ -277,9 +287,7 @@ class SeerrHttpClient {
       data: body,
       options: _authJsonOptions(),
     );
-    final requestError =
-        SeerrRequestException.fromResponse(response.statusCode, response.data);
-    if (requestError != null) throw requestError;
+    _throwIfRequestError(response);
     _requireSuccess(response, 'createRequest');
     return response.data as Map<String, dynamic>;
   }
@@ -289,6 +297,7 @@ class SeerrHttpClient {
       _apiUrl('request/$requestId'),
       options: _authOptions(),
     );
+    _throwIfRequestError(response);
     _requireSuccess(response, 'deleteRequest');
   }
 
@@ -326,6 +335,7 @@ class SeerrHttpClient {
       _apiUrl(endpoint),
       options: _authJsonOptions(),
     );
+    _throwIfRequestError(response);
     _requireSuccess(response, opName);
   }
 

--- a/lib/data/viewmodels/seerr_media_detail_view_model.dart
+++ b/lib/data/viewmodels/seerr_media_detail_view_model.dart
@@ -133,6 +133,14 @@ class SeerrMediaDetailState {
         .toList();
   }
 
+  List<SeerrRequest> get cancelableRequests {
+    final user = currentUser;
+    if (user == null) return [];
+    final active = activeRequests;
+    if (user.hasPermission(SeerrPermission.manageRequests)) return active;
+    return [];
+  }
+
   bool get hasExistingRequest {
     final requests = mediaInfo?.requests;
     if (requests == null || requests.isEmpty) return false;

--- a/lib/data/viewmodels/seerr_media_detail_view_model.dart
+++ b/lib/data/viewmodels/seerr_media_detail_view_model.dart
@@ -133,13 +133,11 @@ class SeerrMediaDetailState {
         .toList();
   }
 
-  List<SeerrRequest> get cancelableRequests {
-    final user = currentUser;
-    if (user == null) return [];
-    final active = activeRequests;
-    if (user.hasPermission(SeerrPermission.manageRequests)) return active;
-    return [];
-  }
+  bool get canManageRequests =>
+      currentUser?.hasPermission(SeerrPermission.manageRequests) ?? false;
+
+  List<SeerrRequest> get cancelableRequests =>
+      canManageRequests ? activeRequests : const [];
 
   bool get hasExistingRequest {
     final requests = mediaInfo?.requests;
@@ -388,17 +386,8 @@ class SeerrMediaDetailViewModel extends ChangeNotifier {
       );
 
       await _reloadDetails('Request submitted');
-    } on SeerrRequestException catch (e) {
-      _state = _state.copyWith(
-        isRequesting: false,
-        requestError: e.serverMessage ?? e.kind.name,
-        requestErrorKind: e.kind,
-      );
     } catch (e) {
-      _state = _state.copyWith(
-        isRequesting: false,
-        requestError: e.toString(),
-      );
+      _setRequestFailure(e);
     }
     notifyListeners();
   }
@@ -467,10 +456,7 @@ class SeerrMediaDetailViewModel extends ChangeNotifier {
       }
       await _reloadDetails('Request cancelled');
     } catch (e) {
-      _state = _state.copyWith(
-        isRequesting: false,
-        requestError: e.toString(),
-      );
+      _setRequestFailure(e);
     }
     notifyListeners();
   }
@@ -504,10 +490,22 @@ class SeerrMediaDetailViewModel extends ChangeNotifier {
       await mutation();
       await _reloadDetails(successMessage);
     } catch (e) {
-      _state = _state.copyWith(isRequesting: false, requestError: e.toString());
+      _setRequestFailure(e);
     }
 
     notifyListeners();
+  }
+
+  /// Keeps the typed kind when Seerr refused the mutation so the UI can show a
+  /// translated reason instead of a raw exception.
+  void _setRequestFailure(Object error) {
+    _state = error is SeerrRequestException
+        ? _state.copyWith(
+            isRequesting: false,
+            requestError: error.serverMessage ?? error.kind.name,
+            requestErrorKind: error.kind,
+          )
+        : _state.copyWith(isRequesting: false, requestError: error.toString());
   }
 
   Future<void> _reloadDetails(String successMessage) async {
@@ -536,11 +534,7 @@ class SeerrMediaDetailViewModel extends ChangeNotifier {
     _syncDownloadPolling();
   }
 
-  bool get canManageRequests {
-    final user = _state.currentUser;
-    if (user == null) return false;
-    return user.hasPermission(SeerrPermission.manageRequests);
-  }
+  bool get canManageRequests => _state.canManageRequests;
 
   bool get canRequest {
     final user = _state.currentUser;

--- a/lib/ui/screens/seerr/seerr_media_detail_screen.dart
+++ b/lib/ui/screens/seerr/seerr_media_detail_screen.dart
@@ -673,7 +673,8 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
     final canManage = vm.canManageRequests;
     final trailer = s.bestTrailer;
     final showTrailer = trailer != null;
-    final showCancel = s.cancelableRequests.isNotEmpty && !s.isFullyAvailable;
+    final hasOpenRequest = s.activeRequests.isNotEmpty && !s.isFullyAvailable;
+    final showCancel = hasOpenRequest && s.cancelableRequests.isNotEmpty;
 
     final tiles = <Widget>[];
     FocusNode? nextFirstNode = _firstActionFocusNode;
@@ -693,7 +694,7 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
           focusNode: takeFirst(),
         ),
       );
-    } else if (s.activeRequests.isNotEmpty && !s.isFullyAvailable) {
+    } else if (hasOpenRequest) {
       tiles.add(
         _ActionTile(
           icon: Icons.check,
@@ -1255,6 +1256,7 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
         ? l10n.requestMore
         : l10n.request;
     final canManage = vm.canManageRequests;
+    final hasOpenRequest = s.activeRequests.isNotEmpty && !s.isFullyAvailable;
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(32, 16, 32, 0),
@@ -1329,7 +1331,7 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
                     foregroundColor: Colors.white,
                   ),
                 ),
-              if (s.cancelableRequests.isNotEmpty && !s.isFullyAvailable)
+              if (hasOpenRequest && s.cancelableRequests.isNotEmpty)
                 OutlinedButton.icon(
                   onPressed: s.isRequesting ? null : () => _showCancelDialog(s),
                   icon: const Icon(Icons.close, size: 18),
@@ -1341,7 +1343,7 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
                     ),
                   ),
                 )
-              else if (s.activeRequests.isNotEmpty && !s.isFullyAvailable)
+              else if (hasOpenRequest)
                 OutlinedButton.icon(
                   onPressed: null,
                   icon: const Icon(Icons.check, size: 18),
@@ -1528,10 +1530,16 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
     final vm = _vm;
     if (vm == null) return;
     await vm.cancelRequests(requests.map((r) => r.id).toList());
-    if (mounted && vm.state.requestError == null) {
-      try {
-        GetIt.instance<SeerrDiscoverViewModel>().refresh();
-      } catch (_) {}
+    if (!mounted || vm.state.requestError != null) return;
+
+    // Discover caches the rows that still list this request, so drop them
+    // before the user lands back on it.
+    if (GetIt.instance.isRegistered<SeerrDiscoverViewModel>()) {
+      GetIt.instance<SeerrDiscoverViewModel>().refresh();
+    }
+    if (context.canPop()) {
+      context.pop();
+    } else {
       context.go(Destinations.seerrDiscover);
     }
   }
@@ -1920,44 +1928,42 @@ class _ActionTileState extends State<_ActionTile> with FocusStateMixin {
             child: AnimatedScale(
               scale: showFocusBorder ? 1.05 : 1.0,
               duration: const Duration(milliseconds: 150),
-            child: SizedBox(
-              width: 96,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    width: 88,
-                    height: 88,
-                    decoration: BoxDecoration(
-                      color: bg,
-                      borderRadius: AppRadius.circular(14),
-                      border: showFocusBorder
-                          ? Border.fromBorderSide(
-                              ThemeRegistry.active.borders.focusBorder.copyWith(
-                                color: focusColor,
-                                width: 3,
-                              ),
-                            )
-                          : null,
+              child: SizedBox(
+                width: 96,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 88,
+                      height: 88,
+                      decoration: BoxDecoration(
+                        color: bg,
+                        borderRadius: AppRadius.circular(14),
+                        border: showFocusBorder
+                            ? Border.fromBorderSide(
+                                ThemeRegistry.active.borders.focusBorder
+                                    .copyWith(color: focusColor, width: 3),
+                              )
+                            : null,
+                      ),
+                      child: Icon(widget.icon, color: fg, size: 38),
                     ),
-                    child: Icon(widget.icon, color: fg, size: 38),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    widget.label,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w500,
+                    const SizedBox(height: 8),
+                    Text(
+                      widget.label,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      textAlign: TextAlign.center,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    textAlign: TextAlign.center,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
-          ),
           ),
         ),
       ),

--- a/lib/ui/screens/seerr/seerr_media_detail_screen.dart
+++ b/lib/ui/screens/seerr/seerr_media_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../data/services/seerr/seerr_error.dart';
 import '../../../data/viewmodels/seerr_media_detail_view_model.dart';
+import '../../../data/viewmodels/seerr_discover_view_model.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/seerr_preferences.dart';
 import '../../../preference/user_preferences.dart';
@@ -672,7 +673,7 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
     final canManage = vm.canManageRequests;
     final trailer = s.bestTrailer;
     final showTrailer = trailer != null;
-    final showCancel = s.activeRequests.isNotEmpty && !s.isFullyAvailable;
+    final showCancel = s.cancelableRequests.isNotEmpty && !s.isFullyAvailable;
 
     final tiles = <Widget>[];
     FocusNode? nextFirstNode = _firstActionFocusNode;
@@ -690,6 +691,16 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
           onTap: s.isRequesting ? null : () => _showCancelDialog(s),
           primary: !(s.isFullyAvailable || s.isPartiallyAvailable),
           focusNode: takeFirst(),
+        ),
+      );
+    } else if (s.activeRequests.isNotEmpty && !s.isFullyAvailable) {
+      tiles.add(
+        _ActionTile(
+          icon: Icons.check,
+          label: l10n.seerrRequestedStatus,
+          onTap: null,
+          primary: false,
+          focusNode: null,
         ),
       );
     } else if (canShowRequest) {
@@ -1318,7 +1329,7 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
                     foregroundColor: Colors.white,
                   ),
                 ),
-              if (s.activeRequests.isNotEmpty && !s.isFullyAvailable)
+              if (s.cancelableRequests.isNotEmpty && !s.isFullyAvailable)
                 OutlinedButton.icon(
                   onPressed: s.isRequesting ? null : () => _showCancelDialog(s),
                   icon: const Icon(Icons.close, size: 18),
@@ -1327,6 +1338,18 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
                     foregroundColor: Colors.red[300],
                     side: ThemeRegistry.active.borders.chipBorder.copyWith(
                       color: Colors.red[300]!,
+                    ),
+                  ),
+                )
+              else if (s.activeRequests.isNotEmpty && !s.isFullyAvailable)
+                OutlinedButton.icon(
+                  onPressed: null,
+                  icon: const Icon(Icons.check, size: 18),
+                  label: Text(l10n.seerrRequestedStatus),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.white54,
+                    side: ThemeRegistry.active.borders.chipBorder.copyWith(
+                      color: Colors.white24,
                     ),
                   ),
                 ),
@@ -1465,7 +1488,7 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
 
   void _showCancelDialog(SeerrMediaDetailState s) {
     final l10n = AppLocalizations.of(context);
-    final active = s.activeRequests;
+    final active = s.cancelableRequests;
     if (active.isEmpty) return;
 
     final title = s.displayTitle;
@@ -1505,6 +1528,12 @@ class _SeerrMediaDetailScreenState extends State<SeerrMediaDetailScreen> {
     final vm = _vm;
     if (vm == null) return;
     await vm.cancelRequests(requests.map((r) => r.id).toList());
+    if (mounted && vm.state.requestError == null) {
+      try {
+        GetIt.instance<SeerrDiscoverViewModel>().refresh();
+      } catch (_) {}
+      context.go(Destinations.seerrDiscover);
+    }
   }
 
   Future<void> _playInMoonfin(SeerrMediaDetailState s) async {
@@ -1864,6 +1893,7 @@ class _ActionTileState extends State<_ActionTile> with FocusStateMixin {
     return Focus(
       focusNode: widget.focusNode,
       onFocusChange: setFocused,
+      canRequestFocus: !disabled,
       onKeyEvent: (node, event) {
         if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
           return KeyEventResult.ignored;
@@ -1885,9 +1915,11 @@ class _ActionTileState extends State<_ActionTile> with FocusStateMixin {
               : SystemMouseCursors.click,
           onEnter: (_) => setHovered(true),
           onExit: (_) => setHovered(false),
-          child: AnimatedScale(
-            scale: showFocusBorder ? 1.05 : 1.0,
-            duration: const Duration(milliseconds: 150),
+          child: Opacity(
+            opacity: disabled ? 0.5 : 1.0,
+            child: AnimatedScale(
+              scale: showFocusBorder ? 1.05 : 1.0,
+              duration: const Duration(milliseconds: 150),
             child: SizedBox(
               width: 96,
               child: Column(
@@ -1925,6 +1957,7 @@ class _ActionTileState extends State<_ActionTile> with FocusStateMixin {
                 ],
               ),
             ),
+          ),
           ),
         ),
       ),


### PR DESCRIPTION
# Pull Request

## Summary
Restricts Seerr request cancellation to administrators/managers and auto-refreshes the Seerr discover screen upon cancellation. 

## Related Issues
Link related issues or tickets separated by commas.

Discord related issue

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/194

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added a cancelableRequests getter in SeerrMediaDetailState that returns active requests only when the logged-in user possesses manageRequests permissions, disabling cancellation options for regular users.
- Replaced the cancel action tile/button with a disabled, dim status tile showing "Requested" with a checkmark for regular users.
- On successful cancellation, refreshes the SeerrDiscoverViewModel lazy singleton to clear cache and redirects the user back to /seerr/discover to show updated rows.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Request a media item as a normal user. Verify they see a disabled "Requested" tile instead of a "Cancel Request" button.
2. Request a media item as an admin. Verify they see a working "Cancel Request" button.
3. Click "Cancel Request" as an admin. Verify that the cancellation succeeds, the Seerr Discover row automatically refreshes, and the screen navigates back to the Seerr discover page.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previous:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_09-15-31" src="https://github.com/user-attachments/assets/3c3d43be-0aca-449b-aa2e-c5dfc2af5959" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_09-15-45" src="https://github.com/user-attachments/assets/245f3fbf-790d-4ac7-9e69-d9ca70f66b74" />

### Non-Admin (can't cancel):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_09-40-17" src="https://github.com/user-attachments/assets/b5dc882f-1a4a-409d-9a64-4d921a45c077" />

### Admin (still can cancel):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_09-41-31" src="https://github.com/user-attachments/assets/20693ceb-d2e0-476e-866a-84e63b2922b3" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_09-41-41" src="https://github.com/user-attachments/assets/79445b79-0ca1-4bd6-9970-39c4b30cfdec" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
