### PR TITLE
bugfix-seerr - Fix Seerr 4K vs non-4K request toggle logic

### DIFF
--- a/lib/ui/screens/seerr/seerr_collection_screen.dart
+++ b/lib/ui/screens/seerr/seerr_collection_screen.dart
@@ -377,7 +377,7 @@ class _CollectionRequestSheetState extends State<_CollectionRequestSheet> {
   @override
   void initState() {
     super.initState();
-    _advanced = SeerrAdvancedRequestController(isTv: false);
+    _advanced = SeerrAdvancedRequestController(isTv: false, is4k: _is4k);
     _applySavedPreferences(resetSelection: false);
     if (widget.vm.canRequestAdvanced) {
       _advanced.load();
@@ -409,6 +409,7 @@ class _CollectionRequestSheetState extends State<_CollectionRequestSheet> {
           ? _seerrPrefs.fourKMovieRootFolderId
           : _seerrPrefs.hdMovieRootFolderId,
       resetSelection: resetSelection,
+      is4k: _is4k,
     );
   }
 

--- a/lib/ui/screens/seerr/seerr_media_detail_screen.dart
+++ b/lib/ui/screens/seerr/seerr_media_detail_screen.dart
@@ -1962,6 +1962,7 @@ class _RequestDialogState extends State<_RequestDialog> {
     _advanced = SeerrAdvancedRequestController(
       isTv: widget.isTv,
       isAnime: widget.vm.state.isAnime,
+      is4k: _is4k,
     );
     _applySavedPreferences(resetSelection: false);
     if (widget.vm.canRequestAdvanced) {
@@ -1989,6 +1990,7 @@ class _RequestDialogState extends State<_RequestDialog> {
       profileId: _is4k ? vm.saved4kProfileId : vm.savedProfileId,
       rootFolderId: _is4k ? vm.saved4kRootFolderId : vm.savedRootFolderId,
       resetSelection: resetSelection,
+      is4k: _is4k,
     );
   }
 

--- a/lib/ui/widgets/seerr/seerr_advanced_request_options.dart
+++ b/lib/ui/widgets/seerr/seerr_advanced_request_options.dart
@@ -14,6 +14,7 @@ import 'seerr_tv_controls.dart';
 class SeerrAdvancedRequestController extends ChangeNotifier {
   final bool isTv;
   final bool isAnime;
+  bool is4k;
 
   List<SeerrServiceServerDetails>? servers;
   bool loading = false;
@@ -26,7 +27,11 @@ class SeerrAdvancedRequestController extends ChangeNotifier {
   String? _savedProfileId;
   String? _savedRootFolderId;
 
-  SeerrAdvancedRequestController({required this.isTv, this.isAnime = false});
+  SeerrAdvancedRequestController({
+    required this.isTv,
+    this.isAnime = false,
+    this.is4k = false,
+  });
 
   Future<void> load() async {
     loading = true;
@@ -59,11 +64,16 @@ class SeerrAdvancedRequestController extends ChangeNotifier {
     String? profileId,
     String? rootFolderId,
     bool resetSelection = false,
+    bool? is4k,
   }) {
+    if (is4k != null) {
+      this.is4k = is4k;
+    }
     _savedServerId = serverId;
     _savedProfileId = profileId;
     _savedRootFolderId = rootFolderId;
     if (resetSelection) {
+      selectedServerId = null;
       selectedProfileId = null;
       selectedRootFolderId = null;
     }
@@ -111,17 +121,36 @@ class SeerrAdvancedRequestController extends ChangeNotifier {
     }
   }
 
+  SeerrServiceServerDetails? _findDefaultServer() {
+    if (servers == null || servers!.isEmpty) return null;
+
+    // 1. Try to find a server that matches both is4k and isDefault
+    final primaryMatch = servers!
+        .where((s) => s.server.is4k == is4k && s.server.isDefault)
+        .firstOrNull;
+    if (primaryMatch != null) return primaryMatch;
+
+    // 2. Try to find any server that matches is4k
+    final secondaryMatch = servers!
+        .where((s) => s.server.is4k == is4k)
+        .firstOrNull;
+    if (secondaryMatch != null) return secondaryMatch;
+
+    // 3. Fall back to the first server in the list
+    return servers!.first;
+  }
+
   SeerrServiceServerDetails? get activeServer {
     if (servers == null || servers!.isEmpty) return null;
-    if (selectedServerId == null) return servers!.first;
+    if (selectedServerId == null) return _findDefaultServer();
     return servers!
             .where((s) => s.server.id == selectedServerId)
             .firstOrNull ??
-        servers!.first;
+        _findDefaultServer();
   }
 
   int? get effectiveServerId =>
-      selectedServerId ?? servers?.firstOrNull?.server.id;
+      selectedServerId ?? activeServer?.server.id;
 
   int? get effectiveProfileId {
     if (selectedProfileId != null) return selectedProfileId;


### PR DESCRIPTION
# Pull Request

## Summary
Somehow the 4k toggle got unplugged. This fixes the issue where toggling the 4K switch in the media request dialog did not change the destination server or profile (always defaulting to the first server in the list).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #843 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified **seerr_advanced_request_options.dart**: Added `is4k` context to `SeerrAdvancedRequestController`, cleared `selectedServerId` on `resetSelection` to allow the active server to recalculate when toggling, and resolved default servers using the `_findDefaultServer()` helper which filters by `is4k` and `isDefault` properties.
- Modified **seerr_media_detail_screen.dart**: Passed the `is4k` parameter when instantiating `SeerrAdvancedRequestController` and applying saved preferences.
- Modified **seerr_collection_screen.dart**: Passed the `is4k` parameter when instantiating `SeerrAdvancedRequestController` and applying saved preferences.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Flutter analyzed but had to run on an errand. Testing still needed.

### Test Steps
1. Configure two Radarr/Sonarr servers in Seerr (one HD, one 4K).
2. Request a movie/show in the UI and toggle between HD and 4K options.
3. Observe that the advanced options correctly update to the corresponding default HD or 4K server and profiles.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
