### PR TITLE
bug-gamepad - Fix Android TV startup crash from gamepad dependency

### DIFF
--- a/android/app/src/main/kotlin/org/moonfin/androidtv/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/MainActivity.kt
@@ -52,7 +52,26 @@ import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 import java.io.ByteArrayOutputStream
 
-class MainActivity : AudioServiceActivity() {
+import android.hardware.input.InputManager
+import org.flame_engine.gamepads_android.GamepadsCompatibleActivity
+
+class MainActivity : AudioServiceActivity(), GamepadsCompatibleActivity {
+
+    private var keyHandler: ((KeyEvent) -> Boolean)? = null
+    private var motionHandler: ((MotionEvent) -> Boolean)? = null
+
+    override fun registerInputDeviceListener(listener: InputManager.InputDeviceListener, handler: Handler?) {
+        val inputManager = getSystemService(Context.INPUT_SERVICE) as InputManager
+        inputManager.registerInputDeviceListener(listener, handler)
+    }
+
+    override fun registerKeyEventHandler(handler: (KeyEvent) -> Boolean) {
+        keyHandler = handler
+    }
+
+    override fun registerMotionEventHandler(handler: (MotionEvent) -> Boolean) {
+        motionHandler = handler
+    }
 
     private var methodChannel: MethodChannel? = null
     private var castChannel: MethodChannel? = null
@@ -602,6 +621,9 @@ class MainActivity : AudioServiceActivity() {
                 return true
             }
         }
+        if (keyHandler?.invoke(event) == true) {
+            return true
+        }
         return super.dispatchKeyEvent(event)
     }
 
@@ -647,6 +669,9 @@ class MainActivity : AudioServiceActivity() {
                 sendGamepadNavigate("v", if (y == -1) "up" else if (y == 1) "down" else "none")
             }
             // Not consumed, since other views may still want the motion event.
+        }
+        if (motionHandler?.invoke(event) == true) {
+            return true
         }
         return super.dispatchGenericMotionEvent(event)
     }


### PR DESCRIPTION
# Pull Request

Fix Android TV startup crash from gamepad dependency. The earlier commit registers listeners assuming the activity implements the GamepadsCompatibleActivity interface. Because MainActivity lacked that interface, ClassCastException was crashing on boot resulting in crashing the app before it could even start.

This PR implements the interface methods on MainActivity and correctly forwards the input/key/motion events to the gamepad library to resolve the crash.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Implemented GamepadsCompatibleActivity interface on MainActivity to resolve compile-time errors and prevent startup ClassCastException crashes caused by the recent gamepads_android dependency introduction.

## Platform
- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Launch app on Android TV and verify it boots successfully without throwing ClassCastException.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
