### PR TITLE
bugfix-seerrdiscoverypage - Fix Seerr Sub-Library Pages

### DIFF
--- a/lib/data/viewmodels/seerr_browse_view_model.dart
+++ b/lib/data/viewmodels/seerr_browse_view_model.dart
@@ -79,6 +79,13 @@ class SeerrBrowseState {
 }
 
 class SeerrBrowseViewModel extends ChangeNotifier {
+  /// How many filtered items a load aims for before it stops reading ahead.
+  static const _minMatchesPerLoad = 10;
+
+  /// Ceiling on pages read in one go, so a filter that matches almost nothing
+  /// cannot walk the whole library.
+  static const _maxPagesPerScan = 6;
+
   final SeerrRepository _repo;
   final String? filterId;
   final String mediaType;
@@ -99,9 +106,7 @@ class SeerrBrowseViewModel extends ChangeNotifier {
     required this.mediaType,
     this.filterType,
   }) {
-    _state = SeerrBrowseState(
-      sortBy: sortOptions.first,
-    );
+    _state = SeerrBrowseState(sortBy: sortOptions.first);
   }
 
   Future<void> load() async {
@@ -115,33 +120,30 @@ class SeerrBrowseViewModel extends ChangeNotifier {
 
     try {
       await _repo.ensureInitialized();
+      await _ensureRequestLookup();
       var pageNum = 1;
-      var matches = <SeerrDiscoverItem>[];
-      SeerrDiscoverPage? pageResult;
+      final matches = <SeerrDiscoverItem>[];
+      late SeerrDiscoverPage lastPage;
 
-      while (matches.length < 10 && pageNum <= 6) {
+      // A letter or availability filter can reject a whole page, so keep
+      // reading ahead until there is enough to fill the grid.
+      while (matches.length < _minMatchesPerLoad &&
+          pageNum <= _maxPagesPerScan) {
         final page = await _fetchPage(pageNum);
-        pageResult = page;
-        await _ensureRequestLookup();
-        final enriched = _attachRequesters(page.results);
-        final filtered = _applyFilter(enriched);
-        matches.addAll(filtered);
+        lastPage = page;
+        matches.addAll(_applyFilter(_attachRequesters(page.results)));
         if (page.page >= page.totalPages || page.results.isEmpty) {
           break;
         }
         pageNum++;
       }
 
-      if (pageResult != null) {
-        _state = _state.copyWith(
-          isLoading: false,
-          items: matches,
-          currentPage: pageResult.page,
-          totalPages: pageResult.totalPages,
-        );
-      } else {
-        _state = _state.copyWith(isLoading: false, items: []);
-      }
+      _state = _state.copyWith(
+        isLoading: false,
+        items: matches,
+        currentPage: lastPage.page,
+        totalPages: lastPage.totalPages,
+      );
     } catch (e) {
       _state = _state.copyWith(isLoading: false, error: e.toString());
     }
@@ -155,34 +157,29 @@ class SeerrBrowseViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      var pageNum = _state.currentPage + 1;
-      var matches = <SeerrDiscoverItem>[];
-      SeerrDiscoverPage? pageResult;
-      final startPage = pageNum;
+      await _ensureRequestLookup();
+      final startPage = _state.currentPage + 1;
+      var pageNum = startPage;
+      final matches = <SeerrDiscoverItem>[];
+      late SeerrDiscoverPage lastPage;
 
-      while (matches.length < 10 && pageNum < startPage + 6) {
+      while (matches.length < _minMatchesPerLoad &&
+          pageNum < startPage + _maxPagesPerScan) {
         final page = await _fetchPage(pageNum);
-        pageResult = page;
-        await _ensureRequestLookup();
-        final enriched = _attachRequesters(page.results);
-        final filtered = _applyFilter(enriched);
-        matches.addAll(filtered);
+        lastPage = page;
+        matches.addAll(_applyFilter(_attachRequesters(page.results)));
         if (page.page >= page.totalPages || page.results.isEmpty) {
           break;
         }
         pageNum++;
       }
 
-      if (pageResult != null) {
-        _state = _state.copyWith(
-          isLoadingMore: false,
-          items: [..._state.items, ...matches],
-          currentPage: pageResult.page,
-          totalPages: pageResult.totalPages,
-        );
-      } else {
-        _state = _state.copyWith(isLoadingMore: false);
-      }
+      _state = _state.copyWith(
+        isLoadingMore: false,
+        items: [..._state.items, ...matches],
+        currentPage: lastPage.page,
+        totalPages: lastPage.totalPages,
+      );
     } catch (e) {
       _state = _state.copyWith(isLoadingMore: false);
     }

--- a/lib/data/viewmodels/seerr_browse_view_model.dart
+++ b/lib/data/viewmodels/seerr_browse_view_model.dart
@@ -11,13 +11,23 @@ class SeerrSortOption {
   const SeerrSortOption(this.label, this.value);
 }
 
-const seerrSortOptions = [
-  SeerrSortOption('Popularity', 'popularity.desc'),
-  SeerrSortOption('Rating', 'vote_average.desc'),
-  SeerrSortOption('Release Date', 'primary_release_date.desc'),
-  SeerrSortOption('Title', 'original_title.asc'),
-  SeerrSortOption('Revenue', 'revenue.desc'),
-];
+List<SeerrSortOption> getSortOptionsFor(String mediaType) {
+  if (mediaType == 'tv') {
+    return const [
+      SeerrSortOption('Popularity', 'popularity.desc'),
+      SeerrSortOption('Rating', 'vote_average.desc'),
+      SeerrSortOption('Release Date', 'first_air_date.desc'),
+      SeerrSortOption('Title', 'name.asc'),
+    ];
+  }
+  return const [
+    SeerrSortOption('Popularity', 'popularity.desc'),
+    SeerrSortOption('Rating', 'vote_average.desc'),
+    SeerrSortOption('Release Date', 'primary_release_date.desc'),
+    SeerrSortOption('Title', 'original_title.asc'),
+    SeerrSortOption('Revenue', 'revenue.desc'),
+  ];
+}
 
 class SeerrBrowseState {
   final bool isLoading;
@@ -81,12 +91,18 @@ class SeerrBrowseViewModel extends ChangeNotifier {
   SeerrBrowseState _state = const SeerrBrowseState();
   SeerrBrowseState get state => _state;
 
+  List<SeerrSortOption> get sortOptions => getSortOptionsFor(mediaType);
+
   SeerrBrowseViewModel(
     this._repo, {
     this.filterId,
     required this.mediaType,
     this.filterType,
-  });
+  }) {
+    _state = SeerrBrowseState(
+      sortBy: sortOptions.first,
+    );
+  }
 
   Future<void> load() async {
     _state = SeerrBrowseState(
@@ -99,15 +115,33 @@ class SeerrBrowseViewModel extends ChangeNotifier {
 
     try {
       await _repo.ensureInitialized();
-      final page = await _fetchPage(1);
-      await _ensureRequestLookup();
-      final enriched = _attachRequesters(page.results);
-      _state = _state.copyWith(
-        isLoading: false,
-        items: _applyFilter(enriched),
-        currentPage: page.page,
-        totalPages: page.totalPages,
-      );
+      var pageNum = 1;
+      var matches = <SeerrDiscoverItem>[];
+      SeerrDiscoverPage? pageResult;
+
+      while (matches.length < 10 && pageNum <= 6) {
+        final page = await _fetchPage(pageNum);
+        pageResult = page;
+        await _ensureRequestLookup();
+        final enriched = _attachRequesters(page.results);
+        final filtered = _applyFilter(enriched);
+        matches.addAll(filtered);
+        if (page.page >= page.totalPages || page.results.isEmpty) {
+          break;
+        }
+        pageNum++;
+      }
+
+      if (pageResult != null) {
+        _state = _state.copyWith(
+          isLoading: false,
+          items: matches,
+          currentPage: pageResult.page,
+          totalPages: pageResult.totalPages,
+        );
+      } else {
+        _state = _state.copyWith(isLoading: false, items: []);
+      }
     } catch (e) {
       _state = _state.copyWith(isLoading: false, error: e.toString());
     }
@@ -121,16 +155,34 @@ class SeerrBrowseViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final nextPage = _state.currentPage + 1;
-      final page = await _fetchPage(nextPage);
-      await _ensureRequestLookup();
-      final enriched = _attachRequesters(page.results);
-      _state = _state.copyWith(
-        isLoadingMore: false,
-        items: [..._state.items, ..._applyFilter(enriched)],
-        currentPage: page.page,
-        totalPages: page.totalPages,
-      );
+      var pageNum = _state.currentPage + 1;
+      var matches = <SeerrDiscoverItem>[];
+      SeerrDiscoverPage? pageResult;
+      final startPage = pageNum;
+
+      while (matches.length < 10 && pageNum < startPage + 6) {
+        final page = await _fetchPage(pageNum);
+        pageResult = page;
+        await _ensureRequestLookup();
+        final enriched = _attachRequesters(page.results);
+        final filtered = _applyFilter(enriched);
+        matches.addAll(filtered);
+        if (page.page >= page.totalPages || page.results.isEmpty) {
+          break;
+        }
+        pageNum++;
+      }
+
+      if (pageResult != null) {
+        _state = _state.copyWith(
+          isLoadingMore: false,
+          items: [..._state.items, ...matches],
+          currentPage: pageResult.page,
+          totalPages: pageResult.totalPages,
+        );
+      } else {
+        _state = _state.copyWith(isLoadingMore: false);
+      }
     } catch (e) {
       _state = _state.copyWith(isLoadingMore: false);
     }

--- a/lib/ui/screens/seerr/seerr_browse_screen.dart
+++ b/lib/ui/screens/seerr/seerr_browse_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
@@ -228,7 +229,8 @@ class _SeerrBrowseScreenState extends State<SeerrBrowseScreen> {
         final hasSubtitles = s.items.any(
           (item) => (_cardSubtitle(item)?.isNotEmpty ?? false),
         );
-        final textHeight = hasSubtitles ? 38.0 : 22.0;
+        final textScaler = MediaQuery.textScalerOf(context);
+        final textHeight = (hasSubtitles ? 42.0 : 24.0) * textScaler.scale(1.0);
         final childAspectRatio = cellWidth / (cellWidth / (2 / 3) + textHeight);
 
         return CustomScrollView(
@@ -580,35 +582,102 @@ class _SeerrFilterChips extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _chip(l10n.all, SeerrBrowseFilter.all),
+        _SeerrFilterChip(
+          label: l10n.all,
+          selected: filter == SeerrBrowseFilter.all,
+          onTap: () => onChanged(SeerrBrowseFilter.all),
+        ),
         const SizedBox(width: 6),
-        _chip(l10n.seerrAvailableStatus, SeerrBrowseFilter.available),
+        _SeerrFilterChip(
+          label: l10n.seerrAvailableStatus,
+          selected: filter == SeerrBrowseFilter.available,
+          onTap: () => onChanged(SeerrBrowseFilter.available),
+        ),
         const SizedBox(width: 6),
-        _chip(l10n.seerrRequestedStatus, SeerrBrowseFilter.requested),
+        _SeerrFilterChip(
+          label: l10n.seerrRequestedStatus,
+          selected: filter == SeerrBrowseFilter.requested,
+          onTap: () => onChanged(SeerrBrowseFilter.requested),
+        ),
       ],
     );
   }
+}
 
-  Widget _chip(String label, SeerrBrowseFilter value) {
-    final selected = filter == value;
-    return GestureDetector(
-      onTap: () => onChanged(value),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-        decoration: BoxDecoration(
-          color: selected
-              ? _seerrAccent
-              : AppColorScheme.onSurface.withAlpha(20),
-          borderRadius: AppRadius.circular(14),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 12,
-            fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
-            color: selected
-                ? AppColorScheme.onSurface
-                : AppColorScheme.onSurface.withAlpha(179),
+class _SeerrFilterChip extends StatefulWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _SeerrFilterChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  State<_SeerrFilterChip> createState() => _SeerrFilterChipState();
+}
+
+class _SeerrFilterChipState extends State<_SeerrFilterChip>
+    with FocusStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (node, event) {
+          if (event.logicalKey == LogicalKeyboardKey.select ||
+              event.logicalKey == LogicalKeyboardKey.enter ||
+              event.logicalKey == LogicalKeyboardKey.gameButtonA) {
+            if (event is KeyDownEvent) {
+              widget.onTap();
+            }
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: widget.selected
+                  ? _seerrAccent
+                  : (focused
+                      ? AppColorScheme.buttonFocused
+                      : AppColorScheme.onSurface.withAlpha(20)),
+              borderRadius: AppRadius.circular(14),
+              border: showFocusBorder
+                  ? Border.fromBorderSide(
+                      ThemeRegistry.active.borders.focusBorder.copyWith(
+                        color: focusColor,
+                        width: 1.5,
+                      ),
+                    )
+                  : null,
+            ),
+            child: Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: widget.selected ? FontWeight.w600 : FontWeight.normal,
+                color: widget.selected
+                    ? AppColorScheme.onSurface
+                    : (focused
+                        ? AppColorScheme.onButtonFocused
+                        : AppColorScheme.onSurface.withAlpha(179)),
+              ),
+            ),
           ),
         ),
       ),
@@ -711,6 +780,17 @@ class _AlphaLetterButtonState extends State<_AlphaLetterButton>
       child: Focus(
         focusNode: widget.focusNode,
         onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (node, event) {
+          if (event.logicalKey == LogicalKeyboardKey.select ||
+              event.logicalKey == LogicalKeyboardKey.enter ||
+              event.logicalKey == LogicalKeyboardKey.gameButtonA) {
+            if (event is KeyDownEvent) {
+              widget.onTap();
+            }
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
         child: GestureDetector(
           onTap: widget.onTap,
           child: AnimatedContainer(
@@ -774,6 +854,17 @@ class _ToolbarButtonState extends State<_ToolbarButton> with FocusStateMixin {
       onExit: (_) => setHovered(false),
       child: Focus(
         onFocusChange: (f) => setFocused(f),
+        onKeyEvent: (node, event) {
+          if (event.logicalKey == LogicalKeyboardKey.select ||
+              event.logicalKey == LogicalKeyboardKey.enter ||
+              event.logicalKey == LogicalKeyboardKey.gameButtonA) {
+            if (event is KeyDownEvent) {
+              widget.onTap();
+            }
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
         child: GestureDetector(
           onTap: widget.onTap,
           child: AnimatedContainer(
@@ -858,6 +949,8 @@ class _SeerrSortDialog extends StatefulWidget {
 }
 
 class _SeerrSortDialogState extends State<_SeerrSortDialog> {
+  bool _popped = false;
+
   @override
   void initState() {
     super.initState();
@@ -907,15 +1000,33 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
               ),
             ),
             Divider(color: AppColorScheme.onSurface.withAlpha(20)),
-            for (final option in seerrSortOptions)
-              _radioTile(
+            ...vm.sortOptions.map((option) {
+              final isSelected = s.sortBy.value.startsWith(option.value.split('.').first);
+              final isAsc = s.sortBy.value.endsWith('.asc');
+              return _radioTile(
                 label: option.label,
-                selected: s.sortBy.value == option.value,
+                selected: isSelected,
+                trailing: isSelected
+                    ? Icon(
+                        isAsc ? Icons.arrow_upward : Icons.arrow_downward,
+                        size: 16,
+                        color: AppColorScheme.accent,
+                      )
+                    : null,
                 onTap: () {
-                  vm.setSortBy(option);
+                  if (_popped) return;
+                  _popped = true;
+                  if (isSelected) {
+                    final base = option.value.split('.').first;
+                    final newDir = isAsc ? 'desc' : 'asc';
+                    vm.setSortBy(SeerrSortOption(option.label, '$base.$newDir'));
+                  } else {
+                    vm.setSortBy(option);
+                  }
                   Navigator.of(context).pop();
                 },
-              ),
+              );
+            }),
           ],
         ),
       ),
@@ -925,6 +1036,7 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
   Widget _radioTile({
     required String label,
     required bool selected,
+    Widget? trailing,
     required VoidCallback onTap,
   }) {
     return InkWell(
@@ -941,12 +1053,12 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
                 border: Border.fromBorderSide(
                   ThemeRegistry.active.borders.chipBorder.copyWith(
                     color: selected
-                        ? _seerrAccent
+                        ? AppColorScheme.accent
                         : AppColorScheme.onSurface.withAlpha(128),
                     width: 2,
                   ),
                 ),
-                color: selected ? _seerrAccent : Colors.transparent,
+                color: selected ? AppColorScheme.accent : Colors.transparent,
               ),
               child:
                   selected
@@ -974,6 +1086,10 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
                 ),
               ),
             ),
+            if (trailing != null) ...[
+              const SizedBox(width: 12),
+              trailing,
+            ],
           ],
         ),
       ),
@@ -981,15 +1097,22 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
   }
 }
 
-class _SeerrSettingsDialog extends StatelessWidget {
+class _SeerrSettingsDialog extends StatefulWidget {
   final UserPreferences prefs;
 
   const _SeerrSettingsDialog({required this.prefs});
 
   @override
+  State<_SeerrSettingsDialog> createState() => _SeerrSettingsDialogState();
+}
+
+class _SeerrSettingsDialogState extends State<_SeerrSettingsDialog> {
+  bool _popped = false;
+
+  @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final current = prefs.resolveLibraryPosterSize();
+    final current = widget.prefs.resolveLibraryPosterSize();
     final dialogWidth = (MediaQuery.sizeOf(context).width - 32).clamp(
       280.0,
       380.0,
@@ -1034,7 +1157,9 @@ class _SeerrSettingsDialog extends StatelessWidget {
                 label: _posterSizeLabel(option, l10n),
                 selected: current == option,
                 onTap: () async {
-                  await prefs.set(UserPreferences.libraryPosterSize, option);
+                  if (_popped) return;
+                  _popped = true;
+                  await widget.prefs.set(UserPreferences.libraryPosterSize, option);
                   if (context.mounted) {
                     Navigator.of(context).pop();
                   }
@@ -1072,12 +1197,12 @@ class _SeerrSettingsDialog extends StatelessWidget {
                 border: Border.fromBorderSide(
                   ThemeRegistry.active.borders.chipBorder.copyWith(
                     color: selected
-                        ? _seerrAccent
+                        ? AppColorScheme.accent
                         : AppColorScheme.onSurface.withAlpha(128),
                     width: 2,
                   ),
                 ),
-                color: selected ? _seerrAccent : Colors.transparent,
+                color: selected ? AppColorScheme.accent : Colors.transparent,
               ),
               child:
                   selected

--- a/lib/ui/screens/seerr/seerr_browse_screen.dart
+++ b/lib/ui/screens/seerr/seerr_browse_screen.dart
@@ -635,15 +635,11 @@ class _SeerrFilterChipState extends State<_SeerrFilterChip>
       child: Focus(
         onFocusChange: (f) => setFocused(f),
         onKeyEvent: (node, event) {
-          if (event.logicalKey == LogicalKeyboardKey.select ||
-              event.logicalKey == LogicalKeyboardKey.enter ||
-              event.logicalKey == LogicalKeyboardKey.gameButtonA) {
-            if (event is KeyDownEvent) {
-              widget.onTap();
-            }
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
+          if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
+          // Claim the release and repeats as well, otherwise the focus that
+          // gets restored when a dialog closes replays the press underneath.
+          if (event is KeyDownEvent) widget.onTap();
+          return KeyEventResult.handled;
         },
         child: GestureDetector(
           onTap: widget.onTap,
@@ -654,8 +650,8 @@ class _SeerrFilterChipState extends State<_SeerrFilterChip>
               color: widget.selected
                   ? _seerrAccent
                   : (focused
-                      ? AppColorScheme.buttonFocused
-                      : AppColorScheme.onSurface.withAlpha(20)),
+                        ? AppColorScheme.buttonFocused
+                        : AppColorScheme.onSurface.withAlpha(20)),
               borderRadius: AppRadius.circular(14),
               border: showFocusBorder
                   ? Border.fromBorderSide(
@@ -670,12 +666,14 @@ class _SeerrFilterChipState extends State<_SeerrFilterChip>
               widget.label,
               style: TextStyle(
                 fontSize: 12,
-                fontWeight: widget.selected ? FontWeight.w600 : FontWeight.normal,
+                fontWeight: widget.selected
+                    ? FontWeight.w600
+                    : FontWeight.normal,
                 color: widget.selected
                     ? AppColorScheme.onSurface
                     : (focused
-                        ? AppColorScheme.onButtonFocused
-                        : AppColorScheme.onSurface.withAlpha(179)),
+                          ? AppColorScheme.onButtonFocused
+                          : AppColorScheme.onSurface.withAlpha(179)),
               ),
             ),
           ),
@@ -781,15 +779,11 @@ class _AlphaLetterButtonState extends State<_AlphaLetterButton>
         focusNode: widget.focusNode,
         onFocusChange: (f) => setFocused(f),
         onKeyEvent: (node, event) {
-          if (event.logicalKey == LogicalKeyboardKey.select ||
-              event.logicalKey == LogicalKeyboardKey.enter ||
-              event.logicalKey == LogicalKeyboardKey.gameButtonA) {
-            if (event is KeyDownEvent) {
-              widget.onTap();
-            }
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
+          if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
+          // Claim the release and repeats as well, otherwise the focus that
+          // gets restored when a dialog closes replays the press underneath.
+          if (event is KeyDownEvent) widget.onTap();
+          return KeyEventResult.handled;
         },
         child: GestureDetector(
           onTap: widget.onTap,
@@ -855,15 +849,11 @@ class _ToolbarButtonState extends State<_ToolbarButton> with FocusStateMixin {
       child: Focus(
         onFocusChange: (f) => setFocused(f),
         onKeyEvent: (node, event) {
-          if (event.logicalKey == LogicalKeyboardKey.select ||
-              event.logicalKey == LogicalKeyboardKey.enter ||
-              event.logicalKey == LogicalKeyboardKey.gameButtonA) {
-            if (event is KeyDownEvent) {
-              widget.onTap();
-            }
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
+          if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
+          // Claim the release and repeats as well, otherwise the focus that
+          // gets restored when a dialog closes replays the press underneath.
+          if (event is KeyDownEvent) widget.onTap();
+          return KeyEventResult.handled;
         },
         child: GestureDetector(
           onTap: widget.onTap,
@@ -1001,7 +991,8 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
             ),
             Divider(color: AppColorScheme.onSurface.withAlpha(20)),
             ...vm.sortOptions.map((option) {
-              final isSelected = s.sortBy.value.startsWith(option.value.split('.').first);
+              final base = option.value.split('.').first;
+              final isSelected = s.sortBy.value.split('.').first == base;
               final isAsc = s.sortBy.value.endsWith('.asc');
               return _radioTile(
                 label: option.label,
@@ -1010,16 +1001,19 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
                     ? Icon(
                         isAsc ? Icons.arrow_upward : Icons.arrow_downward,
                         size: 16,
-                        color: AppColorScheme.accent,
+                        color: _seerrAccent,
                       )
                     : null,
                 onTap: () {
                   if (_popped) return;
                   _popped = true;
+                  // Tapping the active choice flips direction instead of
+                  // reselecting the same sort.
                   if (isSelected) {
-                    final base = option.value.split('.').first;
                     final newDir = isAsc ? 'desc' : 'asc';
-                    vm.setSortBy(SeerrSortOption(option.label, '$base.$newDir'));
+                    vm.setSortBy(
+                      SeerrSortOption(option.label, '$base.$newDir'),
+                    );
                   } else {
                     vm.setSortBy(option);
                   }
@@ -1053,12 +1047,12 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
                 border: Border.fromBorderSide(
                   ThemeRegistry.active.borders.chipBorder.copyWith(
                     color: selected
-                        ? AppColorScheme.accent
+                        ? _seerrAccent
                         : AppColorScheme.onSurface.withAlpha(128),
                     width: 2,
                   ),
                 ),
-                color: selected ? AppColorScheme.accent : Colors.transparent,
+                color: selected ? _seerrAccent : Colors.transparent,
               ),
               child:
                   selected
@@ -1086,10 +1080,7 @@ class _SeerrSortDialogState extends State<_SeerrSortDialog> {
                 ),
               ),
             ),
-            if (trailing != null) ...[
-              const SizedBox(width: 12),
-              trailing,
-            ],
+            if (trailing != null) ...[const SizedBox(width: 12), trailing],
           ],
         ),
       ),
@@ -1159,7 +1150,10 @@ class _SeerrSettingsDialogState extends State<_SeerrSettingsDialog> {
                 onTap: () async {
                   if (_popped) return;
                   _popped = true;
-                  await widget.prefs.set(UserPreferences.libraryPosterSize, option);
+                  await widget.prefs.set(
+                    UserPreferences.libraryPosterSize,
+                    option,
+                  );
                   if (context.mounted) {
                     Navigator.of(context).pop();
                   }
@@ -1197,12 +1191,12 @@ class _SeerrSettingsDialogState extends State<_SeerrSettingsDialog> {
                 border: Border.fromBorderSide(
                   ThemeRegistry.active.borders.chipBorder.copyWith(
                     color: selected
-                        ? AppColorScheme.accent
+                        ? _seerrAccent
                         : AppColorScheme.onSurface.withAlpha(128),
                     width: 2,
                   ),
                 ),
-                color: selected ? AppColorScheme.accent : Colors.transparent,
+                color: selected ? _seerrAccent : Colors.transparent,
               ),
               child:
                   selected


### PR DESCRIPTION
# Pull Request

## Summary
Fixes issues on the Seerr sub-library browse page (Genres, Networks, Studios, etc.) where header controls (home, sort, settings, filter chips, and alphabetical picker buttons) are not focusable or action-triggerable on TV/Gamepad. It also addresses focus-restoration key leakage after dialog pop (which incorrectly booted users back to the Seerr Discovery screen) and adds support for dynamic sorting options based on media type (TV vs Movies) with direction toggles.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #819 
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

#### **seerr_browse_view_model.dart**
- Defined dynamic sort options based on media type (TV libraries use `popularity`, `vote_average`, `first_air_date`, and `name`; movie libraries also include `revenue` and use movie-appropriate keys like `primary_release_date` and `original_title`).
- Refactored `load()` and `loadMore()` to scan forward up to 6 pages if local filters (availability or letter filters) yield empty matches, preventing endless rendering/layout request loops.

#### **seerr_browse_screen.dart**
- Fixed the grid `textHeight` calculation in `_buildGrid` to scale with text scaling factor and respect standard bounds, resolving the 10px bottom card column layout overflow.
- Replaced the raw `GestureDetector` filter chips with a new focusable `_SeerrFilterChip` widget.
- Added key event interception (`onKeyEvent`) in `_SeerrFilterChipState`, `_AlphaLetterButtonState`, and `_ToolbarButtonState` to map remote/gamepad select actions (Enter, OK, Gamepad A) to tap callbacks on key down.
- Consumed key release (`KeyUpEvent`) and repeat events on the header buttons to prevent focus-restoration leakage from double-triggering actions (like the Home button's `onHome` redirect) upon dialog closure.
- Added `_popped` state checks in `_SeerrSortDialogState` and `_SeerrSettingsDialogState` to prevent duplicate pops from closing the parent page.
- Implemented sort direction toggling (clicking active sort category toggles ascending/descending) with clean dynamic arrow indicators next to the active choice.
- Linked selection indicators and direction arrows to `AppColorScheme.accent` to adapt to custom themes.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a sub-library page (e.g., Studio, Network, or Genre).
2. Verify all toolbar buttons (Home, Sort, Settings), filter chips, and letter picker items are focusable via remote/gamepad.
3. Open the Sort or Settings dialog, change options, and verify the dialog closes without popping the parent page.
4. Verify the sort direction toggles and displays a theme-appropriate arrow indicator.
5. Apply "Available" filters + Title sorting and verify shows load successfully.
6. Verify no layout overflow occurs at the bottom of the grid cards.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Showing various combinations of filters and sorting:

<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_10-59-22" src="https://github.com/user-attachments/assets/8f900ffa-e649-4d5f-a7cc-9c03d552ae6c" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_11-08-24" src="https://github.com/user-attachments/assets/26af68ac-fb76-4232-a542-55ff9dc55d61" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-18_11-10-33" src="https://github.com/user-attachments/assets/09c32a9f-cd97-4887-bbf2-32ee320d3fb0" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
